### PR TITLE
Modified ResourceAttachment and Docker task state engine for EBS volumes

### DIFF
--- a/agent/engine/dockerstate/docker_task_engine_state.go
+++ b/agent/engine/dockerstate/docker_task_engine_state.go
@@ -22,6 +22,8 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	apiresource "github.com/aws/amazon-ecs-agent/ecs-agent/api/resource"
+
 	"github.com/cihub/seelog"
 )
 
@@ -81,6 +83,16 @@ type TaskEngineState interface {
 	DockerIDByV3EndpointID(v3EndpointID string) (string, bool)
 	// TaskARNByV3EndpointID returns a taskARN for a given v3 endpoint ID
 	TaskARNByV3EndpointID(v3EndpointID string) (string, bool)
+	// GetAllEBSAttachments returns all of the ebs attachments
+	GetAllEBSAttachments() []*apiresource.ResourceAttachment
+	// AllPendingEBSAttachments reutrns all of the ebs attachments that haven't sent a state change
+	GetAllPendingEBSAttachments() []*apiresource.ResourceAttachment
+	// AddEBSAttachment adds an ebs attachment from acs to be stored
+	AddEBSAttachment(ebs *apiresource.ResourceAttachment)
+	// RemoveEBSAttachment removes an ebs attachment to stop tracking
+	RemoveEBSAttachment(volumeId string)
+	// EBSByVolumeId returns the specific EBSAttachment of the given volume ID
+	GetEBSByVolumeId(volumeId string) (*apiresource.ResourceAttachment, bool)
 
 	json.Marshaler
 	json.Unmarshaler
@@ -108,6 +120,7 @@ type DockerTaskEngineState struct {
 	taskToPulledContainer  map[string]map[string]*apicontainer.DockerContainer // taskarn -> (containername -> c.DockerContainer)
 	idToContainer          map[string]*apicontainer.DockerContainer            // DockerId -> c.DockerContainer
 	eniAttachments         map[string]*apieni.ENIAttachment                    // ENIMac -> apieni.ENIAttachment
+	ebsAttachments         map[string]*apiresource.ResourceAttachment          // VolumeID -> apiresource.ResourceAttachment
 	imageStates            map[string]*image.ImageState
 	ipToTask               map[string]string // ip address -> task arn
 	v3EndpointIDToTask     map[string]string // container's v3 endpoint id -> taskarn
@@ -136,6 +149,7 @@ func (state *DockerTaskEngineState) initializeDockerTaskEngineState() {
 	state.idToContainer = make(map[string]*apicontainer.DockerContainer)
 	state.imageStates = make(map[string]*image.ImageState)
 	state.eniAttachments = make(map[string]*apieni.ENIAttachment)
+	state.ebsAttachments = make(map[string]*apiresource.ResourceAttachment)
 	state.ipToTask = make(map[string]string)
 	state.v3EndpointIDToTask = make(map[string]string)
 	state.v3EndpointIDToDockerID = make(map[string]string)
@@ -216,7 +230,7 @@ func (state *DockerTaskEngineState) allENIAttachmentsUnsafe() []*apieni.ENIAttac
 	return allENIAttachments
 }
 
-// ENIByMac returns the eni object that match the give mac address
+// ENIByMac returns the eni object that match the given mac address
 func (state *DockerTaskEngineState) ENIByMac(mac string) (*apieni.ENIAttachment, bool) {
 	state.lock.RLock()
 	defer state.lock.RUnlock()
@@ -256,6 +270,82 @@ func (state *DockerTaskEngineState) RemoveENIAttachment(mac string) {
 	} else {
 		seelog.Debugf("Delete non-existed eni attachment: %v", mac)
 	}
+}
+
+// GetAllEBSAttachments returns all the ebs volumes managed by ecs on the instance
+func (state *DockerTaskEngineState) GetAllEBSAttachments() []*apiresource.ResourceAttachment {
+	state.lock.RLock()
+	defer state.lock.RUnlock()
+
+	return state.allEBSAttachmentsUnsafe()
+}
+
+func (state *DockerTaskEngineState) allEBSAttachmentsUnsafe() []*apiresource.ResourceAttachment {
+	var allEBSAttachments []*apiresource.ResourceAttachment
+	for _, v := range state.ebsAttachments {
+		allEBSAttachments = append(allEBSAttachments, v)
+	}
+	return allEBSAttachments
+}
+
+// GetAllPendingEBSAttachments returns all the ebs volumes managed by ecs on the instance that haven't sent a state change yet
+func (state *DockerTaskEngineState) GetAllPendingEBSAttachments() []*apiresource.ResourceAttachment {
+	state.lock.RLock()
+	defer state.lock.RUnlock()
+
+	return state.allPendingEBSAttachmentsUnsafe()
+}
+
+func (state *DockerTaskEngineState) allPendingEBSAttachmentsUnsafe() []*apiresource.ResourceAttachment {
+	var pendingEBSAttachments []*apiresource.ResourceAttachment
+	for _, v := range state.ebsAttachments {
+		if !v.IsSent() {
+			pendingEBSAttachments = append(pendingEBSAttachments, v)
+		}
+	}
+	return pendingEBSAttachments
+}
+
+// AddEBSAttachment adds the ebs volume to state
+func (state *DockerTaskEngineState) AddEBSAttachment(ebsAttachment *apiresource.ResourceAttachment) {
+	if ebsAttachment == nil {
+		seelog.Debug("Cannot add empty ebs attachment information")
+		return
+	}
+	state.lock.Lock()
+	defer state.lock.Unlock()
+	volumeId := ebsAttachment.AttachmentProperties[apiresource.VolumeIdName]
+	if _, ok := state.ebsAttachments[volumeId]; !ok {
+		state.ebsAttachments[volumeId] = ebsAttachment
+		seelog.Debugf("Successfully added EBS attachment: %v", ebsAttachment)
+	} else {
+		seelog.Debugf("Duplicate ebs attachment information: %v", ebsAttachment)
+	}
+}
+
+// RemoveEBSAttachment removes the ebs volume from state and stops managing
+func (state *DockerTaskEngineState) RemoveEBSAttachment(volumeId string) {
+	if volumeId == "" {
+		seelog.Debug("Cannot remove empty ebs attachment information")
+		return
+	}
+	state.lock.Lock()
+	defer state.lock.Unlock()
+	if ebs, ok := state.ebsAttachments[volumeId]; ok {
+		delete(state.ebsAttachments, volumeId)
+		seelog.Debugf("Successfully deleted EBS attachment: %v", ebs)
+	} else {
+		seelog.Debugf("RemoveEBSAttachment: The requested EBS attachment with volume ID: %v does not exist", volumeId)
+	}
+}
+
+// GetEBSByVolumeId returns the ebs object that matches the given volume ID
+func (state *DockerTaskEngineState) GetEBSByVolumeId(volumeId string) (*apiresource.ResourceAttachment, bool) {
+	state.lock.RLock()
+	defer state.lock.RUnlock()
+
+	ebs, ok := state.ebsAttachments[volumeId]
+	return ebs, ok
 }
 
 // GetAllContainerIDs returns all of the Container Ids

--- a/agent/engine/dockerstate/mocks/dockerstate_mocks.go
+++ b/agent/engine/dockerstate/mocks/dockerstate_mocks.go
@@ -25,6 +25,7 @@ import (
 	task "github.com/aws/amazon-ecs-agent/agent/api/task"
 	image "github.com/aws/amazon-ecs-agent/agent/engine/image"
 	eni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	resource "github.com/aws/amazon-ecs-agent/ecs-agent/api/resource"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -61,6 +62,18 @@ func (m *MockTaskEngineState) AddContainer(arg0 *container.DockerContainer, arg1
 func (mr *MockTaskEngineStateMockRecorder) AddContainer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddContainer", reflect.TypeOf((*MockTaskEngineState)(nil).AddContainer), arg0, arg1)
+}
+
+// AddEBSAttachment mocks base method.
+func (m *MockTaskEngineState) AddEBSAttachment(arg0 *resource.ResourceAttachment) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddEBSAttachment", arg0)
+}
+
+// AddEBSAttachment indicates an expected call of AddEBSAttachment.
+func (mr *MockTaskEngineStateMockRecorder) AddEBSAttachment(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEBSAttachment", reflect.TypeOf((*MockTaskEngineState)(nil).AddEBSAttachment), arg0)
 }
 
 // AddENIAttachment mocks base method.
@@ -253,6 +266,49 @@ func (mr *MockTaskEngineStateMockRecorder) GetAllContainerIDs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllContainerIDs", reflect.TypeOf((*MockTaskEngineState)(nil).GetAllContainerIDs))
 }
 
+// GetAllEBSAttachments mocks base method.
+func (m *MockTaskEngineState) GetAllEBSAttachments() []*resource.ResourceAttachment {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllEBSAttachments")
+	ret0, _ := ret[0].([]*resource.ResourceAttachment)
+	return ret0
+}
+
+// GetAllEBSAttachments indicates an expected call of GetAllEBSAttachments.
+func (mr *MockTaskEngineStateMockRecorder) GetAllEBSAttachments() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllEBSAttachments", reflect.TypeOf((*MockTaskEngineState)(nil).GetAllEBSAttachments))
+}
+
+// GetAllPendingEBSAttachments mocks base method.
+func (m *MockTaskEngineState) GetAllPendingEBSAttachments() []*resource.ResourceAttachment {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllPendingEBSAttachments")
+	ret0, _ := ret[0].([]*resource.ResourceAttachment)
+	return ret0
+}
+
+// GetAllPendingEBSAttachments indicates an expected call of GetAllPendingEBSAttachments.
+func (mr *MockTaskEngineStateMockRecorder) GetAllPendingEBSAttachments() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllPendingEBSAttachments", reflect.TypeOf((*MockTaskEngineState)(nil).GetAllPendingEBSAttachments))
+}
+
+// GetEBSByVolumeId mocks base method.
+func (m *MockTaskEngineState) GetEBSByVolumeId(arg0 string) (*resource.ResourceAttachment, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEBSByVolumeId", arg0)
+	ret0, _ := ret[0].(*resource.ResourceAttachment)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetEBSByVolumeId indicates an expected call of GetEBSByVolumeId.
+func (mr *MockTaskEngineStateMockRecorder) GetEBSByVolumeId(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEBSByVolumeId", reflect.TypeOf((*MockTaskEngineState)(nil).GetEBSByVolumeId), arg0)
+}
+
 // GetIPAddressByTaskARN mocks base method.
 func (m *MockTaskEngineState) GetIPAddressByTaskARN(arg0 string) (string, bool) {
 	m.ctrl.T.Helper()
@@ -311,6 +367,18 @@ func (m *MockTaskEngineState) PulledContainerMapByArn(arg0 string) (map[string]*
 func (mr *MockTaskEngineStateMockRecorder) PulledContainerMapByArn(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PulledContainerMapByArn", reflect.TypeOf((*MockTaskEngineState)(nil).PulledContainerMapByArn), arg0)
+}
+
+// RemoveEBSAttachment mocks base method.
+func (m *MockTaskEngineState) RemoveEBSAttachment(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RemoveEBSAttachment", arg0)
+}
+
+// RemoveEBSAttachment indicates an expected call of RemoveEBSAttachment.
+func (mr *MockTaskEngineStateMockRecorder) RemoveEBSAttachment(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveEBSAttachment", reflect.TypeOf((*MockTaskEngineState)(nil).RemoveEBSAttachment), arg0)
 }
 
 // RemoveENIAttachment mocks base method.

--- a/ecs-agent/api/resource/resource_attachment_test.go
+++ b/ecs-agent/api/resource/resource_attachment_test.go
@@ -1,0 +1,171 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package resource
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachmentinfo"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/status"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	taskARN       = "t1"
+	attachmentARN = "att1"
+	attachSent    = true
+)
+
+var (
+	testAttachmentProperties = map[string]string{
+		ResourceTypeName:    ElasticBlockStorage,
+		RequestedSizeName:   "5",
+		VolumeSizeInGiBName: "7",
+		DeviceName:          "/dev/nvme0n0",
+		VolumeIdName:        "vol-123",
+		FileSystemTypeName:  "testXFS",
+	}
+)
+
+func TestMarshalUnmarshal(t *testing.T) {
+	expiresAt := time.Now()
+	attachment := &ResourceAttachment{
+		AttachmentInfo: attachmentinfo.AttachmentInfo{
+			TaskARN:          taskARN,
+			AttachmentARN:    attachmentARN,
+			AttachStatusSent: attachSent,
+			Status:           status.AttachmentNone,
+			ExpiresAt:        expiresAt,
+		},
+		AttachmentProperties: testAttachmentProperties,
+	}
+	bytes, err := json.Marshal(attachment)
+	assert.NoError(t, err)
+	var unmarshalledAttachment ResourceAttachment
+	err = json.Unmarshal(bytes, &unmarshalledAttachment)
+	assert.NoError(t, err)
+	assert.Equal(t, attachment.TaskARN, unmarshalledAttachment.TaskARN)
+	assert.Equal(t, attachment.AttachmentARN, unmarshalledAttachment.AttachmentARN)
+	assert.Equal(t, attachment.AttachStatusSent, unmarshalledAttachment.AttachStatusSent)
+	assert.Equal(t, attachment.Status, unmarshalledAttachment.Status)
+
+	assert.Equal(t, attachment.AttachmentProperties[ResourceTypeName], unmarshalledAttachment.AttachmentProperties[ResourceTypeName])
+	assert.Equal(t, attachment.AttachmentProperties[RequestedSizeName], unmarshalledAttachment.AttachmentProperties[RequestedSizeName])
+	assert.Equal(t, attachment.AttachmentProperties[DeviceName], unmarshalledAttachment.AttachmentProperties[DeviceName])
+	assert.Equal(t, attachment.AttachmentProperties[VolumeIdName], unmarshalledAttachment.AttachmentProperties[VolumeIdName])
+	assert.Equal(t, attachment.AttachmentProperties[FileSystemTypeName], unmarshalledAttachment.AttachmentProperties[FileSystemTypeName])
+
+	expectedExpiresAtUTC, err := time.Parse(time.RFC3339, attachment.ExpiresAt.Format(time.RFC3339))
+	assert.NoError(t, err)
+	unmarshalledExpiresAtUTC, err := time.Parse(time.RFC3339, unmarshalledAttachment.ExpiresAt.Format(time.RFC3339))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedExpiresAtUTC, unmarshalledExpiresAtUTC)
+}
+
+func TestStartTimerErrorWhenExpiresAtIsInThePast(t *testing.T) {
+	expiresAt := time.Now().Unix() - 1
+	attachment := &ResourceAttachment{
+		AttachmentInfo: attachmentinfo.AttachmentInfo{
+			TaskARN:          taskARN,
+			AttachmentARN:    attachmentARN,
+			AttachStatusSent: attachSent,
+			Status:           status.AttachmentNone,
+			ExpiresAt:        time.Unix(expiresAt, 0),
+		},
+		AttachmentProperties: testAttachmentProperties,
+	}
+	assert.Error(t, attachment.StartTimer(func() {}))
+}
+
+func TestHasExpired(t *testing.T) {
+	for _, tc := range []struct {
+		expiresAt int64
+		expected  bool
+		name      string
+	}{
+		{time.Now().Unix() - 1, true, "expiresAt in past returns true"},
+		{time.Now().Unix() + 10, false, "expiresAt in future returns false"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			attachment := &ResourceAttachment{
+				AttachmentInfo: attachmentinfo.AttachmentInfo{
+					TaskARN:          taskARN,
+					AttachmentARN:    attachmentARN,
+					AttachStatusSent: attachSent,
+					Status:           status.AttachmentNone,
+					ExpiresAt:        time.Unix(tc.expiresAt, 0),
+				},
+				AttachmentProperties: testAttachmentProperties,
+			}
+			assert.Equal(t, tc.expected, attachment.HasExpired())
+		})
+	}
+}
+
+func TestInitialize(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	timeoutFunc := func() {
+		wg.Done()
+	}
+
+	expiresAt := time.Now().Unix() + 1
+	attachment := &ResourceAttachment{
+		AttachmentInfo: attachmentinfo.AttachmentInfo{
+			TaskARN:       taskARN,
+			AttachmentARN: attachmentARN,
+			Status:        status.AttachmentNone,
+			ExpiresAt:     time.Unix(expiresAt, 0),
+		},
+		AttachmentProperties: testAttachmentProperties,
+	}
+	assert.NoError(t, attachment.Initialize(timeoutFunc))
+	wg.Wait()
+}
+
+func TestInitializeExpired(t *testing.T) {
+	expiresAt := time.Now().Unix() - 1
+	attachment := &ResourceAttachment{
+		AttachmentInfo: attachmentinfo.AttachmentInfo{
+			TaskARN:       taskARN,
+			AttachmentARN: attachmentARN,
+			Status:        status.AttachmentNone,
+			ExpiresAt:     time.Unix(expiresAt, 0),
+		},
+		AttachmentProperties: testAttachmentProperties,
+	}
+	assert.Error(t, attachment.Initialize(func() {}))
+}
+
+func TestInitializeExpiredButAlreadySent(t *testing.T) {
+	expiresAt := time.Now().Unix() - 1
+	attachment := &ResourceAttachment{
+		AttachmentInfo: attachmentinfo.AttachmentInfo{
+			TaskARN:          taskARN,
+			AttachmentARN:    attachmentARN,
+			AttachStatusSent: attachSent,
+			Status:           status.AttachmentNone,
+			ExpiresAt:        time.Unix(expiresAt, 0),
+		},
+		AttachmentProperties: testAttachmentProperties,
+	}
+	assert.NoError(t, attachment.Initialize(func() {}))
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
The goal of this PR is to refactor the existing `ResourceAttachment` implementation to be used in the the docker task state engine within the `/agent` directory. 

(Note: There will be a follow up PR to address additional changes to docker task state engine and this PR is more so of the groundwork being laid out)

### Implementation details
* Refactor the existing Resource attachment implementation (similar to what we have with [ENI attachment](https://github.com/aws/amazon-ecs-agent/blob/master/ecs-agent/api/eni/eniattachment.go))
  *  ecs-agent/api/resource/resource_attachment.go
     * Added two new fields to the `ResourceAttachment` struct called `ackTimer` and `guard`
     * Added new functionality to initialize/start /stop the `ackTimer` field + check if it expired
     * Added new functionality to safely check if a resource attachment sent a state change to the backend
* Introduce ResourceAttachment into the docker task state engine
  * agent/engine/dockerstate/docker_task_engine_state.go
    * Modified the `DockerTaskEngineState` to keep a map of "volume ID" ->`ResourceAttachment` objects for EBS volumes
    * Added new functionality to:
       *  Get all ResourceAttachment objects
       *  Get all ResourceAttachment objects that haven't sent over an attachment state change
       *  Add a new ResourceAttachment object to the map
       * Delete a ResourceAttachment object by volume ID
       * Get a specific ResourceAttachment object by volume ID

### Testing
Unit test

New tests cover the changes: Yes

### Description for the changelog
Modify ResourceAttachment and integrate into Docker task state engine.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
