### PR TITLE
Add Snapshotter field to V4 Container Response

### DIFF
--- a/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/ecs-agent/tmds/handlers/v4/state/response.go
@@ -57,7 +57,8 @@ type EphemeralStorageMetrics struct {
 // with the v2 container response object.
 type ContainerResponse struct {
 	*v2.ContainerResponse
-	Networks []Network `json:"Networks,omitempty"`
+	Networks    []Network `json:"Networks,omitempty"`
+	Snapshotter string    `json:"Snapshotter,omitempty"`
 }
 
 // Network is the v4 Network response. It adds a bunch of information about network

--- a/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/ecs-agent/tmds/handlers/v4/state/response.go
@@ -57,8 +57,7 @@ type EphemeralStorageMetrics struct {
 // with the v2 container response object.
 type ContainerResponse struct {
 	*v2.ContainerResponse
-	Networks    []Network `json:"Networks,omitempty"`
-	Snapshotter string    `json:"ContainerARN,omitempty"`
+	Networks []Network `json:"Networks,omitempty"`
 }
 
 // Network is the v4 Network response. It adds a bunch of information about network

--- a/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/ecs-agent/tmds/handlers/v4/state/response.go
@@ -57,7 +57,8 @@ type EphemeralStorageMetrics struct {
 // with the v2 container response object.
 type ContainerResponse struct {
 	*v2.ContainerResponse
-	Networks []Network `json:"Networks,omitempty"`
+	Networks    []Network `json:"Networks,omitempty"`
+	Snapshotter string    `json:"ContainerARN,omitempty"`
 }
 
 // Network is the v4 Network response. It adds a bunch of information about network


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Snapshotter field was recently added to the v4 container response in fargate agent.
Adding this field to the v4 container response in shared library where its currently missing.

### Implementation details
Add optional field Snapshotter of type String in v4 container response in shared TMDS library.

### Testing
Unit, integration, and functional tests.

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add new field Snapshotter to V4 Container response

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
