### PR TITLE
greedy task resource accounting instead of blocking on tasks ahead in the queue

### DIFF
--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -379,14 +379,14 @@ func getTestHostResources() map[string]*ecs.Resource {
 		Type:         utils.Strptr("INTEGER"),
 		IntegerValue: &CPUs,
 	}
-	//MEMORY
+	// MEMORY
 	memory := int64(1024)
 	hostResources["MEMORY"] = &ecs.Resource{
 		Name:         utils.Strptr("MEMORY"),
 		Type:         utils.Strptr("INTEGER"),
 		IntegerValue: &memory,
 	}
-	//PORTS
+	// PORTS
 	ports_tcp := []*string{}
 	hostResources["PORTS_TCP"] = &ecs.Resource{
 		Name:           utils.Strptr("PORTS_TCP"),
@@ -394,14 +394,14 @@ func getTestHostResources() map[string]*ecs.Resource {
 		StringSetValue: ports_tcp,
 	}
 
-	//PORTS_UDP
+	// PORTS_UDP
 	ports_udp := []*string{}
 	hostResources["PORTS_UDP"] = &ecs.Resource{
 		Name:           utils.Strptr("PORTS_UDP"),
 		Type:           utils.Strptr("STRINGSET"),
 		StringSetValue: ports_udp,
 	}
-	//GPUs
+	// GPUs
 	numGPUs := int64(3)
 	hostResources["GPU"] = &ecs.Resource{
 		Name:         utils.Strptr("GPU"),

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -260,7 +260,11 @@ func (engine *DockerTaskEngine) reconcileHostResources() {
 		if taskStatus.Terminal() {
 			err := engine.hostResourceManager.release(task.Arn, resources)
 			if err != nil {
-				logger.Critical("Failed to release resources during reconciliation", logger.Fields{field.TaskARN: task.Arn})
+				logger.Critical("Failed to release resources during reconciliation",
+					logger.Fields{
+						field.TaskARN: task.Arn,
+						field.Error:   err,
+					})
 			}
 			continue
 		}
@@ -271,7 +275,11 @@ func (engine *DockerTaskEngine) reconcileHostResources() {
 		if !task.IsInternal && task.HasActiveContainers() {
 			consumed, err := engine.hostResourceManager.consume(task.Arn, resources)
 			if err != nil || !consumed {
-				logger.Critical("Failed to consume resources for created/running tasks during reconciliation", logger.Fields{field.TaskARN: task.Arn})
+				logger.Critical("Failed to consume resources for created/running tasks during reconciliation",
+					logger.Fields{
+						field.TaskARN: task.Arn,
+						field.Error:   err,
+					})
 			}
 		}
 	}
@@ -347,37 +355,53 @@ func (engine *DockerTaskEngine) wakeUpTaskQueueMonitor() {
 	}
 }
 
-func (engine *DockerTaskEngine) topTask() (*managedTask, error) {
+func (engine *DockerTaskEngine) validateIndex(index int) error {
+	waitingTaskQueueLength := len(engine.waitingTaskQueue)
+	// empty queue
+	if waitingTaskQueueLength == 0 {
+		return fmt.Errorf("no tasks in the waiting queue")
+	}
+	// invalid index
+	if index < 0 || index >= waitingTaskQueueLength {
+		return fmt.Errorf("invalid index: %v", index)
+	}
+	return nil
+}
+
+// getTaskByIndex returns the task from waitingTaskQueue at the given index
+func (engine *DockerTaskEngine) getTaskByIndex(index int) (*managedTask, error) {
 	engine.waitingTasksLock.Lock()
 	defer engine.waitingTasksLock.Unlock()
-	if len(engine.waitingTaskQueue) > 0 {
-		return engine.waitingTaskQueue[0], nil
+	err := engine.validateIndex(index)
+	if err != nil {
+		return nil, err
 	}
-	return nil, fmt.Errorf("no tasks in waiting queue")
+	return engine.waitingTaskQueue[index], nil
 }
 
 func (engine *DockerTaskEngine) enqueueTask(task *managedTask) {
 	engine.waitingTasksLock.Lock()
 	engine.waitingTaskQueue = append(engine.waitingTaskQueue, task)
 	engine.waitingTasksLock.Unlock()
-	logger.Debug("Enqueued task in Waiting Task Queue", logger.Fields{field.TaskARN: task.Arn})
+	logger.Debug("Enqueued task in the waiting task queue", logger.Fields{field.TaskARN: task.Arn})
 	engine.wakeUpTaskQueueMonitor()
 }
 
-func (engine *DockerTaskEngine) dequeueTask() (*managedTask, error) {
+// dequeueTaskByIndex dequeues a task from the waitingTaskQueue at the given index
+func (engine *DockerTaskEngine) dequeueTaskByIndex(index int) (*managedTask, error) {
 	engine.waitingTasksLock.Lock()
 	defer engine.waitingTasksLock.Unlock()
-	if len(engine.waitingTaskQueue) > 0 {
-		task := engine.waitingTaskQueue[0]
-		engine.waitingTaskQueue = engine.waitingTaskQueue[1:]
-		logger.Debug("Dequeued task from Waiting Task Queue", logger.Fields{field.TaskARN: task.Arn})
-		return task, nil
+	err := engine.validateIndex(index)
+	if err != nil {
+		return nil, err
 	}
-
-	return nil, fmt.Errorf("no tasks in waiting queue")
+	task := engine.waitingTaskQueue[index]
+	engine.waitingTaskQueue = append(engine.waitingTaskQueue[:index], engine.waitingTaskQueue[index+1:]...)
+	logger.Debug("Dequeued task from the waiting task queue", logger.Fields{field.TaskARN: task.Arn})
+	return task, nil
 }
 
-// monitorQueuedTasks starts as many tasks as possible based on FIFO order of waitingTaskQueue
+// monitorQueuedTasks starts as many tasks as possible based from the waitingTaskQueue
 // and availability of host resources. When no more tasks can be started, it will wait on
 // monitorQueuedTaskEvent channel. This channel receives (best effort) messages when
 // - a task stops
@@ -391,15 +415,23 @@ func (engine *DockerTaskEngine) monitorQueuedTasks(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-engine.monitorQueuedTaskEvent:
-			// Dequeue as many tasks as possible and start wake up their goroutines
+			// Dequeue as many tasks as possible and start waking up their goroutines
+			index := 0
 			for {
-				task, err := engine.topTask()
+				task, err := engine.getTaskByIndex(index)
 				if err != nil {
+					// either the queue is empty or we've traversed through all the tasks in the queue
+					logger.Debug("Unable to get task from the wait queue at the given index", logger.Fields{
+						field.Error: err,
+						"index":     index,
+					})
 					break
 				}
-				dequeuedTask := engine.tryDequeueWaitingTasks(task)
+				dequeuedTask := engine.tryDequeueWaitingTasks(task, index)
 				if !dequeuedTask {
-					break
+					// if the task was not dequeued, increment index so that we can process the next task in the queue
+					// else, keep index as is since by de-queuing, the queue is shifted to the left by 1
+					index += 1
 				}
 			}
 			logger.Debug("No more tasks could be started at this moment, waiting")
@@ -407,50 +439,91 @@ func (engine *DockerTaskEngine) monitorQueuedTasks(ctx context.Context) {
 	}
 }
 
-func (engine *DockerTaskEngine) tryDequeueWaitingTasks(task *managedTask) bool {
+// tryDequeueWaitingTasks tries to dequeue a task at the given index from the waitingTaskQueue
+// it returns true if it was able to dequeue, false otherwise
+func (engine *DockerTaskEngine) tryDequeueWaitingTasks(task *managedTask, index int) bool {
 	// Isolate monitorQueuedTasks processing from changes of desired status updates to prevent
 	// unexpected updates to host resource manager when tasks are being processed by monitorQueuedTasks
-	// For example when ACS StopTask event updates arrives and simultaneously monitorQueuedTasks
-	// could be processing
+	// For example when ACS StopTask event updates arrives and simultaneously monitorQueuedTasks could be processing
 	engine.monitorQueuedTasksLock.Lock()
 	defer engine.monitorQueuedTasksLock.Unlock()
 	taskDesiredStatus := task.GetDesiredStatus()
+	// dequeue terminal task
 	if taskDesiredStatus.Terminal() {
-		logger.Info("Task desired status changed to STOPPED while waiting for host resources, progressing without consuming resources", logger.Fields{field.TaskARN: task.Arn})
-		engine.returnWaitingTask()
+		logger.Info("Task desired status changed to STOPPED while waiting for host resources, "+
+			"progressing without consuming resources", logger.Fields{field.TaskARN: task.Arn})
+		err := engine.returnWaitingTask(index)
+		if err != nil {
+			logger.Error("Unable to dequeue task from the waiting task queue", logger.Fields{
+				field.TaskARN: task.Arn,
+				field.Error:   err,
+			})
+			return false
+		}
 		return true
 	}
 	taskHostResources := task.ToHostResources()
 	consumed, err := task.engine.hostResourceManager.consume(task.Arn, taskHostResources)
+	// the task has an invalid task resource map; dequeue it and set its desired status to terminal
 	if err != nil {
-		engine.failWaitingTask(err)
+		logger.Error("Error consuming resources due to invalid task resource map", logger.Fields{
+			field.TaskARN: task.Arn,
+			field.Error:   err,
+		})
+		err := engine.failWaitingTask(index)
+		if err != nil {
+			logger.Error("Unable to dequeue task from the waiting task queue", logger.Fields{
+				field.TaskARN: task.Arn,
+				field.Error:   err,
+			})
+			return false
+		}
 		return true
 	}
 	if consumed {
-		engine.startWaitingTask()
+		// the task consumed resources as needed; dequeue it
+		logger.Info("Host resources consumed, progressing task", logger.Fields{field.TaskARN: task.Arn})
+		err := engine.startWaitingTask(index)
+		if err != nil {
+			logger.Error("Unable to dequeue task from the waiting task queue", logger.Fields{
+				field.TaskARN: task.Arn,
+				field.Error:   err,
+			})
+			return false
+		}
 		return true
 	}
+	// the task could not consume resources; it stays in the waitingTaskQueue
 	return false
-	// not consumed, go to wait
 }
 
 // To be called when resources are not to be consumed by host resource manager, just dequeues and returns
-func (engine *DockerTaskEngine) returnWaitingTask() {
-	task, _ := engine.dequeueTask()
+func (engine *DockerTaskEngine) returnWaitingTask(index int) error {
+	task, err := engine.dequeueTaskByIndex(index)
+	if err != nil {
+		return err
+	}
 	task.consumedHostResourceEvent <- struct{}{}
+	return nil
 }
 
-func (engine *DockerTaskEngine) failWaitingTask(err error) {
-	task, _ := engine.dequeueTask()
-	logger.Error(fmt.Sprintf("Error consuming resources due to invalid task config : %s", err.Error()), logger.Fields{field.TaskARN: task.Arn})
+func (engine *DockerTaskEngine) failWaitingTask(index int) error {
+	task, err := engine.dequeueTaskByIndex(index)
+	if err != nil {
+		return err
+	}
 	task.SetDesiredStatus(apitaskstatus.TaskStopped)
 	task.consumedHostResourceEvent <- struct{}{}
+	return nil
 }
 
-func (engine *DockerTaskEngine) startWaitingTask() {
-	task, _ := engine.dequeueTask()
-	logger.Info("Host resources consumed, progressing task", logger.Fields{field.TaskARN: task.Arn})
+func (engine *DockerTaskEngine) startWaitingTask(index int) error {
+	task, err := engine.dequeueTaskByIndex(index)
+	if err != nil {
+		return err
+	}
 	task.consumedHostResourceEvent <- struct{}{}
+	return nil
 }
 
 func (engine *DockerTaskEngine) startPeriodicExecAgentsMonitoring(ctx context.Context) {

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -1201,12 +1201,12 @@ func TestHostResourceManagerTrickleQueue(t *testing.T) {
 	// After ~4s, 3rd task should be queued up and will not be dequeued until ~10s, i.e. until 1st task stops and gets dequeued
 	go func() {
 		time.Sleep(6 * time.Second)
-		task, err := taskEngine.(*DockerTaskEngine).topTask()
+		task, err := taskEngine.(*DockerTaskEngine).getTaskByIndex(0)
 		assert.NoError(t, err, "one task should be queued up after 6s")
 		assert.Equal(t, task.Arn, tasks[2].Arn, "wrong task at top of queue")
 
 		time.Sleep(6 * time.Second)
-		_, err = taskEngine.(*DockerTaskEngine).topTask()
+		_, err = taskEngine.(*DockerTaskEngine).getTaskByIndex(0)
 		assert.Error(t, err, "no task should be queued up after 12s")
 	}()
 	waitFinished(t, finished, testTimeout)

--- a/agent/engine/host_resource_manager.go
+++ b/agent/engine/host_resource_manager.go
@@ -40,7 +40,7 @@ type HostResourceManager struct {
 	consumedResource          map[string]*ecs.Resource
 	hostResourceManagerRWLock sync.Mutex
 
-	//task.arn to boolean whether host resources consumed or not
+	// task.arn to boolean whether host resources consumed or not
 	taskConsumed map[string]bool
 }
 
@@ -116,7 +116,7 @@ func (h *HostResourceManager) consume(taskArn string, resources map[string]*ecs.
 
 	ok, err := h.consumable(resources)
 	if err != nil {
-		logger.Error("Resources failing to consume, error in task resources", logger.Fields{
+		logger.Error("Failed to consume resources, error in the task resource map", logger.Fields{
 			"taskArn":   taskArn,
 			field.Error: err,
 		})
@@ -152,7 +152,7 @@ func (h *HostResourceManager) checkConsumableIntType(resourceName string, resour
 func (h *HostResourceManager) checkConsumableStringSetType(resourceName string, resources map[string]*ecs.Resource) bool {
 	resourceSlice := resources[resourceName].StringSetValue
 
-	// (optimizization) Get a resource specific map to ease look up
+	// (optimization) Get a resource specific map to ease look up
 	resourceMap := make(map[string]struct{}, len(resourceSlice))
 	for _, v := range resourceSlice {
 		resourceMap[*v] = struct{}{}
@@ -325,22 +325,22 @@ func NewHostResourceManager(resourceMap map[string]*ecs.Resource) HostResourceMa
 	consumedResourceMap := make(map[string]*ecs.Resource)
 	taskConsumed := make(map[string]bool)
 	// assigns CPU, MEMORY, PORTS_TCP, PORTS_UDP from host
-	//CPU
+	// CPU
 	CPUs := int64(0)
 	consumedResourceMap[CPU] = &ecs.Resource{
 		Name:         utils.Strptr(CPU),
 		Type:         utils.Strptr("INTEGER"),
 		IntegerValue: &CPUs,
 	}
-	//MEMORY
+	// MEMORY
 	memory := int64(0)
 	consumedResourceMap[MEMORY] = &ecs.Resource{
 		Name:         utils.Strptr(MEMORY),
 		Type:         utils.Strptr("INTEGER"),
 		IntegerValue: &memory,
 	}
-	//PORTS_TCP
-	//Copying ports from host resources as consumed ports for initializing
+	// PORTS_TCP
+	// Copying ports from host resources as consumed ports for initializing
 	portsTcp := []*string{}
 	if resourceMap != nil && resourceMap[PORTSTCP] != nil {
 		portsTcp = resourceMap[PORTSTCP].StringSetValue
@@ -351,7 +351,7 @@ func NewHostResourceManager(resourceMap map[string]*ecs.Resource) HostResourceMa
 		StringSetValue: portsTcp,
 	}
 
-	//PORTS_UDP
+	// PORTS_UDP
 	portsUdp := []*string{}
 	if resourceMap != nil && resourceMap[PORTSUDP] != nil {
 		portsUdp = resourceMap[PORTSUDP].StringSetValue
@@ -362,7 +362,7 @@ func NewHostResourceManager(resourceMap map[string]*ecs.Resource) HostResourceMa
 		StringSetValue: portsUdp,
 	}
 
-	//GPUs
+	// GPUs
 	numGPUs := int64(0)
 	consumedResourceMap[GPU] = &ecs.Resource{
 		Name:         utils.Strptr(GPU),

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -594,7 +594,10 @@ func (mtask *managedTask) emitTaskEvent(task *apitask.Task, reason string) {
 		resourcesToRelease := mtask.ToHostResources()
 		err := mtask.engine.hostResourceManager.release(mtask.Arn, resourcesToRelease)
 		if err != nil {
-			logger.Critical("Failed to release resources after tast stopped", logger.Fields{field.TaskARN: mtask.Arn})
+			logger.Critical("Failed to release resources after the task stopped", logger.Fields{
+				field.TaskARN: mtask.Arn,
+				field.Error:   err,
+			})
 		}
 	}
 	if !taskKnownStatus.BackendRecognized() {

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -2175,12 +2175,13 @@ func TestContainerNextStateDependsStoppedContainer(t *testing.T) {
 	}
 }
 
-// TestTaskWaitForHostResources tests task queuing behavior based on available host resources
-func TestTaskWaitForHostResources(t *testing.T) {
+// TestTaskWaitForHostResourcesWithIdenticalRequests tests task queuing behavior based on available host resources
+// for tasks with identical resource requests
+func TestTaskWaitForHostResourcesWithIdenticalRequests(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
-	// 1 vCPU available on host
+	// 1 vCPU available on the host
 	hostResourceManager := NewHostResourceManager(getTestHostResources())
 	taskEngine := &DockerTaskEngine{
 		managedTasks:           make(map[string]*managedTask),
@@ -2188,8 +2189,8 @@ func TestTaskWaitForHostResources(t *testing.T) {
 		hostResourceManager:    &hostResourceManager,
 	}
 	go taskEngine.monitorQueuedTasks(ctx)
+
 	// 3 tasks requesting 0.5 vCPUs each
-	tasks := []*apitask.Task{}
 	for i := 0; i < 3; i++ {
 		task := testdata.LoadTask("sleep5")
 		task.Arn = fmt.Sprintf("arn%d", i)
@@ -2199,7 +2200,6 @@ func TestTaskWaitForHostResources(t *testing.T) {
 			engine:                    taskEngine,
 			consumedHostResourceEvent: make(chan struct{}, 1),
 		}
-		tasks = append(tasks, task)
 		taskEngine.managedTasks[task.Arn] = mtask
 	}
 
@@ -2211,19 +2211,102 @@ func TestTaskWaitForHostResources(t *testing.T) {
 	}()
 	time.Sleep(500 * time.Millisecond)
 
-	// Verify waiting queue is waiting at arn2
-	topTask, err := taskEngine.topTask()
+	// Verify waiting queue has arn2 only
+	task, err := taskEngine.getTaskByIndex(0)
 	assert.NoError(t, err)
-	assert.Equal(t, topTask.Arn, "arn2")
+	assert.Equal(t, "arn2", task.Arn)
+	assert.Equal(t, 1, len(taskEngine.waitingTaskQueue))
 
-	// Remove 1 task
+	// Remove task arn0
 	taskResources := taskEngine.managedTasks["arn0"].ToHostResources()
-	taskEngine.hostResourceManager.release("arn0", taskResources)
+	err = taskEngine.hostResourceManager.release("arn0", taskResources)
+	assert.NoError(t, err)
 	taskEngine.wakeUpTaskQueueMonitor()
 
 	time.Sleep(500 * time.Millisecond)
 
-	// Verify arn2 got dequeued
-	topTask, err = taskEngine.topTask()
+	// Verify arn2 got dequeued and the queue is empty
+	_, err = taskEngine.getTaskByIndex(0)
 	assert.Error(t, err)
+	assert.Empty(t, taskEngine.waitingTaskQueue)
+}
+
+// TestTaskWaitForHostResourcesWithDifferentRequests tests task queuing behavior based on available host resources
+// for tasks with different resource requests.
+// It tests the scenario where a task can consume resources even when there are tasks ahead in the queue that cannot.
+func TestTaskWaitForHostResourcesWithDifferentRequests(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	// 1024 MiB memory available on the host
+	hostResourceManager := NewHostResourceManager(getTestHostResources())
+	taskEngine := &DockerTaskEngine{
+		managedTasks:           make(map[string]*managedTask),
+		monitorQueuedTaskEvent: make(chan struct{}, 1),
+		hostResourceManager:    &hostResourceManager,
+	}
+	go taskEngine.monitorQueuedTasks(ctx)
+
+	// 3 tasks with different memory requirements
+	mem := []int64{512, 1024, 256}
+	for i := 0; i < 3; i++ {
+		task := testdata.LoadTask("sleep5")
+		task.Arn = fmt.Sprintf("arn%d", i)
+		task.Memory = mem[i]
+		task.CPU = float64(0)
+		mtask := &managedTask{
+			Task:                      task,
+			engine:                    taskEngine,
+			consumedHostResourceEvent: make(chan struct{}, 1),
+		}
+		taskEngine.managedTasks[task.Arn] = mtask
+	}
+
+	// acquire host resources for task arn0
+	taskEngine.managedTasks["arn0"].waitForHostResources()
+
+	// acquire host resources for task arn1
+	// do not wait on this since task arn1 will continue to wait for resources until enough resources are available
+	go func() {
+		taskEngine.managedTasks["arn1"].waitForHostResources()
+	}()
+
+	// sleep here to let task arn1 go in the queue, before task arn2 is evaluated for resources
+	time.Sleep(500 * time.Millisecond)
+
+	// acquire host resources for task arn2
+	taskEngine.managedTasks["arn2"].waitForHostResources()
+
+	// Verify waiting queue has arn1 only
+	task, err := taskEngine.getTaskByIndex(0)
+	assert.NoError(t, err)
+	assert.Equal(t, "arn1", task.Arn)
+	assert.Equal(t, 1, len(taskEngine.waitingTaskQueue))
+
+	// Remove task arn0
+	taskResources := taskEngine.managedTasks["arn0"].ToHostResources()
+	err = taskEngine.hostResourceManager.release("arn0", taskResources)
+	assert.NoError(t, err)
+	taskEngine.wakeUpTaskQueueMonitor()
+
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify waiting queue still has arn1 since enough resources were not freed up for it
+	task, err = taskEngine.getTaskByIndex(0)
+	assert.NoError(t, err)
+	assert.Equal(t, "arn1", task.Arn)
+	assert.Equal(t, 1, len(taskEngine.waitingTaskQueue))
+
+	// Remove task arn2
+	taskResources = taskEngine.managedTasks["arn2"].ToHostResources()
+	err = taskEngine.hostResourceManager.release("arn2", taskResources)
+	assert.NoError(t, err)
+	taskEngine.wakeUpTaskQueueMonitor()
+
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify arn1 got dequeued and the queue is empty
+	_, err = taskEngine.getTaskByIndex(0)
+	assert.Error(t, err)
+	assert.Empty(t, taskEngine.waitingTaskQueue)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Traditionally, the ECS agent wouldn't start new tasks until all stopping tasks have stopped on a container instance. 

With the task resource accounting project, we replaced this serialization with a resource accounting strategy that uses a FIFO queue to serve incoming tasks: https://github.com/aws/amazon-ecs-agent/pull/3819. If there are no resources available on the host, we queue tasks up until resources are available.

As soon as resources become available, the first task in the queue gets priority. The other waiting tasks continue to wait, until the first task gets served. There are corner cases when the first task in the queue is large enough to block all other tasks from being served (forever).

This PR changes the above behavior. With this change, although we give preference to tasks in a FIFO fashion, we will try to run as many tasks from the queue as possible, instead of blocking on tasks ahead in the queue that cannot start.

Example:
Consider a container instance with memory 1024 MiB. 3 tasks land on the instance: task T1 with memory 512 MiB, task T2 with memory 1024 MiB, and task T3 with memory 256 MiB.

T1 will run, since the requested memory is available. T2 needs more memory (1024 MiB) than whats available (512 MiB), hence it will be placed in the wait queue. T3 will also run because the requested memory is available. Prior to this change, the T3 would not run until T2 has been served first (and the only way T2 would run is if T1 stops).

**Note**:
- The target branch for this PR is feature/greedy-task-resource-accounting.
- There are corner cases with this approach as well, for example, there's a scenario when smaller tasks will always start and large tasks may be stuck in the queue. After speaking with product, we plan to introduce a mechanism to remove tasks from the queue if it has been in there for too long (with a wait timeout). This will be addressed in a follow-up PR.

### Implementation details
<!-- How are the changes implemented? -->
- Updated the `dequeueTask()` to dequeue at the given index, instead of dequeuing first task always.
- Updated the `topTask()` to `getTaskByIndex()` to return a task at the given index, instead of returning the first task always.
- Updated the `monitorQueuedTasks()` to try dequeuing as many tasks as possible, instead of stopping if unable to dequeue the first task in the queue.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

- Updated the unit test to mimic how tasks will be queued up when resource requirements are identical and different.
- Integration tests will be updated/added in a follow-up PR.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

enhancement: switch to greedy task resource accounting instead of blocking on tasks ahead in the queue.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
