### PR TITLE
Add  eni and appmesh ecs-agent module, and refactor eni to have a more general naming "NetworkInterface" with expanded attributes

### DIFF
--- a/agent/acs/handler/attach_eni_handler_common.go
+++ b/agent/acs/handler/attach_eni_handler_common.go
@@ -19,9 +19,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/arn"
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
@@ -48,7 +48,7 @@ func NewENIHandler(state dockerstate.TaskEngineState, dataClient data.Client) *e
 // 2. Otherwise add the attachment to state, start its ack timer, and save the state
 // These are common tasks for handling a task ENI attachment and an instance ENI attachment, so they are put
 // into this function to be shared by both attachment handlers
-func (eniHandler *eniHandler) HandleENIAttachment(ea *apieni.ENIAttachment) error {
+func (eniHandler *eniHandler) HandleENIAttachment(ea *ni.ENIAttachment) error {
 	attachmentType := ea.AttachmentType
 	attachmentARN := ea.AttachmentARN
 	taskARN := ea.TaskARN
@@ -70,7 +70,7 @@ func (eniHandler *eniHandler) HandleENIAttachment(ea *apieni.ENIAttachment) erro
 }
 
 // addENIAttachmentToState adds an ENI attachment to state, and start its ack timer
-func (eniHandler *eniHandler) addENIAttachmentToState(ea *apieni.ENIAttachment) error {
+func (eniHandler *eniHandler) addENIAttachmentToState(ea *ni.ENIAttachment) error {
 	attachmentType := ea.AttachmentType
 	attachmentARN := ea.AttachmentARN
 	taskARN := ea.TaskARN
@@ -82,14 +82,14 @@ func (eniHandler *eniHandler) addENIAttachmentToState(ea *apieni.ENIAttachment) 
 	}
 
 	switch attachmentType {
-	case apieni.ENIAttachmentTypeTaskENI:
+	case ni.ENIAttachmentTypeTaskENI:
 		taskId, _ := arn.TaskIdFromArn(taskARN)
 		logger.Info("Adding eni attachment info to state for task", logger.Fields{
 			field.TaskID:    taskId,
 			"attachmentARN": attachmentARN,
 			"mac":           mac,
 		})
-	case apieni.ENIAttachmentTypeInstanceENI:
+	case ni.ENIAttachmentTypeInstanceENI:
 		logger.Info("Adding instance eni attachment info to state", logger.Fields{
 			"attachmentARN": attachmentARN,
 			"mac":           mac,

--- a/agent/acs/handler/attach_eni_handler_common_test.go
+++ b/agent/acs/handler/attach_eni_handler_common_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/testconst"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 )
 
 const (
@@ -36,12 +36,12 @@ const (
 
 // TestTaskENIAckTimeout tests acknowledge timeout for a task eni before submit the state change
 func TestTaskENIAckTimeout(t *testing.T) {
-	testENIAckTimeout(t, apieni.ENIAttachmentTypeTaskENI)
+	testENIAckTimeout(t, ni.ENIAttachmentTypeTaskENI)
 }
 
 // TestInstanceENIAckTimeout tests acknowledge timeout for an instance level eni before submit the state change
 func TestInstanceENIAckTimeout(t *testing.T) {
-	testENIAckTimeout(t, apieni.ENIAttachmentTypeInstanceENI)
+	testENIAckTimeout(t, ni.ENIAttachmentTypeInstanceENI)
 }
 
 func testENIAckTimeout(t *testing.T, attachmentType string) {
@@ -52,7 +52,7 @@ func testENIAckTimeout(t *testing.T, attachmentType string) {
 	dataClient := newTestDataClient(t)
 
 	expiresAt := time.Now().Add(time.Millisecond * testconst.WaitTimeoutMillis)
-	eniAttachment := &apieni.ENIAttachment{
+	eniAttachment := &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			TaskARN:          testconst.TaskARN,
 			AttachmentARN:    attachmentArn,
@@ -83,12 +83,12 @@ func testENIAckTimeout(t *testing.T, attachmentType string) {
 
 // TestTaskENIAckWithinTimeout tests the eni state change was reported before the timeout, for a task eni
 func TestTaskENIAckWithinTimeout(t *testing.T) {
-	testENIAckWithinTimeout(t, apieni.ENIAttachmentTypeTaskENI)
+	testENIAckWithinTimeout(t, ni.ENIAttachmentTypeTaskENI)
 }
 
 // TestInstanceENIAckWithinTimeout tests the eni state change was reported before the timeout, for an instance eni
 func TestInstanceENIAckWithinTimeout(t *testing.T) {
-	testENIAckWithinTimeout(t, apieni.ENIAttachmentTypeInstanceENI)
+	testENIAckWithinTimeout(t, ni.ENIAttachmentTypeInstanceENI)
 }
 
 func testENIAckWithinTimeout(t *testing.T, attachmentType string) {
@@ -98,7 +98,7 @@ func testENIAckWithinTimeout(t *testing.T, attachmentType string) {
 	taskEngineState := dockerstate.NewTaskEngineState()
 	dataClient := data.NewNoopClient()
 	expiresAt := time.Now().Add(time.Millisecond * testconst.WaitTimeoutMillis)
-	eniAttachment := &apieni.ENIAttachment{
+	eniAttachment := &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			TaskARN:          testconst.TaskARN,
 			AttachmentARN:    attachmentArn,
@@ -124,12 +124,12 @@ func testENIAckWithinTimeout(t *testing.T, attachmentType string) {
 
 // TestHandleENIAttachmentTaskENI tests handling a new task eni
 func TestHandleENIAttachmentTaskENI(t *testing.T) {
-	testHandleENIAttachment(t, apieni.ENIAttachmentTypeTaskENI, testconst.TaskARN)
+	testHandleENIAttachment(t, ni.ENIAttachmentTypeTaskENI, testconst.TaskARN)
 }
 
 // TestHandleENIAttachmentInstanceENI tests handling a new instance eni
 func TestHandleENIAttachmentInstanceENI(t *testing.T) {
-	testHandleENIAttachment(t, apieni.ENIAttachmentTypeInstanceENI, "")
+	testHandleENIAttachment(t, ni.ENIAttachmentTypeInstanceENI, "")
 }
 
 func testHandleENIAttachment(t *testing.T, attachmentType, taskArn string) {
@@ -140,7 +140,7 @@ func testHandleENIAttachment(t *testing.T, attachmentType, taskArn string) {
 
 	taskEngineState := dockerstate.NewTaskEngineState()
 	expiresAt := time.Now().Add(time.Millisecond * testconst.WaitTimeoutMillis)
-	eniAttachment := &apieni.ENIAttachment{
+	eniAttachment := &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			TaskARN:          taskArn,
 			AttachmentARN:    attachmentArn,
@@ -169,12 +169,12 @@ func testHandleENIAttachment(t *testing.T, attachmentType, taskArn string) {
 
 // TestHandleExpiredENIAttachmentTaskENI tests handling an expired task eni
 func TestHandleExpiredENIAttachmentTaskENI(t *testing.T) {
-	testHandleExpiredENIAttachment(t, apieni.ENIAttachmentTypeTaskENI, testconst.TaskARN)
+	testHandleExpiredENIAttachment(t, ni.ENIAttachmentTypeTaskENI, testconst.TaskARN)
 }
 
 // TestHandleExpiredENIAttachmentInstanceENI tests handling an expired instance eni
 func TestHandleExpiredENIAttachmentInstanceENI(t *testing.T) {
-	testHandleExpiredENIAttachment(t, apieni.ENIAttachmentTypeInstanceENI, "")
+	testHandleExpiredENIAttachment(t, ni.ENIAttachmentTypeInstanceENI, "")
 }
 
 func testHandleExpiredENIAttachment(t *testing.T, attachmentType, taskArn string) {
@@ -187,7 +187,7 @@ func testHandleExpiredENIAttachment(t *testing.T, attachmentType, taskArn string
 	taskEngineState := dockerstate.NewTaskEngineState()
 	dataClient := data.NewNoopClient()
 
-	eniAttachment := &apieni.ENIAttachment{
+	eniAttachment := &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			TaskARN:       taskArn,
 			AttachmentARN: attachmentArn,

--- a/agent/acs/handler/attach_instance_eni_responder_test.go
+++ b/agent/acs/handler/attach_instance_eni_responder_test.go
@@ -32,7 +32,7 @@ import (
 	acssession "github.com/aws/amazon-ecs-agent/ecs-agent/acs/session"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/testconst"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 )
 
 var testAttachInstanceENIMessage = &ecsacs.AttachInstanceNetworkInterfacesMessage{
@@ -112,7 +112,7 @@ func TestInstanceENIAckSingleMessageWithDuplicateENIAttachment(t *testing.T) {
 		// the task engine state.
 		mockState.EXPECT().
 			ENIByMac(testconst.RandomMAC).
-			Return(&apieni.ENIAttachment{
+			Return(&ni.ENIAttachment{
 				AttachmentInfo: attachmentinfo.AttachmentInfo{
 					ExpiresAt: expiresAt,
 				},

--- a/agent/acs/handler/attach_task_eni_responder_test.go
+++ b/agent/acs/handler/attach_task_eni_responder_test.go
@@ -32,7 +32,7 @@ import (
 	acssession "github.com/aws/amazon-ecs-agent/ecs-agent/acs/session"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/testconst"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 )
 
 var testAttachTaskENIMessage = &ecsacs.AttachTaskNetworkInterfacesMessage{
@@ -112,7 +112,7 @@ func TestTaskENIAckSingleMessageWithDuplicateENIAttachment(t *testing.T) {
 		// the task engine state.
 		mockState.EXPECT().
 			ENIByMac(testconst.RandomMAC).
-			Return(&apieni.ENIAttachment{
+			Return(&ni.ENIAttachment{
 				AttachmentInfo: attachmentinfo.AttachmentInfo{
 					ExpiresAt: expiresAt,
 				},

--- a/agent/acs/handler/payload_responder.go
+++ b/agent/acs/handler/payload_responder.go
@@ -17,17 +17,17 @@ import (
 	"fmt"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
-	apiappmesh "github.com/aws/amazon-ecs-agent/agent/api/appmesh"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	loggerfield "github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	nlappmesh "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
 )
@@ -140,7 +140,7 @@ func (pmHandler *payloadMessageHandler) addPayloadTasks(payload *ecsacs.PayloadM
 
 		// Add ENI information to the task struct.
 		for _, acsENI := range task.ElasticNetworkInterfaces {
-			eni, err := apieni.ENIFromACS(acsENI)
+			eni, err := ni.ENIFromACS(acsENI)
 			if err != nil {
 				pmHandler.handleInvalidTask(task, err, payload)
 				allTasksOK = false
@@ -151,7 +151,7 @@ func (pmHandler *payloadMessageHandler) addPayloadTasks(payload *ecsacs.PayloadM
 
 		// Add the app mesh information to task struct.
 		if task.ProxyConfiguration != nil {
-			appmesh, err := apiappmesh.AppMeshFromACS(task.ProxyConfiguration)
+			appmesh, err := nlappmesh.AppMeshFromACS(task.ProxyConfiguration)
 			if err != nil {
 				pmHandler.handleInvalidTask(task, err, payload)
 				allTasksOK = false

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -41,8 +41,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	mock_ec2 "github.com/aws/amazon-ecs-agent/agent/ec2/mocks"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ecs_client/model/ecs"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -1085,7 +1085,7 @@ func TestSubmitTaskStateChangeWithAttachments(t *testing.T) {
 
 	err := client.SubmitTaskStateChange(api.TaskStateChange{
 		TaskARN: "task_arn",
-		Attachment: &apieni.ENIAttachment{
+		Attachment: &ni.ENIAttachment{
 			AttachmentInfo: attachmentinfo.AttachmentInfo{
 				AttachmentARN: "eni_arn",
 				Status:        status.AttachmentAttached,

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -23,8 +23,8 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/pkg/errors"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -73,7 +73,7 @@ type ManagedAgentStateChange struct {
 // SubmitTaskStateChange API
 type TaskStateChange struct {
 	// Attachment is the eni attachment object to send
-	Attachment *apieni.ENIAttachment
+	Attachment *ni.ENIAttachment
 	// TaskArn is the unique identifier for the task
 	TaskARN string
 	// Status is the status to send
@@ -99,7 +99,7 @@ type TaskStateChange struct {
 // SubmitAttachmentStateChanges API
 type AttachmentStateChange struct {
 	// Attachment is the eni attachment object to send
-	Attachment *apieni.ENIAttachment
+	Attachment *ni.ENIAttachment
 }
 
 type ErrShouldNotSendEvent struct {
@@ -218,7 +218,7 @@ func NewManagedAgentChangeEvent(task *apitask.Task, cont *apicontainer.Container
 }
 
 // NewAttachmentStateChangeEvent creates a new attachment state change event
-func NewAttachmentStateChangeEvent(eniAttachment *apieni.ENIAttachment) AttachmentStateChange {
+func NewAttachmentStateChangeEvent(eniAttachment *ni.ENIAttachment) AttachmentStateChange {
 	return AttachmentStateChange{
 		Attachment: eniAttachment,
 	}

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -24,8 +24,6 @@ import (
 	"sync"
 	"time"
 
-	apiappmesh "github.com/aws/amazon-ecs-agent/agent/api/appmesh"
-	"github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
@@ -45,12 +43,13 @@ import (
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	nlappmesh "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/arn"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime"
 
@@ -251,7 +250,7 @@ type Task struct {
 	ENIs TaskENIs `json:"ENI"`
 
 	// AppMesh is the service mesh specified by the task
-	AppMesh *apiappmesh.AppMesh
+	AppMesh *nlappmesh.AppMesh
 
 	// MemoryCPULimitsEnabled to determine if task supports CPU, memory limits
 	MemoryCPULimitsEnabled bool `json:"MemoryCPULimitsEnabled,omitempty"`
@@ -2770,18 +2769,18 @@ func (task *Task) SetSentStatus(status apitaskstatus.TaskStatus) {
 }
 
 // AddTaskENI adds ENI information to the task.
-func (task *Task) AddTaskENI(eni *apieni.ENI) {
+func (task *Task) AddTaskENI(eni *ni.NetworkInterface) {
 	task.lock.Lock()
 	defer task.lock.Unlock()
 
 	if task.ENIs == nil {
-		task.ENIs = make([]*apieni.ENI, 0)
+		task.ENIs = make([]*ni.NetworkInterface, 0)
 	}
 	task.ENIs = append(task.ENIs, eni)
 }
 
 // GetTaskENIs returns the list of ENIs for the task.
-func (task *Task) GetTaskENIs() []*apieni.ENI {
+func (task *Task) GetTaskENIs() []*ni.NetworkInterface {
 	// TODO: what's the point of locking if we are returning a pointer?
 	task.lock.RLock()
 	defer task.lock.RUnlock()
@@ -2791,7 +2790,7 @@ func (task *Task) GetTaskENIs() []*apieni.ENI {
 
 // GetPrimaryENI returns the primary ENI of the task. Since ACS can potentially send
 // multiple ENIs to the agent, the first ENI in the list is considered as the primary ENI.
-func (task *Task) GetPrimaryENI() *apieni.ENI {
+func (task *Task) GetPrimaryENI() *ni.NetworkInterface {
 	task.lock.RLock()
 	defer task.lock.RUnlock()
 
@@ -2803,7 +2802,7 @@ func (task *Task) GetPrimaryENI() *apieni.ENI {
 }
 
 // SetAppMesh sets the app mesh config of the task
-func (task *Task) SetAppMesh(appMesh *apiappmesh.AppMesh) {
+func (task *Task) SetAppMesh(appMesh *nlappmesh.AppMesh) {
 	task.lock.Lock()
 	defer task.lock.Unlock()
 
@@ -2811,7 +2810,7 @@ func (task *Task) SetAppMesh(appMesh *apiappmesh.AppMesh) {
 }
 
 // GetAppMesh returns the app mesh config of the task
-func (task *Task) GetAppMesh() *apiappmesh.AppMesh {
+func (task *Task) GetAppMesh() *nlappmesh.AppMesh {
 	task.lock.RLock()
 	defer task.lock.RUnlock()
 
@@ -3595,9 +3594,9 @@ func (task *Task) ToHostResources() map[string]*ecs.Resource {
 			for _, port := range c.Ports {
 				hostPort := port.HostPort
 				protocol := port.Protocol
-				if hostPort > 0 && protocol == container.TransportProtocolTCP {
+				if hostPort > 0 && protocol == apicontainer.TransportProtocolTCP {
 					tcpPortSet = append(tcpPortSet, hostPort)
-				} else if hostPort > 0 && protocol == container.TransportProtocolUDP {
+				} else if hostPort > 0 && protocol == apicontainer.TransportProtocolUDP {
 					udpPortSet = append(udpPortSet, hostPort)
 				}
 			}

--- a/agent/api/task/task_enis.go
+++ b/agent/api/task/task_enis.go
@@ -16,7 +16,7 @@ package task
 import (
 	"encoding/json"
 
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 )
 
 // TaskENIs type enumerates the list of ENI objects as a type. It is used for
@@ -29,10 +29,10 @@ import (
 // since this is only required for unmarshaling 'Task' object. None of the
 // functionality/types in the 'eni' package themselves have any dependencies on this
 // type.
-type TaskENIs []*apieni.ENI
+type TaskENIs []*ni.NetworkInterface
 
 func (taskENIs *TaskENIs) UnmarshalJSON(b []byte) error {
-	var enis []*apieni.ENI
+	var enis []*ni.NetworkInterface
 	// Try to unmarshal this as a list of ENI objects.
 	err := json.Unmarshal(b, &enis)
 	if err == nil {
@@ -43,12 +43,12 @@ func (taskENIs *TaskENIs) UnmarshalJSON(b []byte) error {
 	// There was an error unmarshaling the byte slice as a list of ENIs. This is the case
 	// where we're restoring from a previous version of the state file, where the ENI is
 	// being stored as a standalone object and not as a list.
-	var eni apieni.ENI
+	var eni ni.NetworkInterface
 	err = json.Unmarshal(b, &eni)
 	if err != nil {
 		return err
 	}
-	enis = []*apieni.ENI{&eni}
+	enis = []*ni.NetworkInterface{&eni}
 	*taskENIs = enis
 	return nil
 }

--- a/agent/api/task/task_linux.go
+++ b/agent/api/task/task_linux.go
@@ -31,8 +31,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	resourcetype "github.com/aws/amazon-ecs-agent/agent/taskresource/types"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/arn"
 	"github.com/cihub/seelog"
 	"github.com/containernetworking/cni/libcni"
@@ -273,10 +273,10 @@ func (task *Task) BuildCNIConfigAwsvpc(includeIPAMConfig bool, cniConfig *ecscni
 		switch eni.InterfaceAssociationProtocol {
 		// If the association protocol is set to "default" or unset (to preserve backwards
 		// compatibility), consider it a "standard" ENI attachment.
-		case "", apieni.DefaultInterfaceAssociationProtocol:
+		case "", ni.DefaultInterfaceAssociationProtocol:
 			cniConfig.ID = eni.MacAddress
 			ifName, netconf, err = ecscni.NewENINetworkConfig(eni, cniConfig)
-		case apieni.VLANInterfaceAssociationProtocol:
+		case ni.VLANInterfaceAssociationProtocol:
 			cniConfig.ID = eni.MacAddress
 			ifName, netconf, err = ecscni.NewBranchENINetworkConfig(eni, cniConfig)
 		default:

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 
-	"github.com/aws/amazon-ecs-agent/agent/api/appmesh"
-	apiappmesh "github.com/aws/amazon-ecs-agent/agent/api/appmesh"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -37,7 +35,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/firelens"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/ssmsecret"
 	mock_ioutilwrapper "github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper/mocks"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
+	nlappmesh "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/golang/mock/gomock"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -103,7 +103,7 @@ func TestAddNetworkResourceProvisioningDependencyNop(t *testing.T) {
 
 func TestAddNetworkResourceProvisioningDependencyWithENI(t *testing.T) {
 	testTask := &Task{
-		ENIs: []*apieni.ENI{{}},
+		ENIs: []*ni.NetworkInterface{{}},
 		Containers: []*apicontainer.Container{
 			{
 				Name:                      "c1",
@@ -136,10 +136,10 @@ func TestAddNetworkResourceProvisioningDependencyWithAppMesh(t *testing.T) {
 	serializedConfig := string(bytes)
 
 	testTask := &Task{
-		AppMesh: &apiappmesh.AppMesh{
+		AppMesh: &nlappmesh.AppMesh{
 			ContainerName: proxyName,
 		},
-		ENIs:        []*apieni.ENI{{}},
+		ENIs:        []*ni.NetworkInterface{{}},
 		NetworkMode: AWSVPCNetworkMode,
 		Containers: []*apicontainer.Container{
 			{
@@ -183,10 +183,10 @@ func TestAddNetworkResourceProvisioningDependencyWithAppMeshDefaultImage(t *test
 	serializedConfig := string(bytes)
 
 	testTask := &Task{
-		AppMesh: &apiappmesh.AppMesh{
+		AppMesh: &nlappmesh.AppMesh{
 			ContainerName: proxyName,
 		},
-		ENIs:        []*apieni.ENI{{}},
+		ENIs:        []*ni.NetworkInterface{{}},
 		NetworkMode: AWSVPCNetworkMode,
 		Containers: []*apicontainer.Container{
 			{
@@ -220,10 +220,10 @@ func TestAddNetworkResourceProvisioningDependencyWithAppMeshDefaultImage(t *test
 
 func TestAddNetworkResourceProvisioningDependencyWithAppMeshError(t *testing.T) {
 	testTask := &Task{
-		AppMesh: &apiappmesh.AppMesh{
+		AppMesh: &nlappmesh.AppMesh{
 			ContainerName: proxyName,
 		},
-		ENIs:        []*apieni.ENI{{}},
+		ENIs:        []*ni.NetworkInterface{{}},
 		NetworkMode: AWSVPCNetworkMode,
 		Containers: []*apicontainer.Container{
 			{
@@ -1398,22 +1398,22 @@ func TestBuildCNIConfigTrunkBranchENI(t *testing.T) {
 		t.Run(fmt.Sprintf("When BlockInstanceMetadata is %t", blockIMDS), func(t *testing.T) {
 			testTask := &Task{}
 			testTask.NetworkMode = AWSVPCNetworkMode
-			testTask.AddTaskENI(&apieni.ENI{
+			testTask.AddTaskENI(&ni.NetworkInterface{
 				ID:                           "TestBuildCNIConfigTrunkBranchENI",
 				MacAddress:                   mac,
-				InterfaceAssociationProtocol: apieni.VLANInterfaceAssociationProtocol,
-				InterfaceVlanProperties: &apieni.InterfaceVlanProperties{
+				InterfaceAssociationProtocol: ni.VLANInterfaceAssociationProtocol,
+				InterfaceVlanProperties: &ni.InterfaceVlanProperties{
 					VlanID:                   "1234",
 					TrunkInterfaceMacAddress: "macTrunk",
 				},
 				SubnetGatewayIPV4Address: ipv4Gateway + ipv4Block,
-				IPV4Addresses: []*apieni.ENIIPV4Address{
+				IPV4Addresses: []*ni.IPV4Address{
 					{
 						Primary: true,
 						Address: ipv4,
 					},
 				},
-				IPV6Addresses: []*apieni.ENIIPV6Address{
+				IPV6Addresses: []*ni.IPV6Address{
 					{
 						Address: ipv6,
 					},

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -50,10 +50,10 @@ import (
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	mock_credentials "github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ecs_client/model/ecs"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/asmsecret"
@@ -716,7 +716,7 @@ func TestDockerHostConfigRawConfig(t *testing.T) {
 
 func TestDockerHostConfigPauseContainer(t *testing.T) {
 	testTask := &Task{
-		ENIs: []*apieni.ENI{
+		ENIs: []*ni.NetworkInterface{
 			{
 				ID: "eniID",
 			},
@@ -776,11 +776,11 @@ func TestDockerHostConfigPauseContainer(t *testing.T) {
 	assert.Equal(t, []string{"us-west-2.compute.internal"}, cfg.DNSSearch)
 
 	// Verify eni ExtraHosts  added to HostConfig for pause container
-	ipaddr := &apieni.ENIIPV4Address{Primary: true, Address: "10.0.1.1"}
-	testTask.ENIs[0].IPV4Addresses = []*apieni.ENIIPV4Address{ipaddr}
+	ipaddr := &ni.IPV4Address{Primary: true, Address: "10.0.1.1"}
+	testTask.ENIs[0].IPV4Addresses = []*ni.IPV4Address{ipaddr}
 	testTask.ENIs[0].PrivateDNSName = "eni.ip.region.compute.internal"
 
-	testTask.ENIs[0].IPV6Addresses = []*apieni.ENIIPV6Address{{Address: ipv6}}
+	testTask.ENIs[0].IPV6Addresses = []*ni.IPV6Address{{Address: ipv6}}
 	cfg, err = testTask.DockerHostConfig(pauseContainer, dockerMap(testTask), defaultDockerClientAPIVersion,
 		&config.Config{})
 	assert.Nil(t, err)
@@ -2157,7 +2157,7 @@ func TestGetIDHappyPath(t *testing.T) {
 
 // TestTaskGetPrimaryENI tests the eni can be correctly acquired by calling GetTaskPrimaryENI
 func TestTaskGetPrimaryENI(t *testing.T) {
-	enisOfTask := []*apieni.ENI{
+	enisOfTask := []*ni.NetworkInterface{
 		{
 			ID: "id",
 		},
@@ -3969,24 +3969,24 @@ func TestPopulateTaskARN(t *testing.T) {
 
 func TestShouldEnableIPv6(t *testing.T) {
 	task := &Task{
-		ENIs: []*apieni.ENI{getTestENI()},
+		ENIs: []*ni.NetworkInterface{getTestENI()},
 	}
 	assert.True(t, task.shouldEnableIPv6())
 	task.ENIs[0].IPV6Addresses = nil
 	assert.False(t, task.shouldEnableIPv6())
 }
 
-func getTestENI() *apieni.ENI {
-	return &apieni.ENI{
+func getTestENI() *ni.NetworkInterface {
+	return &ni.NetworkInterface{
 		ID: "test",
-		IPV4Addresses: []*apieni.ENIIPV4Address{
+		IPV4Addresses: []*ni.IPV4Address{
 			{
 				Primary: true,
 				Address: ipv4,
 			},
 		},
 		MacAddress: mac,
-		IPV6Addresses: []*apieni.ENIIPV6Address{
+		IPV6Addresses: []*ni.IPV6Address{
 			{
 				Address: ipv6,
 			},

--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -31,8 +31,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/fsxwindowsfileserver"
 	resourcetype "github.com/aws/amazon-ecs-agent/agent/taskresource/types"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/cihub/seelog"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/pkg/errors"
@@ -228,7 +228,7 @@ func (task *Task) BuildCNIConfigAwsvpc(includeIPAMConfig bool, cniConfig *ecscni
 		switch eni.InterfaceAssociationProtocol {
 		// If the association protocol is set to "default" or unset (to preserve backwards
 		// compatibility), consider it a "standard" ENI attachment.
-		case "", apieni.DefaultInterfaceAssociationProtocol:
+		case "", ni.DefaultInterfaceAssociationProtocol:
 			cniConfig.ID = eni.MacAddress
 			netconf, err = ecscni.NewVPCENIPluginConfigForTaskNSSetup(eni, cniConfig)
 		default:

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -32,7 +32,7 @@ import (
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/golang/mock/gomock"
 
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
@@ -571,12 +571,12 @@ func TestPostUnmarshalTaskWithFSxWindowsFileServerVolumes(t *testing.T) {
 func TestBuildCNIConfig(t *testing.T) {
 	testTask := &Task{}
 	testTask.NetworkMode = AWSVPCNetworkMode
-	testTask.AddTaskENI(&apieni.ENI{
+	testTask.AddTaskENI(&ni.NetworkInterface{
 		ID:                           "TestBuildCNIConfig",
 		MacAddress:                   mac,
-		InterfaceAssociationProtocol: apieni.DefaultInterfaceAssociationProtocol,
+		InterfaceAssociationProtocol: ni.DefaultInterfaceAssociationProtocol,
 		SubnetGatewayIPV4Address:     "10.0.1.0/24",
-		IPV4Addresses: []*apieni.ENIIPV4Address{
+		IPV4Addresses: []*ni.IPV4Address{
 			{
 				Primary: true,
 				Address: ipv4,

--- a/agent/app/data_test.go
+++ b/agent/app/data_test.go
@@ -30,9 +30,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
-
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,7 +75,7 @@ var (
 		ImageID: testImageId,
 	}
 
-	testENIAttachment = &eni.ENIAttachment{
+	testENIAttachment = &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			AttachmentARN:    testAttachmentArn,
 			AttachStatusSent: false,

--- a/agent/data/client.go
+++ b/agent/data/client.go
@@ -20,8 +20,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
-
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -78,11 +77,11 @@ type Client interface {
 	GetImageStates() ([]*image.ImageState, error)
 
 	// SaveENIAttachment saves the data of an ENI attachment.
-	SaveENIAttachment(*eni.ENIAttachment) error
+	SaveENIAttachment(*networkinterface.ENIAttachment) error
 	// DeleteENIAttachment deletes the data of an ENI atttachment.
 	DeleteENIAttachment(string) error
 	// GetENIAttachments gets the data of all the ENI attachment.
-	GetENIAttachments() ([]*eni.ENIAttachment, error)
+	GetENIAttachments() ([]*networkinterface.ENIAttachment, error)
 
 	// SaveMetadata saves a key value pair of metadata.
 	SaveMetadata(string, string) error

--- a/agent/data/eniattachment_client.go
+++ b/agent/data/eniattachment_client.go
@@ -17,13 +17,13 @@ import (
 	"encoding/json"
 
 	"github.com/aws/amazon-ecs-agent/agent/utils"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 
 	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 )
 
-func (c *client) SaveENIAttachment(eni *apieni.ENIAttachment) error {
+func (c *client) SaveENIAttachment(eni *ni.ENIAttachment) error {
 	id, err := utils.GetENIAttachmentId(eni.AttachmentARN)
 	if err != nil {
 		return errors.Wrap(err, "failed to generate database id")
@@ -41,12 +41,12 @@ func (c *client) DeleteENIAttachment(id string) error {
 	})
 }
 
-func (c *client) GetENIAttachments() ([]*apieni.ENIAttachment, error) {
-	var eniAttachments []*apieni.ENIAttachment
+func (c *client) GetENIAttachments() ([]*ni.ENIAttachment, error) {
+	var eniAttachments []*ni.ENIAttachment
 	err := c.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(eniAttachmentsBucketName))
 		return walk(bucket, func(id string, data []byte) error {
-			eniAttachment := apieni.ENIAttachment{}
+			eniAttachment := ni.ENIAttachment{}
 			if err := json.Unmarshal(data, &eniAttachment); err != nil {
 				return err
 			}

--- a/agent/data/eniattachment_client_test.go
+++ b/agent/data/eniattachment_client_test.go
@@ -20,8 +20,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
-
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,7 +32,7 @@ const (
 func TestManageENIAttachments(t *testing.T) {
 	testClient := newTestClient(t)
 
-	testEniAttachment := &eni.ENIAttachment{
+	testEniAttachment := &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			AttachmentARN:    testAttachmentArn,
 			AttachStatusSent: false,
@@ -49,7 +48,7 @@ func TestManageENIAttachments(t *testing.T) {
 	assert.Equal(t, true, res[0].AttachStatusSent)
 	assert.Equal(t, testAttachmentArn, res[0].AttachmentARN)
 
-	testEniAttachment2 := &eni.ENIAttachment{
+	testEniAttachment2 := &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			AttachmentARN:    testAttachmentArn2,
 			AttachStatusSent: true,
@@ -71,7 +70,7 @@ func TestManageENIAttachments(t *testing.T) {
 func TestSaveENIAttachmentInvalidID(t *testing.T) {
 	testClient := newTestClient(t)
 
-	testEniAttachment := &eni.ENIAttachment{
+	testEniAttachment := &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			AttachmentARN:    "invalid-arn",
 			AttachStatusSent: false,

--- a/agent/data/noop_client.go
+++ b/agent/data/noop_client.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 )
 
 type noopClient struct{}
@@ -68,7 +68,7 @@ func (c *noopClient) GetImageStates() ([]*image.ImageState, error) {
 	return nil, nil
 }
 
-func (c *noopClient) SaveENIAttachment(*eni.ENIAttachment) error {
+func (c *noopClient) SaveENIAttachment(*networkinterface.ENIAttachment) error {
 	return nil
 }
 
@@ -76,7 +76,7 @@ func (c *noopClient) DeleteENIAttachment(string) error {
 	return nil
 }
 
-func (c *noopClient) GetENIAttachments() ([]*eni.ENIAttachment, error) {
+func (c *noopClient) GetENIAttachments() ([]*networkinterface.ENIAttachment, error) {
 	return nil, nil
 }
 

--- a/agent/ecscni/mocks/namespace_helper_mocks.go
+++ b/agent/ecscni/mocks/namespace_helper_mocks.go
@@ -23,7 +23,7 @@ import (
 	reflect "reflect"
 
 	ecscni "github.com/aws/amazon-ecs-agent/agent/ecscni"
-	eni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	networkinterface "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	types100 "github.com/containernetworking/cni/pkg/types/100"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -52,7 +52,7 @@ func (m *MockNamespaceHelper) EXPECT() *MockNamespaceHelperMockRecorder {
 }
 
 // ConfigureTaskNamespaceRouting mocks base method.
-func (m *MockNamespaceHelper) ConfigureTaskNamespaceRouting(arg0 context.Context, arg1 *eni.ENI, arg2 *ecscni.Config, arg3 *types100.Result) error {
+func (m *MockNamespaceHelper) ConfigureTaskNamespaceRouting(arg0 context.Context, arg1 *networkinterface.NetworkInterface, arg2 *ecscni.Config, arg3 *types100.Result) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfigureTaskNamespaceRouting", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/agent/ecscni/namespace_helper.go
+++ b/agent/ecscni/namespace_helper.go
@@ -19,14 +19,14 @@ import (
 	cniTypesCurrent "github.com/containernetworking/cni/pkg/types/100"
 
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 )
 
 // NamespaceHelper defines the methods for performing additional actions to setup/clean the task namespace.
 // Task namespace in awsvpc network mode is configured using pause container which is the first container
 // launched for the task. These commands are executed inside that container.
 type NamespaceHelper interface {
-	ConfigureTaskNamespaceRouting(ctx context.Context, taskENI *apieni.ENI, config *Config, result *cniTypesCurrent.Result) error
+	ConfigureTaskNamespaceRouting(ctx context.Context, taskENI *ni.NetworkInterface, config *Config, result *cniTypesCurrent.Result) error
 }
 
 // helper is the client for executing methods of NamespaceHelper interface.

--- a/agent/ecscni/namespace_helper_linux.go
+++ b/agent/ecscni/namespace_helper_linux.go
@@ -21,11 +21,11 @@ import (
 
 	cniTypesCurrent "github.com/containernetworking/cni/pkg/types/100"
 
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 )
 
 // ConfigureTaskNamespaceRouting executes the commands required for setting up appropriate routing inside task namespace.
 // This is applicable only for Windows.
-func (nsHelper *helper) ConfigureTaskNamespaceRouting(ctx context.Context, taskENI *apieni.ENI, config *Config, result *cniTypesCurrent.Result) error {
+func (nsHelper *helper) ConfigureTaskNamespaceRouting(ctx context.Context, taskENI *ni.NetworkInterface, config *Config, result *cniTypesCurrent.Result) error {
 	return nil
 }

--- a/agent/ecscni/namespace_helper_unsupported.go
+++ b/agent/ecscni/namespace_helper_unsupported.go
@@ -21,11 +21,11 @@ import (
 
 	cniTypesCurrent "github.com/containernetworking/cni/pkg/types/100"
 
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 )
 
 // ConfigureTaskNamespaceRouting executes the commands required for setting up appropriate routing inside task namespace.
 // This is applicable only for Windows.
-func (nsHelper *helper) ConfigureTaskNamespaceRouting(ctx context.Context, taskENI *apieni.ENI, config *Config, result *cniTypesCurrent.Result) error {
+func (nsHelper *helper) ConfigureTaskNamespaceRouting(ctx context.Context, taskENI *ni.NetworkInterface, config *Config, result *cniTypesCurrent.Result) error {
 	return nil
 }

--- a/agent/ecscni/namespace_helper_windows.go
+++ b/agent/ecscni/namespace_helper_windows.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 )
 
 const (
@@ -58,7 +58,7 @@ const (
 // netsh interface ipv4 add route prefix=169.254.169.254/32 interface="vEthernet (task-br-<mac>-ep-<container_id>)
 // netsh interface ipv4 add route prefix=169.254.169.254/32 interface="Loopback"
 // netsh interface ipv4 add route prefix=<local-route> interface="vEthernet (nat-ep-<container_id>)
-func (nsHelper *helper) ConfigureTaskNamespaceRouting(ctx context.Context, taskENI *apieni.ENI, config *Config, result *cniTypesCurrent.Result) error {
+func (nsHelper *helper) ConfigureTaskNamespaceRouting(ctx context.Context, taskENI *ni.NetworkInterface, config *Config, result *cniTypesCurrent.Result) error {
 	// Obtain the ecs-bridge endpoint's subnet IP address from the CNI plugin execution result.
 	ecsBridgeSubnetIPAddress := &net.IPNet{
 		IP:   result.IPs[0].Address.IP.Mask(result.IPs[0].Address.Mask),

--- a/agent/ecscni/netconfig_linux.go
+++ b/agent/ecscni/netconfig_linux.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"net"
 
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 
-	"github.com/aws/amazon-ecs-agent/agent/api/appmesh"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
-
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
 	"github.com/cihub/seelog"
 	"github.com/containernetworking/cni/libcni"
 	cniTypes "github.com/containernetworking/cni/pkg/types"
@@ -113,7 +113,7 @@ func newIPAMConfig(cfg *Config) (IPAMConfig, error) {
 }
 
 // NewENINetworkConfig creates a new ENI CNI network configuration.
-func NewENINetworkConfig(eni *eni.ENI, cfg *Config) (string, *libcni.NetworkConfig, error) {
+func NewENINetworkConfig(eni *ni.NetworkInterface, cfg *Config) (string, *libcni.NetworkConfig, error) {
 	eniConf := ENIConfig{
 		Type:                  ECSENIPluginName,
 		ENIID:                 eni.ID,
@@ -132,7 +132,7 @@ func NewENINetworkConfig(eni *eni.ENI, cfg *Config) (string, *libcni.NetworkConf
 }
 
 // NewBranchENINetworkConfig creates a new branch ENI CNI network configuration.
-func NewBranchENINetworkConfig(eni *eni.ENI, cfg *Config) (string, *libcni.NetworkConfig, error) {
+func NewBranchENINetworkConfig(eni *ni.NetworkInterface, cfg *Config) (string, *libcni.NetworkConfig, error) {
 	eniConf := BranchENIConfig{
 		Type:                  ECSBranchENIPluginName,
 		TrunkMACAddress:       eni.InterfaceVlanProperties.TrunkInterfaceMacAddress,

--- a/agent/ecscni/netconfig_windows.go
+++ b/agent/ecscni/netconfig_windows.go
@@ -19,8 +19,7 @@ package ecscni
 import (
 	"regexp"
 
-	"github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
-
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/cihub/seelog"
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/types"
@@ -35,7 +34,7 @@ const (
 )
 
 // NewVPCENIPluginConfigForTaskNSSetup is used to create the configuration of vpc-eni plugin for task namespace setup.
-func NewVPCENIPluginConfigForTaskNSSetup(eni *eni.ENI, cfg *Config) (*libcni.NetworkConfig, error) {
+func NewVPCENIPluginConfigForTaskNSSetup(eni *ni.NetworkInterface, cfg *Config) (*libcni.NetworkConfig, error) {
 	// Use the DNS server addresses of the instance ENI it would belong in the same VPC as
 	// the task ENI and therefore, have same DNS configuration.
 	dns := types.DNS{

--- a/agent/ecscni/netconfig_windows_test.go
+++ b/agent/ecscni/netconfig_windows_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,14 +36,14 @@ const (
 	invalidMACAddress       = "12:34;56-78"
 )
 
-func getTaskENI() *apieni.ENI {
-	return &apieni.ENI{
+func getTaskENI() *ni.NetworkInterface {
+	return &ni.NetworkInterface{
 		ID:                           "TestENI",
 		LinkName:                     linkName,
 		MacAddress:                   mac,
-		InterfaceAssociationProtocol: apieni.DefaultInterfaceAssociationProtocol,
+		InterfaceAssociationProtocol: ni.DefaultInterfaceAssociationProtocol,
 		SubnetGatewayIPV4Address:     validVPCGatewayCIDR,
-		IPV4Addresses: []*apieni.ENIIPV4Address{
+		IPV4Addresses: []*ni.IPV4Address{
 			{
 				Primary: true,
 				Address: ipv4,

--- a/agent/ecscni/plugin_linux_test.go
+++ b/agent/ecscni/plugin_linux_test.go
@@ -33,16 +33,16 @@ import (
 	cniTypes "github.com/containernetworking/cni/pkg/types"
 	cniTypesCurrent "github.com/containernetworking/cni/pkg/types/100"
 
-	"github.com/aws/amazon-ecs-agent/agent/api/appmesh"
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 	mock_libcni "github.com/aws/amazon-ecs-agent/agent/ecscni/mocks_libcni"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 )
 
 const (
 	eniID                                       = "eni-12345678"
-	eniIPV4Address                              = "172.31.21.40"
-	eniIPV6Address                              = "abcd:dcba:1234:4321::"
+	ipv4Address                                 = "172.31.21.40"
+	ipv6Address                                 = "abcd:dcba:1234:4321::"
 	eniIPV4AddressWithBlockSize                 = "172.31.21.40/20"
 	eniIPV6AddressWithBlockSize                 = "abcd:dcba:1234:4321::/64"
 	eniMACAddress                               = "02:7b:64:49:b1:40"
@@ -99,10 +99,10 @@ func TestSetupNS(t *testing.T) {
 
 func eniNetworkConfig(config *Config) *NetworkConfig {
 	_, eniNetworkConfig, _ := NewENINetworkConfig(
-		&eni.ENI{
+		&ni.NetworkInterface{
 			ID: eniID,
-			IPV4Addresses: []*eni.ENIIPV4Address{
-				{Address: eniIPV4Address, Primary: true},
+			IPV4Addresses: []*ni.IPV4Address{
+				{Address: ipv4Address, Primary: true},
 			},
 			MacAddress:               eniMACAddress,
 			SubnetGatewayIPV4Address: eniSubnetGatewayIPV4Address,
@@ -159,14 +159,14 @@ func TestSetupNSTrunk(t *testing.T) {
 
 func branchENINetworkConfig(config *Config) *NetworkConfig {
 	_, eniNetworkConfig, _ := NewBranchENINetworkConfig(
-		&eni.ENI{
+		&ni.NetworkInterface{
 			ID: eniID,
-			IPV4Addresses: []*eni.ENIIPV4Address{
-				{Address: eniIPV4Address, Primary: true},
+			IPV4Addresses: []*ni.IPV4Address{
+				{Address: ipv4Address, Primary: true},
 			},
 			MacAddress:               eniMACAddress,
 			SubnetGatewayIPV4Address: eniSubnetGatewayIPV4Address,
-			InterfaceVlanProperties: &eni.InterfaceVlanProperties{
+			InterfaceVlanProperties: &ni.InterfaceVlanProperties{
 				TrunkInterfaceMacAddress: trunkENIMACAddress,
 				VlanID:                   branchENIVLANID,
 			},
@@ -499,14 +499,14 @@ func TestConstructENINetworkConfig(t *testing.T) {
 	}
 
 	eniName, eniNetworkConfig, err := NewENINetworkConfig(
-		&eni.ENI{
+		&ni.NetworkInterface{
 			ID: eniID,
-			IPV4Addresses: []*eni.ENIIPV4Address{
-				{Address: eniIPV4Address, Primary: true},
+			IPV4Addresses: []*ni.IPV4Address{
+				{Address: ipv4Address, Primary: true},
 			},
-			IPV6Addresses: []*eni.ENIIPV6Address{
+			IPV6Addresses: []*ni.IPV6Address{
 				{
-					Address: eniIPV6Address,
+					Address: ipv6Address,
 				},
 			},
 			MacAddress:               eniMACAddress,
@@ -538,19 +538,19 @@ func TestConstructBranchENINetworkConfig(t *testing.T) {
 	}
 
 	eniName, eniNetworkConfig, err := NewBranchENINetworkConfig(
-		&eni.ENI{
+		&ni.NetworkInterface{
 			ID: eniID,
-			IPV4Addresses: []*eni.ENIIPV4Address{
-				{Address: eniIPV4Address, Primary: true},
+			IPV4Addresses: []*ni.IPV4Address{
+				{Address: ipv4Address, Primary: true},
 			},
-			IPV6Addresses: []*eni.ENIIPV6Address{
+			IPV6Addresses: []*ni.IPV6Address{
 				{
-					Address: eniIPV6Address,
+					Address: ipv6Address,
 				},
 			},
 			MacAddress:               eniMACAddress,
 			SubnetGatewayIPV4Address: eniSubnetGatewayIPV4Address,
-			InterfaceVlanProperties: &eni.InterfaceVlanProperties{
+			InterfaceVlanProperties: &ni.InterfaceVlanProperties{
 				TrunkInterfaceMacAddress: trunkENIMACAddress,
 				VlanID:                   branchENIVLANID,
 			},

--- a/agent/ecscni/plugin_windows_test.go
+++ b/agent/ecscni/plugin_windows_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -33,12 +35,11 @@ import (
 	cniTypesCurrent "github.com/containernetworking/cni/pkg/types/100"
 
 	mock_libcni "github.com/aws/amazon-ecs-agent/agent/ecscni/mocks_libcni"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 )
 
 const (
 	eniID                       = "eni-12345678"
-	eniIPV4Address              = "172.31.21.40"
+	ipv4Address                 = "172.31.21.40"
 	eniMACAddress               = "02:7b:64:49:b1:40"
 	eniSubnetGatewayIPV4Address = "172.31.1.1/20"
 )
@@ -66,12 +67,12 @@ func getNetworkConfig() *Config {
 }
 
 // getTestENI returns a sample ENI for the task.
-func getTestENI() *eni.ENI {
-	return &eni.ENI{
+func getTestENI() *ni.NetworkInterface {
+	return &ni.NetworkInterface{
 		ID:       eniID,
 		LinkName: eniID,
-		IPV4Addresses: []*eni.ENIIPV4Address{
-			{Address: eniIPV4Address, Primary: true},
+		IPV4Addresses: []*ni.IPV4Address{
+			{Address: ipv4Address, Primary: true},
 		},
 		MacAddress:               eniMACAddress,
 		SubnetGatewayIPV4Address: eniSubnetGatewayIPV4Address,

--- a/agent/engine/data_test.go
+++ b/agent/engine/data_test.go
@@ -19,6 +19,8 @@ package engine
 import (
 	"testing"
 
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
@@ -26,8 +28,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -77,7 +77,7 @@ var (
 		ImageID: testImageId,
 	}
 
-	testENIAttachment = &eni.ENIAttachment{
+	testENIAttachment = &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			AttachmentARN:    testAttachmentArn,
 			AttachStatusSent: false,

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/amazon-ecs-agent/agent/api/appmesh"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
@@ -55,9 +54,10 @@ import (
 	mock_ioutilwrapper "github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper/mocks"
 	mock_appnet "github.com/aws/amazon-ecs-agent/ecs-agent/api/appnet/mocks"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 
 	"github.com/aws/aws-sdk-go/aws"
 	cniTypesCurrent "github.com/containernetworking/cni/pkg/types/100"
@@ -204,7 +204,7 @@ func TestDeleteTask(t *testing.T) {
 	cgroupResource := cgroup.NewCgroupResource("", mockControl, nil, "cgroupRoot", "", specs.LinuxResources{})
 	task := &apitask.Task{
 		Arn: testTaskARN,
-		ENIs: []*apieni.ENI{
+		ENIs: []*ni.NetworkInterface{
 			{
 				MacAddress: mac,
 			},
@@ -224,7 +224,7 @@ func TestDeleteTask(t *testing.T) {
 		cfg:        &cfg,
 	}
 
-	attachment := &apieni.ENIAttachment{
+	attachment := &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			TaskARN:          "TaskARN",
 			AttachmentARN:    testAttachmentArn,
@@ -263,10 +263,10 @@ func TestDeleteTaskBranchENIEnabled(t *testing.T) {
 	cgroupResource := cgroup.NewCgroupResource("", mockControl, nil, "cgroupRoot", "", specs.LinuxResources{})
 	task := &apitask.Task{
 		Arn: testTaskARN,
-		ENIs: []*apieni.ENI{
+		ENIs: []*ni.NetworkInterface{
 			{
 				MacAddress:                   mac,
-				InterfaceAssociationProtocol: apieni.VLANInterfaceAssociationProtocol,
+				InterfaceAssociationProtocol: ni.VLANInterfaceAssociationProtocol,
 			},
 		},
 	}

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
-	"github.com/aws/amazon-ecs-agent/agent/api/appmesh"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
@@ -61,12 +60,13 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/ssmsecret"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	mock_credentials "github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	mock_ttime "github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime/mocks"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -118,16 +118,16 @@ var (
 	defaultConfig config.Config
 	nsResult      = mockSetupNSResult()
 
-	mockENI = &apieni.ENI{
+	mockENI = &ni.NetworkInterface{
 		ID: "eni-id",
-		IPV4Addresses: []*apieni.ENIIPV4Address{
+		IPV4Addresses: []*ni.IPV4Address{
 			{
 				Primary: true,
 				Address: ipv4,
 			},
 		},
 		MacAddress: mac,
-		IPV6Addresses: []*apieni.ENIIPV6Address{
+		IPV6Addresses: []*ni.IPV6Address{
 			{
 				Address: ipv6,
 			},
@@ -2423,7 +2423,7 @@ func TestSynchronizeENIAttachment(t *testing.T) {
 	state := dockerTaskEngine.State()
 	testTask := testdata.LoadTask("sleep5")
 	expiresAt := time.Now().Unix() + 1
-	attachment := &apieni.ENIAttachment{
+	attachment := &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			TaskARN:       "TaskARN",
 			AttachmentARN: "AttachmentARN",
@@ -2459,7 +2459,7 @@ func TestSynchronizeENIAttachmentRemoveData(t *testing.T) {
 	taskEngine.(*DockerTaskEngine).dataClient = dataClient
 	dockerTaskEngine := taskEngine.(*DockerTaskEngine)
 
-	attachment := &apieni.ENIAttachment{
+	attachment := &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			TaskARN:          "TaskARN",
 			AttachmentARN:    testAttachmentArn,
@@ -2837,9 +2837,9 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 			Version:     taskVersion,
 			Family:      taskFamily,
 			NetworkMode: networkMode,
-			ENIs: []*apieni.ENI{
+			ENIs: []*ni.NetworkInterface{
 				{
-					IPV4Addresses: []*apieni.ENIIPV4Address{
+					IPV4Addresses: []*ni.IPV4Address{
 						{
 							Address: eniIPv4Address,
 						},

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -26,7 +26,6 @@ import (
 
 	mock_asm_factory "github.com/aws/amazon-ecs-agent/agent/asm/factory/mocks"
 
-	"github.com/aws/amazon-ecs-agent/agent/api/appmesh"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
@@ -40,6 +39,7 @@ import (
 	mock_ssm_factory "github.com/aws/amazon-ecs-agent/agent/ssm/factory/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/credentialspec"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"

--- a/agent/engine/dockerstate/dockerstate_test.go
+++ b/agent/engine/dockerstate/dockerstate_test.go
@@ -23,9 +23,8 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	apiresource "github.com/aws/amazon-ecs-agent/ecs-agent/api/resource"
-
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -103,7 +102,7 @@ func TestAddTask(t *testing.T) {
 func TestAddRemoveENIAttachment(t *testing.T) {
 	state := NewTaskEngineState()
 
-	attachment := &apieni.ENIAttachment{
+	attachment := &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			TaskARN:       "taskarn",
 			AttachmentARN: "eni1",

--- a/agent/engine/dockerstate/json.go
+++ b/agent/engine/dockerstate/json.go
@@ -20,7 +20,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 )
 
 // These bits of information should be enough to reconstruct the entire
@@ -30,8 +30,8 @@ type savedState struct {
 	IdToContainer  map[string]*apicontainer.DockerContainer `json:"IdToContainer"` // DockerId -> apicontainer.DockerContainer
 	IdToTask       map[string]string                        `json:"IdToTask"`      // DockerId -> taskarn
 	ImageStates    []*image.ImageState
-	ENIAttachments []*apieni.ENIAttachment `json:"ENIAttachments"`
-	IPToTask       map[string]string       `json:"IPToTask"`
+	ENIAttachments []*ni.ENIAttachment `json:"ENIAttachments"`
+	IPToTask       map[string]string   `json:"IPToTask"`
 }
 
 func (state *DockerTaskEngineState) MarshalJSON() ([]byte, error) {

--- a/agent/engine/dockerstate/mocks/dockerstate_mocks.go
+++ b/agent/engine/dockerstate/mocks/dockerstate_mocks.go
@@ -24,8 +24,8 @@ import (
 	container "github.com/aws/amazon-ecs-agent/agent/api/container"
 	task "github.com/aws/amazon-ecs-agent/agent/api/task"
 	image "github.com/aws/amazon-ecs-agent/agent/engine/image"
-	eni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	resource "github.com/aws/amazon-ecs-agent/ecs-agent/api/resource"
+	networkinterface "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -77,7 +77,7 @@ func (mr *MockTaskEngineStateMockRecorder) AddEBSAttachment(arg0 interface{}) *g
 }
 
 // AddENIAttachment mocks base method.
-func (m *MockTaskEngineState) AddENIAttachment(arg0 *eni.ENIAttachment) {
+func (m *MockTaskEngineState) AddENIAttachment(arg0 *networkinterface.ENIAttachment) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddENIAttachment", arg0)
 }
@@ -137,10 +137,10 @@ func (mr *MockTaskEngineStateMockRecorder) AddTaskIPAddress(arg0, arg1 interface
 }
 
 // AllENIAttachments mocks base method.
-func (m *MockTaskEngineState) AllENIAttachments() []*eni.ENIAttachment {
+func (m *MockTaskEngineState) AllENIAttachments() []*networkinterface.ENIAttachment {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllENIAttachments")
-	ret0, _ := ret[0].([]*eni.ENIAttachment)
+	ret0, _ := ret[0].([]*networkinterface.ENIAttachment)
 	return ret0
 }
 
@@ -238,10 +238,10 @@ func (mr *MockTaskEngineStateMockRecorder) DockerIDByV3EndpointID(arg0 interface
 }
 
 // ENIByMac mocks base method.
-func (m *MockTaskEngineState) ENIByMac(arg0 string) (*eni.ENIAttachment, bool) {
+func (m *MockTaskEngineState) ENIByMac(arg0 string) (*networkinterface.ENIAttachment, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ENIByMac", arg0)
-	ret0, _ := ret[0].(*eni.ENIAttachment)
+	ret0, _ := ret[0].(*networkinterface.ENIAttachment)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }

--- a/agent/engine/serviceconnect/manager_linux_test_common.go
+++ b/agent/engine/serviceconnect/manager_linux_test_common.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
@@ -38,16 +38,16 @@ const (
 
 var (
 	cfg     config.Config
-	mockENI = &apieni.ENI{
+	mockENI = &ni.NetworkInterface{
 		ID: "eni-id",
-		IPV4Addresses: []*apieni.ENIIPV4Address{
+		IPV4Addresses: []*ni.IPV4Address{
 			{
 				Primary: true,
 				Address: ipv4,
 			},
 		},
 		MacAddress: mac,
-		IPV6Addresses: []*apieni.ENIIPV6Address{
+		IPV6Addresses: []*ni.IPV6Address{
 			{
 				Address: ipv6,
 			},

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -46,11 +46,11 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	mock_credentials "github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	mock_ttime "github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime/mocks"
 	"github.com/stretchr/testify/assert"
 
@@ -1342,16 +1342,16 @@ func TestCleanupTaskENIs(t *testing.T) {
 		resourceStateChangeEvent: make(chan resourceStateChange),
 		cfg:                      taskEngine.cfg,
 	}
-	mTask.AddTaskENI(&apieni.ENI{
+	mTask.AddTaskENI(&ni.NetworkInterface{
 		ID: "TestCleanupTaskENIs",
-		IPV4Addresses: []*apieni.ENIIPV4Address{
+		IPV4Addresses: []*ni.IPV4Address{
 			{
 				Primary: true,
 				Address: ipv4,
 			},
 		},
 		MacAddress: mac,
-		IPV6Addresses: []*apieni.ENIIPV6Address{
+		IPV6Addresses: []*ni.IPV6Address{
 			{
 				Address: ipv6,
 			},

--- a/agent/eni/watcher/watcher.go
+++ b/agent/eni/watcher/watcher.go
@@ -27,8 +27,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 )
 
@@ -142,7 +142,7 @@ func (eniWatcher *ENIWatcher) sendENIStateChange(mac string) error {
 
 	// We found an ENI, which has the expiration time set in future and
 	// needs to be acknowledged as having been 'attached' to the Instance
-	if eni.AttachmentType == apieni.ENIAttachmentTypeInstanceENI {
+	if eni.AttachmentType == ni.ENIAttachmentTypeInstanceENI {
 		go eniWatcher.emitInstanceENIAttachedEvent(eni)
 	} else {
 		go eniWatcher.emitTaskENIAttachedEvent(eni)
@@ -152,7 +152,7 @@ func (eniWatcher *ENIWatcher) sendENIStateChange(mac string) error {
 
 // emitTaskENIChangeEvent sends a state change event for a task ENI attachment to the event channel with eni status as
 // attached
-func (eniWatcher *ENIWatcher) emitTaskENIAttachedEvent(eni *apieni.ENIAttachment) {
+func (eniWatcher *ENIWatcher) emitTaskENIAttachedEvent(eni *ni.ENIAttachment) {
 	eni.Status = status.AttachmentAttached
 	log.Infof("Emitting task ENI attached event for: %s", eni.String())
 	eniWatcher.eniChangeEvent <- api.TaskStateChange{
@@ -163,7 +163,7 @@ func (eniWatcher *ENIWatcher) emitTaskENIAttachedEvent(eni *apieni.ENIAttachment
 
 // emitInstanceENIChangeEvent sends a state change event for an instance ENI attachment to the event channel with eni
 // status as attached
-func (eniWatcher *ENIWatcher) emitInstanceENIAttachedEvent(eni *apieni.ENIAttachment) {
+func (eniWatcher *ENIWatcher) emitInstanceENIAttachedEvent(eni *ni.ENIAttachment) {
 	eni.Status = status.AttachmentAttached
 	log.Infof("Emitting instance ENI attached event for: %s", eni.String())
 	eniWatcher.eniChangeEvent <- api.NewAttachmentStateChangeEvent(eni)

--- a/agent/eni/watcher/watcher_linux_test.go
+++ b/agent/eni/watcher/watcher_linux_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/eni/netlinkwrapper"
@@ -86,7 +86,7 @@ func TestWatcherInit(t *testing.T) {
 	assert.NoError(t, err)
 
 	taskEngineState := dockerstate.NewTaskEngineState()
-	taskEngineState.AddENIAttachment(&apieni.ENIAttachment{
+	taskEngineState.AddENIAttachment(&ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			AttachStatusSent: false,
 			ExpiresAt:        time.Unix(time.Now().Unix()+10, 0),
@@ -248,8 +248,8 @@ func TestReconcileENIsWithRetry(t *testing.T) {
 	}
 }
 
-func getMockAttachment() *apieni.ENIAttachment {
-	return &apieni.ENIAttachment{
+func getMockAttachment() *ni.ENIAttachment {
+	return &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			AttachStatusSent: false,
 			ExpiresAt:        time.Unix(time.Now().Unix()+10, 0),
@@ -370,7 +370,7 @@ func TestUdevAddEvent(t *testing.T) {
 					Name:         randomDevice,
 				},
 			}, nil),
-		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(&apieni.ENIAttachment{
+		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(&ni.ENIAttachment{
 			AttachmentInfo: attachmentinfo.AttachmentInfo{
 				ExpiresAt: time.Unix(time.Now().Unix()+10, 0),
 			},

--- a/agent/eni/watcher/watcher_test.go
+++ b/agent/eni/watcher/watcher_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,7 +65,7 @@ func TestSendENIStateChange(t *testing.T) {
 	ctx := context.TODO()
 
 	gomock.InOrder(
-		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(&apieni.ENIAttachment{
+		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(&ni.ENIAttachment{
 			AttachmentInfo: attachmentinfo.AttachmentInfo{
 				ExpiresAt: time.Now().Add(expirationTimeAddition),
 			},
@@ -111,7 +111,7 @@ func TestSendENIStateChangeAlreadySent(t *testing.T) {
 	ctx := context.TODO()
 
 	gomock.InOrder(
-		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(&apieni.ENIAttachment{
+		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(&ni.ENIAttachment{
 			AttachmentInfo: attachmentinfo.AttachmentInfo{
 				AttachStatusSent: true,
 				ExpiresAt:        time.Now().Add(expirationTimeAddition),
@@ -136,7 +136,7 @@ func TestSendENIStateChangeExpired(t *testing.T) {
 	ctx := context.TODO()
 
 	gomock.InOrder(
-		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(&apieni.ENIAttachment{
+		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(&ni.ENIAttachment{
 			AttachmentInfo: attachmentinfo.AttachmentInfo{
 				AttachStatusSent: false,
 				ExpiresAt:        time.Now().Add(expirationTimeSubtraction),
@@ -162,7 +162,7 @@ func TestSendENIStateChangeWithRetries(t *testing.T) {
 
 	gomock.InOrder(
 		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(nil, false),
-		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(&apieni.ENIAttachment{
+		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(&ni.ENIAttachment{
 			AttachmentInfo: attachmentinfo.AttachmentInfo{
 				ExpiresAt: time.Now().Add(expirationTimeAddition),
 			},
@@ -193,7 +193,7 @@ func TestSendENIStateChangeWithRetriesDoesNotRetryExpiredENI(t *testing.T) {
 		// ENIByMAC returns an error for exipred ENI attachment, which should
 		// mean that it doesn't get retried.
 		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(
-			&apieni.ENIAttachment{
+			&ni.ENIAttachment{
 				AttachmentInfo: attachmentinfo.AttachmentInfo{
 					AttachStatusSent: false,
 					ExpiresAt:        time.Now().Add(expirationTimeSubtraction),
@@ -220,11 +220,11 @@ func TestSendENIStateChangeWithAttachmentTypeInstanceENI(t *testing.T) {
 	ctx := context.TODO()
 
 	gomock.InOrder(
-		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(&apieni.ENIAttachment{
+		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(&ni.ENIAttachment{
 			AttachmentInfo: attachmentinfo.AttachmentInfo{
 				ExpiresAt: time.Now().Add(expirationTimeAddition),
 			},
-			AttachmentType: apieni.ENIAttachmentTypeInstanceENI,
+			AttachmentType: ni.ENIAttachmentTypeInstanceENI,
 		}, true),
 	)
 
@@ -249,11 +249,11 @@ func TestSendENIStateChangeWithAttachmentTypeTaskENI(t *testing.T) {
 	ctx := context.TODO()
 
 	gomock.InOrder(
-		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(&apieni.ENIAttachment{
+		mockStateManager.EXPECT().ENIByMac(randomMAC).Return(&ni.ENIAttachment{
 			AttachmentInfo: attachmentinfo.AttachmentInfo{
 				ExpiresAt: time.Now().Add(expirationTimeAddition),
 			},
-			AttachmentType: apieni.ENIAttachmentTypeTaskENI,
+			AttachmentType: ni.ENIAttachmentTypeTaskENI,
 		}, true),
 	)
 

--- a/agent/eni/watcher/watcher_windows_test.go
+++ b/agent/eni/watcher/watcher_windows_test.go
@@ -33,7 +33,7 @@ import (
 	mock_networkutils "github.com/aws/amazon-ecs-agent/agent/eni/networkutils/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
@@ -150,7 +150,7 @@ func TestReconcileOnce(t *testing.T) {
 
 	mockStateManager := mock_dockerstate.NewMockTaskEngineState(mockCtrl)
 	mockStateManager.EXPECT().ENIByMac(macAddress1).
-		Return(&apieni.ENIAttachment{
+		Return(&ni.ENIAttachment{
 			AttachmentInfo: attachmentinfo.AttachmentInfo{
 				AttachStatusSent: false,
 				ExpiresAt:        time.Now().Add(expirationTimeAddition),
@@ -161,7 +161,7 @@ func TestReconcileOnce(t *testing.T) {
 		func(mac string) {
 			waitForEvents.Done()
 		}).
-		Return(&apieni.ENIAttachment{
+		Return(&ni.ENIAttachment{
 			AttachmentInfo: attachmentinfo.AttachmentInfo{
 				AttachStatusSent: true,
 			},
@@ -258,7 +258,7 @@ func TestEventHandlerSuccess(t *testing.T) {
 		mockiphelper.EXPECT().Start(gomock.Any()).Return(nil),
 		mockNetworkUtils.EXPECT().GetInterfaceMACByIndex(interfaceIndex1, gomock.Any(), sendENIStateChangeRetryTimeout).Return(macAddress1, nil),
 		mockStateManager.EXPECT().ENIByMac(macAddress1).
-			Return(&apieni.ENIAttachment{
+			Return(&ni.ENIAttachment{
 				AttachmentInfo: attachmentinfo.AttachmentInfo{
 					ExpiresAt: time.Now().Add(expirationTimeAddition),
 				},
@@ -348,7 +348,7 @@ func TestEventHandlerENIStatusAlreadySent(t *testing.T) {
 		mockiphelper.EXPECT().Start(gomock.Any()).Return(nil),
 		mockNetworkUtils.EXPECT().GetInterfaceMACByIndex(interfaceIndex1, gomock.Any(), sendENIStateChangeRetryTimeout).Return(macAddress1, nil),
 		mockStateManager.EXPECT().ENIByMac(macAddress1).
-			Return(&apieni.ENIAttachment{
+			Return(&ni.ENIAttachment{
 				AttachmentInfo: attachmentinfo.AttachmentInfo{
 					AttachStatusSent: true,
 				},
@@ -431,7 +431,7 @@ func TestEventHandlerExpiredENI(t *testing.T) {
 		mockiphelper.EXPECT().Start(gomock.Any()).Return(nil),
 		mockNetworkUtils.EXPECT().GetInterfaceMACByIndex(interfaceIndex1, gomock.Any(), sendENIStateChangeRetryTimeout).Return(macAddress1, nil),
 		mockStateManager.EXPECT().ENIByMac(macAddress1).
-			Return(&apieni.ENIAttachment{
+			Return(&ni.ENIAttachment{
 				AttachmentInfo: attachmentinfo.AttachmentInfo{
 					ExpiresAt: time.Now().Add(expirationTimeSubtraction),
 				},

--- a/agent/eventhandler/attachment_handler_test.go
+++ b/agent/eventhandler/attachment_handler_test.go
@@ -26,8 +26,8 @@ import (
 	mock_api "github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
@@ -264,13 +264,13 @@ func TestAttachmentChangeShouldBeSentAttachmentIsSent(t *testing.T) {
 
 func attachmentEvent(attachmentARN string) api.AttachmentStateChange {
 	return api.AttachmentStateChange{
-		Attachment: &apieni.ENIAttachment{
+		Attachment: &ni.ENIAttachment{
 			AttachmentInfo: attachmentinfo.AttachmentInfo{
 				AttachmentARN:    attachmentARN,
 				AttachStatusSent: false,
 				ExpiresAt:        time.Now().Add(time.Second),
 			},
-			AttachmentType: apieni.ENIAttachmentTypeInstanceENI,
+			AttachmentType: ni.ENIAttachmentTypeInstanceENI,
 		},
 	}
 }

--- a/agent/eventhandler/task_handler_test.go
+++ b/agent/eventhandler/task_handler_test.go
@@ -36,9 +36,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ecs_client/model/ecs"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	mock_retry "github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry/mock"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -376,7 +376,7 @@ func TestENISentStatusChange(t *testing.T) {
 		Arn: taskARN,
 	}
 
-	eniAttachment := &apieni.ENIAttachment{
+	eniAttachment := &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			TaskARN:          taskARN,
 			AttachStatusSent: false,

--- a/agent/eventhandler/task_handler_types_test.go
+++ b/agent/eventhandler/task_handler_types_test.go
@@ -28,7 +28,7 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -306,7 +306,7 @@ func TestShouldTaskAttachmentEventBeSent(t *testing.T) {
 			// ack timeout is set for future
 			event: newSendableTaskEvent(api.TaskStateChange{
 				Status: apitaskstatus.TaskStatusNone,
-				Attachment: &apieni.ENIAttachment{
+				Attachment: &ni.ENIAttachment{
 					AttachmentInfo: attachmentinfo.AttachmentInfo{
 						ExpiresAt:        time.Unix(time.Now().Unix()-1, 0),
 						AttachStatusSent: false,
@@ -323,7 +323,7 @@ func TestShouldTaskAttachmentEventBeSent(t *testing.T) {
 			// already been sent
 			event: newSendableTaskEvent(api.TaskStateChange{
 				Status: apitaskstatus.TaskStatusNone,
-				Attachment: &apieni.ENIAttachment{
+				Attachment: &ni.ENIAttachment{
 					AttachmentInfo: attachmentinfo.AttachmentInfo{
 						ExpiresAt:        time.Unix(time.Now().Unix()+10, 0),
 						AttachStatusSent: true,
@@ -337,7 +337,7 @@ func TestShouldTaskAttachmentEventBeSent(t *testing.T) {
 			// Valid attachment event, ensure that its sent
 			event: newSendableTaskEvent(api.TaskStateChange{
 				Status: apitaskstatus.TaskStatusNone,
-				Attachment: &apieni.ENIAttachment{
+				Attachment: &ni.ENIAttachment{
 					AttachmentInfo: attachmentinfo.AttachmentInfo{
 						ExpiresAt:        time.Unix(time.Now().Unix()+10, 0),
 						AttachStatusSent: false,
@@ -469,7 +469,7 @@ func TestSetContainerSentStatus(t *testing.T) {
 func TestSetAttachmentSentStatus(t *testing.T) {
 	dataClient := newTestDataClient(t)
 
-	testAttachment := &apieni.ENIAttachment{
+	testAttachment := &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			AttachStatusSent: true,
 			ExpiresAt:        time.Unix(time.Now().Unix()+100, 0),

--- a/agent/handlers/introspection_server_setup_test.go
+++ b/agent/handlers/introspection_server_setup_test.go
@@ -32,7 +32,7 @@ import (
 	mock_utils "github.com/aws/amazon-ecs-agent/agent/handlers/mocks"
 	v1 "github.com/aws/amazon-ecs-agent/agent/handlers/v1"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,7 +41,7 @@ import (
 const (
 	testContainerInstanceArn = "test_container_instance_arn"
 	testClusterArn           = "test_cluster_arn"
-	eniIPV4Address           = "10.0.0.2"
+	ipv4Address              = "10.0.0.2"
 )
 
 var runtimeStatsConfigForTest = config.BooleanDefaultFalse{}
@@ -145,7 +145,7 @@ func TestGetAWSVPCTaskByTaskArn(t *testing.T) {
 
 	resp := v1.TasksResponse{Tasks: []*v1.TaskResponse{&taskResponse}}
 
-	assert.Equal(t, eniIPV4Address, resp.Tasks[0].Containers[0].Networks[0].IPv4Addresses[0])
+	assert.Equal(t, ipv4Address, resp.Tasks[0].Containers[0].Networks[0].IPv4Addresses[0])
 	taskDiffHelper(t, []*apitask.Task{testTasks[3]}, resp)
 }
 
@@ -405,11 +405,11 @@ var testTasks = []*apitask.Task{
 				Name: "awsvpc",
 			},
 		},
-		ENIs: []*apieni.ENI{
+		ENIs: []*ni.NetworkInterface{
 			{
-				IPV4Addresses: []*apieni.ENIIPV4Address{
+				IPV4Addresses: []*ni.IPV4Address{
 					{
-						Address: eniIPV4Address,
+						Address: ipv4Address,
 					},
 				},
 			},

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -38,12 +38,12 @@ import (
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	v3 "github.com/aws/amazon-ecs-agent/agent/handlers/v3"
 	mock_stats "github.com/aws/amazon-ecs-agent/agent/stats/mock"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	mock_taskprotection "github.com/aws/amazon-ecs-agent/ecs-agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	mock_credentials "github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ecs_client/model/ecs"
 	mock_audit "github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/mocks"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/stats"
 	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	tp "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/taskprotection/v1/handlers"
@@ -138,9 +138,9 @@ var (
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		KnownStatusUnsafe:   apitaskstatus.TaskStatusNone,
 		NetworkMode:         apitask.AWSVPCNetworkMode,
-		ENIs: []*apieni.ENI{
+		ENIs: []*ni.NetworkInterface{
 			{
-				IPV4Addresses: []*apieni.ENIIPV4Address{
+				IPV4Addresses: []*ni.IPV4Address{
 					{
 						Address: eniIPv4Address,
 					},
@@ -419,9 +419,9 @@ func standardTask() *apitask.Task {
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
 		NetworkMode:         apitask.AWSVPCNetworkMode,
-		ENIs: []*apieni.ENI{
+		ENIs: []*ni.NetworkInterface{
 			{
-				IPV4Addresses: []*apieni.ENIIPV4Address{
+				IPV4Addresses: []*ni.IPV4Address{
 					{
 						Address: eniIPv4Address,
 					},

--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -17,7 +17,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
 )
@@ -85,7 +85,7 @@ func NewTaskResponse(task *apitask.Task, containerMap map[string]*apicontainer.D
 }
 
 // NewContainerResponse creates ContainerResponse for a container.
-func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *apieni.ENI) ContainerResponse {
+func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *ni.NetworkInterface) ContainerResponse {
 	container := dockerContainer.Container
 	resp := ContainerResponse{
 		Name:       container.Name,
@@ -109,7 +109,7 @@ func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *ap
 }
 
 // NewPortBindingsResponse creates PortResponse for a container.
-func NewPortBindingsResponse(dockerContainer *apicontainer.DockerContainer, eni *apieni.ENI) []tmdsresponse.PortResponse {
+func NewPortBindingsResponse(dockerContainer *apicontainer.DockerContainer, eni *ni.NetworkInterface) []tmdsresponse.PortResponse {
 	container := dockerContainer.Container
 	resp := []tmdsresponse.PortResponse{}
 

--- a/agent/handlers/v1/response_test.go
+++ b/agent/handlers/v1/response_test.go
@@ -23,7 +23,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 
 	"github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/assert"
@@ -86,9 +86,9 @@ func TestTaskResponse(t *testing.T) {
 		Version:             version,
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
-		ENIs: []*apieni.ENI{
+		ENIs: []*ni.NetworkInterface{
 			{
-				IPV4Addresses: []*apieni.ENIIPV4Address{
+				IPV4Addresses: []*ni.IPV4Address{
 					{
 						Address: eniIPv4Address,
 					},
@@ -184,8 +184,8 @@ func TestContainerResponse(t *testing.T) {
 		Container:  container,
 	}
 
-	eni := &apieni.ENI{
-		IPV4Addresses: []*apieni.ENIIPV4Address{
+	eni := &ni.NetworkInterface{
+		IPV4Addresses: []*ni.IPV4Address{
 			{
 				Address: eniIPv4Address,
 			},

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -21,7 +21,7 @@ import (
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	v1 "github.com/aws/amazon-ecs-agent/agent/handlers/v1"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
 	tmdsv2 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v2"
@@ -154,7 +154,7 @@ func NewContainerResponseFromState(
 // TODO: remove includeV4Metadata from NewContainerResponse
 func NewContainerResponse(
 	dockerContainer *apicontainer.DockerContainer,
-	eni *apieni.ENI,
+	eni *ni.NetworkInterface,
 	includeV4Metadata bool,
 ) tmdsv2.ContainerResponse {
 	container := dockerContainer.Container

--- a/agent/handlers/v2/response_test.go
+++ b/agent/handlers/v2/response_test.go
@@ -28,8 +28,8 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ecs_client/model/ecs"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	tmdsv2 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v2"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -73,9 +73,9 @@ func TestTaskResponse(t *testing.T) {
 		Version:             version,
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
-		ENIs: []*apieni.ENI{
+		ENIs: []*ni.NetworkInterface{
 			{
-				IPV4Addresses: []*apieni.ENIIPV4Address{
+				IPV4Addresses: []*ni.IPV4Address{
 					{
 						Address: eniIPv4Address,
 					},
@@ -169,9 +169,9 @@ func TestTaskResponseWithV4Metadata(t *testing.T) {
 		Version:             version,
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
-		ENIs: []*apieni.ENI{
+		ENIs: []*ni.NetworkInterface{
 			{
-				IPV4Addresses: []*apieni.ENIIPV4Address{
+				IPV4Addresses: []*ni.IPV4Address{
 					{
 						Address: eniIPv4Address,
 					},
@@ -302,9 +302,9 @@ func TestContainerResponse(t *testing.T) {
 				Container:  container,
 			}
 			task := &apitask.Task{
-				ENIs: []*apieni.ENI{
+				ENIs: []*ni.NetworkInterface{
 					{
-						IPV4Addresses: []*apieni.ENIIPV4Address{
+						IPV4Addresses: []*ni.IPV4Address{
 							{
 								Address: eniIPv4Address,
 							},
@@ -403,9 +403,9 @@ func TestTaskResponseMarshal(t *testing.T) {
 		Version:             version,
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
-		ENIs: []*apieni.ENI{
+		ENIs: []*ni.NetworkInterface{
 			{
-				IPV4Addresses: []*apieni.ENIIPV4Address{
+				IPV4Addresses: []*ni.IPV4Address{
 					{
 						Address: eniIPv4Address,
 					},
@@ -577,9 +577,9 @@ func TestContainerResponseMarshal(t *testing.T) {
 		Container:  container,
 	}
 	task := &apitask.Task{
-		ENIs: []*apieni.ENI{
+		ENIs: []*ni.NetworkInterface{
 			{
-				IPV4Addresses: []*apieni.ENIIPV4Address{
+				IPV4Addresses: []*ni.IPV4Address{
 					{
 						Address: eniIPv4Address,
 					},
@@ -624,9 +624,9 @@ func TestTaskResponseWithV4TagsError(t *testing.T) {
 		Version:             version,
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
-		ENIs: []*apieni.ENI{
+		ENIs: []*ni.NetworkInterface{
 			{
-				IPV4Addresses: []*apieni.ENIIPV4Address{
+				IPV4Addresses: []*ni.IPV4Address{
 					{
 						Address: eniIPv4Address,
 					},

--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -19,7 +19,7 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
 	tmdsv4 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state"
@@ -151,7 +151,7 @@ func newNetworkInterfaceProperties(task *apitask.Task) (tmdsv4.NetworkInterfaceP
 // It augments v4 container response with an additional empty network interface field.
 func NewPulledContainerResponse(
 	dockerContainer *apicontainer.DockerContainer,
-	eni *apieni.ENI,
+	eni *ni.NetworkInterface,
 ) tmdsv4.ContainerResponse {
 	resp := v2.NewContainerResponse(dockerContainer, eni, true)
 	return tmdsv4.ContainerResponse{

--- a/agent/handlers/v4/response_test.go
+++ b/agent/handlers/v4/response_test.go
@@ -27,7 +27,7 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
@@ -74,14 +74,14 @@ func TestNewTaskContainerResponses(t *testing.T) {
 		ServiceName:         serviceName,
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
-		ENIs: []*apieni.ENI{
+		ENIs: []*ni.NetworkInterface{
 			{
-				IPV4Addresses: []*apieni.ENIIPV4Address{
+				IPV4Addresses: []*ni.IPV4Address{
 					{
 						Address: eniIPv4Address,
 					},
 				},
-				IPV6Addresses: []*apieni.ENIIPV6Address{
+				IPV6Addresses: []*ni.IPV6Address{
 					{
 						Address: eniIPv6Address,
 					},

--- a/agent/sighandlers/termination_handler_test.go
+++ b/agent/sighandlers/termination_handler_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,7 +61,7 @@ func TestFinalSave(t *testing.T) {
 		},
 	}
 
-	eniAttachment := &apieni.ENIAttachment{
+	eniAttachment := &ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			TaskARN:          taskARN,
 			AttachmentARN:    eniAttachmentArn,

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
 	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/docker/docker/api/types"
@@ -724,7 +724,7 @@ func TestSynchronizeOnRestart(t *testing.T) {
 
 func TestTaskNetworkStatsSet(t *testing.T) {
 	var networkModes = []struct {
-		ENIs                  []*apieni.ENI
+		ENIs                  []*ni.NetworkInterface
 		NetworkMode           string
 		ServiceConnectEnabled bool
 		StatsEmpty            bool
@@ -737,7 +737,7 @@ func TestTaskNetworkStatsSet(t *testing.T) {
 	}
 }
 
-func testNetworkModeStats(t *testing.T, netMode string, enis []*apieni.ENI, serviceConnectEnabled, emptyStats bool) {
+func testNetworkModeStats(t *testing.T, netMode string, enis []*ni.NetworkInterface, serviceConnectEnabled, emptyStats bool) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
 	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -35,11 +35,11 @@ import (
 
 func TestLinuxTaskNetworkStatsSet(t *testing.T) {
 	var networkModes = []struct {
-		ENIs        []*apieni.ENI
+		ENIs        []*ni.NetworkInterface
 		NetworkMode string
 		StatsEmpty  bool
 	}{
-		{[]*apieni.ENI{{ID: "ec2Id"}}, "awsvpc", true},
+		{[]*ni.NetworkInterface{{ID: "ec2Id"}}, "awsvpc", true},
 		{nil, "host", true},
 		{nil, "bridge", false},
 		{nil, "none", true},
@@ -71,7 +71,7 @@ func TestNetworkModeStatsAWSVPCMode(t *testing.T) {
 	t1 := &apitask.Task{
 		Arn:               "t1",
 		Family:            "f1",
-		ENIs:              []*apieni.ENI{{ID: "ec2Id"}},
+		ENIs:              []*ni.NetworkInterface{{ID: "ec2Id"}},
 		NetworkMode:       apitask.AWSVPCNetworkMode,
 		KnownStatusUnsafe: apitaskstatus.TaskRunning,
 		Containers: []*apicontainer.Container{

--- a/agent/stats/service_connect_linux_test.go
+++ b/agent/stats/service_connect_linux_test.go
@@ -30,7 +30,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/gorilla/mux"
@@ -41,7 +41,7 @@ func TestRetrieveServiceConnectMetrics(t *testing.T) {
 	t1 := &apitask.Task{
 		Arn:               "t1",
 		Family:            "f1",
-		ENIs:              []*apieni.ENI{{ID: "ec2Id"}},
+		ENIs:              []*ni.NetworkInterface{{ID: "ec2Id"}},
 		KnownStatusUnsafe: apitaskstatus.TaskRunning,
 		Containers: []*apicontainer.Container{
 			{Name: "test"},

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_eni_common.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_eni_common.go
@@ -13,10 +13,8 @@
 
 package session
 
-import (
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
-)
+import ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 
 type ENIHandler interface {
-	HandleENIAttachment(eniAttachment *apieni.ENIAttachment) error
+	HandleENIAttachment(eniAttachment *ni.ENIAttachment) error
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_instance_eni_responder.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_instance_eni_responder.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/wsclient"
 )
 
@@ -98,7 +98,7 @@ func (r *attachInstanceENIResponder) handleAttachMessage(message *ecsacs.AttachI
 func (r *attachInstanceENIResponder) handleInstanceENIFromMessage(eni *ecsacs.ElasticNetworkInterface,
 	messageID, clusterARN, containerInstanceARN string, receivedAt time.Time, waitTimeoutMs int64) {
 	expiresAt := receivedAt.Add(time.Duration(waitTimeoutMs) * time.Millisecond)
-	err := r.eniHandler.HandleENIAttachment(&apieni.ENIAttachment{
+	err := r.eniHandler.HandleENIAttachment(&ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			AttachmentARN:        aws.StringValue(eni.AttachmentArn),
 			Status:               status.AttachmentNone,
@@ -107,7 +107,7 @@ func (r *attachInstanceENIResponder) handleInstanceENIFromMessage(eni *ecsacs.El
 			ClusterARN:           clusterARN,
 			ContainerInstanceARN: containerInstanceARN,
 		},
-		AttachmentType: apieni.ENIAttachmentTypeInstanceENI,
+		AttachmentType: ni.ENIAttachmentTypeInstanceENI,
 		MACAddress:     aws.StringValue(eni.MacAddress),
 	})
 	if err != nil {
@@ -151,7 +151,7 @@ func validateAttachInstanceNetworkInterfacesMessage(message *ecsacs.AttachInstan
 	}
 
 	for _, eni := range enis {
-		err := apieni.ValidateENI(eni)
+		err := ni.ValidateENI(eni)
 		if err != nil {
 			return err
 		}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_task_eni_responder.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_task_eni_responder.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/wsclient"
 )
 
@@ -99,7 +99,7 @@ func (r *attachTaskENIResponder) handleAttachMessage(message *ecsacs.AttachTaskN
 func (r *attachTaskENIResponder) handleTaskENIFromMessage(eni *ecsacs.ElasticNetworkInterface,
 	messageID, taskARN, clusterARN, containerInstanceARN string, receivedAt time.Time, waitTimeoutMs int64) {
 	expiresAt := receivedAt.Add(time.Duration(waitTimeoutMs) * time.Millisecond)
-	err := r.eniHandler.HandleENIAttachment(&apieni.ENIAttachment{
+	err := r.eniHandler.HandleENIAttachment(&ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			TaskARN:              taskARN,
 			AttachmentARN:        aws.StringValue(eni.AttachmentArn),
@@ -109,7 +109,7 @@ func (r *attachTaskENIResponder) handleTaskENIFromMessage(eni *ecsacs.ElasticNet
 			ClusterARN:           clusterARN,
 			ContainerInstanceARN: containerInstanceARN,
 		},
-		AttachmentType: apieni.ENIAttachmentTypeTaskENI,
+		AttachmentType: ni.ENIAttachmentTypeTaskENI,
 		MACAddress:     aws.StringValue(eni.MacAddress),
 	})
 	if err != nil {
@@ -158,7 +158,7 @@ func validateAttachTaskNetworkInterfacesMessage(message *ecsacs.AttachTaskNetwor
 	}
 
 	for _, eni := range enis {
-		err := apieni.ValidateENI(eni)
+		err := ni.ValidateENI(eni)
 		if err != nil {
 			return err
 		}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/eni/eni.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/eni/eni.go
@@ -36,9 +36,9 @@ type ENI struct {
 	// MacAddress is the mac address of the eni
 	MacAddress string
 	// IPV4Addresses is the ipv4 address associated with the eni
-	IPV4Addresses []*ENIIPV4Address
+	IPV4Addresses []*IPV4Address
 	// IPV6Addresses is the ipv6 address associated with the eni
-	IPV6Addresses []*ENIIPV6Address
+	IPV6Addresses []*IPV6Address
 	// SubnetGatewayIPV4Address is the IPv4 address of the subnet gateway of the ENI
 	SubnetGatewayIPV4Address string `json:",omitempty"`
 	// DomainNameServers specifies the nameserver IP addresses for the eni
@@ -272,16 +272,16 @@ func (eni *ENI) String() string {
 		strings.Join(eni.DomainNameSearchList, ","), eni.SubnetGatewayIPV4Address, eniString)
 }
 
-// ENIIPV4Address is the ipv4 information of the eni
-type ENIIPV4Address struct {
+// IPV4Address is the ipv4 information of the eni
+type IPV4Address struct {
 	// Primary indicates whether the ip address is primary
 	Primary bool
 	// Address is the ipv4 address associated with eni
 	Address string
 }
 
-// ENIIPV6Address is the ipv6 information of the eni
-type ENIIPV6Address struct {
+// IPV6Address is the ipv6 information of the eni
+type IPV6Address struct {
 	// Address is the ipv6 address associated with eni
 	Address string
 }
@@ -293,12 +293,12 @@ func ENIFromACS(acsENI *ecsacs.ElasticNetworkInterface) (*ENI, error) {
 		return nil, err
 	}
 
-	var ipv4Addrs []*ENIIPV4Address
-	var ipv6Addrs []*ENIIPV6Address
+	var ipv4Addrs []*IPV4Address
+	var ipv6Addrs []*IPV6Address
 
 	// Read IPv4 address information of the ENI.
 	for _, ec2Ipv4 := range acsENI.Ipv4Addresses {
-		ipv4Addrs = append(ipv4Addrs, &ENIIPV4Address{
+		ipv4Addrs = append(ipv4Addrs, &IPV4Address{
 			Primary: aws.BoolValue(ec2Ipv4.Primary),
 			Address: aws.StringValue(ec2Ipv4.PrivateAddress),
 		})
@@ -306,7 +306,7 @@ func ENIFromACS(acsENI *ecsacs.ElasticNetworkInterface) (*ENI, error) {
 
 	// Read IPv6 address information of the ENI.
 	for _, ec2Ipv6 := range acsENI.Ipv6Addresses {
-		ipv6Addrs = append(ipv6Addrs, &ENIIPV6Address{
+		ipv6Addrs = append(ipv6Addrs, &IPV6Address{
 			Address: aws.StringValue(ec2Ipv6.Address),
 		})
 	}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh/appmesh.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh/appmesh.go
@@ -1,0 +1,127 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package appmesh
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+const (
+	appMesh                    = "APPMESH"
+	splitter                   = ","
+	ignoredUID                 = "IgnoredUID"
+	ignoredGID                 = "IgnoredGID"
+	proxyIngressPort           = "ProxyIngressPort"
+	proxyEgressPort            = "ProxyEgressPort"
+	appPorts                   = "AppPorts"
+	egressIgnoredIPs           = "EgressIgnoredIPs"
+	egressIgnoredPorts         = "EgressIgnoredPorts"
+	taskMetadataEndpointIP     = "169.254.170.2"
+	instanceMetadataEndpointIP = "169.254.169.254"
+)
+
+// AppMesh contains information of app mesh config
+type AppMesh struct {
+	// ContainerName is the proxy container name
+	ContainerName string
+	// IgnoredUID is egress traffic from the processes owned by the UID will be ignored
+	IgnoredUID string
+	// IgnoredGID specifies egress traffic from the processes owned by the GID will be ignored
+	IgnoredGID string
+	// ProxyIngressPort is the ingress port number that proxy is listening on
+	ProxyIngressPort string
+	// ProxyEgressPort is the egress port number that proxy is listening on
+	ProxyEgressPort string
+	// AppPorts is the port number that application is listening on
+	AppPorts []string
+	// EgressIgnoredIPs is the list of IPs for which egress traffic will be ignored
+	EgressIgnoredIPs []string
+	// EgressIgnoredPorts is the list of ports for which egress traffic will be ignored
+	EgressIgnoredPorts []string
+}
+
+// AppMeshFromACS validates proxy config if it is app mesh type and creates AppMesh object
+func AppMeshFromACS(proxyConfig *ecsacs.ProxyConfiguration) (*AppMesh, error) {
+
+	if *proxyConfig.Type != appMesh {
+		return nil, fmt.Errorf("agent does not support proxy type other than app mesh")
+	}
+
+	return &AppMesh{
+		ContainerName:      aws.StringValue(proxyConfig.ContainerName),
+		IgnoredUID:         aws.StringValue(proxyConfig.Properties[ignoredUID]),
+		IgnoredGID:         aws.StringValue(proxyConfig.Properties[ignoredGID]),
+		ProxyIngressPort:   aws.StringValue(proxyConfig.Properties[proxyIngressPort]),
+		ProxyEgressPort:    aws.StringValue(proxyConfig.Properties[proxyEgressPort]),
+		AppPorts:           buildAppPorts(proxyConfig),
+		EgressIgnoredIPs:   buildEgressIgnoredIPs(proxyConfig),
+		EgressIgnoredPorts: buildEgressIgnoredPorts(proxyConfig),
+	}, nil
+}
+
+// buildAppPorts creates app ports from proxy config
+func buildAppPorts(proxyConfig *ecsacs.ProxyConfiguration) []string {
+	var inputAppPorts []string
+	if proxyConfig.Properties[appPorts] != nil && len(*proxyConfig.Properties[appPorts]) > 0 {
+		inputAppPorts = strings.Split(*proxyConfig.Properties[appPorts], splitter)
+	}
+	return inputAppPorts
+}
+
+// buildEgressIgnoredIPs creates egress ignored IPs from proxy config
+func buildEgressIgnoredIPs(proxyConfig *ecsacs.ProxyConfiguration) []string {
+	var inputEgressIgnoredIPs []string
+	if proxyConfig.Properties[egressIgnoredIPs] != nil && len(*proxyConfig.Properties[egressIgnoredIPs]) > 0 {
+		inputEgressIgnoredIPs = strings.Split(*proxyConfig.Properties[egressIgnoredIPs], splitter)
+	}
+	// append agent default egress ignored IPs
+	return appendDefaultEgressIgnoredIPs(inputEgressIgnoredIPs)
+}
+
+// buildEgressIgnoredPorts creates egress ignored ports from proxy config
+func buildEgressIgnoredPorts(proxyConfig *ecsacs.ProxyConfiguration) []string {
+	var inputEgressIgnoredPorts []string
+	if proxyConfig.Properties[egressIgnoredPorts] != nil && len(*proxyConfig.Properties[egressIgnoredPorts]) > 0 {
+		inputEgressIgnoredPorts = strings.Split(*proxyConfig.Properties[egressIgnoredPorts], splitter)
+	}
+	return inputEgressIgnoredPorts
+}
+
+// appendDefaultEgressIgnoredIPs append task metadata endpoint ip and
+// instance metadata ip address to egress ignored IPs if does not exist
+func appendDefaultEgressIgnoredIPs(egressIgnoredIPs []string) []string {
+	hasTaskMetadataEndpointIP := false
+	hasInstanceMetadataEndpointIP := false
+	for _, egressIgnoredIP := range egressIgnoredIPs {
+		if strings.TrimSpace(egressIgnoredIP) == taskMetadataEndpointIP {
+			hasTaskMetadataEndpointIP = true
+		}
+		if strings.TrimSpace(egressIgnoredIP) == instanceMetadataEndpointIP {
+			hasInstanceMetadataEndpointIP = true
+		}
+	}
+
+	if !hasTaskMetadataEndpointIP {
+		egressIgnoredIPs = append(egressIgnoredIPs, taskMetadataEndpointIP)
+	}
+	if !hasInstanceMetadataEndpointIP {
+		egressIgnoredIPs = append(egressIgnoredIPs, instanceMetadataEndpointIP)
+	}
+
+	return egressIgnoredIPs
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/eniattachment.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/eniattachment.go
@@ -1,0 +1,165 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package networkinterface
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/arn"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// ENIAttachmentTypeTaskENI represents the type of a task level eni
+	ENIAttachmentTypeTaskENI = "task-eni"
+	// ENIAttachmentTypeInstanceENI represents the type of an instance level eni
+	ENIAttachmentTypeInstanceENI = "instance-eni"
+)
+
+// ENIAttachment contains the information of the eni attachment
+type ENIAttachment struct {
+	attachmentinfo.AttachmentInfo
+	// AttachmentType is the type of the eni attachment, can either be "task-eni" or "instance-eni"
+	AttachmentType string `json:"attachmentType"`
+	// MACAddress is the mac address of eni
+	MACAddress string `json:"macAddress"`
+	// ackTimer is used to register the expiration timeout callback for unsuccessful
+	// ENI attachments
+	ackTimer ttime.Timer
+	// guard protects access to fields of this struct
+	guard sync.RWMutex
+}
+
+func getEniAttachmentLogFields(eni *ENIAttachment, duration time.Duration) logger.Fields {
+	fields := logger.Fields{
+		"duration":       duration.String(),
+		"attachmentARN":  eni.AttachmentARN,
+		"attachmentType": eni.AttachmentType,
+		"attachmentSent": eni.AttachStatusSent,
+		"mac":            eni.MACAddress,
+		"status":         eni.Status.String(),
+		"expiresAt":      eni.ExpiresAt.Format(time.RFC3339),
+	}
+
+	if eni.AttachmentType != ENIAttachmentTypeInstanceENI {
+		taskId, _ := arn.TaskIdFromArn(eni.TaskARN)
+		fields[field.TaskID] = taskId
+	}
+
+	return fields
+}
+
+// StartTimer starts the ack timer to record the expiration of ENI attachment
+func (eni *ENIAttachment) StartTimer(timeoutFunc func()) error {
+	eni.guard.Lock()
+	defer eni.guard.Unlock()
+
+	if eni.ackTimer != nil {
+		// The timer has already been initialized, do nothing
+		return nil
+	}
+	now := time.Now()
+	duration := eni.ExpiresAt.Sub(now)
+	if duration <= 0 {
+		return errors.Errorf("eni attachment: timer expiration is in the past; expiration [%s] < now [%s]",
+			eni.ExpiresAt.String(), now.String())
+	}
+	logger.Info("Starting ENI ack timer", getEniAttachmentLogFields(eni, duration))
+	eni.ackTimer = time.AfterFunc(duration, timeoutFunc)
+	return nil
+}
+
+// Initialize initializes the fields that can't be populated from loading state file.
+// Notably, this initializes the ack timer so that if we times out waiting for the eni to be attached, the attachment
+// can be removed from state.
+func (eni *ENIAttachment) Initialize(timeoutFunc func()) error {
+	eni.guard.Lock()
+	defer eni.guard.Unlock()
+
+	if eni.AttachStatusSent { // eni attachment status has been sent, no need to start ack timer.
+		return nil
+	}
+
+	now := time.Now()
+	duration := eni.ExpiresAt.Sub(now)
+	if duration <= 0 {
+		return errors.New("ENI attachment has already expired")
+	}
+
+	logger.Info("Starting ENI ack timer", getEniAttachmentLogFields(eni, duration))
+	eni.ackTimer = time.AfterFunc(duration, timeoutFunc)
+	return nil
+}
+
+// IsSent checks if the eni attached status has been sent
+func (eni *ENIAttachment) IsSent() bool {
+	eni.guard.RLock()
+	defer eni.guard.RUnlock()
+
+	return eni.AttachStatusSent
+}
+
+// SetSentStatus marks the eni attached status has been sent
+func (eni *ENIAttachment) SetSentStatus() {
+	eni.guard.Lock()
+	defer eni.guard.Unlock()
+
+	eni.AttachStatusSent = true
+}
+
+// StopAckTimer stops the ack timer set on the ENI attachment
+func (eni *ENIAttachment) StopAckTimer() {
+	eni.guard.Lock()
+	defer eni.guard.Unlock()
+
+	eni.ackTimer.Stop()
+}
+
+// HasExpired returns true if the ENI attachment object has exceeded the
+// threshold for notifying the backend of the attachment
+func (eni *ENIAttachment) HasExpired() bool {
+	eni.guard.RLock()
+	defer eni.guard.RUnlock()
+
+	return time.Now().After(eni.ExpiresAt)
+}
+
+// String returns a string representation of the ENI Attachment
+func (eni *ENIAttachment) String() string {
+	eni.guard.RLock()
+	defer eni.guard.RUnlock()
+
+	return eni.stringUnsafe()
+}
+
+// stringUnsafe returns a string representation of the ENI Attachment
+func (eni *ENIAttachment) stringUnsafe() string {
+	// skip TaskArn field for instance level eni attachment since it won't have a task arn
+	if eni.AttachmentType == ENIAttachmentTypeInstanceENI {
+		return fmt.Sprintf(
+			"ENI Attachment: attachment=%s attachmentType=%s attachmentSent=%t mac=%s status=%s expiresAt=%s",
+			eni.AttachmentARN, eni.AttachmentType, eni.AttachStatusSent, eni.MACAddress, eni.Status.String(), eni.ExpiresAt.Format(time.RFC3339))
+	}
+
+	return fmt.Sprintf(
+		"ENI Attachment: task=%s attachment=%s attachmentType=%s attachmentSent=%t mac=%s status=%s expiresAt=%s",
+		eni.TaskARN, eni.AttachmentARN, eni.AttachmentType, eni.AttachStatusSent, eni.MACAddress, eni.Status.String(), eni.ExpiresAt.Format(time.RFC3339))
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/errors.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/errors.go
@@ -1,0 +1,36 @@
+package networkinterface
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// UnableToFindENIError is an error type that is used to handle cases where
+// the ENI device cannot be found, even after it has been acknowledged as
+// "attached" by the agent. It lets us special case this error in dispatcher
+// and task director workflows.
+type UnableToFindENIError struct {
+	macAddress          string
+	associationProtocol string
+}
+
+// NewUnableToFindENIError creates a new UnableToFindENIError object.
+func NewUnableToFindENIError(macAddress, associationProtocol string) error {
+	return &UnableToFindENIError{
+		macAddress:          macAddress,
+		associationProtocol: associationProtocol,
+	}
+}
+
+func (e *UnableToFindENIError) Error() string {
+	return fmt.Sprintf("unable to find device name for '%s' eni %s",
+		e.associationProtocol, e.macAddress)
+}
+
+// IsUnableToFindENIError returns true if the error type is of type
+// `UnableToFindENIError`.
+func IsUnableToFindENIError(err error) bool {
+	_, ok := errors.Cause(err).(*UnableToFindENIError)
+	return ok
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface.go
@@ -1,0 +1,647 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//lint:file-ignore U1000 Ignore unused fields as some of them are only used by Fargate
+
+package networkinterface
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	loggerfield "github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/pkg/errors"
+)
+
+// NetworkInterface contains information of the network interface
+type NetworkInterface struct {
+	// ID is the id of eni
+	ID string `json:"ec2Id"`
+	// LinkName is the name of the NetworkInterface on the instance.
+	// Currently, this field is being used only for Windows and is used during task networking setup.
+	LinkName string
+	// MacAddress is the mac address of the eni
+	MacAddress string
+	// IPV4Addresses is the ipv4 address associated with the eni
+	IPV4Addresses []*IPV4Address
+	// IPV6Addresses is the ipv6 address associated with the eni
+	IPV6Addresses []*IPV6Address
+	// SubnetGatewayIPV4Address is the IPv4 address of the subnet gateway of the NetworkInterface
+	SubnetGatewayIPV4Address string `json:",omitempty"`
+	// DomainNameServers specifies the nameserver IP addresses for the eni
+	DomainNameServers []string `json:",omitempty"`
+	// DomainNameSearchList specifies the search list for the domain
+	// name lookup, for the eni
+	DomainNameSearchList []string `json:",omitempty"`
+	// PrivateDNSName is the dns name assigned by the vpc to this eni
+	PrivateDNSName string `json:",omitempty"`
+	// InterfaceAssociationProtocol is the type of NetworkInterface, valid value: "default", "vlan"
+	InterfaceAssociationProtocol string `json:",omitempty"`
+
+	Index          int64  `json:"Index,omitempty"`
+	UserID         uint32 `json:"UserID,omitempty"`
+	Name           string `json:"Name,omitempty"`
+	NetNSName      string `json:"NetNSName,omitempty"`
+	NetNSPath      string `json:"NetNSPath,omitempty"`
+	DeviceName     string `json:"DeviceName,omitempty"`
+	GuestNetNSName string `json:"GuestNetNSName,omitempty"`
+	KnownStatus    Status `json:"KnownStatus,omitempty"`
+	DesiredStatus  Status `json:"DesiredStatus,omitempty"`
+
+	// InterfaceVlanProperties contains information for an interface
+	// that is supposed to be used as a VLAN device
+	InterfaceVlanProperties *InterfaceVlanProperties `json:",omitempty"`
+	// TunnelProperties contains information for tunnel interface
+	TunnelProperties *TunnelProperties `json:",omitempty"`
+	// VETHProperties contains information for a virtual ethernet interface
+	VETHProperties *VETHProperties `json:",omitempty"`
+	// Certain tasks such as service connect tasks may require additional
+	// domain name to IP address mapping defined in their /etc/hosts files.
+	// DNSMappingList will contain this for each NetworkInterface since /etc/hosts file
+	// is created per NetworkInterface.
+	DNSMappingList []DNSMapping
+
+	// Due to historical reasons, the IPv4 subnet prefix length is sent with IPv4 subnet gateway
+	// address instead of the NetworkInterface's IP addresses. However, CNI plugins and many OS APIs expect it
+	// the other way around. Instead of doing this conversion all the time for each CNI and TMDS
+	// request, compute it once on demand and cache it here.
+	ipv4SubnetPrefixLength string
+	ipv4SubnetCIDRBlock    string
+	ipv6SubnetCIDRBlock    string
+
+	// guard protects access to fields of this struct.
+	guard sync.RWMutex
+}
+
+// InterfaceVlanProperties contains information for an interface that
+// is supposed to be used as a VLAN device
+type InterfaceVlanProperties struct {
+	VlanID                   string
+	TrunkInterfaceMacAddress string
+}
+
+// TunnelProperties holds ID (e.g. VNI), destination IP address and port for tunnel interfaces.
+type TunnelProperties struct {
+	ID                   string `json:"ID"`
+	DestinationIPAddress string `json:"DestinationIPAddress"`
+	DestinationPort      uint16 `json:"DestinationPort"`
+}
+
+// VETHProperties holds the properties for virtual ethernet interfaces.
+type VETHProperties struct {
+	PeerInterfaceName string `json:"PeerInterfaceName"`
+}
+
+// DNSMapping holds additional pre-defined DNS entries for containers.
+// These additional entries will be written into /etc/hosts file eventually.
+type DNSMapping struct {
+	Hostname string
+	Address  string
+}
+
+const (
+	// DefaultInterfaceAssociationProtocol represents the standard NetworkInterface type.
+	DefaultInterfaceAssociationProtocol = "default"
+
+	// VLANInterfaceAssociationProtocol represents the NetworkInterface with trunking enabled.
+	VLANInterfaceAssociationProtocol = "vlan"
+
+	// IPv6SubnetPrefixLength is the IPv6 global unicast address prefix length, consisting of
+	// global routing prefix and subnet ID lengths as specified in IPv6 addressing architecture
+	// (RFC 4291 section 2.5.4) and IPv6 Global Unicast Address Format (RFC 3587).
+	// The ACS NetworkInterface payload structure does not contain an IPv6 subnet prefix length because "/64" is
+	// the only allowed length per RFCs above, and the only one that VPC supports.
+	IPv6SubnetPrefixLength = "64"
+
+	// TapDeviceNamePrefix holds the name prefix for interfaces attached to a MicroVM.
+	// In a multi NetworkInterface task, there will be multiple tap ENIs attached to it.
+	// They follow a naming pattern 'eth<eni index>'.
+	TapDeviceNamePrefix = "eth"
+
+	// DefaultTapDeviceName is the name of the tap device created by CNI plugin
+	// which connects the MicroVM with the branch NetworkInterface.
+	DefaultTapDeviceName = TapDeviceNamePrefix + "0"
+
+	// Standard ENIs and branch ENIs are supported both in ECS EC2 instances and Fargate. Therefore
+	// the processing of those common interface types are implemented in the ECS Agent's NetworkInterface package
+	// (ecseni) and simply imported here. VETH and V2N interface types are supported only in Fargate
+	// The constants below and functionality specific to those types are implemented in this file.
+
+	// VETHInterfaceAssociationProtocol is the interface association protocol for veth interfaces.
+	VETHInterfaceAssociationProtocol = "veth"
+
+	// V2NInterfaceAssociationProtocol is the interface association protocol for V2N tunnel interfaces.
+	V2NInterfaceAssociationProtocol = "tunnel"
+
+	// GeneveInterfaceNamePattern holds pattern of GENEVE interface name:
+	// 'gnv<v2nVNI><destination port>'.
+	// We have both the VNI and destination port in the name because that is the only
+	// guaranteed combination that can make the name of the interface unique.
+	// It is important that the name is unique for all GENEVE interfaces because
+	// the interface is always first created in the default network namespace
+	// before moving it to a custom namespace.
+	GeneveInterfaceNamePattern = "gnv%s%d"
+
+	// DefaultGeneveInterfaceIPAddress is the IP address that will be assigned to the
+	// GENEVE interface created for the V2N NetworkInterface. These IP addresses are chosen because
+	// they come under the ECS reserved link-local IP range. By having the subnet mask as /31,
+	// it means there are only 2 available IPs in this chosen subnet - 169.254.175.252 and
+	// 169.254.175.253. We set 169.254.175.252 as the geneve interface IP and set
+	// 169.254.175.253 as the default default gateway in the routing rules.
+	// We also assign a place holder MAC address for the gateway in the ARP table. This
+	// configuration ensures all traffic generated in the V2N NetworkInterface's netns will pass through
+	// the GENEVE interface.
+	DefaultGeneveInterfaceIPAddress = "169.254.175.252"
+	DefaultGeneveInterfaceGateway   = "169.254.175.253/31"
+)
+
+var (
+	// netInterfaces is the Interfaces() method of net package.
+	netInterfaces = net.Interfaces
+)
+
+// GetIPV4Addresses returns the list of IPv4 addresses assigned to the NetworkInterface.
+func (ni *NetworkInterface) GetIPV4Addresses() []string {
+	var addresses []string
+	for _, addr := range ni.IPV4Addresses {
+		addresses = append(addresses, addr.Address)
+	}
+
+	return addresses
+}
+
+// GetIPV6Addresses returns the list of IPv6 addresses assigned to the NetworkInterface.
+func (ni *NetworkInterface) GetIPV6Addresses() []string {
+	var addresses []string
+	for _, addr := range ni.IPV6Addresses {
+		addresses = append(addresses, addr.Address)
+	}
+
+	return addresses
+}
+
+// GetPrimaryIPv4Address returns the primary IPv4 address assigned to the NetworkInterface.
+func (ni *NetworkInterface) GetPrimaryIPv4Address() string {
+	var primaryAddr string
+	for _, addr := range ni.IPV4Addresses {
+		if addr.Primary {
+			primaryAddr = addr.Address
+			break
+		}
+	}
+
+	return primaryAddr
+}
+
+// GetPrimaryIPv4AddressWithPrefixLength returns the primary IPv4 address assigned to the NetworkInterface with
+// its subnet prefix length.
+func (ni *NetworkInterface) GetPrimaryIPv4AddressWithPrefixLength() string {
+	return ni.GetPrimaryIPv4Address() + "/" + ni.GetIPv4SubnetPrefixLength()
+}
+
+// GetIPAddressesWithPrefixLength returns the list of all IP addresses assigned to the NetworkInterface with
+// their subnet prefix length.
+func (ni *NetworkInterface) GetIPAddressesWithPrefixLength() []string {
+	var addresses []string
+	for _, addr := range ni.IPV4Addresses {
+		addresses = append(addresses, addr.Address+"/"+ni.GetIPv4SubnetPrefixLength())
+	}
+	for _, addr := range ni.IPV6Addresses {
+		addresses = append(addresses, addr.Address+"/"+IPv6SubnetPrefixLength)
+	}
+
+	return addresses
+}
+
+// GetIPv4SubnetPrefixLength returns the IPv4 prefix length of the NetworkInterface's subnet.
+func (ni *NetworkInterface) GetIPv4SubnetPrefixLength() string {
+	if ni.ipv4SubnetPrefixLength == "" && ni.SubnetGatewayIPV4Address != "" {
+		ni.ipv4SubnetPrefixLength = strings.Split(ni.SubnetGatewayIPV4Address, "/")[1]
+	}
+
+	return ni.ipv4SubnetPrefixLength
+}
+
+// GetIPv4SubnetCIDRBlock returns the IPv4 CIDR block, if any, of the NetworkInterface's subnet.
+func (ni *NetworkInterface) GetIPv4SubnetCIDRBlock() string {
+	if ni.ipv4SubnetCIDRBlock == "" && ni.SubnetGatewayIPV4Address != "" {
+		_, ipv4Net, err := net.ParseCIDR(ni.SubnetGatewayIPV4Address)
+		if err == nil {
+			ni.ipv4SubnetCIDRBlock = ipv4Net.String()
+		}
+	}
+
+	return ni.ipv4SubnetCIDRBlock
+}
+
+// GetIPv6SubnetCIDRBlock returns the IPv6 CIDR block, if any, of the NetworkInterface's subnet.
+func (ni *NetworkInterface) GetIPv6SubnetCIDRBlock() string {
+	if ni.ipv6SubnetCIDRBlock == "" && len(ni.IPV6Addresses) > 0 {
+		ipv6Addr := ni.IPV6Addresses[0].Address + "/" + IPv6SubnetPrefixLength
+		_, ipv6Net, err := net.ParseCIDR(ipv6Addr)
+		if err == nil {
+			ni.ipv6SubnetCIDRBlock = ipv6Net.String()
+		}
+	}
+
+	return ni.ipv6SubnetCIDRBlock
+}
+
+// GetSubnetGatewayIPv4Address returns the subnet gateway IPv4 address for the NetworkInterface.
+func (ni *NetworkInterface) GetSubnetGatewayIPv4Address() string {
+	var gwAddr string
+	if ni.SubnetGatewayIPV4Address != "" {
+		gwAddr = strings.Split(ni.SubnetGatewayIPV4Address, "/")[0]
+	}
+
+	return gwAddr
+}
+
+// GetHostname returns the hostname assigned to the NetworkInterface
+func (ni *NetworkInterface) GetHostname() string {
+	return ni.PrivateDNSName
+}
+
+// GetLinkName returns the name of the NetworkInterface on the instance.
+func (ni *NetworkInterface) GetLinkName() string {
+	ni.guard.Lock()
+	defer ni.guard.Unlock()
+
+	if ni.LinkName == "" {
+		// Find all interfaces on the instance.
+		ifaces, err := netInterfaces()
+		if err != nil {
+			logger.Error("Failed to find link name:", logger.Fields{
+				loggerfield.Error: err,
+			})
+			return ""
+		}
+		// Iterate over the list and find the interface with the NetworkInterface's MAC address.
+		for _, iface := range ifaces {
+			if strings.EqualFold(ni.MacAddress, iface.HardwareAddr.String()) {
+				ni.LinkName = iface.Name
+				break
+			}
+		}
+		// If the NetworkInterface is not matched by MAC address above, we will fail to
+		// assign the LinkName. Log that here since CNI will fail with the empty
+		// name.
+		if ni.LinkName == "" {
+			logger.Error("Failed to find LinkName for given MAC", logger.Fields{
+				"mac": ni.MacAddress,
+			})
+		}
+	}
+
+	return ni.LinkName
+}
+
+// IsStandardENI returns true if the NetworkInterface is a standard/regular NetworkInterface. That is, if it
+// has its association protocol as standard. To be backwards compatible, if the
+// association protocol is not set for an NetworkInterface, it's considered a standard NetworkInterface as well.
+func (ni *NetworkInterface) IsStandardENI() bool {
+	switch ni.InterfaceAssociationProtocol {
+	case "", DefaultInterfaceAssociationProtocol:
+		return true
+	case VLANInterfaceAssociationProtocol:
+		return false
+	default:
+		return false
+	}
+}
+
+// String returns a human-readable version of the NetworkInterface object
+func (ni *NetworkInterface) String() string {
+	var ipv4Addresses []string
+	for _, addr := range ni.IPV4Addresses {
+		ipv4Addresses = append(ipv4Addresses, addr.Address)
+	}
+	var ipv6Addresses []string
+	for _, addr := range ni.IPV6Addresses {
+		ipv6Addresses = append(ipv6Addresses, addr.Address)
+	}
+
+	eniString := ""
+
+	if len(ni.InterfaceAssociationProtocol) == 0 {
+		eniString += fmt.Sprintf(" ,NetworkInterface type: [%s]", ni.InterfaceAssociationProtocol)
+	}
+
+	if ni.InterfaceVlanProperties != nil {
+		eniString += fmt.Sprintf(" ,VLan ID: [%s], TrunkInterfaceMacAddress: [%s]",
+			ni.InterfaceVlanProperties.VlanID, ni.InterfaceVlanProperties.TrunkInterfaceMacAddress)
+	}
+
+	return fmt.Sprintf(
+		"eni id:%s, mac: %s, hostname: %s, ipv4addresses: [%s], ipv6addresses: [%s], dns: [%s], dns search: [%s],"+
+			" gateway ipv4: [%s][%s]", ni.ID, ni.MacAddress, ni.GetHostname(), strings.Join(ipv4Addresses, ","),
+		strings.Join(ipv6Addresses, ","), strings.Join(ni.DomainNameServers, ","),
+		strings.Join(ni.DomainNameSearchList, ","), ni.SubnetGatewayIPV4Address, eniString)
+}
+
+// IPV4Address is the ipv4 information of the eni
+type IPV4Address struct {
+	// Primary indicates whether the ip address is primary
+	Primary bool
+	// Address is the ipv4 address associated with eni
+	Address string
+}
+
+// IPV6Address is the ipv6 information of the eni
+type IPV6Address struct {
+	// Address is the ipv6 address associated with eni
+	Address string
+}
+
+// ENIFromACS validates the given ACS NetworkInterface information and creates an NetworkInterface object from it.
+func ENIFromACS(acsENI *ecsacs.ElasticNetworkInterface) (*NetworkInterface, error) {
+	err := ValidateENI(acsENI)
+	if err != nil {
+		return nil, err
+	}
+
+	var ipv4Addrs []*IPV4Address
+	var ipv6Addrs []*IPV6Address
+
+	// Read IPv4 address information of the NetworkInterface.
+	for _, ec2Ipv4 := range acsENI.Ipv4Addresses {
+		ipv4Addrs = append(ipv4Addrs, &IPV4Address{
+			Primary: aws.BoolValue(ec2Ipv4.Primary),
+			Address: aws.StringValue(ec2Ipv4.PrivateAddress),
+		})
+	}
+
+	// Read IPv6 address information of the NetworkInterface.
+	for _, ec2Ipv6 := range acsENI.Ipv6Addresses {
+		ipv6Addrs = append(ipv6Addrs, &IPV6Address{
+			Address: aws.StringValue(ec2Ipv6.Address),
+		})
+	}
+
+	// Read NetworkInterface association properties.
+	var interfaceVlanProperties InterfaceVlanProperties
+
+	if aws.StringValue(acsENI.InterfaceAssociationProtocol) == VLANInterfaceAssociationProtocol {
+		interfaceVlanProperties.TrunkInterfaceMacAddress = aws.StringValue(acsENI.InterfaceVlanProperties.TrunkInterfaceMacAddress)
+		interfaceVlanProperties.VlanID = aws.StringValue(acsENI.InterfaceVlanProperties.VlanId)
+	}
+
+	ni := &NetworkInterface{
+		ID:                           aws.StringValue(acsENI.Ec2Id),
+		MacAddress:                   aws.StringValue(acsENI.MacAddress),
+		IPV4Addresses:                ipv4Addrs,
+		IPV6Addresses:                ipv6Addrs,
+		SubnetGatewayIPV4Address:     aws.StringValue(acsENI.SubnetGatewayIpv4Address),
+		PrivateDNSName:               aws.StringValue(acsENI.PrivateDnsName),
+		InterfaceAssociationProtocol: aws.StringValue(acsENI.InterfaceAssociationProtocol),
+		InterfaceVlanProperties:      &interfaceVlanProperties,
+	}
+
+	for _, nameserverIP := range acsENI.DomainNameServers {
+		ni.DomainNameServers = append(ni.DomainNameServers, aws.StringValue(nameserverIP))
+	}
+	for _, nameserverDomain := range acsENI.DomainName {
+		ni.DomainNameSearchList = append(ni.DomainNameSearchList, aws.StringValue(nameserverDomain))
+	}
+
+	return ni, nil
+}
+
+// ValidateENI validates the NetworkInterface information sent from ACS.
+func ValidateENI(acsENI *ecsacs.ElasticNetworkInterface) error {
+	// At least one IPv4 address should be associated with the NetworkInterface.
+	if len(acsENI.Ipv4Addresses) < 1 {
+		return errors.Errorf("eni message validation: no ipv4 addresses in the message")
+	}
+
+	if acsENI.SubnetGatewayIpv4Address == nil {
+		return errors.Errorf("eni message validation: no subnet gateway ipv4 address in the message")
+	}
+	gwIPv4Addr := aws.StringValue(acsENI.SubnetGatewayIpv4Address)
+	s := strings.Split(gwIPv4Addr, "/")
+	if len(s) != 2 {
+		return errors.Errorf(
+			"eni message validation: invalid subnet gateway ipv4 address %s", gwIPv4Addr)
+	}
+
+	if acsENI.MacAddress == nil {
+		return errors.Errorf("eni message validation: empty eni mac address in the message")
+	}
+
+	if acsENI.Ec2Id == nil {
+		return errors.Errorf("eni message validation: empty eni id in the message")
+	}
+
+	// The association protocol, if specified, must be a supported value.
+	if (acsENI.InterfaceAssociationProtocol != nil) &&
+		(aws.StringValue(acsENI.InterfaceAssociationProtocol) != VLANInterfaceAssociationProtocol) &&
+		(aws.StringValue(acsENI.InterfaceAssociationProtocol) != DefaultInterfaceAssociationProtocol) {
+		return errors.Errorf("invalid interface association protocol: %s",
+			aws.StringValue(acsENI.InterfaceAssociationProtocol))
+	}
+
+	// If the interface association protocol is vlan, InterfaceVlanProperties must be specified.
+	if aws.StringValue(acsENI.InterfaceAssociationProtocol) == VLANInterfaceAssociationProtocol {
+		if acsENI.InterfaceVlanProperties == nil ||
+			len(aws.StringValue(acsENI.InterfaceVlanProperties.VlanId)) == 0 ||
+			len(aws.StringValue(acsENI.InterfaceVlanProperties.TrunkInterfaceMacAddress)) == 0 {
+			return errors.New("vlan interface properties missing")
+		}
+	}
+
+	return nil
+}
+
+// New creates a new NetworkInterface model.
+func New(
+	acsENI *ecsacs.ElasticNetworkInterface,
+	netNSName string,
+	netNSPath string,
+	guestNetNSName string,
+	peerInterface *ecsacs.ElasticNetworkInterface,
+) (*NetworkInterface, error) {
+	var err error
+
+	var networkInterface *NetworkInterface
+
+	interfaceAssociationProtocol := aws.StringValue(acsENI.InterfaceAssociationProtocol)
+
+	switch interfaceAssociationProtocol {
+
+	case V2NInterfaceAssociationProtocol:
+		// In case of V2N ENIs, network tunnel properties need to be included in the NetworkInterface object.
+		// This will be used in creating the GENEVE interface to connect the baremetal host and the BigMac tunnel.
+		networkInterface, err = v2nTunnelFromACS(acsENI)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal interface tunnel properties")
+		}
+
+	case VETHInterfaceAssociationProtocol:
+		networkInterface, err = vethPairFromACS(acsENI, peerInterface)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal interface veth properties")
+		}
+
+	// Standard ENIs (Default) and branch ENIs (VLANInterfaceAssociationProtocol) are both processed
+	// by the common NetworkInterface handler.
+	default:
+		// Acquire the NetworkInterface information from the payload.
+		networkInterface, err = ENIFromACS(acsENI)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal eni")
+		}
+
+		// Historically, if there is no interface association protocol in the NetworkInterface payload, we assume
+		// it is a standard NetworkInterface. For more context, see the `IsStandardENI()` method in the `ecseni` model.
+		if networkInterface.InterfaceAssociationProtocol == "" {
+			networkInterface.InterfaceAssociationProtocol = DefaultInterfaceAssociationProtocol
+		}
+	}
+
+	networkInterface.Index = aws.Int64Value(acsENI.Index)
+	networkInterface.Name = GetENIName(acsENI)
+	networkInterface.KnownStatus = StatusNone
+	networkInterface.DesiredStatus = StatusReadyPull
+	networkInterface.NetNSName = netNSName
+	networkInterface.NetNSPath = netNSPath
+	networkInterface.GuestNetNSName = guestNetNSName
+
+	return networkInterface, nil
+}
+
+// setDeviceName sets the device name for the NetworkInterface based on its type and MAC address.
+func (ni *NetworkInterface) setDeviceName(macToName map[string]string) error {
+	switch ni.InterfaceAssociationProtocol {
+	case DefaultInterfaceAssociationProtocol:
+		name, ok := macToName[ni.MacAddress]
+		if !ok {
+			// This should never happen in theory. ACS can only send the payload message once
+			// Agent has acknowledged attachment on the instance. However, we have found that
+			// in some instances, EC2 detaches the NetworkInterface after attaching it when there are
+			// asynchornous errors in the NetworkInterface attachment workflow. We return a typed error in
+			// such scenarios to ensure that we don't get paged when that happens.
+			return NewUnableToFindENIError(ni.MacAddress, ni.InterfaceAssociationProtocol)
+		}
+		ni.DeviceName = name
+	case VLANInterfaceAssociationProtocol:
+		// We don't need to find the name for a branch NetworkInterface as it's just a vlan association.
+		// Get the name of the trunk interface since we need it for constructing the
+		// name of the branch interface.
+		trunkName, ok := macToName[ni.InterfaceVlanProperties.TrunkInterfaceMacAddress]
+		if !ok {
+			// Same as above. Guard against edge-cases where we're unable to find the trunk
+			// NetworkInterface because of internal EC2 errors.
+			return NewUnableToFindENIError(
+				ni.InterfaceVlanProperties.TrunkInterfaceMacAddress, ni.InterfaceAssociationProtocol)
+		}
+		// Name of the branch is based on the vlan id and the name of the trunk.
+		// Example: eth1.24, where trunk is attached as `eth1` and vlan id is `24`.
+		ni.DeviceName = fmt.Sprintf("%s.%s", trunkName, ni.InterfaceVlanProperties.VlanID)
+	default:
+		// Do nothing.
+	}
+	return nil
+}
+
+// IsPrimary returns whether the NetworkInterface is the primary NetworkInterface of the task.
+func (ni *NetworkInterface) IsPrimary() bool {
+	return ni.Index == 0
+}
+
+// ShouldGenerateNetworkConfigFiles can be used to check if network configuration files (hosts,
+// hostname and resolv.conf) need to be generated using this eni's information. In case of warmpool,
+// network config files should only be generated for primary ENIs. But as part of multi-NetworkInterface implementation
+// it was decided that for firecracker platform the files had to be generated for secondary ENIs as well.
+// Hence the NetworkInterface IsPrimary check was moved from here to warmpool specific APIs.
+func (ni *NetworkInterface) ShouldGenerateNetworkConfigFiles() bool {
+	return ni.DesiredStatus == StatusReadyPull
+}
+
+// GetENIName creates the NetworkInterface name from the NetworkInterface mac address in case it is empty in the ACS payload.
+func GetENIName(acsENI *ecsacs.ElasticNetworkInterface) string {
+	if acsENI.Name != nil {
+		return aws.StringValue(acsENI.Name)
+	}
+
+	return strings.ReplaceAll(aws.StringValue(acsENI.MacAddress), ":", "")
+}
+
+// v2nTunnelFromACS creates an NetworkInterface model with V2N tunnel properties from the ACS NetworkInterface payload.
+func v2nTunnelFromACS(acsENI *ecsacs.ElasticNetworkInterface) (*NetworkInterface, error) {
+	// We only require the association protocol and the mac address.
+	// Mac address is needed primarily because according to current logic, this mac address is assigned to the
+	// interface that gets attached inside the MicroVM. The mac address is also used to find the interface inside
+	// the MicroVM to move it to the desired network namespace when the network topology inside the MicroVM is setup.
+
+	acsTunnelProperties := acsENI.InterfaceTunnelProperties
+	if acsTunnelProperties == nil {
+		return nil, errors.New("interface tunnel properties not found in payload")
+	}
+	if acsTunnelProperties.TunnelId == nil {
+		return nil, errors.New("tunnel ID not found in payload")
+	}
+	if acsTunnelProperties.InterfaceIpAddress == nil {
+		return nil, errors.New("tunnel interface IP not found in payload")
+	}
+
+	return &NetworkInterface{
+			InterfaceAssociationProtocol: V2NInterfaceAssociationProtocol,
+			SubnetGatewayIPV4Address:     DefaultGeneveInterfaceGateway,
+
+			IPV4Addresses: []*IPV4Address{
+				{
+					Address: DefaultGeneveInterfaceIPAddress,
+				},
+			},
+
+			DomainNameServers:    aws.StringValueSlice(acsENI.DomainNameServers),
+			DomainNameSearchList: aws.StringValueSlice(acsENI.DomainName),
+			TunnelProperties: &TunnelProperties{
+				ID:                   aws.StringValue(acsTunnelProperties.TunnelId),
+				DestinationIPAddress: aws.StringValue(acsTunnelProperties.InterfaceIpAddress),
+			},
+		},
+		nil
+}
+
+// vethPairFromACS creates an NetworkInterface model with veth pair properties from the ACS NetworkInterface payload.
+func vethPairFromACS(
+	acsENI *ecsacs.ElasticNetworkInterface,
+	peerInterface *ecsacs.ElasticNetworkInterface) (*NetworkInterface, error) {
+	if acsENI.InterfaceVethProperties == nil ||
+		acsENI.InterfaceVethProperties.PeerInterface == nil {
+		return nil, errors.New("interface veth properties not found in payload")
+	}
+	if aws.StringValue(peerInterface.InterfaceAssociationProtocol) == VETHInterfaceAssociationProtocol {
+		return nil, errors.New("peer interface cannot be veth")
+	}
+
+	return &NetworkInterface{
+			InterfaceAssociationProtocol: VETHInterfaceAssociationProtocol,
+
+			// DNS related data for VETH interface will be copied from the peer interface's DNS data.
+			// This is because if default traffic of the container needs to use the VETH interface,
+			// domain name resolution will be based on the DNS config of the peer interface.
+			DomainNameServers:    aws.StringValueSlice(peerInterface.DomainNameServers),
+			DomainNameSearchList: aws.StringValueSlice(peerInterface.DomainName),
+			VETHProperties: &VETHProperties{
+				PeerInterfaceName: aws.StringValue(acsENI.InterfaceVethProperties.PeerInterface),
+			},
+		},
+		nil
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface_status.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface_status.go
@@ -1,0 +1,42 @@
+package networkinterface
+
+// Status represents the status of an ENI resource.
+type Status string
+
+const (
+	// StatusNone is the initial staus of the ENI.
+	StatusNone Status = "NONE"
+	// StatusReadyPull indicates that the ENI is ready for downloading resources associated with
+	// the execution role. This includes container images, task secrets and configs.
+	StatusReadyPull Status = "READY_PULL"
+	// StatusReady indicates that the ENI is ready for use by containers in the task.
+	StatusReady Status = "READY"
+	// StatusDeleted indicates that the ENI is deleted.
+	StatusDeleted Status = "DELETED"
+)
+
+var (
+	eniStatusOrder = map[Status]int{
+		StatusNone:      0,
+		StatusReadyPull: 1,
+		StatusReady:     2,
+		StatusDeleted:   3,
+	}
+)
+
+func (es Status) String() string {
+	return string(es)
+}
+
+func (es Status) StatusBackwards(es2 Status) bool {
+	return eniStatusOrder[es] < eniStatusOrder[es2]
+}
+
+func GetAllStatuses() []Status {
+	return []Status{
+		StatusNone,
+		StatusReadyPull,
+		StatusReady,
+		StatusDeleted,
+	}
+}

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -32,6 +32,8 @@ github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/request
 github.com/aws/amazon-ecs-agent/ecs-agent/logger/field
 github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon
 github.com/aws/amazon-ecs-agent/ecs-agent/metrics
+github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh
+github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface
 github.com/aws/amazon-ecs-agent/ecs-agent/stats
 github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client
 github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler

--- a/ecs-agent/acs/session/attach_eni_common.go
+++ b/ecs-agent/acs/session/attach_eni_common.go
@@ -13,10 +13,8 @@
 
 package session
 
-import (
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
-)
+import ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 
 type ENIHandler interface {
-	HandleENIAttachment(eniAttachment *apieni.ENIAttachment) error
+	HandleENIAttachment(eniAttachment *ni.ENIAttachment) error
 }

--- a/ecs-agent/acs/session/attach_instance_eni_responder.go
+++ b/ecs-agent/acs/session/attach_instance_eni_responder.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/wsclient"
 )
 
@@ -98,7 +98,7 @@ func (r *attachInstanceENIResponder) handleAttachMessage(message *ecsacs.AttachI
 func (r *attachInstanceENIResponder) handleInstanceENIFromMessage(eni *ecsacs.ElasticNetworkInterface,
 	messageID, clusterARN, containerInstanceARN string, receivedAt time.Time, waitTimeoutMs int64) {
 	expiresAt := receivedAt.Add(time.Duration(waitTimeoutMs) * time.Millisecond)
-	err := r.eniHandler.HandleENIAttachment(&apieni.ENIAttachment{
+	err := r.eniHandler.HandleENIAttachment(&ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			AttachmentARN:        aws.StringValue(eni.AttachmentArn),
 			Status:               status.AttachmentNone,
@@ -107,7 +107,7 @@ func (r *attachInstanceENIResponder) handleInstanceENIFromMessage(eni *ecsacs.El
 			ClusterARN:           clusterARN,
 			ContainerInstanceARN: containerInstanceARN,
 		},
-		AttachmentType: apieni.ENIAttachmentTypeInstanceENI,
+		AttachmentType: ni.ENIAttachmentTypeInstanceENI,
 		MACAddress:     aws.StringValue(eni.MacAddress),
 	})
 	if err != nil {
@@ -151,7 +151,7 @@ func validateAttachInstanceNetworkInterfacesMessage(message *ecsacs.AttachInstan
 	}
 
 	for _, eni := range enis {
-		err := apieni.ValidateENI(eni)
+		err := ni.ValidateENI(eni)
 		if err != nil {
 			return err
 		}

--- a/ecs-agent/acs/session/attach_instance_eni_responder_test.go
+++ b/ecs-agent/acs/session/attach_instance_eni_responder_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
 	mock_session "github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/mocks"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/testconst"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 )
 
 var testAttachInstanceENIMessage = &ecsacs.AttachInstanceNetworkInterfacesMessage{
@@ -177,7 +177,7 @@ func TestAttachInstanceENIMessageWithInvalidNetworkDetails(t *testing.T) {
 	assert.EqualError(t, err, fmt.Sprintf("invalid interface association protocol: %s",
 		aws.StringValue(unsupportedInterfaceAssociationProtocol)))
 	testAttachInstanceENIMessage.ElasticNetworkInterfaces[0].InterfaceAssociationProtocol =
-		aws.String(apieni.VLANInterfaceAssociationProtocol)
+		aws.String(ni.VLANInterfaceAssociationProtocol)
 	err = validateAttachInstanceNetworkInterfacesMessage(testAttachInstanceENIMessage)
 	assert.EqualError(t, err, "vlan interface properties missing")
 	testAttachInstanceENIMessage.ElasticNetworkInterfaces[0].InterfaceAssociationProtocol =

--- a/ecs-agent/acs/session/attach_task_eni_responder.go
+++ b/ecs-agent/acs/session/attach_task_eni_responder.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/wsclient"
 )
 
@@ -99,7 +99,7 @@ func (r *attachTaskENIResponder) handleAttachMessage(message *ecsacs.AttachTaskN
 func (r *attachTaskENIResponder) handleTaskENIFromMessage(eni *ecsacs.ElasticNetworkInterface,
 	messageID, taskARN, clusterARN, containerInstanceARN string, receivedAt time.Time, waitTimeoutMs int64) {
 	expiresAt := receivedAt.Add(time.Duration(waitTimeoutMs) * time.Millisecond)
-	err := r.eniHandler.HandleENIAttachment(&apieni.ENIAttachment{
+	err := r.eniHandler.HandleENIAttachment(&ni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			TaskARN:              taskARN,
 			AttachmentARN:        aws.StringValue(eni.AttachmentArn),
@@ -109,7 +109,7 @@ func (r *attachTaskENIResponder) handleTaskENIFromMessage(eni *ecsacs.ElasticNet
 			ClusterARN:           clusterARN,
 			ContainerInstanceARN: containerInstanceARN,
 		},
-		AttachmentType: apieni.ENIAttachmentTypeTaskENI,
+		AttachmentType: ni.ENIAttachmentTypeTaskENI,
 		MACAddress:     aws.StringValue(eni.MacAddress),
 	})
 	if err != nil {
@@ -158,7 +158,7 @@ func validateAttachTaskNetworkInterfacesMessage(message *ecsacs.AttachTaskNetwor
 	}
 
 	for _, eni := range enis {
-		err := apieni.ValidateENI(eni)
+		err := ni.ValidateENI(eni)
 		if err != nil {
 			return err
 		}

--- a/ecs-agent/acs/session/attach_task_eni_responder_test.go
+++ b/ecs-agent/acs/session/attach_task_eni_responder_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/testconst"
-	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 )
 
 var testAttachTaskENIMessage = &ecsacs.AttachTaskNetworkInterfacesMessage{
@@ -175,7 +175,7 @@ func TestAttachTaskENIMessageWithInvalidNetworkDetails(t *testing.T) {
 	assert.EqualError(t, err, fmt.Sprintf("invalid interface association protocol: %s",
 		aws.StringValue(unsupportedInterfaceAssociationProtocol)))
 	testAttachTaskENIMessage.ElasticNetworkInterfaces[0].InterfaceAssociationProtocol =
-		aws.String(apieni.VLANInterfaceAssociationProtocol)
+		aws.String(ni.VLANInterfaceAssociationProtocol)
 	err = validateAttachTaskNetworkInterfacesMessage(testAttachTaskENIMessage)
 	assert.EqualError(t, err, "vlan interface properties missing")
 	testAttachTaskENIMessage.ElasticNetworkInterfaces[0].InterfaceAssociationProtocol = tempInterfaceAssociationProtocol

--- a/ecs-agent/acs/session/mocks/session_mock.go
+++ b/ecs-agent/acs/session/mocks/session_mock.go
@@ -22,8 +22,8 @@ import (
 	reflect "reflect"
 
 	ecsacs "github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
-	eni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	resource "github.com/aws/amazon-ecs-agent/ecs-agent/api/resource"
+	networkinterface "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -51,7 +51,7 @@ func (m *MockENIHandler) EXPECT() *MockENIHandlerMockRecorder {
 }
 
 // HandleENIAttachment mocks base method.
-func (m *MockENIHandler) HandleENIAttachment(arg0 *eni.ENIAttachment) error {
+func (m *MockENIHandler) HandleENIAttachment(arg0 *networkinterface.ENIAttachment) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleENIAttachment", arg0)
 	ret0, _ := ret[0].(error)

--- a/ecs-agent/api/eni/eni.go
+++ b/ecs-agent/api/eni/eni.go
@@ -36,9 +36,9 @@ type ENI struct {
 	// MacAddress is the mac address of the eni
 	MacAddress string
 	// IPV4Addresses is the ipv4 address associated with the eni
-	IPV4Addresses []*ENIIPV4Address
+	IPV4Addresses []*IPV4Address
 	// IPV6Addresses is the ipv6 address associated with the eni
-	IPV6Addresses []*ENIIPV6Address
+	IPV6Addresses []*IPV6Address
 	// SubnetGatewayIPV4Address is the IPv4 address of the subnet gateway of the ENI
 	SubnetGatewayIPV4Address string `json:",omitempty"`
 	// DomainNameServers specifies the nameserver IP addresses for the eni
@@ -272,16 +272,16 @@ func (eni *ENI) String() string {
 		strings.Join(eni.DomainNameSearchList, ","), eni.SubnetGatewayIPV4Address, eniString)
 }
 
-// ENIIPV4Address is the ipv4 information of the eni
-type ENIIPV4Address struct {
+// IPV4Address is the ipv4 information of the eni
+type IPV4Address struct {
 	// Primary indicates whether the ip address is primary
 	Primary bool
 	// Address is the ipv4 address associated with eni
 	Address string
 }
 
-// ENIIPV6Address is the ipv6 information of the eni
-type ENIIPV6Address struct {
+// IPV6Address is the ipv6 information of the eni
+type IPV6Address struct {
 	// Address is the ipv6 address associated with eni
 	Address string
 }
@@ -293,12 +293,12 @@ func ENIFromACS(acsENI *ecsacs.ElasticNetworkInterface) (*ENI, error) {
 		return nil, err
 	}
 
-	var ipv4Addrs []*ENIIPV4Address
-	var ipv6Addrs []*ENIIPV6Address
+	var ipv4Addrs []*IPV4Address
+	var ipv6Addrs []*IPV6Address
 
 	// Read IPv4 address information of the ENI.
 	for _, ec2Ipv4 := range acsENI.Ipv4Addresses {
-		ipv4Addrs = append(ipv4Addrs, &ENIIPV4Address{
+		ipv4Addrs = append(ipv4Addrs, &IPV4Address{
 			Primary: aws.BoolValue(ec2Ipv4.Primary),
 			Address: aws.StringValue(ec2Ipv4.PrivateAddress),
 		})
@@ -306,7 +306,7 @@ func ENIFromACS(acsENI *ecsacs.ElasticNetworkInterface) (*ENI, error) {
 
 	// Read IPv6 address information of the ENI.
 	for _, ec2Ipv6 := range acsENI.Ipv6Addresses {
-		ipv6Addrs = append(ipv6Addrs, &ENIIPV6Address{
+		ipv6Addrs = append(ipv6Addrs, &IPV6Address{
 			Address: aws.StringValue(ec2Ipv6.Address),
 		})
 	}

--- a/ecs-agent/api/eni/eni_test.go
+++ b/ecs-agent/api/eni/eni_test.go
@@ -51,13 +51,13 @@ var (
 	testENI = &ENI{
 		ID:                           "eni-123",
 		InterfaceAssociationProtocol: DefaultInterfaceAssociationProtocol,
-		IPV4Addresses: []*ENIIPV4Address{
+		IPV4Addresses: []*IPV4Address{
 			{
 				Primary: true,
 				Address: ipv4Addr,
 			},
 		},
-		IPV6Addresses: []*ENIIPV6Address{
+		IPV6Addresses: []*IPV6Address{
 			{
 				Address: ipv6Addr,
 			},

--- a/ecs-agent/netlib/model/appmesh/appmesh.go
+++ b/ecs-agent/netlib/model/appmesh/appmesh.go
@@ -1,0 +1,127 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package appmesh
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+const (
+	appMesh                    = "APPMESH"
+	splitter                   = ","
+	ignoredUID                 = "IgnoredUID"
+	ignoredGID                 = "IgnoredGID"
+	proxyIngressPort           = "ProxyIngressPort"
+	proxyEgressPort            = "ProxyEgressPort"
+	appPorts                   = "AppPorts"
+	egressIgnoredIPs           = "EgressIgnoredIPs"
+	egressIgnoredPorts         = "EgressIgnoredPorts"
+	taskMetadataEndpointIP     = "169.254.170.2"
+	instanceMetadataEndpointIP = "169.254.169.254"
+)
+
+// AppMesh contains information of app mesh config
+type AppMesh struct {
+	// ContainerName is the proxy container name
+	ContainerName string
+	// IgnoredUID is egress traffic from the processes owned by the UID will be ignored
+	IgnoredUID string
+	// IgnoredGID specifies egress traffic from the processes owned by the GID will be ignored
+	IgnoredGID string
+	// ProxyIngressPort is the ingress port number that proxy is listening on
+	ProxyIngressPort string
+	// ProxyEgressPort is the egress port number that proxy is listening on
+	ProxyEgressPort string
+	// AppPorts is the port number that application is listening on
+	AppPorts []string
+	// EgressIgnoredIPs is the list of IPs for which egress traffic will be ignored
+	EgressIgnoredIPs []string
+	// EgressIgnoredPorts is the list of ports for which egress traffic will be ignored
+	EgressIgnoredPorts []string
+}
+
+// AppMeshFromACS validates proxy config if it is app mesh type and creates AppMesh object
+func AppMeshFromACS(proxyConfig *ecsacs.ProxyConfiguration) (*AppMesh, error) {
+
+	if *proxyConfig.Type != appMesh {
+		return nil, fmt.Errorf("agent does not support proxy type other than app mesh")
+	}
+
+	return &AppMesh{
+		ContainerName:      aws.StringValue(proxyConfig.ContainerName),
+		IgnoredUID:         aws.StringValue(proxyConfig.Properties[ignoredUID]),
+		IgnoredGID:         aws.StringValue(proxyConfig.Properties[ignoredGID]),
+		ProxyIngressPort:   aws.StringValue(proxyConfig.Properties[proxyIngressPort]),
+		ProxyEgressPort:    aws.StringValue(proxyConfig.Properties[proxyEgressPort]),
+		AppPorts:           buildAppPorts(proxyConfig),
+		EgressIgnoredIPs:   buildEgressIgnoredIPs(proxyConfig),
+		EgressIgnoredPorts: buildEgressIgnoredPorts(proxyConfig),
+	}, nil
+}
+
+// buildAppPorts creates app ports from proxy config
+func buildAppPorts(proxyConfig *ecsacs.ProxyConfiguration) []string {
+	var inputAppPorts []string
+	if proxyConfig.Properties[appPorts] != nil && len(*proxyConfig.Properties[appPorts]) > 0 {
+		inputAppPorts = strings.Split(*proxyConfig.Properties[appPorts], splitter)
+	}
+	return inputAppPorts
+}
+
+// buildEgressIgnoredIPs creates egress ignored IPs from proxy config
+func buildEgressIgnoredIPs(proxyConfig *ecsacs.ProxyConfiguration) []string {
+	var inputEgressIgnoredIPs []string
+	if proxyConfig.Properties[egressIgnoredIPs] != nil && len(*proxyConfig.Properties[egressIgnoredIPs]) > 0 {
+		inputEgressIgnoredIPs = strings.Split(*proxyConfig.Properties[egressIgnoredIPs], splitter)
+	}
+	// append agent default egress ignored IPs
+	return appendDefaultEgressIgnoredIPs(inputEgressIgnoredIPs)
+}
+
+// buildEgressIgnoredPorts creates egress ignored ports from proxy config
+func buildEgressIgnoredPorts(proxyConfig *ecsacs.ProxyConfiguration) []string {
+	var inputEgressIgnoredPorts []string
+	if proxyConfig.Properties[egressIgnoredPorts] != nil && len(*proxyConfig.Properties[egressIgnoredPorts]) > 0 {
+		inputEgressIgnoredPorts = strings.Split(*proxyConfig.Properties[egressIgnoredPorts], splitter)
+	}
+	return inputEgressIgnoredPorts
+}
+
+// appendDefaultEgressIgnoredIPs append task metadata endpoint ip and
+// instance metadata ip address to egress ignored IPs if does not exist
+func appendDefaultEgressIgnoredIPs(egressIgnoredIPs []string) []string {
+	hasTaskMetadataEndpointIP := false
+	hasInstanceMetadataEndpointIP := false
+	for _, egressIgnoredIP := range egressIgnoredIPs {
+		if strings.TrimSpace(egressIgnoredIP) == taskMetadataEndpointIP {
+			hasTaskMetadataEndpointIP = true
+		}
+		if strings.TrimSpace(egressIgnoredIP) == instanceMetadataEndpointIP {
+			hasInstanceMetadataEndpointIP = true
+		}
+	}
+
+	if !hasTaskMetadataEndpointIP {
+		egressIgnoredIPs = append(egressIgnoredIPs, taskMetadataEndpointIP)
+	}
+	if !hasInstanceMetadataEndpointIP {
+		egressIgnoredIPs = append(egressIgnoredIPs, instanceMetadataEndpointIP)
+	}
+
+	return egressIgnoredIPs
+}

--- a/ecs-agent/netlib/model/appmesh/appmesh_test.go
+++ b/ecs-agent/netlib/model/appmesh/appmesh_test.go
@@ -1,0 +1,147 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package appmesh
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	mockEgressIgnoredIP1   = "128.0.0.1"
+	mockEgressIgnoredIP2   = "171.1.3.24"
+	mockAppPort1           = "8000"
+	mockAppPort2           = "8001"
+	mockEgressIgnoredPort1 = "13000"
+	mockEgressIgnoredPort2 = "13001"
+	mockIgnoredUID         = "1337"
+	mockIgnoredGID         = "2339"
+	mockProxyIngressPort   = "9000"
+	mockProxyEgressPort    = "9001"
+	mockAppPorts           = mockAppPort1 + splitter + mockAppPort2
+	mockEgressIgnoredIPs   = mockEgressIgnoredIP1 + splitter + mockEgressIgnoredIP2
+	mockEgressIgnoredPorts = mockEgressIgnoredPort1 + splitter + mockEgressIgnoredPort2
+	mockContainerName      = "testEnvoyContainer"
+)
+
+func TestAppMeshFromACS(t *testing.T) {
+	testProxyConfig := prepareProxyConfig()
+
+	appMesh, err := AppMeshFromACS(&testProxyConfig)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, appMesh)
+	assert.Equal(t, mockContainerName, appMesh.ContainerName)
+	assert.Equal(t, mockIgnoredUID, appMesh.IgnoredUID)
+	assert.Equal(t, mockIgnoredGID, appMesh.IgnoredGID)
+	assert.Equal(t, mockProxyEgressPort, appMesh.ProxyEgressPort)
+	assert.Equal(t, mockProxyIngressPort, appMesh.ProxyIngressPort)
+	assert.Equal(t, mockAppPort1, appMesh.AppPorts[0])
+	assert.Equal(t, mockAppPort2, appMesh.AppPorts[1])
+	assert.Equal(t, mockEgressIgnoredIP1, appMesh.EgressIgnoredIPs[0])
+	assert.Equal(t, mockEgressIgnoredIP2, appMesh.EgressIgnoredIPs[1])
+	assert.Equal(t, taskMetadataEndpointIP, appMesh.EgressIgnoredIPs[2])
+	assert.Equal(t, instanceMetadataEndpointIP, appMesh.EgressIgnoredIPs[3])
+	assert.Equal(t, mockEgressIgnoredPort1, appMesh.EgressIgnoredPorts[0])
+	assert.Equal(t, mockEgressIgnoredPort2, appMesh.EgressIgnoredPorts[1])
+}
+
+func TestAppMeshFromACSContainsDefaultEgressIgnoredIP(t *testing.T) {
+	testProxyConfig := prepareProxyConfig()
+	egressIgnoredIPs := mockEgressIgnoredIPs + splitter + taskMetadataEndpointIP + splitter + instanceMetadataEndpointIP
+	testProxyConfig.Properties[egressIgnoredIPs] = aws.String(egressIgnoredIPs)
+
+	appMesh, err := AppMeshFromACS(&testProxyConfig)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, appMesh)
+	assert.Equal(t, mockIgnoredUID, appMesh.IgnoredUID)
+	assert.Equal(t, mockIgnoredGID, appMesh.IgnoredGID)
+	assert.Equal(t, mockProxyEgressPort, appMesh.ProxyEgressPort)
+	assert.Equal(t, mockProxyIngressPort, appMesh.ProxyIngressPort)
+	assert.Equal(t, mockAppPort1, appMesh.AppPorts[0])
+	assert.Equal(t, mockAppPort2, appMesh.AppPorts[1])
+	assert.Equal(t, mockEgressIgnoredIP1, appMesh.EgressIgnoredIPs[0])
+	assert.Equal(t, mockEgressIgnoredIP2, appMesh.EgressIgnoredIPs[1])
+	assert.Equal(t, taskMetadataEndpointIP, appMesh.EgressIgnoredIPs[2])
+	assert.Equal(t, instanceMetadataEndpointIP, appMesh.EgressIgnoredIPs[3])
+	assert.Equal(t, mockEgressIgnoredPort1, appMesh.EgressIgnoredPorts[0])
+	assert.Equal(t, mockEgressIgnoredPort2, appMesh.EgressIgnoredPorts[1])
+}
+
+func TestAppMeshFromACSNonAppMeshProxyInput(t *testing.T) {
+	someOtherProxyType := "fooProxy"
+	testProxyConfig := prepareProxyConfig()
+	testProxyConfig.Type = &someOtherProxyType
+
+	_, err := AppMeshFromACS(&testProxyConfig)
+
+	assert.Error(t, err)
+}
+
+func TestAppMeshEmptyAppPorts(t *testing.T) {
+	emptyAppPorts := ""
+	testProxyConfig := prepareProxyConfig()
+	testProxyConfig.Properties[appPorts] = &emptyAppPorts
+
+	appMesh, err := AppMeshFromACS(&testProxyConfig)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(appMesh.AppPorts))
+}
+
+func TestAppMeshEmptyIgnoredIPs(t *testing.T) {
+	emptyIgnoredIPs := ""
+	testProxyConfig := prepareProxyConfig()
+	testProxyConfig.Properties[egressIgnoredIPs] = &emptyIgnoredIPs
+
+	appMesh, err := AppMeshFromACS(&testProxyConfig)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(appMesh.EgressIgnoredIPs))
+}
+
+func TestAppMeshEmptyIgnoredPorts(t *testing.T) {
+	emptyIgnoredPorts := ""
+	testProxyConfig := prepareProxyConfig()
+	testProxyConfig.Properties[egressIgnoredPorts] = &emptyIgnoredPorts
+
+	appMesh, err := AppMeshFromACS(&testProxyConfig)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(appMesh.EgressIgnoredPorts))
+}
+
+func prepareProxyConfig() ecsacs.ProxyConfiguration {
+
+	return ecsacs.ProxyConfiguration{
+		Type: aws.String(appMesh),
+		Properties: map[string]*string{
+			ignoredUID:         aws.String(mockIgnoredUID),
+			ignoredGID:         aws.String(mockIgnoredGID),
+			proxyIngressPort:   aws.String(mockProxyIngressPort),
+			proxyEgressPort:    aws.String(mockProxyEgressPort),
+			appPorts:           aws.String(mockAppPorts),
+			egressIgnoredIPs:   aws.String(mockEgressIgnoredIPs),
+			egressIgnoredPorts: aws.String(mockEgressIgnoredPorts),
+		},
+		ContainerName: aws.String(mockContainerName),
+	}
+}

--- a/ecs-agent/netlib/model/networkinterface/eniattachment.go
+++ b/ecs-agent/netlib/model/networkinterface/eniattachment.go
@@ -1,0 +1,165 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package networkinterface
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/arn"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// ENIAttachmentTypeTaskENI represents the type of a task level eni
+	ENIAttachmentTypeTaskENI = "task-eni"
+	// ENIAttachmentTypeInstanceENI represents the type of an instance level eni
+	ENIAttachmentTypeInstanceENI = "instance-eni"
+)
+
+// ENIAttachment contains the information of the eni attachment
+type ENIAttachment struct {
+	attachmentinfo.AttachmentInfo
+	// AttachmentType is the type of the eni attachment, can either be "task-eni" or "instance-eni"
+	AttachmentType string `json:"attachmentType"`
+	// MACAddress is the mac address of eni
+	MACAddress string `json:"macAddress"`
+	// ackTimer is used to register the expiration timeout callback for unsuccessful
+	// ENI attachments
+	ackTimer ttime.Timer
+	// guard protects access to fields of this struct
+	guard sync.RWMutex
+}
+
+func getEniAttachmentLogFields(eni *ENIAttachment, duration time.Duration) logger.Fields {
+	fields := logger.Fields{
+		"duration":       duration.String(),
+		"attachmentARN":  eni.AttachmentARN,
+		"attachmentType": eni.AttachmentType,
+		"attachmentSent": eni.AttachStatusSent,
+		"mac":            eni.MACAddress,
+		"status":         eni.Status.String(),
+		"expiresAt":      eni.ExpiresAt.Format(time.RFC3339),
+	}
+
+	if eni.AttachmentType != ENIAttachmentTypeInstanceENI {
+		taskId, _ := arn.TaskIdFromArn(eni.TaskARN)
+		fields[field.TaskID] = taskId
+	}
+
+	return fields
+}
+
+// StartTimer starts the ack timer to record the expiration of ENI attachment
+func (eni *ENIAttachment) StartTimer(timeoutFunc func()) error {
+	eni.guard.Lock()
+	defer eni.guard.Unlock()
+
+	if eni.ackTimer != nil {
+		// The timer has already been initialized, do nothing
+		return nil
+	}
+	now := time.Now()
+	duration := eni.ExpiresAt.Sub(now)
+	if duration <= 0 {
+		return errors.Errorf("eni attachment: timer expiration is in the past; expiration [%s] < now [%s]",
+			eni.ExpiresAt.String(), now.String())
+	}
+	logger.Info("Starting ENI ack timer", getEniAttachmentLogFields(eni, duration))
+	eni.ackTimer = time.AfterFunc(duration, timeoutFunc)
+	return nil
+}
+
+// Initialize initializes the fields that can't be populated from loading state file.
+// Notably, this initializes the ack timer so that if we times out waiting for the eni to be attached, the attachment
+// can be removed from state.
+func (eni *ENIAttachment) Initialize(timeoutFunc func()) error {
+	eni.guard.Lock()
+	defer eni.guard.Unlock()
+
+	if eni.AttachStatusSent { // eni attachment status has been sent, no need to start ack timer.
+		return nil
+	}
+
+	now := time.Now()
+	duration := eni.ExpiresAt.Sub(now)
+	if duration <= 0 {
+		return errors.New("ENI attachment has already expired")
+	}
+
+	logger.Info("Starting ENI ack timer", getEniAttachmentLogFields(eni, duration))
+	eni.ackTimer = time.AfterFunc(duration, timeoutFunc)
+	return nil
+}
+
+// IsSent checks if the eni attached status has been sent
+func (eni *ENIAttachment) IsSent() bool {
+	eni.guard.RLock()
+	defer eni.guard.RUnlock()
+
+	return eni.AttachStatusSent
+}
+
+// SetSentStatus marks the eni attached status has been sent
+func (eni *ENIAttachment) SetSentStatus() {
+	eni.guard.Lock()
+	defer eni.guard.Unlock()
+
+	eni.AttachStatusSent = true
+}
+
+// StopAckTimer stops the ack timer set on the ENI attachment
+func (eni *ENIAttachment) StopAckTimer() {
+	eni.guard.Lock()
+	defer eni.guard.Unlock()
+
+	eni.ackTimer.Stop()
+}
+
+// HasExpired returns true if the ENI attachment object has exceeded the
+// threshold for notifying the backend of the attachment
+func (eni *ENIAttachment) HasExpired() bool {
+	eni.guard.RLock()
+	defer eni.guard.RUnlock()
+
+	return time.Now().After(eni.ExpiresAt)
+}
+
+// String returns a string representation of the ENI Attachment
+func (eni *ENIAttachment) String() string {
+	eni.guard.RLock()
+	defer eni.guard.RUnlock()
+
+	return eni.stringUnsafe()
+}
+
+// stringUnsafe returns a string representation of the ENI Attachment
+func (eni *ENIAttachment) stringUnsafe() string {
+	// skip TaskArn field for instance level eni attachment since it won't have a task arn
+	if eni.AttachmentType == ENIAttachmentTypeInstanceENI {
+		return fmt.Sprintf(
+			"ENI Attachment: attachment=%s attachmentType=%s attachmentSent=%t mac=%s status=%s expiresAt=%s",
+			eni.AttachmentARN, eni.AttachmentType, eni.AttachStatusSent, eni.MACAddress, eni.Status.String(), eni.ExpiresAt.Format(time.RFC3339))
+	}
+
+	return fmt.Sprintf(
+		"ENI Attachment: task=%s attachment=%s attachmentType=%s attachmentSent=%t mac=%s status=%s expiresAt=%s",
+		eni.TaskARN, eni.AttachmentARN, eni.AttachmentType, eni.AttachStatusSent, eni.MACAddress, eni.Status.String(), eni.ExpiresAt.Format(time.RFC3339))
+}

--- a/ecs-agent/netlib/model/networkinterface/eniattachment_test.go
+++ b/ecs-agent/netlib/model/networkinterface/eniattachment_test.go
@@ -1,0 +1,189 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package networkinterface
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/status"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	taskARN        = "t1"
+	attachmentARN  = "att1"
+	mac            = "mac1"
+	attachSent     = true
+	attachmentType = "eni"
+)
+
+func TestMarshalUnmarshal(t *testing.T) {
+	expiresAt := time.Now()
+	attachment := &ENIAttachment{
+		AttachmentInfo: attachmentinfo.AttachmentInfo{
+			TaskARN:          taskARN,
+			AttachmentARN:    attachmentARN,
+			AttachStatusSent: attachSent,
+			Status:           status.AttachmentNone,
+			ExpiresAt:        expiresAt,
+		},
+		MACAddress: mac,
+	}
+	bytes, err := json.Marshal(attachment)
+	assert.NoError(t, err)
+	var unmarshalledAttachment ENIAttachment
+	err = json.Unmarshal(bytes, &unmarshalledAttachment)
+	assert.NoError(t, err)
+	assert.Equal(t, attachment.TaskARN, unmarshalledAttachment.TaskARN)
+	assert.Equal(t, attachment.AttachmentARN, unmarshalledAttachment.AttachmentARN)
+	assert.Equal(t, attachment.AttachStatusSent, unmarshalledAttachment.AttachStatusSent)
+	assert.Equal(t, attachment.MACAddress, unmarshalledAttachment.MACAddress)
+	assert.Equal(t, attachment.Status, unmarshalledAttachment.Status)
+
+	expectedExpiresAtUTC, err := time.Parse(time.RFC3339, attachment.ExpiresAt.Format(time.RFC3339))
+	assert.NoError(t, err)
+	unmarshalledExpiresAtUTC, err := time.Parse(time.RFC3339, unmarshalledAttachment.ExpiresAt.Format(time.RFC3339))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedExpiresAtUTC, unmarshalledExpiresAtUTC)
+}
+
+func TestMarshalUnmarshalWithAttachmentType(t *testing.T) {
+	expiresAt := time.Now()
+	attachment := &ENIAttachment{
+		AttachmentInfo: attachmentinfo.AttachmentInfo{
+			TaskARN:          taskARN,
+			AttachmentARN:    attachmentARN,
+			AttachStatusSent: attachSent,
+			Status:           status.AttachmentNone,
+			ExpiresAt:        expiresAt,
+		},
+		AttachmentType: attachmentType,
+		MACAddress:     mac,
+	}
+	bytes, err := json.Marshal(attachment)
+	assert.NoError(t, err)
+	var unmarshalledAttachment ENIAttachment
+	err = json.Unmarshal(bytes, &unmarshalledAttachment)
+	assert.NoError(t, err)
+	assert.Equal(t, attachment.AttachmentType, unmarshalledAttachment.AttachmentType)
+	assert.Equal(t, attachment.TaskARN, unmarshalledAttachment.TaskARN)
+	assert.Equal(t, attachment.AttachmentARN, unmarshalledAttachment.AttachmentARN)
+	assert.Equal(t, attachment.AttachStatusSent, unmarshalledAttachment.AttachStatusSent)
+	assert.Equal(t, attachment.MACAddress, unmarshalledAttachment.MACAddress)
+	assert.Equal(t, attachment.Status, unmarshalledAttachment.Status)
+
+	expectedExpiresAtUTC, err := time.Parse(time.RFC3339, attachment.ExpiresAt.Format(time.RFC3339))
+	assert.NoError(t, err)
+	unmarshalledExpiresAtUTC, err := time.Parse(time.RFC3339, unmarshalledAttachment.ExpiresAt.Format(time.RFC3339))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedExpiresAtUTC, unmarshalledExpiresAtUTC)
+}
+
+func TestStartTimerErrorWhenExpiresAtIsInThePast(t *testing.T) {
+	expiresAt := time.Now().Unix() - 1
+	attachment := &ENIAttachment{
+		AttachmentInfo: attachmentinfo.AttachmentInfo{
+			TaskARN:          taskARN,
+			AttachmentARN:    attachmentARN,
+			AttachStatusSent: attachSent,
+			Status:           status.AttachmentNone,
+			ExpiresAt:        time.Unix(expiresAt, 0),
+		},
+		MACAddress: mac,
+	}
+	assert.Error(t, attachment.StartTimer(func() {}))
+}
+
+func TestHasExpired(t *testing.T) {
+	for _, tc := range []struct {
+		expiresAt int64
+		expected  bool
+		name      string
+	}{
+		{time.Now().Unix() - 1, true, "expiresAt in past returns true"},
+		{time.Now().Unix() + 10, false, "expiresAt in future returns false"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			attachment := &ENIAttachment{
+				AttachmentInfo: attachmentinfo.AttachmentInfo{
+					TaskARN:          taskARN,
+					AttachmentARN:    attachmentARN,
+					AttachStatusSent: attachSent,
+					Status:           status.AttachmentNone,
+					ExpiresAt:        time.Unix(tc.expiresAt, 0),
+				},
+				MACAddress: mac,
+			}
+			assert.Equal(t, tc.expected, attachment.HasExpired())
+		})
+	}
+}
+
+func TestInitialize(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	timeoutFunc := func() {
+		wg.Done()
+	}
+
+	expiresAt := time.Now().Unix() + 1
+	attachment := &ENIAttachment{
+		AttachmentInfo: attachmentinfo.AttachmentInfo{
+			TaskARN:       taskARN,
+			AttachmentARN: attachmentARN,
+			Status:        status.AttachmentNone,
+			ExpiresAt:     time.Unix(expiresAt, 0),
+		},
+		MACAddress: mac,
+	}
+	assert.NoError(t, attachment.Initialize(timeoutFunc))
+	wg.Wait()
+}
+
+func TestInitializeExpired(t *testing.T) {
+	expiresAt := time.Now().Unix() - 1
+	attachment := &ENIAttachment{
+		AttachmentInfo: attachmentinfo.AttachmentInfo{
+			TaskARN:       taskARN,
+			AttachmentARN: attachmentARN,
+			Status:        status.AttachmentNone,
+			ExpiresAt:     time.Unix(expiresAt, 0),
+		},
+		MACAddress: mac,
+	}
+	assert.Error(t, attachment.Initialize(func() {}))
+}
+
+func TestInitializeExpiredButAlreadySent(t *testing.T) {
+	expiresAt := time.Now().Unix() - 1
+	attachment := &ENIAttachment{
+		AttachmentInfo: attachmentinfo.AttachmentInfo{
+			TaskARN:          taskARN,
+			AttachmentARN:    attachmentARN,
+			AttachStatusSent: attachSent,
+			Status:           status.AttachmentNone,
+			ExpiresAt:        time.Unix(expiresAt, 0),
+		},
+		MACAddress: mac,
+	}
+	assert.NoError(t, attachment.Initialize(func() {}))
+}

--- a/ecs-agent/netlib/model/networkinterface/errors.go
+++ b/ecs-agent/netlib/model/networkinterface/errors.go
@@ -1,0 +1,36 @@
+package networkinterface
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// UnableToFindENIError is an error type that is used to handle cases where
+// the ENI device cannot be found, even after it has been acknowledged as
+// "attached" by the agent. It lets us special case this error in dispatcher
+// and task director workflows.
+type UnableToFindENIError struct {
+	macAddress          string
+	associationProtocol string
+}
+
+// NewUnableToFindENIError creates a new UnableToFindENIError object.
+func NewUnableToFindENIError(macAddress, associationProtocol string) error {
+	return &UnableToFindENIError{
+		macAddress:          macAddress,
+		associationProtocol: associationProtocol,
+	}
+}
+
+func (e *UnableToFindENIError) Error() string {
+	return fmt.Sprintf("unable to find device name for '%s' eni %s",
+		e.associationProtocol, e.macAddress)
+}
+
+// IsUnableToFindENIError returns true if the error type is of type
+// `UnableToFindENIError`.
+func IsUnableToFindENIError(err error) bool {
+	_, ok := errors.Cause(err).(*UnableToFindENIError)
+	return ok
+}

--- a/ecs-agent/netlib/model/networkinterface/networkinterface.go
+++ b/ecs-agent/netlib/model/networkinterface/networkinterface.go
@@ -1,0 +1,647 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//lint:file-ignore U1000 Ignore unused fields as some of them are only used by Fargate
+
+package networkinterface
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	loggerfield "github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/pkg/errors"
+)
+
+// NetworkInterface contains information of the network interface
+type NetworkInterface struct {
+	// ID is the id of eni
+	ID string `json:"ec2Id"`
+	// LinkName is the name of the NetworkInterface on the instance.
+	// Currently, this field is being used only for Windows and is used during task networking setup.
+	LinkName string
+	// MacAddress is the mac address of the eni
+	MacAddress string
+	// IPV4Addresses is the ipv4 address associated with the eni
+	IPV4Addresses []*IPV4Address
+	// IPV6Addresses is the ipv6 address associated with the eni
+	IPV6Addresses []*IPV6Address
+	// SubnetGatewayIPV4Address is the IPv4 address of the subnet gateway of the NetworkInterface
+	SubnetGatewayIPV4Address string `json:",omitempty"`
+	// DomainNameServers specifies the nameserver IP addresses for the eni
+	DomainNameServers []string `json:",omitempty"`
+	// DomainNameSearchList specifies the search list for the domain
+	// name lookup, for the eni
+	DomainNameSearchList []string `json:",omitempty"`
+	// PrivateDNSName is the dns name assigned by the vpc to this eni
+	PrivateDNSName string `json:",omitempty"`
+	// InterfaceAssociationProtocol is the type of NetworkInterface, valid value: "default", "vlan"
+	InterfaceAssociationProtocol string `json:",omitempty"`
+
+	Index          int64  `json:"Index,omitempty"`
+	UserID         uint32 `json:"UserID,omitempty"`
+	Name           string `json:"Name,omitempty"`
+	NetNSName      string `json:"NetNSName,omitempty"`
+	NetNSPath      string `json:"NetNSPath,omitempty"`
+	DeviceName     string `json:"DeviceName,omitempty"`
+	GuestNetNSName string `json:"GuestNetNSName,omitempty"`
+	KnownStatus    Status `json:"KnownStatus,omitempty"`
+	DesiredStatus  Status `json:"DesiredStatus,omitempty"`
+
+	// InterfaceVlanProperties contains information for an interface
+	// that is supposed to be used as a VLAN device
+	InterfaceVlanProperties *InterfaceVlanProperties `json:",omitempty"`
+	// TunnelProperties contains information for tunnel interface
+	TunnelProperties *TunnelProperties `json:",omitempty"`
+	// VETHProperties contains information for a virtual ethernet interface
+	VETHProperties *VETHProperties `json:",omitempty"`
+	// Certain tasks such as service connect tasks may require additional
+	// domain name to IP address mapping defined in their /etc/hosts files.
+	// DNSMappingList will contain this for each NetworkInterface since /etc/hosts file
+	// is created per NetworkInterface.
+	DNSMappingList []DNSMapping
+
+	// Due to historical reasons, the IPv4 subnet prefix length is sent with IPv4 subnet gateway
+	// address instead of the NetworkInterface's IP addresses. However, CNI plugins and many OS APIs expect it
+	// the other way around. Instead of doing this conversion all the time for each CNI and TMDS
+	// request, compute it once on demand and cache it here.
+	ipv4SubnetPrefixLength string
+	ipv4SubnetCIDRBlock    string
+	ipv6SubnetCIDRBlock    string
+
+	// guard protects access to fields of this struct.
+	guard sync.RWMutex
+}
+
+// InterfaceVlanProperties contains information for an interface that
+// is supposed to be used as a VLAN device
+type InterfaceVlanProperties struct {
+	VlanID                   string
+	TrunkInterfaceMacAddress string
+}
+
+// TunnelProperties holds ID (e.g. VNI), destination IP address and port for tunnel interfaces.
+type TunnelProperties struct {
+	ID                   string `json:"ID"`
+	DestinationIPAddress string `json:"DestinationIPAddress"`
+	DestinationPort      uint16 `json:"DestinationPort"`
+}
+
+// VETHProperties holds the properties for virtual ethernet interfaces.
+type VETHProperties struct {
+	PeerInterfaceName string `json:"PeerInterfaceName"`
+}
+
+// DNSMapping holds additional pre-defined DNS entries for containers.
+// These additional entries will be written into /etc/hosts file eventually.
+type DNSMapping struct {
+	Hostname string
+	Address  string
+}
+
+const (
+	// DefaultInterfaceAssociationProtocol represents the standard NetworkInterface type.
+	DefaultInterfaceAssociationProtocol = "default"
+
+	// VLANInterfaceAssociationProtocol represents the NetworkInterface with trunking enabled.
+	VLANInterfaceAssociationProtocol = "vlan"
+
+	// IPv6SubnetPrefixLength is the IPv6 global unicast address prefix length, consisting of
+	// global routing prefix and subnet ID lengths as specified in IPv6 addressing architecture
+	// (RFC 4291 section 2.5.4) and IPv6 Global Unicast Address Format (RFC 3587).
+	// The ACS NetworkInterface payload structure does not contain an IPv6 subnet prefix length because "/64" is
+	// the only allowed length per RFCs above, and the only one that VPC supports.
+	IPv6SubnetPrefixLength = "64"
+
+	// TapDeviceNamePrefix holds the name prefix for interfaces attached to a MicroVM.
+	// In a multi NetworkInterface task, there will be multiple tap ENIs attached to it.
+	// They follow a naming pattern 'eth<eni index>'.
+	TapDeviceNamePrefix = "eth"
+
+	// DefaultTapDeviceName is the name of the tap device created by CNI plugin
+	// which connects the MicroVM with the branch NetworkInterface.
+	DefaultTapDeviceName = TapDeviceNamePrefix + "0"
+
+	// Standard ENIs and branch ENIs are supported both in ECS EC2 instances and Fargate. Therefore
+	// the processing of those common interface types are implemented in the ECS Agent's NetworkInterface package
+	// (ecseni) and simply imported here. VETH and V2N interface types are supported only in Fargate
+	// The constants below and functionality specific to those types are implemented in this file.
+
+	// VETHInterfaceAssociationProtocol is the interface association protocol for veth interfaces.
+	VETHInterfaceAssociationProtocol = "veth"
+
+	// V2NInterfaceAssociationProtocol is the interface association protocol for V2N tunnel interfaces.
+	V2NInterfaceAssociationProtocol = "tunnel"
+
+	// GeneveInterfaceNamePattern holds pattern of GENEVE interface name:
+	// 'gnv<v2nVNI><destination port>'.
+	// We have both the VNI and destination port in the name because that is the only
+	// guaranteed combination that can make the name of the interface unique.
+	// It is important that the name is unique for all GENEVE interfaces because
+	// the interface is always first created in the default network namespace
+	// before moving it to a custom namespace.
+	GeneveInterfaceNamePattern = "gnv%s%d"
+
+	// DefaultGeneveInterfaceIPAddress is the IP address that will be assigned to the
+	// GENEVE interface created for the V2N NetworkInterface. These IP addresses are chosen because
+	// they come under the ECS reserved link-local IP range. By having the subnet mask as /31,
+	// it means there are only 2 available IPs in this chosen subnet - 169.254.175.252 and
+	// 169.254.175.253. We set 169.254.175.252 as the geneve interface IP and set
+	// 169.254.175.253 as the default default gateway in the routing rules.
+	// We also assign a place holder MAC address for the gateway in the ARP table. This
+	// configuration ensures all traffic generated in the V2N NetworkInterface's netns will pass through
+	// the GENEVE interface.
+	DefaultGeneveInterfaceIPAddress = "169.254.175.252"
+	DefaultGeneveInterfaceGateway   = "169.254.175.253/31"
+)
+
+var (
+	// netInterfaces is the Interfaces() method of net package.
+	netInterfaces = net.Interfaces
+)
+
+// GetIPV4Addresses returns the list of IPv4 addresses assigned to the NetworkInterface.
+func (ni *NetworkInterface) GetIPV4Addresses() []string {
+	var addresses []string
+	for _, addr := range ni.IPV4Addresses {
+		addresses = append(addresses, addr.Address)
+	}
+
+	return addresses
+}
+
+// GetIPV6Addresses returns the list of IPv6 addresses assigned to the NetworkInterface.
+func (ni *NetworkInterface) GetIPV6Addresses() []string {
+	var addresses []string
+	for _, addr := range ni.IPV6Addresses {
+		addresses = append(addresses, addr.Address)
+	}
+
+	return addresses
+}
+
+// GetPrimaryIPv4Address returns the primary IPv4 address assigned to the NetworkInterface.
+func (ni *NetworkInterface) GetPrimaryIPv4Address() string {
+	var primaryAddr string
+	for _, addr := range ni.IPV4Addresses {
+		if addr.Primary {
+			primaryAddr = addr.Address
+			break
+		}
+	}
+
+	return primaryAddr
+}
+
+// GetPrimaryIPv4AddressWithPrefixLength returns the primary IPv4 address assigned to the NetworkInterface with
+// its subnet prefix length.
+func (ni *NetworkInterface) GetPrimaryIPv4AddressWithPrefixLength() string {
+	return ni.GetPrimaryIPv4Address() + "/" + ni.GetIPv4SubnetPrefixLength()
+}
+
+// GetIPAddressesWithPrefixLength returns the list of all IP addresses assigned to the NetworkInterface with
+// their subnet prefix length.
+func (ni *NetworkInterface) GetIPAddressesWithPrefixLength() []string {
+	var addresses []string
+	for _, addr := range ni.IPV4Addresses {
+		addresses = append(addresses, addr.Address+"/"+ni.GetIPv4SubnetPrefixLength())
+	}
+	for _, addr := range ni.IPV6Addresses {
+		addresses = append(addresses, addr.Address+"/"+IPv6SubnetPrefixLength)
+	}
+
+	return addresses
+}
+
+// GetIPv4SubnetPrefixLength returns the IPv4 prefix length of the NetworkInterface's subnet.
+func (ni *NetworkInterface) GetIPv4SubnetPrefixLength() string {
+	if ni.ipv4SubnetPrefixLength == "" && ni.SubnetGatewayIPV4Address != "" {
+		ni.ipv4SubnetPrefixLength = strings.Split(ni.SubnetGatewayIPV4Address, "/")[1]
+	}
+
+	return ni.ipv4SubnetPrefixLength
+}
+
+// GetIPv4SubnetCIDRBlock returns the IPv4 CIDR block, if any, of the NetworkInterface's subnet.
+func (ni *NetworkInterface) GetIPv4SubnetCIDRBlock() string {
+	if ni.ipv4SubnetCIDRBlock == "" && ni.SubnetGatewayIPV4Address != "" {
+		_, ipv4Net, err := net.ParseCIDR(ni.SubnetGatewayIPV4Address)
+		if err == nil {
+			ni.ipv4SubnetCIDRBlock = ipv4Net.String()
+		}
+	}
+
+	return ni.ipv4SubnetCIDRBlock
+}
+
+// GetIPv6SubnetCIDRBlock returns the IPv6 CIDR block, if any, of the NetworkInterface's subnet.
+func (ni *NetworkInterface) GetIPv6SubnetCIDRBlock() string {
+	if ni.ipv6SubnetCIDRBlock == "" && len(ni.IPV6Addresses) > 0 {
+		ipv6Addr := ni.IPV6Addresses[0].Address + "/" + IPv6SubnetPrefixLength
+		_, ipv6Net, err := net.ParseCIDR(ipv6Addr)
+		if err == nil {
+			ni.ipv6SubnetCIDRBlock = ipv6Net.String()
+		}
+	}
+
+	return ni.ipv6SubnetCIDRBlock
+}
+
+// GetSubnetGatewayIPv4Address returns the subnet gateway IPv4 address for the NetworkInterface.
+func (ni *NetworkInterface) GetSubnetGatewayIPv4Address() string {
+	var gwAddr string
+	if ni.SubnetGatewayIPV4Address != "" {
+		gwAddr = strings.Split(ni.SubnetGatewayIPV4Address, "/")[0]
+	}
+
+	return gwAddr
+}
+
+// GetHostname returns the hostname assigned to the NetworkInterface
+func (ni *NetworkInterface) GetHostname() string {
+	return ni.PrivateDNSName
+}
+
+// GetLinkName returns the name of the NetworkInterface on the instance.
+func (ni *NetworkInterface) GetLinkName() string {
+	ni.guard.Lock()
+	defer ni.guard.Unlock()
+
+	if ni.LinkName == "" {
+		// Find all interfaces on the instance.
+		ifaces, err := netInterfaces()
+		if err != nil {
+			logger.Error("Failed to find link name:", logger.Fields{
+				loggerfield.Error: err,
+			})
+			return ""
+		}
+		// Iterate over the list and find the interface with the NetworkInterface's MAC address.
+		for _, iface := range ifaces {
+			if strings.EqualFold(ni.MacAddress, iface.HardwareAddr.String()) {
+				ni.LinkName = iface.Name
+				break
+			}
+		}
+		// If the NetworkInterface is not matched by MAC address above, we will fail to
+		// assign the LinkName. Log that here since CNI will fail with the empty
+		// name.
+		if ni.LinkName == "" {
+			logger.Error("Failed to find LinkName for given MAC", logger.Fields{
+				"mac": ni.MacAddress,
+			})
+		}
+	}
+
+	return ni.LinkName
+}
+
+// IsStandardENI returns true if the NetworkInterface is a standard/regular NetworkInterface. That is, if it
+// has its association protocol as standard. To be backwards compatible, if the
+// association protocol is not set for an NetworkInterface, it's considered a standard NetworkInterface as well.
+func (ni *NetworkInterface) IsStandardENI() bool {
+	switch ni.InterfaceAssociationProtocol {
+	case "", DefaultInterfaceAssociationProtocol:
+		return true
+	case VLANInterfaceAssociationProtocol:
+		return false
+	default:
+		return false
+	}
+}
+
+// String returns a human-readable version of the NetworkInterface object
+func (ni *NetworkInterface) String() string {
+	var ipv4Addresses []string
+	for _, addr := range ni.IPV4Addresses {
+		ipv4Addresses = append(ipv4Addresses, addr.Address)
+	}
+	var ipv6Addresses []string
+	for _, addr := range ni.IPV6Addresses {
+		ipv6Addresses = append(ipv6Addresses, addr.Address)
+	}
+
+	eniString := ""
+
+	if len(ni.InterfaceAssociationProtocol) == 0 {
+		eniString += fmt.Sprintf(" ,NetworkInterface type: [%s]", ni.InterfaceAssociationProtocol)
+	}
+
+	if ni.InterfaceVlanProperties != nil {
+		eniString += fmt.Sprintf(" ,VLan ID: [%s], TrunkInterfaceMacAddress: [%s]",
+			ni.InterfaceVlanProperties.VlanID, ni.InterfaceVlanProperties.TrunkInterfaceMacAddress)
+	}
+
+	return fmt.Sprintf(
+		"eni id:%s, mac: %s, hostname: %s, ipv4addresses: [%s], ipv6addresses: [%s], dns: [%s], dns search: [%s],"+
+			" gateway ipv4: [%s][%s]", ni.ID, ni.MacAddress, ni.GetHostname(), strings.Join(ipv4Addresses, ","),
+		strings.Join(ipv6Addresses, ","), strings.Join(ni.DomainNameServers, ","),
+		strings.Join(ni.DomainNameSearchList, ","), ni.SubnetGatewayIPV4Address, eniString)
+}
+
+// IPV4Address is the ipv4 information of the eni
+type IPV4Address struct {
+	// Primary indicates whether the ip address is primary
+	Primary bool
+	// Address is the ipv4 address associated with eni
+	Address string
+}
+
+// IPV6Address is the ipv6 information of the eni
+type IPV6Address struct {
+	// Address is the ipv6 address associated with eni
+	Address string
+}
+
+// ENIFromACS validates the given ACS NetworkInterface information and creates an NetworkInterface object from it.
+func ENIFromACS(acsENI *ecsacs.ElasticNetworkInterface) (*NetworkInterface, error) {
+	err := ValidateENI(acsENI)
+	if err != nil {
+		return nil, err
+	}
+
+	var ipv4Addrs []*IPV4Address
+	var ipv6Addrs []*IPV6Address
+
+	// Read IPv4 address information of the NetworkInterface.
+	for _, ec2Ipv4 := range acsENI.Ipv4Addresses {
+		ipv4Addrs = append(ipv4Addrs, &IPV4Address{
+			Primary: aws.BoolValue(ec2Ipv4.Primary),
+			Address: aws.StringValue(ec2Ipv4.PrivateAddress),
+		})
+	}
+
+	// Read IPv6 address information of the NetworkInterface.
+	for _, ec2Ipv6 := range acsENI.Ipv6Addresses {
+		ipv6Addrs = append(ipv6Addrs, &IPV6Address{
+			Address: aws.StringValue(ec2Ipv6.Address),
+		})
+	}
+
+	// Read NetworkInterface association properties.
+	var interfaceVlanProperties InterfaceVlanProperties
+
+	if aws.StringValue(acsENI.InterfaceAssociationProtocol) == VLANInterfaceAssociationProtocol {
+		interfaceVlanProperties.TrunkInterfaceMacAddress = aws.StringValue(acsENI.InterfaceVlanProperties.TrunkInterfaceMacAddress)
+		interfaceVlanProperties.VlanID = aws.StringValue(acsENI.InterfaceVlanProperties.VlanId)
+	}
+
+	ni := &NetworkInterface{
+		ID:                           aws.StringValue(acsENI.Ec2Id),
+		MacAddress:                   aws.StringValue(acsENI.MacAddress),
+		IPV4Addresses:                ipv4Addrs,
+		IPV6Addresses:                ipv6Addrs,
+		SubnetGatewayIPV4Address:     aws.StringValue(acsENI.SubnetGatewayIpv4Address),
+		PrivateDNSName:               aws.StringValue(acsENI.PrivateDnsName),
+		InterfaceAssociationProtocol: aws.StringValue(acsENI.InterfaceAssociationProtocol),
+		InterfaceVlanProperties:      &interfaceVlanProperties,
+	}
+
+	for _, nameserverIP := range acsENI.DomainNameServers {
+		ni.DomainNameServers = append(ni.DomainNameServers, aws.StringValue(nameserverIP))
+	}
+	for _, nameserverDomain := range acsENI.DomainName {
+		ni.DomainNameSearchList = append(ni.DomainNameSearchList, aws.StringValue(nameserverDomain))
+	}
+
+	return ni, nil
+}
+
+// ValidateENI validates the NetworkInterface information sent from ACS.
+func ValidateENI(acsENI *ecsacs.ElasticNetworkInterface) error {
+	// At least one IPv4 address should be associated with the NetworkInterface.
+	if len(acsENI.Ipv4Addresses) < 1 {
+		return errors.Errorf("eni message validation: no ipv4 addresses in the message")
+	}
+
+	if acsENI.SubnetGatewayIpv4Address == nil {
+		return errors.Errorf("eni message validation: no subnet gateway ipv4 address in the message")
+	}
+	gwIPv4Addr := aws.StringValue(acsENI.SubnetGatewayIpv4Address)
+	s := strings.Split(gwIPv4Addr, "/")
+	if len(s) != 2 {
+		return errors.Errorf(
+			"eni message validation: invalid subnet gateway ipv4 address %s", gwIPv4Addr)
+	}
+
+	if acsENI.MacAddress == nil {
+		return errors.Errorf("eni message validation: empty eni mac address in the message")
+	}
+
+	if acsENI.Ec2Id == nil {
+		return errors.Errorf("eni message validation: empty eni id in the message")
+	}
+
+	// The association protocol, if specified, must be a supported value.
+	if (acsENI.InterfaceAssociationProtocol != nil) &&
+		(aws.StringValue(acsENI.InterfaceAssociationProtocol) != VLANInterfaceAssociationProtocol) &&
+		(aws.StringValue(acsENI.InterfaceAssociationProtocol) != DefaultInterfaceAssociationProtocol) {
+		return errors.Errorf("invalid interface association protocol: %s",
+			aws.StringValue(acsENI.InterfaceAssociationProtocol))
+	}
+
+	// If the interface association protocol is vlan, InterfaceVlanProperties must be specified.
+	if aws.StringValue(acsENI.InterfaceAssociationProtocol) == VLANInterfaceAssociationProtocol {
+		if acsENI.InterfaceVlanProperties == nil ||
+			len(aws.StringValue(acsENI.InterfaceVlanProperties.VlanId)) == 0 ||
+			len(aws.StringValue(acsENI.InterfaceVlanProperties.TrunkInterfaceMacAddress)) == 0 {
+			return errors.New("vlan interface properties missing")
+		}
+	}
+
+	return nil
+}
+
+// New creates a new NetworkInterface model.
+func New(
+	acsENI *ecsacs.ElasticNetworkInterface,
+	netNSName string,
+	netNSPath string,
+	guestNetNSName string,
+	peerInterface *ecsacs.ElasticNetworkInterface,
+) (*NetworkInterface, error) {
+	var err error
+
+	var networkInterface *NetworkInterface
+
+	interfaceAssociationProtocol := aws.StringValue(acsENI.InterfaceAssociationProtocol)
+
+	switch interfaceAssociationProtocol {
+
+	case V2NInterfaceAssociationProtocol:
+		// In case of V2N ENIs, network tunnel properties need to be included in the NetworkInterface object.
+		// This will be used in creating the GENEVE interface to connect the baremetal host and the BigMac tunnel.
+		networkInterface, err = v2nTunnelFromACS(acsENI)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal interface tunnel properties")
+		}
+
+	case VETHInterfaceAssociationProtocol:
+		networkInterface, err = vethPairFromACS(acsENI, peerInterface)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal interface veth properties")
+		}
+
+	// Standard ENIs (Default) and branch ENIs (VLANInterfaceAssociationProtocol) are both processed
+	// by the common NetworkInterface handler.
+	default:
+		// Acquire the NetworkInterface information from the payload.
+		networkInterface, err = ENIFromACS(acsENI)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal eni")
+		}
+
+		// Historically, if there is no interface association protocol in the NetworkInterface payload, we assume
+		// it is a standard NetworkInterface. For more context, see the `IsStandardENI()` method in the `ecseni` model.
+		if networkInterface.InterfaceAssociationProtocol == "" {
+			networkInterface.InterfaceAssociationProtocol = DefaultInterfaceAssociationProtocol
+		}
+	}
+
+	networkInterface.Index = aws.Int64Value(acsENI.Index)
+	networkInterface.Name = GetENIName(acsENI)
+	networkInterface.KnownStatus = StatusNone
+	networkInterface.DesiredStatus = StatusReadyPull
+	networkInterface.NetNSName = netNSName
+	networkInterface.NetNSPath = netNSPath
+	networkInterface.GuestNetNSName = guestNetNSName
+
+	return networkInterface, nil
+}
+
+// setDeviceName sets the device name for the NetworkInterface based on its type and MAC address.
+func (ni *NetworkInterface) setDeviceName(macToName map[string]string) error {
+	switch ni.InterfaceAssociationProtocol {
+	case DefaultInterfaceAssociationProtocol:
+		name, ok := macToName[ni.MacAddress]
+		if !ok {
+			// This should never happen in theory. ACS can only send the payload message once
+			// Agent has acknowledged attachment on the instance. However, we have found that
+			// in some instances, EC2 detaches the NetworkInterface after attaching it when there are
+			// asynchornous errors in the NetworkInterface attachment workflow. We return a typed error in
+			// such scenarios to ensure that we don't get paged when that happens.
+			return NewUnableToFindENIError(ni.MacAddress, ni.InterfaceAssociationProtocol)
+		}
+		ni.DeviceName = name
+	case VLANInterfaceAssociationProtocol:
+		// We don't need to find the name for a branch NetworkInterface as it's just a vlan association.
+		// Get the name of the trunk interface since we need it for constructing the
+		// name of the branch interface.
+		trunkName, ok := macToName[ni.InterfaceVlanProperties.TrunkInterfaceMacAddress]
+		if !ok {
+			// Same as above. Guard against edge-cases where we're unable to find the trunk
+			// NetworkInterface because of internal EC2 errors.
+			return NewUnableToFindENIError(
+				ni.InterfaceVlanProperties.TrunkInterfaceMacAddress, ni.InterfaceAssociationProtocol)
+		}
+		// Name of the branch is based on the vlan id and the name of the trunk.
+		// Example: eth1.24, where trunk is attached as `eth1` and vlan id is `24`.
+		ni.DeviceName = fmt.Sprintf("%s.%s", trunkName, ni.InterfaceVlanProperties.VlanID)
+	default:
+		// Do nothing.
+	}
+	return nil
+}
+
+// IsPrimary returns whether the NetworkInterface is the primary NetworkInterface of the task.
+func (ni *NetworkInterface) IsPrimary() bool {
+	return ni.Index == 0
+}
+
+// ShouldGenerateNetworkConfigFiles can be used to check if network configuration files (hosts,
+// hostname and resolv.conf) need to be generated using this eni's information. In case of warmpool,
+// network config files should only be generated for primary ENIs. But as part of multi-NetworkInterface implementation
+// it was decided that for firecracker platform the files had to be generated for secondary ENIs as well.
+// Hence the NetworkInterface IsPrimary check was moved from here to warmpool specific APIs.
+func (ni *NetworkInterface) ShouldGenerateNetworkConfigFiles() bool {
+	return ni.DesiredStatus == StatusReadyPull
+}
+
+// GetENIName creates the NetworkInterface name from the NetworkInterface mac address in case it is empty in the ACS payload.
+func GetENIName(acsENI *ecsacs.ElasticNetworkInterface) string {
+	if acsENI.Name != nil {
+		return aws.StringValue(acsENI.Name)
+	}
+
+	return strings.ReplaceAll(aws.StringValue(acsENI.MacAddress), ":", "")
+}
+
+// v2nTunnelFromACS creates an NetworkInterface model with V2N tunnel properties from the ACS NetworkInterface payload.
+func v2nTunnelFromACS(acsENI *ecsacs.ElasticNetworkInterface) (*NetworkInterface, error) {
+	// We only require the association protocol and the mac address.
+	// Mac address is needed primarily because according to current logic, this mac address is assigned to the
+	// interface that gets attached inside the MicroVM. The mac address is also used to find the interface inside
+	// the MicroVM to move it to the desired network namespace when the network topology inside the MicroVM is setup.
+
+	acsTunnelProperties := acsENI.InterfaceTunnelProperties
+	if acsTunnelProperties == nil {
+		return nil, errors.New("interface tunnel properties not found in payload")
+	}
+	if acsTunnelProperties.TunnelId == nil {
+		return nil, errors.New("tunnel ID not found in payload")
+	}
+	if acsTunnelProperties.InterfaceIpAddress == nil {
+		return nil, errors.New("tunnel interface IP not found in payload")
+	}
+
+	return &NetworkInterface{
+			InterfaceAssociationProtocol: V2NInterfaceAssociationProtocol,
+			SubnetGatewayIPV4Address:     DefaultGeneveInterfaceGateway,
+
+			IPV4Addresses: []*IPV4Address{
+				{
+					Address: DefaultGeneveInterfaceIPAddress,
+				},
+			},
+
+			DomainNameServers:    aws.StringValueSlice(acsENI.DomainNameServers),
+			DomainNameSearchList: aws.StringValueSlice(acsENI.DomainName),
+			TunnelProperties: &TunnelProperties{
+				ID:                   aws.StringValue(acsTunnelProperties.TunnelId),
+				DestinationIPAddress: aws.StringValue(acsTunnelProperties.InterfaceIpAddress),
+			},
+		},
+		nil
+}
+
+// vethPairFromACS creates an NetworkInterface model with veth pair properties from the ACS NetworkInterface payload.
+func vethPairFromACS(
+	acsENI *ecsacs.ElasticNetworkInterface,
+	peerInterface *ecsacs.ElasticNetworkInterface) (*NetworkInterface, error) {
+	if acsENI.InterfaceVethProperties == nil ||
+		acsENI.InterfaceVethProperties.PeerInterface == nil {
+		return nil, errors.New("interface veth properties not found in payload")
+	}
+	if aws.StringValue(peerInterface.InterfaceAssociationProtocol) == VETHInterfaceAssociationProtocol {
+		return nil, errors.New("peer interface cannot be veth")
+	}
+
+	return &NetworkInterface{
+			InterfaceAssociationProtocol: VETHInterfaceAssociationProtocol,
+
+			// DNS related data for VETH interface will be copied from the peer interface's DNS data.
+			// This is because if default traffic of the container needs to use the VETH interface,
+			// domain name resolution will be based on the DNS config of the peer interface.
+			DomainNameServers:    aws.StringValueSlice(peerInterface.DomainNameServers),
+			DomainNameSearchList: aws.StringValueSlice(peerInterface.DomainName),
+			VETHProperties: &VETHProperties{
+				PeerInterfaceName: aws.StringValue(acsENI.InterfaceVethProperties.PeerInterface),
+			},
+		},
+		nil
+}

--- a/ecs-agent/netlib/model/networkinterface/networkinterface_status.go
+++ b/ecs-agent/netlib/model/networkinterface/networkinterface_status.go
@@ -1,0 +1,42 @@
+package networkinterface
+
+// Status represents the status of an ENI resource.
+type Status string
+
+const (
+	// StatusNone is the initial staus of the ENI.
+	StatusNone Status = "NONE"
+	// StatusReadyPull indicates that the ENI is ready for downloading resources associated with
+	// the execution role. This includes container images, task secrets and configs.
+	StatusReadyPull Status = "READY_PULL"
+	// StatusReady indicates that the ENI is ready for use by containers in the task.
+	StatusReady Status = "READY"
+	// StatusDeleted indicates that the ENI is deleted.
+	StatusDeleted Status = "DELETED"
+)
+
+var (
+	eniStatusOrder = map[Status]int{
+		StatusNone:      0,
+		StatusReadyPull: 1,
+		StatusReady:     2,
+		StatusDeleted:   3,
+	}
+)
+
+func (es Status) String() string {
+	return string(es)
+}
+
+func (es Status) StatusBackwards(es2 Status) bool {
+	return eniStatusOrder[es] < eniStatusOrder[es2]
+}
+
+func GetAllStatuses() []Status {
+	return []Status{
+		StatusNone,
+		StatusReadyPull,
+		StatusReady,
+		StatusDeleted,
+	}
+}

--- a/ecs-agent/netlib/model/networkinterface/networkinterface_test.go
+++ b/ecs-agent/netlib/model/networkinterface/networkinterface_test.go
@@ -1,0 +1,373 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package networkinterface
+
+import (
+	"net"
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	defaultDNS         = "169.254.169.253"
+	customDNS          = "10.0.0.2"
+	customSearchDomain = "us-west-2.compute.internal"
+
+	linkName                 = "eth1"
+	macAddr                  = "02:22:ea:8c:81:dc"
+	ipv4Addr                 = "1.2.3.4"
+	ipv4Gw                   = "1.2.3.1"
+	ipv4SubnetPrefixLength   = "20"
+	ipv4Subnet               = "1.2.0.0"
+	ipv4AddrWithPrefixLength = ipv4Addr + "/" + ipv4SubnetPrefixLength
+	ipv4GwWithPrefixLength   = ipv4Gw + "/" + ipv4SubnetPrefixLength
+	ipv4SubnetCIDRBlock      = ipv4Subnet + "/" + ipv4SubnetPrefixLength
+	ipv6Addr                 = "abcd:dcba:1234:4321::"
+	ipv6SubnetPrefixLength   = "64"
+	ipv6SubnetCIDRBlock      = ipv6Addr + "/" + ipv6SubnetPrefixLength
+	ipv6AddrWithPrefixLength = ipv6Addr + "/" + ipv6SubnetPrefixLength
+	vethPeerInterfaceName    = "veth1-peer"
+	v2nVNI                   = "ABCDE"
+	v2nDestinationIP         = "10.0.2.129"
+	v2nDnsIP                 = "10.3.0.2"
+	v2nDnsSearch             = "us-west-2.test.compute.internal"
+)
+
+var (
+	testENI = &NetworkInterface{
+		ID:                           "eni-123",
+		InterfaceAssociationProtocol: DefaultInterfaceAssociationProtocol,
+		IPV4Addresses: []*IPV4Address{
+			{
+				Primary: true,
+				Address: ipv4Addr,
+			},
+		},
+		IPV6Addresses: []*IPV6Address{
+			{
+				Address: ipv6Addr,
+			},
+		},
+		SubnetGatewayIPV4Address: ipv4GwWithPrefixLength,
+	}
+	// validNetInterfacesFunc represents a mock of valid response from net.Interfaces() method.
+	validNetInterfacesFunc = func() ([]net.Interface, error) {
+		parsedMAC, _ := net.ParseMAC(macAddr)
+		return []net.Interface{
+			net.Interface{
+				Name:         linkName,
+				HardwareAddr: parsedMAC,
+			},
+		}, nil
+	}
+	// invalidNetInterfacesFunc represents a mock of error response from net.Interfaces() method.
+	invalidNetInterfacesFunc = func() ([]net.Interface, error) {
+		return nil, errors.New("failed to find interfaces")
+	}
+)
+
+func TestIsStandardENI(t *testing.T) {
+	testCases := []struct {
+		protocol   string
+		isStandard bool
+	}{
+		{
+			protocol:   "",
+			isStandard: true,
+		},
+		{
+			protocol:   DefaultInterfaceAssociationProtocol,
+			isStandard: true,
+		},
+		{
+			protocol:   VLANInterfaceAssociationProtocol,
+			isStandard: false,
+		},
+		{
+			protocol:   "invalid",
+			isStandard: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.protocol, func(t *testing.T) {
+			ni := &NetworkInterface{
+				InterfaceAssociationProtocol: tc.protocol,
+			}
+			assert.Equal(t, tc.isStandard, ni.IsStandardENI())
+		})
+	}
+}
+
+func TestGetIPV4Addresses(t *testing.T) {
+	assert.Equal(t, []string{ipv4Addr}, testENI.GetIPV4Addresses())
+}
+
+func TestGetIPV6Addresses(t *testing.T) {
+	assert.Equal(t, []string{ipv6Addr}, testENI.GetIPV6Addresses())
+}
+
+func TestGetPrimaryIPv4Address(t *testing.T) {
+	assert.Equal(t, ipv4Addr, testENI.GetPrimaryIPv4Address())
+}
+
+func TestGetPrimaryIPv4AddressWithPrefixLength(t *testing.T) {
+	assert.Equal(t, ipv4AddrWithPrefixLength, testENI.GetPrimaryIPv4AddressWithPrefixLength())
+}
+
+func TestGetIPAddressesWithPrefixLength(t *testing.T) {
+	assert.Equal(t, []string{ipv4AddrWithPrefixLength, ipv6AddrWithPrefixLength}, testENI.GetIPAddressesWithPrefixLength())
+}
+
+func TestGetIPv4SubnetPrefixLength(t *testing.T) {
+	assert.Equal(t, ipv4SubnetPrefixLength, testENI.GetIPv4SubnetPrefixLength())
+}
+
+func TestGetIPv4SubnetCIDRBlock(t *testing.T) {
+	assert.Equal(t, ipv4SubnetCIDRBlock, testENI.GetIPv4SubnetCIDRBlock())
+}
+
+func TestGetIPv6SubnetCIDRBlock(t *testing.T) {
+	assert.Equal(t, ipv6SubnetCIDRBlock, testENI.GetIPv6SubnetCIDRBlock())
+}
+
+func TestGetSubnetGatewayIPv4Address(t *testing.T) {
+	assert.Equal(t, ipv4Gw, testENI.GetSubnetGatewayIPv4Address())
+}
+
+// TestGetLinkNameSuccess tests the retrieval of ENIs name on the instance.
+func TestGetLinkNameSuccess(t *testing.T) {
+	netInterfaces = validNetInterfacesFunc
+	ni := &NetworkInterface{
+		MacAddress: macAddr,
+	}
+
+	eniLinkName := ni.GetLinkName()
+	assert.EqualValues(t, linkName, eniLinkName)
+}
+
+// TestGetLinkNameFailure tests the retrieval of Network Interface Name in case of failure.
+func TestGetLinkNameFailure(t *testing.T) {
+	netInterfaces = invalidNetInterfacesFunc
+	ni := &NetworkInterface{
+		MacAddress: macAddr,
+	}
+
+	eniLinkName := ni.GetLinkName()
+	assert.EqualValues(t, "", eniLinkName)
+}
+
+func TestENIToString(t *testing.T) {
+	expectedStr := `eni id:eni-123, mac: , hostname: , ipv4addresses: [1.2.3.4], ipv6addresses: [abcd:dcba:1234:4321::], dns: [], dns search: [], gateway ipv4: [1.2.3.1/20][]`
+	assert.Equal(t, expectedStr, testENI.String())
+}
+
+// TestENIFromACS tests the eni information was correctly read from the acs
+func TestENIFromACS(t *testing.T) {
+	acsENI := getTestACSENI()
+	eni, err := ENIFromACS(acsENI)
+	assert.NoError(t, err)
+	assert.NotNil(t, eni)
+	assert.Equal(t, aws.StringValue(acsENI.Ec2Id), eni.ID)
+	assert.Len(t, eni.IPV4Addresses, 1)
+	assert.Len(t, eni.GetIPV4Addresses(), 1)
+	assert.Equal(t, aws.StringValue(acsENI.Ipv4Addresses[0].PrivateAddress), eni.IPV4Addresses[0].Address)
+	assert.Equal(t, aws.BoolValue(acsENI.Ipv4Addresses[0].Primary), eni.IPV4Addresses[0].Primary)
+	assert.Equal(t, aws.StringValue(acsENI.MacAddress), eni.MacAddress)
+	assert.Len(t, eni.IPV6Addresses, 1)
+	assert.Len(t, eni.GetIPV6Addresses(), 1)
+	assert.Equal(t, aws.StringValue(acsENI.Ipv6Addresses[0].Address), eni.IPV6Addresses[0].Address)
+	assert.Len(t, eni.DomainNameServers, 2)
+	assert.Equal(t, defaultDNS, eni.DomainNameServers[0])
+	assert.Equal(t, customDNS, eni.DomainNameServers[1])
+	assert.Len(t, eni.DomainNameSearchList, 1)
+	assert.Equal(t, customSearchDomain, eni.DomainNameSearchList[0])
+	assert.Equal(t, aws.StringValue(acsENI.PrivateDnsName), eni.PrivateDNSName)
+}
+
+// TestValidateENIFromACS tests the validation of enis from acs
+func TestValidateENIFromACS(t *testing.T) {
+	acsENI := getTestACSENI()
+	err := ValidateENI(acsENI)
+	assert.NoError(t, err)
+
+	acsENI.Ipv6Addresses = nil
+	err = ValidateENI(acsENI)
+	assert.NoError(t, err)
+
+	acsENI.Ipv4Addresses = nil
+	err = ValidateENI(acsENI)
+	assert.Error(t, err)
+}
+
+func TestInvalidENIInterfaceVlanPropertyMissing(t *testing.T) {
+	acsENI := &ecsacs.ElasticNetworkInterface{
+		InterfaceAssociationProtocol: aws.String(VLANInterfaceAssociationProtocol),
+		AttachmentArn:                aws.String("arn"),
+		Ec2Id:                        aws.String("ec2id"),
+		Ipv4Addresses: []*ecsacs.IPv4AddressAssignment{
+			{
+				Primary:        aws.Bool(true),
+				PrivateAddress: aws.String("ipv4"),
+			},
+		},
+		SubnetGatewayIpv4Address: aws.String(ipv4GwWithPrefixLength),
+		Ipv6Addresses: []*ecsacs.IPv6AddressAssignment{
+			{
+				Address: aws.String("ipv6"),
+			},
+		},
+		MacAddress: aws.String("mac"),
+	}
+
+	err := ValidateENI(acsENI)
+	assert.Error(t, err)
+
+}
+
+func TestInvalidENIInvalidInterfaceAssociationProtocol(t *testing.T) {
+	acsENI := &ecsacs.ElasticNetworkInterface{
+		InterfaceAssociationProtocol: aws.String("no-eni"),
+		AttachmentArn:                aws.String("arn"),
+		Ec2Id:                        aws.String("ec2id"),
+		Ipv4Addresses: []*ecsacs.IPv4AddressAssignment{
+			{
+				Primary:        aws.Bool(true),
+				PrivateAddress: aws.String("ipv4"),
+			},
+		},
+		SubnetGatewayIpv4Address: aws.String(ipv4GwWithPrefixLength),
+		Ipv6Addresses: []*ecsacs.IPv6AddressAssignment{
+			{
+				Address: aws.String("ipv6"),
+			},
+		},
+		MacAddress: aws.String("mac"),
+	}
+	err := ValidateENI(acsENI)
+	assert.Error(t, err)
+}
+
+func TestInvalidSubnetGatewayAddress(t *testing.T) {
+	acsENI := getTestACSENI()
+	acsENI.SubnetGatewayIpv4Address = aws.String(ipv4Addr)
+	_, err := ENIFromACS(acsENI)
+	assert.Error(t, err)
+}
+
+func getTestACSENI() *ecsacs.ElasticNetworkInterface {
+	return &ecsacs.ElasticNetworkInterface{
+		AttachmentArn: aws.String("arn"),
+		Ec2Id:         aws.String("ec2id"),
+		Ipv4Addresses: []*ecsacs.IPv4AddressAssignment{
+			{
+				Primary:        aws.Bool(true),
+				PrivateAddress: aws.String(ipv4Addr),
+			},
+		},
+		SubnetGatewayIpv4Address: aws.String(ipv4GwWithPrefixLength),
+		Ipv6Addresses: []*ecsacs.IPv6AddressAssignment{
+			{
+				Address: aws.String(ipv6Addr)},
+		},
+		MacAddress:        aws.String("mac"),
+		DomainNameServers: []*string{aws.String(defaultDNS), aws.String(customDNS)},
+		DomainName:        []*string{aws.String(customSearchDomain)},
+		PrivateDnsName:    aws.String("ip.region.compute.internal"),
+	}
+}
+
+// TestV2NTunnelFromACS tests the ENI model created from ACS V2N interface payload.
+func TestV2NTunnelFromACS(t *testing.T) {
+	v2nTunnelACS := &ecsacs.ElasticNetworkInterface{
+		DomainNameServers: []*string{
+			aws.String(v2nDnsIP),
+		},
+		DomainName: []*string{
+			aws.String(v2nDnsSearch),
+		},
+		InterfaceTunnelProperties: &ecsacs.NetworkInterfaceTunnelProperties{
+			TunnelId:           aws.String(v2nVNI),
+			InterfaceIpAddress: aws.String(v2nDestinationIP),
+		},
+	}
+
+	// Test success case.
+	v2nEni, err := v2nTunnelFromACS(v2nTunnelACS)
+	require.NoError(t, err)
+
+	assert.Equal(t, V2NInterfaceAssociationProtocol, v2nEni.InterfaceAssociationProtocol)
+	assert.Equal(t, DefaultGeneveInterfaceGateway, v2nEni.SubnetGatewayIPV4Address)
+	assert.Equal(t, DefaultGeneveInterfaceIPAddress, v2nEni.IPV4Addresses[0].Address)
+	assert.Equal(t, v2nDnsIP, v2nEni.DomainNameServers[0])
+	assert.Equal(t, v2nDnsSearch, v2nEni.DomainNameSearchList[0])
+
+	assert.Equal(t, v2nVNI, v2nEni.TunnelProperties.ID)
+	assert.Equal(t, v2nDestinationIP, v2nEni.TunnelProperties.DestinationIPAddress)
+
+	// Test failure cases.
+	v2nTunnelACS.InterfaceTunnelProperties.TunnelId = nil
+	_, err = v2nTunnelFromACS(v2nTunnelACS)
+	require.Error(t, err)
+	require.Equal(t, "tunnel ID not found in payload", err.Error())
+
+	v2nTunnelACS.InterfaceTunnelProperties.TunnelId = aws.String(v2nVNI)
+	v2nTunnelACS.InterfaceTunnelProperties.InterfaceIpAddress = nil
+	_, err = v2nTunnelFromACS(v2nTunnelACS)
+	require.Error(t, err)
+	require.Equal(t, "tunnel interface IP not found in payload", err.Error())
+
+	v2nTunnelACS.InterfaceTunnelProperties = nil
+	_, err = v2nTunnelFromACS(v2nTunnelACS)
+	require.Error(t, err)
+	assert.Equal(t, "interface tunnel properties not found in payload", err.Error())
+}
+
+// TestVETHPairFromACS tests the ENI model created from ACS VETH interface payload.
+// It tests if the ENI model inherits the DNS config data from the peer interface
+// and also verifies that an error is returned if the peer interface is also veth.
+func TestVETHPairFromACS(t *testing.T) {
+	peerInterface := &ecsacs.ElasticNetworkInterface{
+		Name:              aws.String(vethPeerInterfaceName),
+		DomainNameServers: []*string{aws.String("10.0.23.2")},
+		DomainName:        []*string{aws.String("amazon.com")},
+	}
+
+	vethACS := &ecsacs.ElasticNetworkInterface{
+		InterfaceVethProperties: &ecsacs.NetworkInterfaceVethProperties{
+			PeerInterface: aws.String(vethPeerInterfaceName),
+		},
+	}
+
+	vethInterface, err := vethPairFromACS(vethACS, peerInterface)
+	require.NoError(t, err)
+
+	assert.Equal(t, VETHInterfaceAssociationProtocol, vethInterface.InterfaceAssociationProtocol)
+	assert.Equal(t, vethPeerInterfaceName, vethInterface.VETHProperties.PeerInterfaceName)
+	assert.Equal(t, vethInterface.DomainNameServers[0], "10.0.23.2")
+	assert.Equal(t, vethInterface.DomainNameSearchList[0], "amazon.com")
+
+	peerInterface.InterfaceAssociationProtocol = aws.String(VETHInterfaceAssociationProtocol)
+	_, err = vethPairFromACS(vethACS, peerInterface)
+	require.Error(t, err)
+	assert.Equal(t, "peer interface cannot be veth", err.Error())
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request adds eni and appmesh to `netlib/model` path to `ecs-agent` module, as well as renaming `eni` to `networkInterface` to accommodate expanded attributes to support Fargate better.

### Implementation details
<!-- How are the changes implemented? -->
- Creates `netlib/model` path in `ecs-agent` module.
- Duplicate `eni` and `appmesh` to above path. I didn't do direct move but duplication first, because Fargate is directly importing and inheriting the definitions on mentioned two models.
- Change the imports from code base to use the updated model.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> N/A

Existing github testing workflow passed.

Manual testing: this is a model change (including naming change), I did a test on agent update to make sure it does not break our data model persistence mechanism.

After an in place update (run a task, run `make release`, then `sudo systemctl restart ecs`), a new non-“omitempty” field `DNSMappingList` shows up in boltdb, without breaking anything else.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add eni and appmesh ecs-agent module and refactor eni to have a more general naming


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
