### PR TITLE
Revert "add container metadata to introspection response"

### DIFF
--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -14,8 +14,6 @@
 package v1
 
 import (
-	"time"
-
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
@@ -51,10 +49,6 @@ type ContainerResponse struct {
 	DockerID   string                        `json:"DockerId"`
 	DockerName string                        `json:"DockerName"`
 	Name       string                        `json:"Name"`
-	Image      string                        `json:"Image"`
-	ImageID    string                        `json:"ImageID"`
-	CreatedAt  *time.Time                    `json:"CreatedAt,omitempty"`
-	StartedAt  *time.Time                    `json:"StartedAt,omitempty"`
 	Ports      []tmdsresponse.PortResponse   `json:"Ports,omitempty"`
 	Networks   []tmdsresponse.Network        `json:"Networks,omitempty"`
 	Volumes    []tmdsresponse.VolumeResponse `json:"Volumes,omitempty"`
@@ -95,8 +89,6 @@ func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *ap
 	container := dockerContainer.Container
 	resp := ContainerResponse{
 		Name:       container.Name,
-		Image:      container.Image,
-		ImageID:    container.ImageID,
 		DockerID:   dockerContainer.DockerID,
 		DockerName: dockerContainer.DockerName,
 	}
@@ -112,14 +104,6 @@ func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *ap
 				IPv6Addresses: eni.GetIPV6Addresses(),
 			},
 		}
-	}
-	if createdAt := container.GetCreatedAt(); !createdAt.IsZero() {
-		createdAt = createdAt.UTC()
-		resp.CreatedAt = &createdAt
-	}
-	if startedAt := container.GetStartedAt(); !startedAt.IsZero() {
-		startedAt = startedAt.UTC()
-		resp.StartedAt = &startedAt
 	}
 	return resp
 }

--- a/agent/handlers/v1/response_test.go
+++ b/agent/handlers/v1/response_test.go
@@ -19,13 +19,11 @@ package v1
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 
 	"github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/assert"
@@ -35,68 +33,53 @@ const (
 	taskARN        = "t1"
 	family         = "sleep"
 	version        = "1"
-	status         = "RUNNING"
 	containerID    = "cid"
 	containerName  = "sleepy"
-	imageName      = "busybox"
-	imageID        = "busyboxID"
-	networkMode    = "awsvpc"
 	eniIPv4Address = "10.0.0.2"
-	port           = 80
-	protocol       = "tcp"
 	volName        = "volume1"
 	volSource      = "/var/lib/volume1"
 	volDestination = "/volume"
 )
 
