### PR TITLE
Fix failing static checks

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_resource_responder.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_resource_responder.go
@@ -69,7 +69,7 @@ func (r *attachResourceResponder) handleAttachMessage(message *ecsacs.ConfirmAtt
 
 	// Validate fields in the message.
 	attachmentProperties, err := validateAttachResourceMessage(message)
-	r.metricsFactory.New(metrics.ResourceValidationMetricName).Done(err)()
+	r.metricsFactory.New(metrics.ResourceValidationMetricName).Done(err)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Error validating %s received from ECS", AttachResourceMessageName), logger.Fields{
 			field.Error: err,

--- a/ecs-agent/acs/session/attach_resource_responder.go
+++ b/ecs-agent/acs/session/attach_resource_responder.go
@@ -69,7 +69,7 @@ func (r *attachResourceResponder) handleAttachMessage(message *ecsacs.ConfirmAtt
 
 	// Validate fields in the message.
 	attachmentProperties, err := validateAttachResourceMessage(message)
-	r.metricsFactory.New(metrics.ResourceValidationMetricName).Done(err)()
+	r.metricsFactory.New(metrics.ResourceValidationMetricName).Done(err)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Error validating %s received from ECS", AttachResourceMessageName), logger.Fields{
 			field.Error: err,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Motivation:
1. This PR was raised: https://github.com/aws/amazon-ecs-agent/pull/3803
2. Then this PR was raised (without the changes in the above PR taken into account): https://github.com/aws/amazon-ecs-agent/pull/3807
3. PR #3803 was merged
4. PR #3807 was then subsequently successfully rebased and merged via Github, but now this line of code is not valid: https://github.com/aws/amazon-ecs-agent/blob/dev/ecs-agent/acs/session/attach_resource_responder.go#L72
5. Static checks are now failing

This PR addresses the line of code mentioned above to fix the failing static checks.

### Implementation details
<!-- How are the changes implemented? -->
Update usage of metrics `Entry` interface `Done` method in attach resource responder.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Existing PR tests

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Fix failing static checks

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
