### PR TITLE
Add gpu-driver-version ECS attribute

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -77,6 +77,7 @@ const (
 	capabilityExecCertsRelativePath                        = "certs"
 	capabilityExternal                                     = "external"
 	capabilityServiceConnect                               = "service-connect-v1"
+	capabilityGpuDriverVersion                             = "gpu-driver-version"
 
 	// network capabilities, going forward, please append "network." prefix to any new networking capability we introduce
 	networkCapabilityPrefix      = "network."

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -104,6 +104,10 @@ func (agent *ecsAgent) appendNvidiaDriverVersionAttribute(capabilities []*ecs.At
 		driverVersion := agent.resourceFields.NvidiaGPUManager.GetDriverVersion()
 		if driverVersion != "" {
 			capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityNvidiaDriverVersionInfix+driverVersion)
+			capabilities = append(capabilities, &ecs.Attribute{
+				Name:  aws.String(attributePrefix + capabilityGpuDriverVersion),
+				Value: aws.String(driverVersion),
+			})
 		}
 	}
 	return capabilities

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -177,6 +177,8 @@ func TestNvidiaDriverCapabilitiesUnix(t *testing.T) {
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
 	)
 
+	nvidiaDriverVersion := "396.44"
+
 	expectedCapabilityNames := []string{
 		capabilityPrefix + "docker-remote-api.1.17",
 		attributePrefix + "docker-plugin.local",
@@ -184,7 +186,7 @@ func TestNvidiaDriverCapabilitiesUnix(t *testing.T) {
 		attributePrefix + capabilitySecretEnvSSM,
 		attributePrefix + capabilitySecretLogDriverSSM,
 		// nvidia driver version capability
-		attributePrefix + "nvidia-driver-version.396.44",
+		attributePrefix + capabilityNvidiaDriverVersionInfix + nvidiaDriverVersion,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -192,6 +194,10 @@ func TestNvidiaDriverCapabilitiesUnix(t *testing.T) {
 		expectedCapabilities = append(expectedCapabilities,
 			&ecs.Attribute{Name: aws.String(name)})
 	}
+
+	expectedCapabilities = append(expectedCapabilities,
+		&ecs.Attribute{Name: aws.String(attributePrefix + capabilityGpuDriverVersion),
+			Value: aws.String(nvidiaDriverVersion)})
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -205,7 +211,7 @@ func TestNvidiaDriverCapabilitiesUnix(t *testing.T) {
 		mobyPlugins:        mockMobyPlugins,
 		resourceFields: &taskresource.ResourceFields{
 			NvidiaGPUManager: &gpu.NvidiaGPUManager{
-				DriverVersion: "396.44",
+				DriverVersion: nvidiaDriverVersion,
 			},
 		},
 		serviceconnectManager: mockServiceConnectManager,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Implements https://github.com/aws/amazon-ecs-agent/issues/3492

This change adds `gpu-driver-version` ECS attribute requested as a part of [nvidia-driver-version ECS attribute should be a key/value attribut](https://github.com/aws/amazon-ecs-agent/issues/3492). 

`gpu-driver-version` ECS attribute is added to be a key/value attribute as the existing `nvidia-driver-version` ECS attribute is added as a name only attribute. `nvidia-driver-version` doesn't allow advanced filtering with https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html.
The filtering only happens on the attribute value and since the driver version is in the attribute name it is very limiting.

Here we are updating the variable name, key name proposed in this [PR](https://github.com/aws/amazon-ecs-agent/pull/3493) along with its changes.
 
### Implementation details
<!-- How are the changes implemented? -->
* Add `gpu-driver-version` ECS attribute
### Testing
<!-- How was this tested? -->

- `make release-agent`
- Approval workflow

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Add `gpu-driver-version` ECS attribute

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