-var (
-	containerTime        = time.Now()
-	containerTimeUTC     = containerTime.UTC()
-	expectedPortResponse = response.PortResponse{
-		ContainerPort: port,
-		Protocol:      protocol,
-		HostPort:      port,
-	}
-	expectedNetworkResponse = response.Network{
-		NetworkMode:   networkMode,
-		IPv4Addresses: []string{eniIPv4Address},
-	}
-	expectedVolumeResponse = response.VolumeResponse{
-		DockerName:  volName,
-		Source:      volSource,
-		Destination: volDestination,
-	}
-	expectedContainerResponse = ContainerResponse{
-		DockerID:   containerID,
-		DockerName: containerName,
-		Name:       containerName,
-		Image:      imageName,
-		ImageID:    imageID,
-		CreatedAt:  &containerTimeUTC,
-		StartedAt:  &containerTimeUTC,
-		Ports: []response.PortResponse{
-			expectedPortResponse,
-		},
-		Networks: []response.Network{
-			expectedNetworkResponse,
-		},
-		Volumes: []response.VolumeResponse{
-			expectedVolumeResponse,
-		},
-	}
-	expectedTaskResponse = TaskResponse{
-		Arn:           taskARN,
-		DesiredStatus: status,
-		KnownStatus:   status,
-		Family:        family,
-		Version:       version,
-		Containers: []ContainerResponse{
-			expectedContainerResponse,
-		},
-	}
-)
-
 func TestTaskResponse(t *testing.T) {
+	expectedTaskResponseMap := map[string]interface{}{
+		"Arn":           "t1",
+		"DesiredStatus": "RUNNING",
+		"KnownStatus":   "RUNNING",
+		"Family":        "sleep",
+		"Version":       "1",
+		"Containers": []interface{}{
+			map[string]interface{}{
+				"DockerId":   "cid",
+				"DockerName": "sleepy",
+				"Name":       "sleepy",
+				"Ports": []interface{}{
+					map[string]interface{}{
+						// The number should be float here, because when we unmarshal
+						// something and we don't specify the number type, it will be
+						// set to float.
+						"ContainerPort": float64(80),
+						"Protocol":      "tcp",
+						"HostPort":      float64(80),
+					},
+				},
+				"Networks": []interface{}{
+					map[string]interface{}{
+						"NetworkMode":   "awsvpc",
+						"IPv4Addresses": []interface{}{"10.0.0.2"},
+					},
+				},
+				"Volumes": []interface{}{
+					map[string]interface{}{
+						"DockerName":  volName,
+						"Source":      volSource,
+						"Destination": volDestination,
+					},
+				},
+			},
+		},
+	}
+
 	task := &apitask.Task{
 		Arn:                 taskARN,
 		Family:              family,
@@ -115,9 +98,7 @@ func TestTaskResponse(t *testing.T) {
 	}
 
 	container := &apicontainer.Container{
-		Name:    containerName,
-		Image:   imageName,
-		ImageID: imageID,
+		Name: containerName,
 		Ports: []apicontainer.PortBinding{
 			{
 				ContainerPort: 80,
@@ -132,9 +113,6 @@ func TestTaskResponse(t *testing.T) {
 			},
 		},
 	}
-
-	container.SetCreatedAt(containerTime)
-	container.SetStartedAt(containerTime)
 
 	containerNameToDockerContainer := map[string]*apicontainer.DockerContainer{
 		taskARN: {
@@ -146,17 +124,45 @@ func TestTaskResponse(t *testing.T) {
 
 	taskResponse := NewTaskResponse(task, containerNameToDockerContainer)
 
-	_, err := json.Marshal(taskResponse)
+	taskResponseJSON, err := json.Marshal(taskResponse)
 	assert.NoError(t, err)
 
-	assert.Equal(t, expectedTaskResponse, *taskResponse)
+	taskResponseMap := make(map[string]interface{})
+
+	json.Unmarshal(taskResponseJSON, &taskResponseMap)
+
+	assert.Equal(t, expectedTaskResponseMap, taskResponseMap)
 }
 
 func TestContainerResponse(t *testing.T) {
+	expectedContainerResponseMap := map[string]interface{}{
+		"DockerId":   "cid",
+		"DockerName": "sleepy",
+		"Name":       "sleepy",
+		"Ports": []interface{}{
+			map[string]interface{}{
+				"ContainerPort": float64(80),
+				"Protocol":      "tcp",
+				"HostPort":      float64(80),
+			},
+		},
+		"Networks": []interface{}{
+			map[string]interface{}{
+				"NetworkMode":   "awsvpc",
+				"IPv4Addresses": []interface{}{"10.0.0.2"},
+			},
+		},
+		"Volumes": []interface{}{
+			map[string]interface{}{
+				"DockerName":  volName,
+				"Source":      volSource,
+				"Destination": volDestination,
+			},
+		},
+	}
+
 	container := &apicontainer.Container{
-		Name:    containerName,
-		Image:   imageName,
-		ImageID: imageID,
+		Name: containerName,
 		Ports: []apicontainer.PortBinding{
 			{
 				ContainerPort: 80,
@@ -171,9 +177,6 @@ func TestContainerResponse(t *testing.T) {
 			},
 		},
 	}
-
-	container.SetCreatedAt(containerTime)
-	container.SetStartedAt(containerTime)
 
 	dockerContainer := &apicontainer.DockerContainer{
 		DockerID:   containerID,
@@ -191,10 +194,14 @@ func TestContainerResponse(t *testing.T) {
 
 	containerResponse := NewContainerResponse(dockerContainer, eni)
 
-	_, err := json.Marshal(containerResponse)
+	containerResponseJSON, err := json.Marshal(containerResponse)
 	assert.NoError(t, err)
 
-	assert.Equal(t, expectedContainerResponse, containerResponse)
+	containerResponseMap := make(map[string]interface{})
+
+	json.Unmarshal(containerResponseJSON, &containerResponseMap)
+
+	assert.Equal(t, expectedContainerResponseMap, containerResponseMap)
 }
 
 func TestPortBindingsResponse(t *testing.T) {
@@ -214,7 +221,10 @@ func TestPortBindingsResponse(t *testing.T) {
 	}
 
 	PortBindingsResponse := NewPortBindingsResponse(dockerContainer, nil)
-	assert.Equal(t, expectedPortResponse, PortBindingsResponse[0])
+
+	assert.Equal(t, uint16(80), PortBindingsResponse[0].ContainerPort)
+	assert.Equal(t, uint16(80), PortBindingsResponse[0].HostPort)
+	assert.Equal(t, "tcp", PortBindingsResponse[0].Protocol)
 }
 
 func TestVolumesResponse(t *testing.T) {
@@ -234,5 +244,8 @@ func TestVolumesResponse(t *testing.T) {
 	}
 
 	VolumesResponse := NewVolumesResponse(dockerContainer)
-	assert.Equal(t, expectedVolumeResponse, VolumesResponse[0])
+
+	assert.Equal(t, volName, VolumesResponse[0].DockerName)
+	assert.Equal(t, volSource, VolumesResponse[0].Source)
+	assert.Equal(t, volDestination, VolumesResponse[0].Destination)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This reverts commit 67aedb7561c78b312962350ba2848ad7e55586fb from #3788. This commit will be moved to feature/guardduty.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
