### PR TITLE
Revert "Use total_inactive_file for calculating memory usage (#3776)"

### DIFF
--- a/agent/stats/utils_test.go
+++ b/agent/stats/utils_test.go
@@ -51,7 +51,7 @@ func TestDockerStatsToContainerStatsMemUsage(t *testing.T) {
 				"usage": %d,
 				"max_usage": %d,
 				"stats": {
-					"total_inactive_file": %d,
+					"cache": %d,
 					"rss": %d
 				},
 				"privateworkingset": %d

--- a/agent/stats/utils_unix.go
+++ b/agent/stats/utils_unix.go
@@ -49,7 +49,7 @@ func getMemUsage(mem types.MemoryStats) uint64 {
 			return mem.Usage - v
 		}
 	}
-	if v, ok := mem.Stats["total_inactive_file"]; ok && v < mem.Usage {
+	if v, ok := mem.Stats["cache"]; ok && v < mem.Usage {
 		return mem.Usage - v
 	}
 	return mem.Usage


### PR DESCRIPTION
This reverts commit 5b4e23130c11afc856eaaf047bd4a4575a89514e.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Reasoning can be found https://github.com/aws/amazon-ecs-agent/pull/3776#issuecomment-1640849419

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
