### PR TITLE
Add some unit tests for config parsers where coverage was missing

### DIFF
--- a/agent/api/task/task_attachment_handler_test.go
+++ b/agent/api/task/task_attachment_handler_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/app/healthcheck_test.go
+++ b/agent/app/healthcheck_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/config/parse_test.go
+++ b/agent/config/parse_test.go
@@ -1,0 +1,116 @@
+//go:build unit
+// +build unit
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseReservedPorts(t *testing.T) {
+	envVar := "ECS_RESERVED_PORTS"
+	// unset value
+	v := parseReservedPorts(envVar)
+	assert.Empty(t, v)
+	// invalid value
+	t.Setenv(envVar, "1,2,3")
+	v = parseReservedPorts(envVar)
+	assert.Empty(t, v)
+	// valid value
+	t.Setenv(envVar, "[1,2,3]")
+	v = parseReservedPorts(envVar)
+	assert.Equal(t, []uint16{1, 2, 3}, v)
+	// number too large
+	t.Setenv(envVar, "[1,2,3,99999999999]")
+	v = parseReservedPorts(envVar)
+	assert.Equal(t, []uint16{1, 2, 3, 0}, v)
+}
+
+func TestParseVolumePluginCapabilities(t *testing.T) {
+	// unset value
+	t.Setenv("ECS_VOLUME_PLUGIN_CAPABILITIES", "")
+	v := parseVolumePluginCapabilities()
+	assert.Empty(t, v)
+	// invalid value
+	t.Setenv("ECS_VOLUME_PLUGIN_CAPABILITIES", "1,2,3")
+	v = parseVolumePluginCapabilities()
+	assert.Empty(t, v)
+	// valid value
+	t.Setenv("ECS_VOLUME_PLUGIN_CAPABILITIES", "[1,2,3]")
+	v = parseVolumePluginCapabilities()
+	assert.Equal(t, []string{"", "", ""}, v)
+	// valid values
+	t.Setenv("ECS_VOLUME_PLUGIN_CAPABILITIES", `["cap1","cap2"]`)
+	v = parseVolumePluginCapabilities()
+	assert.Equal(t, []string{"cap1", "cap2"}, v)
+}
+
+func TestParseNumImagesToDeletePerCycle(t *testing.T) {
+	// unset value
+	t.Setenv("ECS_NUM_IMAGES_DELETE_PER_CYCLE", "")
+	v := parseNumImagesToDeletePerCycle()
+	assert.Zero(t, v)
+	// invalid value
+	t.Setenv("ECS_NUM_IMAGES_DELETE_PER_CYCLE", "1")
+	v = parseNumImagesToDeletePerCycle()
+	assert.Equal(t, 1, v)
+	// valid value
+	t.Setenv("ECS_NUM_IMAGES_DELETE_PER_CYCLE", "2000000")
+	v = parseNumImagesToDeletePerCycle()
+	assert.Equal(t, 2000000, v)
+	// valid values
+	t.Setenv("ECS_NUM_IMAGES_DELETE_PER_CYCLE", "foobar")
+	v = parseNumImagesToDeletePerCycle()
+	assert.Zero(t, v)
+}
+
+func TestParseNumNonECSContainersToDeletePerCycle(t *testing.T) {
+	// unset value
+	t.Setenv("NONECS_NUM_CONTAINERS_DELETE_PER_CYCLE", "")
+	v := parseNumNonECSContainersToDeletePerCycle()
+	assert.Zero(t, v)
+	// invalid value
+	t.Setenv("NONECS_NUM_CONTAINERS_DELETE_PER_CYCLE", "1")
+	v = parseNumNonECSContainersToDeletePerCycle()
+	assert.Equal(t, 1, v)
+	// valid value
+	t.Setenv("NONECS_NUM_CONTAINERS_DELETE_PER_CYCLE", "2000000")
+	v = parseNumNonECSContainersToDeletePerCycle()
+	assert.Equal(t, 2000000, v)
+	// valid values
+	t.Setenv("NONECS_NUM_CONTAINERS_DELETE_PER_CYCLE", "foobar")
+	v = parseNumNonECSContainersToDeletePerCycle()
+	assert.Zero(t, v)
+}
+
+func TestParseBooleanDefaultFalseConfig(t *testing.T) {
+	t.Setenv("ECS_PARSE_BOOLEAN_DEFAULT_FALSE", "")
+	v := parseBooleanDefaultFalseConfig("ECS_PARSE_BOOLEAN_DEFAULT_FALSE")
+	assert.False(t, v.Enabled())
+	t.Setenv("ECS_PARSE_BOOLEAN_DEFAULT_FALSE", "true")
+	v = parseBooleanDefaultFalseConfig("ECS_PARSE_BOOLEAN_DEFAULT_FALSE")
+	assert.True(t, v.Enabled())
+	t.Setenv("ECS_PARSE_BOOLEAN_DEFAULT_FALSE", "false")
+	v = parseBooleanDefaultFalseConfig("ECS_PARSE_BOOLEAN_DEFAULT_FALSE")
+	assert.False(t, v.Enabled())
+	t.Setenv("ECS_PARSE_BOOLEAN_DEFAULT_FALSE", "foobar")
+	v = parseBooleanDefaultFalseConfig("ECS_PARSE_BOOLEAN_DEFAULT_FALSE")
+	assert.False(t, v.Enabled())
+}
+
+func TestParseBooleanDefaultTrueConfig(t *testing.T) {
+	t.Setenv("ECS_PARSE_BOOLEAN_DEFAULT_TRUE", "")
+	v := parseBooleanDefaultTrueConfig("ECS_PARSE_BOOLEAN_DEFAULT_TRUE")
+	assert.True(t, v.Enabled())
+	t.Setenv("ECS_PARSE_BOOLEAN_DEFAULT_TRUE", "true")
+	v = parseBooleanDefaultTrueConfig("ECS_PARSE_BOOLEAN_DEFAULT_TRUE")
+	assert.True(t, v.Enabled())
+	t.Setenv("ECS_PARSE_BOOLEAN_DEFAULT_TRUE", "false")
+	v = parseBooleanDefaultTrueConfig("ECS_PARSE_BOOLEAN_DEFAULT_TRUE")
+	assert.False(t, v.Enabled())
+	t.Setenv("ECS_PARSE_BOOLEAN_DEFAULT_TRUE", "foobar")
+	v = parseBooleanDefaultTrueConfig("ECS_PARSE_BOOLEAN_DEFAULT_TRUE")
+	assert.True(t, v.Enabled())
+}

