### PR TITLE
Update metrics interface to couple metric completion and publish

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/metrics.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/metrics.go
@@ -43,11 +43,8 @@ type Entry interface {
 	// rate for an image pull operation.
 	WithGauge(value interface{}) Entry
 	// Done makes a metric operation as complete. It records the end time of the operation
-	// and returns a function pointer that can be used to flush the metrics to a
-	// persistent store. Callers can optionally defer the function pointer. Example:
-	//
-	// defer lookupMetric.Done(nil) ()
-	Done(err error) func()
+	// flushes the metrics to a persistent store.
+	Done(err error)
 }
 
 // nopEntryFactory implements the EntryFactory interface with no-ops.
@@ -73,4 +70,4 @@ func newNopEntry(op string) Entry {
 func (e *nopEntry) WithFields(f map[string]interface{}) Entry { return e }
 func (e *nopEntry) WithCount(count int) Entry                 { return e }
 func (e *nopEntry) WithGauge(value interface{}) Entry         { return e }
-func (e *nopEntry) Done(err error) func()                     { return func() {} }
+func (e *nopEntry) Done(err error)                            {}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/taskprotection/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/taskprotection/v1/handlers/handlers.go
@@ -76,7 +76,7 @@ func GetTaskProtectionHandler(
 		if errResponseBody != nil {
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
 			if utils.Is5XXStatus(errResponseCode) {
-				successMetric.WithCount(0).Done(nil)()
+				successMetric.WithCount(0).Done(nil)
 			}
 			return
 		}
@@ -89,7 +89,7 @@ func GetTaskProtectionHandler(
 		taskCreds, errResponseCode, errResponseBody := getTaskCredentials(credentialsManager, *task)
 		if errResponseBody != nil {
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
-			successMetric.WithCount(0).Done(nil)()
+			successMetric.WithCount(0).Done(nil)
 			return
 		}
 
@@ -104,7 +104,7 @@ func GetTaskProtectionHandler(
 		if err != nil {
 			errResponseCode, errResponseBody := logAndHandleECSError(err, *task, requestType)
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
-			successMetric.WithCount(0).Done(nil)()
+			successMetric.WithCount(0).Done(nil)
 			return
 		}
 
@@ -113,14 +113,14 @@ func GetTaskProtectionHandler(
 			responseBody.ProtectedTasks, responseBody.Failures, *task, requestType)
 		if errResponseBody != nil {
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
-			successMetric.WithCount(0).Done(nil)()
+			successMetric.WithCount(0).Done(nil)
 			return
 		}
 
 		// ECS call was successful
 		utils.WriteJSONResponse(w, http.StatusOK,
 			types.NewTaskProtectionResponseProtection(responseBody.ProtectedTasks[0]), requestType)
-		successMetric.WithCount(1).Done(nil)()
+		successMetric.WithCount(1).Done(nil)
 	}
 }
 
@@ -162,7 +162,7 @@ func UpdateTaskProtectionHandler(
 		if errResponseBody != nil {
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
 			if utils.Is5XXStatus(errResponseCode) {
-				successMetric.WithCount(0).Done(nil)()
+				successMetric.WithCount(0).Done(nil)
 			}
 			return
 		}
@@ -193,7 +193,7 @@ func UpdateTaskProtectionHandler(
 		taskCreds, errResponseCode, errResponseBody := getTaskCredentials(credentialsManager, *task)
 		if errResponseBody != nil {
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
-			successMetric.WithCount(0).Done(nil)()
+			successMetric.WithCount(0).Done(nil)
 			return
 		}
 
@@ -210,7 +210,7 @@ func UpdateTaskProtectionHandler(
 		if err != nil {
 			errResponseCode, errResponseBody := logAndHandleECSError(err, *task, requestType)
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
-			successMetric.WithCount(0).Done(nil)()
+			successMetric.WithCount(0).Done(nil)
 			return
 		}
 
@@ -219,14 +219,14 @@ func UpdateTaskProtectionHandler(
 			response.ProtectedTasks, response.Failures, *task, requestType)
 		if errResponseBody != nil {
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
-			successMetric.WithCount(0).Done(nil)()
+			successMetric.WithCount(0).Done(nil)
 			return
 		}
 
 		// ECS call was successful
 		utils.WriteJSONResponse(w, http.StatusOK,
 			types.NewTaskProtectionResponseProtection(response.ProtectedTasks[0]), requestType)
-		successMetric.WithCount(1).Done(nil)()
+		successMetric.WithCount(1).Done(nil)
 	}
 }
 

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/handlers.go
@@ -83,7 +83,7 @@ func ContainerMetadataHandler(
 			utils.WriteJSONResponse(w, responseCode, responseBody, utils.RequestTypeContainerMetadata)
 
 			if utils.Is5XXStatus(responseCode) {
-				metricsFactory.New(metrics.InternalServerErrorMetricName).Done(err)()
+				metricsFactory.New(metrics.InternalServerErrorMetricName).Done(err)
 			}
 
 			return
@@ -155,7 +155,7 @@ func taskMetadataHandler(
 			utils.WriteJSONResponse(w, responseCode, responseBody, utils.RequestTypeTaskMetadata)
 
 			if utils.Is5XXStatus(responseCode) {
-				metricsFactory.New(metrics.InternalServerErrorMetricName).Done(err)()
+				metricsFactory.New(metrics.InternalServerErrorMetricName).Done(err)
 			}
 
 			return
@@ -231,7 +231,7 @@ func statsHandler[R state.StatsResponse | map[string]*state.StatsResponse](
 			utils.WriteJSONResponse(w, responseCode, responseBody, requestType)
 
 			if utils.Is5XXStatus(responseCode) {
-				metricsFactory.New(metrics.InternalServerErrorMetricName).Done(err)()
+				metricsFactory.New(metrics.InternalServerErrorMetricName).Done(err)
 			}
 
 			return

--- a/ecs-agent/metrics/metrics.go
+++ b/ecs-agent/metrics/metrics.go
@@ -42,8 +42,8 @@ type Entry interface {
 	// for reporting numerical values related to any operation, for instance the data transfer
 	// rate for an image pull operation.
 	WithGauge(value interface{}) Entry
-	// Done makes a metric operation as complete. It records the end time of the operation
-	// flushes the metrics to a persistent store.
+	// Done makes a metric operation as complete. It records the end time of the operation and
+	// flushes the metric to a persistent store.
 	Done(err error)
 }
 

--- a/ecs-agent/metrics/metrics.go
+++ b/ecs-agent/metrics/metrics.go
@@ -43,11 +43,8 @@ type Entry interface {
 	// rate for an image pull operation.
 	WithGauge(value interface{}) Entry
 	// Done makes a metric operation as complete. It records the end time of the operation
-	// and returns a function pointer that can be used to flush the metrics to a
-	// persistent store. Callers can optionally defer the function pointer. Example:
-	//
-	// defer lookupMetric.Done(nil) ()
-	Done(err error) func()
+	// flushes the metrics to a persistent store.
+	Done(err error)
 }
 
 // nopEntryFactory implements the EntryFactory interface with no-ops.
@@ -73,4 +70,4 @@ func newNopEntry(op string) Entry {
 func (e *nopEntry) WithFields(f map[string]interface{}) Entry { return e }
 func (e *nopEntry) WithCount(count int) Entry                 { return e }
 func (e *nopEntry) WithGauge(value interface{}) Entry         { return e }
-func (e *nopEntry) Done(err error) func()                     { return func() {} }
+func (e *nopEntry) Done(err error)                            {}

--- a/ecs-agent/metrics/mocks/mock_entry.go
+++ b/ecs-agent/metrics/mocks/mock_entry.go
@@ -98,11 +98,9 @@ func (m *MockEntry) EXPECT() *MockEntryMockRecorder {
 }
 
 // Done mocks base method.
-func (m *MockEntry) Done(arg0 error) func() {
+func (m *MockEntry) Done(arg0 error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Done", arg0)
-	ret0, _ := ret[0].(func())
-	return ret0
+	m.ctrl.Call(m, "Done", arg0)
 }
 
 // Done indicates an expected call of Done.

--- a/ecs-agent/tmds/handlers/taskprotection/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/taskprotection/v1/handlers/handlers.go
@@ -76,7 +76,7 @@ func GetTaskProtectionHandler(
 		if errResponseBody != nil {
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
 			if utils.Is5XXStatus(errResponseCode) {
-				successMetric.WithCount(0).Done(nil)()
+				successMetric.WithCount(0).Done(nil)
 			}
 			return
 		}
@@ -89,7 +89,7 @@ func GetTaskProtectionHandler(
 		taskCreds, errResponseCode, errResponseBody := getTaskCredentials(credentialsManager, *task)
 		if errResponseBody != nil {
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
-			successMetric.WithCount(0).Done(nil)()
+			successMetric.WithCount(0).Done(nil)
 			return
 		}
 
@@ -104,7 +104,7 @@ func GetTaskProtectionHandler(
 		if err != nil {
 			errResponseCode, errResponseBody := logAndHandleECSError(err, *task, requestType)
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
-			successMetric.WithCount(0).Done(nil)()
+			successMetric.WithCount(0).Done(nil)
 			return
 		}
 
@@ -113,14 +113,14 @@ func GetTaskProtectionHandler(
 			responseBody.ProtectedTasks, responseBody.Failures, *task, requestType)
 		if errResponseBody != nil {
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
-			successMetric.WithCount(0).Done(nil)()
+			successMetric.WithCount(0).Done(nil)
 			return
 		}
 
 		// ECS call was successful
 		utils.WriteJSONResponse(w, http.StatusOK,
 			types.NewTaskProtectionResponseProtection(responseBody.ProtectedTasks[0]), requestType)
-		successMetric.WithCount(1).Done(nil)()
+		successMetric.WithCount(1).Done(nil)
 	}
 }
 
@@ -162,7 +162,7 @@ func UpdateTaskProtectionHandler(
 		if errResponseBody != nil {
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
 			if utils.Is5XXStatus(errResponseCode) {
-				successMetric.WithCount(0).Done(nil)()
+				successMetric.WithCount(0).Done(nil)
 			}
 			return
 		}
@@ -193,7 +193,7 @@ func UpdateTaskProtectionHandler(
 		taskCreds, errResponseCode, errResponseBody := getTaskCredentials(credentialsManager, *task)
 		if errResponseBody != nil {
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
-			successMetric.WithCount(0).Done(nil)()
+			successMetric.WithCount(0).Done(nil)
 			return
 		}
 
@@ -210,7 +210,7 @@ func UpdateTaskProtectionHandler(
 		if err != nil {
 			errResponseCode, errResponseBody := logAndHandleECSError(err, *task, requestType)
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
-			successMetric.WithCount(0).Done(nil)()
+			successMetric.WithCount(0).Done(nil)
 			return
 		}
 
@@ -219,14 +219,14 @@ func UpdateTaskProtectionHandler(
 			response.ProtectedTasks, response.Failures, *task, requestType)
 		if errResponseBody != nil {
 			utils.WriteJSONResponse(w, errResponseCode, errResponseBody, requestType)
-			successMetric.WithCount(0).Done(nil)()
+			successMetric.WithCount(0).Done(nil)
 			return
 		}
 
 		// ECS call was successful
 		utils.WriteJSONResponse(w, http.StatusOK,
 			types.NewTaskProtectionResponseProtection(response.ProtectedTasks[0]), requestType)
-		successMetric.WithCount(1).Done(nil)()
+		successMetric.WithCount(1).Done(nil)
 	}
 }
 

--- a/ecs-agent/tmds/handlers/v4/handlers.go
+++ b/ecs-agent/tmds/handlers/v4/handlers.go
@@ -83,7 +83,7 @@ func ContainerMetadataHandler(
 			utils.WriteJSONResponse(w, responseCode, responseBody, utils.RequestTypeContainerMetadata)
 
 			if utils.Is5XXStatus(responseCode) {
-				metricsFactory.New(metrics.InternalServerErrorMetricName).Done(err)()
+				metricsFactory.New(metrics.InternalServerErrorMetricName).Done(err)
 			}
 
 			return
@@ -155,7 +155,7 @@ func taskMetadataHandler(
 			utils.WriteJSONResponse(w, responseCode, responseBody, utils.RequestTypeTaskMetadata)
 
 			if utils.Is5XXStatus(responseCode) {
-				metricsFactory.New(metrics.InternalServerErrorMetricName).Done(err)()
+				metricsFactory.New(metrics.InternalServerErrorMetricName).Done(err)
 			}
 
 			return
@@ -231,7 +231,7 @@ func statsHandler[R state.StatsResponse | map[string]*state.StatsResponse](
 			utils.WriteJSONResponse(w, responseCode, responseBody, requestType)
 
 			if utils.Is5XXStatus(responseCode) {
-				metricsFactory.New(metrics.InternalServerErrorMetricName).Done(err)()
+				metricsFactory.New(metrics.InternalServerErrorMetricName).Done(err)
 			}
 
 			return

--- a/ecs-agent/tmds/handlers/v4/handlers_test.go
+++ b/ecs-agent/tmds/handlers/v4/handlers_test.go
@@ -208,7 +208,7 @@ func TestContainerMetadata(t *testing.T) {
 		err := state.NewErrorMetadataFetchFailure(externalReason)
 		entry := mock_metrics.NewMockEntry(ctrl)
 
-		entry.EXPECT().Done(err).Return(func() {})
+		entry.EXPECT().Done(err)
 		metricsFactory.EXPECT().New(metrics.InternalServerErrorMetricName).Return(entry)
 		agentState.EXPECT().
 			GetContainerMetadata(endpointContainerID).
@@ -226,7 +226,7 @@ func TestContainerMetadata(t *testing.T) {
 		err := errors.New("unknown")
 		entry := mock_metrics.NewMockEntry(ctrl)
 
-		entry.EXPECT().Done(err).Return(func() {})
+		entry.EXPECT().Done(err)
 		metricsFactory.EXPECT().New(metrics.InternalServerErrorMetricName).Return(entry)
 		agentState.EXPECT().
 			GetContainerMetadata(endpointContainerID).
@@ -291,7 +291,7 @@ func TestTaskMetadata(t *testing.T) {
 		err := state.NewErrorMetadataFetchFailure(externalReason)
 		entry := mock_metrics.NewMockEntry(ctrl)
 
-		entry.EXPECT().Done(err).Return(func() {})
+		entry.EXPECT().Done(err)
 		metricsFactory.EXPECT().New(metrics.InternalServerErrorMetricName).Return(entry)
 		agentState.EXPECT().
 			GetTaskMetadata(endpointContainerID).
@@ -309,7 +309,7 @@ func TestTaskMetadata(t *testing.T) {
 		err := errors.New("unknown")
 		entry := mock_metrics.NewMockEntry(ctrl)
 
-		entry.EXPECT().Done(err).Return(func() {})
+		entry.EXPECT().Done(err)
 		metricsFactory.EXPECT().New(metrics.InternalServerErrorMetricName).Return(entry)
 		agentState.EXPECT().
 			GetTaskMetadata(endpointContainerID).
@@ -389,11 +389,7 @@ func TestContainerStats(t *testing.T) {
 
 			// Expect InternalServerError metric to be published with the error.
 			entry := mock_metrics.NewMockEntry(ctrl)
-			metricPublished := false // tracks if a metrics entry was published
-			entry.EXPECT().Done(tc.err).Return(func() {
-				// Set metricsPublished to true if metric was published.
-				metricPublished = true
-			})
+			entry.EXPECT().Done(tc.err)
 			metricsFactory.EXPECT().New(metrics.InternalServerErrorMetricName).Return(entry)
 
 			// Make test request
@@ -402,9 +398,6 @@ func TestContainerStats(t *testing.T) {
 				expectedStatusCode:   http.StatusInternalServerError,
 				expectedResponseBody: tc.responseBody,
 			})
-
-			// assert the metrics entry was published
-			assert.True(t, metricPublished)
 		})
 	}
 
@@ -472,7 +465,6 @@ func TestTaskStats(t *testing.T) {
 		t.Run("stats fetch failure", func(t *testing.T) {
 			// setup
 			agentState, ctrl, metricsFactory, handler := setup()
-			metricPublished := false // tracks if a metrics entry was published
 
 			// expect GetContainerStats to be called that should return an error
 			agentState.EXPECT().
@@ -480,9 +472,8 @@ func TestTaskStats(t *testing.T) {
 				Return(nil, tc.err)
 
 			// expect InternalServerError metric to be published with the error.
-			// set metricsPublished to true if metric was published
 			entry := mock_metrics.NewMockEntry(ctrl)
-			entry.EXPECT().Done(tc.err).Return(func() { metricPublished = true })
+			entry.EXPECT().Done(tc.err)
 			metricsFactory.EXPECT().New(metrics.InternalServerErrorMetricName).Return(entry)
 
 			// Go
@@ -491,9 +482,6 @@ func TestTaskStats(t *testing.T) {
 				expectedStatusCode:   http.StatusInternalServerError,
 				expectedResponseBody: tc.responseBody,
 			})
-
-			// confirm the metrics entry was published
-			assert.True(t, metricPublished)
 		})
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Metrics `Entry` interface in ecs-agent module has a `Done` method that marks a metric as completed and returns a function that when called publishes the metric. It is supposed to be used like below. 

```go
  entry.Done(err)()
```

It is too easy to forget the trailing `()` which leads to metrics not being published. We don't really have a usecase to separate metrics completion and publish, so this PR updates the `Done` method's signature to not return a function. Instead, the method is suppose to do both - mark the metric as completed and publish it. 

### Implementation details
<!-- How are the changes implemented? -->
* Update `Done` method of `Entry` interface. 
* Update usage and tests.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Automated tests only.

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Update metrics interface to couple metric completion and publish

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
