### PR TITLE
Add struct initialization functions in agent/acs/

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -248,23 +248,14 @@ func (acsSession *session) startSessionOnce() error {
 func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 	cfg := acsSession.agentConfig
 
-	payloadMsgHandler := &payloadMessageHandler{
-		taskEngine:                  acsSession.taskEngine,
-		ecsClient:                   acsSession.ecsClient,
-		dataClient:                  acsSession.dataClient,
-		taskHandler:                 acsSession.taskHandler,
-		credentialsManager:          acsSession.credentialsManager,
-		latestSeqNumberTaskManifest: acsSession.latestSeqNumTaskManifest,
-	}
+	payloadMsgHandler := NewPayloadMessageHandler(acsSession.taskEngine, acsSession.ecsClient, acsSession.dataClient,
+		acsSession.taskHandler, acsSession.credentialsManager, acsSession.latestSeqNumTaskManifest)
 
-	credsMetadataSetter := &credentialsMetadataSetter{taskEngine: acsSession.taskEngine}
+	credsMetadataSetter := NewCredentialsMetadataSetter(acsSession.taskEngine)
 
-	eniHandler := &eniHandler{
-		state:      acsSession.state,
-		dataClient: acsSession.dataClient,
-	}
+	eniHandler := NewENIHandler(acsSession.state, acsSession.dataClient)
 
-	manifestMessageIDAccessor := &manifestMessageIDAccessor{}
+	manifestMessageIDAccessor := NewManifestMessageIDAccessor()
 
 	metricsFactory := metrics.NewNopEntryFactory()
 

--- a/agent/acs/handler/attach_eni_handler_common.go
+++ b/agent/acs/handler/attach_eni_handler_common.go
@@ -27,11 +27,20 @@ import (
 	"github.com/pkg/errors"
 )
 
-// eniHandler remove ENI attachment from agent state after the ENI ack timeout
+// eniHandler struct implements ENIHandler interface defined in ecs-agent module.
+// It removes ENI attachment from agent state after the ENI ack timeout.
 type eniHandler struct {
 	mac        string
 	state      dockerstate.TaskEngineState
 	dataClient data.Client
+}
+
+// NewENIHandler creates a new eniHandler.
+func NewENIHandler(state dockerstate.TaskEngineState, dataClient data.Client) *eniHandler {
+	return &eniHandler{
+		state:      state,
+		dataClient: dataClient,
+	}
 }
 
 // HandleENIAttachment handles an ENI attachment via the following:

--- a/agent/acs/handler/attach_eni_handler_common_test.go
+++ b/agent/acs/handler/attach_eni_handler_common_test.go
@@ -62,10 +62,7 @@ func testENIAckTimeout(t *testing.T, attachmentType string) {
 		AttachmentType: attachmentType,
 		MACAddress:     testconst.RandomMAC,
 	}
-	eniHandler := &eniHandler{
-		state:      taskEngineState,
-		dataClient: dataClient,
-	}
+	eniHandler := NewENIHandler(taskEngineState, dataClient)
 
 	err := eniHandler.addENIAttachmentToState(eniAttachment)
 	assert.NoError(t, err)
@@ -111,10 +108,7 @@ func testENIAckWithinTimeout(t *testing.T, attachmentType string) {
 		AttachmentType: attachmentType,
 		MACAddress:     testconst.RandomMAC,
 	}
-	eniHandler := &eniHandler{
-		state:      taskEngineState,
-		dataClient: dataClient,
-	}
+	eniHandler := NewENIHandler(taskEngineState, dataClient)
 
 	err := eniHandler.addENIAttachmentToState(eniAttachment)
 	assert.NoError(t, err)
@@ -156,10 +150,7 @@ func testHandleENIAttachment(t *testing.T, attachmentType, taskArn string) {
 		AttachmentType: attachmentType,
 		MACAddress:     testconst.RandomMAC,
 	}
-	eniHandler := &eniHandler{
-		state:      taskEngineState,
-		dataClient: dataClient,
-	}
+	eniHandler := NewENIHandler(taskEngineState, dataClient)
 
 	err := eniHandler.HandleENIAttachment(eniAttachment)
 	assert.NoError(t, err)
@@ -205,10 +196,7 @@ func testHandleExpiredENIAttachment(t *testing.T, attachmentType, taskArn string
 		AttachmentType: attachmentType,
 		MACAddress:     testconst.RandomMAC,
 	}
-	eniHandler := &eniHandler{
-		state:      taskEngineState,
-		dataClient: dataClient,
-	}
+	eniHandler := NewENIHandler(taskEngineState, dataClient)
 
 	// Expect an error starting the timer because of <=0 duration.
 	err := eniHandler.HandleENIAttachment(eniAttachment)

--- a/agent/acs/handler/attach_instance_eni_responder_test.go
+++ b/agent/acs/handler/attach_instance_eni_responder_test.go
@@ -73,10 +73,7 @@ func TestInstanceENIAckHappyPath(t *testing.T) {
 		return nil
 	}
 	testAttachInstanceENIResponder := acssession.NewAttachInstanceENIResponder(
-		&eniHandler{
-			state:      taskEngineState,
-			dataClient: dataClient,
-		},
+		NewENIHandler(taskEngineState, dataClient),
 		testResponseSender)
 
 	handleAttachMessage :=
@@ -131,10 +128,7 @@ func TestInstanceENIAckSingleMessageWithDuplicateENIAttachment(t *testing.T) {
 		return nil
 	}
 	testAttachInstanceENIResponder := acssession.NewAttachInstanceENIResponder(
-		&eniHandler{
-			state:      mockState,
-			dataClient: dataClient,
-		},
+		NewENIHandler(mockState, dataClient),
 		testResponseSender)
 
 	handleAttachMessage :=

--- a/agent/acs/handler/attach_task_eni_responder_test.go
+++ b/agent/acs/handler/attach_task_eni_responder_test.go
@@ -74,10 +74,7 @@ func TestTaskENIAckHappyPath(t *testing.T) {
 		return nil
 	}
 	testAttachTaskENIResponder := acssession.NewAttachTaskENIResponder(
-		&eniHandler{
-			state:      taskEngineState,
-			dataClient: dataClient,
-		},
+		NewENIHandler(taskEngineState, dataClient),
 		testResponseSender)
 
 	handleAttachMessage := testAttachTaskENIResponder.HandlerFunc().(func(*ecsacs.AttachTaskNetworkInterfacesMessage))
@@ -131,10 +128,7 @@ func TestTaskENIAckSingleMessageWithDuplicateENIAttachment(t *testing.T) {
 		return nil
 	}
 	testAttachTaskENIResponder := acssession.NewAttachTaskENIResponder(
-		&eniHandler{
-			state:      mockState,
-			dataClient: dataClient,
-		},
+		NewENIHandler(mockState, dataClient),
 		testResponseSender)
 
 	handleAttachMessage := testAttachTaskENIResponder.HandlerFunc().(func(*ecsacs.AttachTaskNetworkInterfacesMessage))

--- a/agent/acs/handler/payload_responder.go
+++ b/agent/acs/handler/payload_responder.go
@@ -36,7 +36,7 @@ import (
 // and returns the boolean comparison result.
 type skipAddTaskComparatorFunc func(apitaskstatus.TaskStatus) bool
 
-// payloadMessageHandler implements PayloadMessageHandler.
+// payloadMessageHandler implements PayloadMessageHandler interface defined in ecs-agent module.
 type payloadMessageHandler struct {
 	taskEngine                  engine.TaskEngine
 	ecsClient                   api.ECSClient
@@ -44,6 +44,23 @@ type payloadMessageHandler struct {
 	taskHandler                 *eventhandler.TaskHandler
 	credentialsManager          credentials.Manager
 	latestSeqNumberTaskManifest *int64
+}
+
+// NewPayloadMessageHandler creates a new payloadMessageHandler.
+func NewPayloadMessageHandler(taskEngine engine.TaskEngine,
+	ecsClient api.ECSClient,
+	dataClient data.Client,
+	taskHandler *eventhandler.TaskHandler,
+	credentialsManager credentials.Manager,
+	latestSeqNumberTaskManifest *int64) *payloadMessageHandler {
+	return &payloadMessageHandler{
+		taskEngine:                  taskEngine,
+		ecsClient:                   ecsClient,
+		dataClient:                  dataClient,
+		taskHandler:                 taskHandler,
+		credentialsManager:          credentialsManager,
+		latestSeqNumberTaskManifest: latestSeqNumberTaskManifest,
+	}
 }
 
 func (pmHandler *payloadMessageHandler) ProcessMessage(message *ecsacs.PayloadMessage,

--- a/agent/acs/handler/payload_responder_test.go
+++ b/agent/acs/handler/payload_responder_test.go
@@ -80,14 +80,8 @@ func setup(t *testing.T, acsResponseSender wsclient.RespondFunc) *testHelper {
 	ctx := context.Background()
 	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 	latestSeqNumberTaskManifest := int64(10)
-	payloadMsgHandler := &payloadMessageHandler{
-		taskEngine:                  taskEngine,
-		ecsClient:                   ecsClient,
-		dataClient:                  dataClient,
-		taskHandler:                 taskHandler,
-		credentialsManager:          credentialsManager,
-		latestSeqNumberTaskManifest: &latestSeqNumberTaskManifest,
-	}
+	payloadMsgHandler := NewPayloadMessageHandler(taskEngine, ecsClient, dataClient, taskHandler, credentialsManager,
+		&latestSeqNumberTaskManifest)
 	payloadResponder := acssession.NewPayloadResponder(payloadMsgHandler, acsResponseSender)
 
 	return &testHelper{

--- a/agent/acs/handler/refresh_credentials_responder.go
+++ b/agent/acs/handler/refresh_credentials_responder.go
@@ -1,3 +1,16 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package handler
 
 import (
@@ -17,9 +30,16 @@ var (
 	checkAndSetDomainlessGMSATaskExecutionRoleCredentialsImpl = checkAndSetDomainlessGMSATaskExecutionRoleCredentials
 )
 
-// credentialsMetadataSetter implements CredentialsMetadataSetter
+// credentialsMetadataSetter struct implements CredentialsMetadataSetter interface defined in ecs-agent module.
 type credentialsMetadataSetter struct {
 	taskEngine engine.TaskEngine
+}
+
+// NewCredentialsMetadataSetter creates a new credentialsMetadataSetter.
+func NewCredentialsMetadataSetter(taskEngine engine.TaskEngine) *credentialsMetadataSetter {
+	return &credentialsMetadataSetter{
+		taskEngine: taskEngine,
+	}
 }
 
 func (cmSetter *credentialsMetadataSetter) SetTaskRoleMetadata(

--- a/agent/acs/handler/refresh_credentials_responder_test.go
+++ b/agent/acs/handler/refresh_credentials_responder_test.go
@@ -87,9 +87,7 @@ func TestInvalidCredentialsMessageNotAcked(t *testing.T) {
 		return nil
 	}
 	testRefreshCredentialsResponder := acssession.NewRefreshCredentialsResponder(credentials.NewManager(),
-		&credentialsMetadataSetter{
-			taskEngine: nil,
-		},
+		NewCredentialsMetadataSetter(nil),
 		metrics.NewNopEntryFactory(),
 		testResponseSender)
 
@@ -116,9 +114,7 @@ func TestCredentialsMessageNotAckedWhenTaskNotFound(t *testing.T) {
 		return nil
 	}
 	testRefreshCredentialsResponder := acssession.NewRefreshCredentialsResponder(credentials.NewManager(),
-		&credentialsMetadataSetter{
-			taskEngine: mockTaskEngine,
-		},
+		NewCredentialsMetadataSetter(mockTaskEngine),
 		metrics.NewNopEntryFactory(),
 		testResponseSender)
 
@@ -162,9 +158,7 @@ func TestHandleRefreshMessageAckedWhenCredentialsUpdated(t *testing.T) {
 				return nil
 			}
 			testRefreshCredentialsResponder := acssession.NewRefreshCredentialsResponder(credentialsManager,
-				&credentialsMetadataSetter{
-					taskEngine: mockTaskEngine,
-				},
+				NewCredentialsMetadataSetter(mockTaskEngine),
 				metrics.NewNopEntryFactory(),
 				testResponseSender)
 
@@ -238,9 +232,7 @@ func TestCredentialsMessageNotAckedWhenDomainlessGMSACredentialsError(t *testing
 				return nil
 			}
 			testRefreshCredentialsResponder := acssession.NewRefreshCredentialsResponder(credentialsManager,
-				&credentialsMetadataSetter{
-					taskEngine: mockTaskEngine,
-				},
+				NewCredentialsMetadataSetter(mockTaskEngine),
 				metrics.NewNopEntryFactory(),
 				testResponseSender)
 

--- a/agent/acs/handler/task_manifest_common.go
+++ b/agent/acs/handler/task_manifest_common.go
@@ -17,9 +17,15 @@ import (
 	"sync"
 )
 
+// manifestMessageIDAccessor struct implements ManifestMessageIDAccessor interface defined in ecs-agent module.
 type manifestMessageIDAccessor struct {
 	messageID string
 	lock      sync.RWMutex
+}
+
+// NewManifestMessageIDAccessor creates a new manifestMessageIDAccessor.
+func NewManifestMessageIDAccessor() *manifestMessageIDAccessor {
+	return &manifestMessageIDAccessor{}
 }
 
 func (mmiAccessor *manifestMessageIDAccessor) GetMessageID() string {

--- a/agent/acs/handler/task_manifest_handler_test.go
+++ b/agent/acs/handler/task_manifest_handler_test.go
@@ -54,7 +54,7 @@ func TestManifestHandlerKillAllTasks(t *testing.T) {
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
 
 	dataClient := newTestDataClient(t)
-	manifestMessageIDAccessor := &manifestMessageIDAccessor{}
+	manifestMessageIDAccessor := NewManifestMessageIDAccessor()
 
 	newTaskManifest := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
 		dataClient, taskEngine, aws.Int64(11), manifestMessageIDAccessor)
@@ -149,7 +149,7 @@ func TestManifestHandlerKillFewTasks(t *testing.T) {
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
 
 	dataClient := newTestDataClient(t)
-	manifestMessageIDAccessor := &manifestMessageIDAccessor{}
+	manifestMessageIDAccessor := NewManifestMessageIDAccessor()
 
 	newTaskManifest := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
 		dataClient, taskEngine, aws.Int64(11), manifestMessageIDAccessor)
@@ -253,7 +253,7 @@ func TestManifestHandlerKillNoTasks(t *testing.T) {
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
 
 	dataClient := newTestDataClient(t)
-	manifestMessageIDAccessor := &manifestMessageIDAccessor{}
+	manifestMessageIDAccessor := NewManifestMessageIDAccessor()
 
 	newTaskManifest := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
 		dataClient, taskEngine, aws.Int64(11), manifestMessageIDAccessor)
@@ -343,7 +343,7 @@ func TestManifestHandlerDifferentTaskLists(t *testing.T) {
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
 
 	dataClient := newTestDataClient(t)
-	manifestMessageIDAccessor := &manifestMessageIDAccessor{}
+	manifestMessageIDAccessor := NewManifestMessageIDAccessor()
 
 	newTaskManifest := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
 		dataClient, taskEngine, aws.Int64(11), manifestMessageIDAccessor)
@@ -465,7 +465,7 @@ func TestManifestHandlerSequenceNumbers(t *testing.T) {
 
 			ctx := context.TODO()
 			mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
-			manifestMessageIDAccessor := &manifestMessageIDAccessor{}
+			manifestMessageIDAccessor := NewManifestMessageIDAccessor()
 
 			newTaskManifest := newTaskManifestHandler(ctx, testconst.ClusterName, testconst.ContainerInstanceARN, mockWSClient,
 				data.NewNoopClient(), taskEngine, aws.Int64(tc.inputSequenceNumber), manifestMessageIDAccessor)
@@ -561,7 +561,7 @@ func TestTaskManifestHandlerSendPendingTaskManifestMessageAck(t *testing.T) {
 	taskEngine := mock_engine.NewMockTaskEngine(ctrl)
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
 	mockWSClient.EXPECT().MakeRequest(gomock.Any()).Return(nil).Times(1)
-	manifestMessageIDAccessor := &manifestMessageIDAccessor{}
+	manifestMessageIDAccessor := NewManifestMessageIDAccessor()
 	handler := newTaskManifestHandler(ctx, testconst.ClusterName, testconst.ContainerInstanceARN, mockWSClient,
 		data.NewNoopClient(), taskEngine, aws.Int64(testSeqNum), manifestMessageIDAccessor)
 
@@ -598,7 +598,7 @@ func TestTaskManifestHandlerHandlePendingTaskStopVerificationAck(t *testing.T) {
 	ctx := context.TODO()
 	taskEngine := mock_engine.NewMockTaskEngine(ctrl)
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
-	manifestMessageIDAccessor := &manifestMessageIDAccessor{}
+	manifestMessageIDAccessor := NewManifestMessageIDAccessor()
 	handler := newTaskManifestHandler(ctx, testconst.ClusterName, testconst.ContainerInstanceARN, mockWSClient,
 		data.NewNoopClient(), taskEngine, aws.Int64(testSeqNum), manifestMessageIDAccessor)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request adds struct initialization functions for some structs in `agent/acs/` that currently do not have one. We then use those struct initialization functions in favor of initializing via struct literals wherever we currently are for those same structs.

Additionally, the file `agent/acs/handler/refresh_credentials_responder.go` is missing a copyright header, so this pull request also adds the missing copyright header to that file. 

### Implementation details
<!-- How are the changes implemented? -->
- Create struct initialization functions for the `credentialsMetadataSetter`, `eniHandler`, `manifestMessageIDAccessor`, and `payloadMessageHandler` structs defined in `agent/acs/`
- Update wherever we are currently initializing these structs via struct literals to use the above newly created struct initialization functions instead
- Add missing copyright header to `agent/acs/handler/refresh_credentials_responder.go`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit, integration, and functional tests.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add struct initialization functions in agent/acs/

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