--- a/agent/doctor/docker_runtime_healthcheck_test.go
+++ b/agent/doctor/docker_runtime_healthcheck_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 package doctor
 
 import (

--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -1,3 +1,6 @@
+//go:build unit || integration || sudo
+// +build unit integration sudo
+
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/daemonmanager/daemon_manager_linux_test.go
+++ b/agent/engine/daemonmanager/daemon_manager_linux_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/execcmd/agent_version_test.go
+++ b/agent/engine/execcmd/agent_version_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/execcmd/manager_test.go
+++ b/agent/engine/execcmd/manager_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/handlers/agentapi/taskprotection/factory_test.go
+++ b/agent/handlers/agentapi/taskprotection/factory_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -1,3 +1,6 @@
+//go:build unit || sudo || integration
+// +build unit sudo integration
+
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/stats/reporter/reporter_test.go
+++ b/agent/stats/reporter/reporter_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/taskresource/credentialspec/credentialspecstatus_test.go
+++ b/agent/taskresource/credentialspec/credentialspecstatus_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/taskresource/volume/dockervolume_efs_test.go
+++ b/agent/taskresource/volume/dockervolume_efs_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/taskresource/volume/mountoptions_test.go
+++ b/agent/taskresource/volume/mountoptions_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/utils/ephemeral_ports_test.go
+++ b/agent/utils/ephemeral_ports_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 package utils
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Some env var config parsing situations were missing coverage, adding unit tests for fuller coverage. Some unit test files were also missing the "unit" tag, which meant they were not running on PRs. Tags were added to these files.

before:
```
% go test -cover -tags unit ./config/.
ok      github.com/aws/amazon-ecs-agent/agent/config    0.460s  coverage: 91.0% of statements
```
after:
```
% go test -cover -tags unit ./config/.
ok      github.com/aws/amazon-ecs-agent/agent/config    0.480s    coverage: 92.6% of statements
```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

n/a

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

no application code changes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
