### PR TITLE
TCS client integration

### DIFF
--- a/agent/stats/reporter/reporter.go
+++ b/agent/stats/reporter/reporter.go
@@ -80,7 +80,6 @@ func NewDockerTelemetrySession(
 		agentVersion,
 		agentHash,
 		containerRuntimeVersion,
-		"", // this will be overridden by DockerTelemetrySession.Start()
 		cfg.DisableMetrics.Enabled(),
 		credentialProvider,
 		&wsclient.WSClientMinAgentConfig{

--- a/agent/stats/reporter/reporter.go
+++ b/agent/stats/reporter/reporter.go
@@ -42,7 +42,7 @@ const (
 )
 
 type DockerTelemetrySession struct {
-	tcshandler.TelemetrySession
+	s tcshandler.TelemetrySession
 }
 
 // NewDockerTelemetrySession returns creates a DockerTelemetrySession, which has a tcshandler.TelemetrySession embedded.
@@ -99,7 +99,7 @@ func NewDockerTelemetrySession(
 }
 
 func (session *DockerTelemetrySession) Start(ctx context.Context) error {
-	return session.Start(ctx)
+	return session.s.Start(ctx)
 }
 
 // generateVersionInfo generates the agentVersion, agentHash and containerRuntimeVersion from dockerTaskEngine state

--- a/agent/stats/reporter/reporter.go
+++ b/agent/stats/reporter/reporter.go
@@ -133,8 +133,8 @@ func NewDockerTelemetrySession(
 //	}
 //}
 
-func (session *DockerTelemetrySession) Start(ctx context.Context) {
-	session.s.Start(ctx)
+func (session *DockerTelemetrySession) Start(ctx context.Context) error {
+	return session.s.Start(ctx)
 }
 
 // generateVersionInfo generates the agentVersion, agentHash and containerRuntimeVersion from dockerTaskEngine state

--- a/agent/stats/reporter/reporter.go
+++ b/agent/stats/reporter/reporter.go
@@ -42,7 +42,7 @@ const (
 )
 
 type DockerTelemetrySession struct {
-	s tcshandler.TelemetrySession
+	tcshandler.TelemetrySession
 }
 
 // NewDockerTelemetrySession returns creates a DockerTelemetrySession, which has a tcshandler.TelemetrySession embedded.
@@ -99,7 +99,7 @@ func NewDockerTelemetrySession(
 }
 
 func (session *DockerTelemetrySession) Start(ctx context.Context) error {
-	return session.s.Start(ctx)
+	return session.Start(ctx)
 }
 
 // generateVersionInfo generates the agentVersion, agentHash and containerRuntimeVersion from dockerTaskEngine state

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
@@ -40,4 +40,8 @@ const (
 	credsRefreshNamespace     = "CredentialsRefresh"
 	CredentialsRefreshFailure = credsRefreshNamespace + ".Failure"
 	CredentialsRefreshSuccess = credsRefreshNamespace + ".Success"
+
+	// Agent Availability
+	agentAvailabilityNamespace     = "Availability"
+	TCSDisconnectTimeoutMetricName = agentAvailabilityNamespace + ".TCSDisconnectTimeout"
 )

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client/client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client/client.go
@@ -31,7 +31,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 
-	//TODO: ricgang: removethis
 	"github.com/cihub/seelog"
 	"github.com/pborman/uuid"
 )

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client/client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client/client.go
@@ -94,7 +94,6 @@ func New(url string,
 			RequestHandlers:    make(map[string]wsclient.RequestHandler),
 		},
 	}
-	//TODO: ricgang: What is this??
 	cs.ServiceError = &tcsError{}
 	return cs
 }
@@ -138,7 +137,7 @@ func (cs *tcsClientServer) publishMessages(ctx context.Context) {
 			logger.Debug("received health message in healthChannel")
 			err := cs.publishHealthOnce(health)
 			if err != nil {
-				logger.Warn("Error publishing metrics", logger.Fields{
+				logger.Warn("Error publishing health", logger.Fields{
 					field.Error: err,
 				})
 			}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client/client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client/client.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 
+	//TODO: ricgang: removethis
 	"github.com/cihub/seelog"
 	"github.com/pborman/uuid"
 )
@@ -93,6 +94,7 @@ func New(url string,
 			RequestHandlers:    make(map[string]wsclient.RequestHandler),
 		},
 	}
+	//TODO: ricgang: What is this??
 	cs.ServiceError = &tcsError{}
 	return cs
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
@@ -46,7 +46,7 @@ type TcsEcsClient interface {
 
 // TelemetrySession defines an interface for handler's long-lived connection with TCS.
 type TelemetrySession interface {
-	StartTelemetrySession(context.Context, string) error
+	StartTelemetrySession(context.Context) error
 	Start(context.Context) error
 }
 
@@ -57,7 +57,6 @@ type telemetrySession struct {
 	agentVersion                  string
 	agentHash                     string
 	containerRuntimeVersion       string
-	endpoint                      string
 	disableMetrics                bool
 	credentialsProvider           *credentials.Credentials
 	cfg                           *wsclient.WSClientMinAgentConfig
@@ -79,7 +78,6 @@ func NewTelemetrySession(
 	agentVersion string,
 	agentHash string,
 	containerRuntimeVersion string,
-	endpoint string,
 	disableMetrics bool,
 	credentialsProvider *credentials.Credentials,
 	cfg *wsclient.WSClientMinAgentConfig,
@@ -100,7 +98,6 @@ func NewTelemetrySession(
 		agentVersion:                  agentVersion,
 		agentHash:                     agentHash,
 		containerRuntimeVersion:       containerRuntimeVersion,
-		endpoint:                      endpoint,
 		disableMetrics:                disableMetrics,
 		credentialsProvider:           credentialsProvider,
 		cfg:                           cfg,
@@ -121,7 +118,7 @@ func NewTelemetrySession(
 func (session *telemetrySession) Start(ctx context.Context) error {
 	backoff := retry.NewExponentialBackoff(time.Second, 1*time.Minute, 0.2, 2)
 	for {
-		tcsError := session.StartTelemetrySession(ctx, session.endpoint)
+		tcsError := session.StartTelemetrySession(ctx)
 		switch tcsError {
 		case context.Canceled, context.DeadlineExceeded:
 			return tcsError
@@ -136,7 +133,7 @@ func (session *telemetrySession) Start(ctx context.Context) error {
 }
 
 // StartTelemetrySession creates a session with the backend and handles requests.
-func (session *telemetrySession) StartTelemetrySession(ctx context.Context, endpoint string) error {
+func (session *telemetrySession) StartTelemetrySession(ctx context.Context) error {
 	wsRWTimeout := 2*session.heartbeatTimeout + session.heartbeatJitterMax
 
 	var containerRuntime string

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
@@ -39,6 +39,10 @@ import (
 const (
 	deregisterContainerInstanceHandler = "TCSDeregisterContainerInstanceHandler"
 	ContainerRuntimeDocker             = "Docker"
+	backoffMin                         = 1 * time.Second
+	backoffMax                         = 1 * time.Minute
+	jitterMultiple                     = 0.2
+	multiple                           = 2
 	// dateTimeFormat is a string format to format time for better readability: YYYY-MM-DD hh:mm:ss
 	dateTimeFormat = "2006-01-02 15:04:05"
 )
@@ -119,7 +123,7 @@ func NewTelemetrySession(
 
 // Start runs in for loop to start telemetry session with exponential backoff
 func (session *telemetrySession) Start(ctx context.Context) error {
-	backoff := retry.NewExponentialBackoff(time.Second, 1*time.Minute, 0.2, 2)
+	backoff := retry.NewExponentialBackoff(backoffMin, backoffMax, jitterMultiple, multiple)
 	for {
 		select {
 		case <-ctx.Done():

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
@@ -121,6 +121,12 @@ func NewTelemetrySession(
 func (session *telemetrySession) Start(ctx context.Context) error {
 	backoff := retry.NewExponentialBackoff(time.Second, 1*time.Minute, 0.2, 2)
 	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("ECS Telemetry service (TCS) session exited cleanly.")
+			return nil
+		default:
+		}
 		tcsError := session.StartTelemetrySession(ctx)
 		switch tcsError {
 		case context.Canceled, context.DeadlineExceeded:

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
@@ -17,6 +17,7 @@ package tcshandler
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/url"
 	"strings"
@@ -38,6 +39,8 @@ import (
 const (
 	deregisterContainerInstanceHandler = "TCSDeregisterContainerInstanceHandler"
 	ContainerRuntimeDocker             = "Docker"
+	// dateTimeFormat is a string format to format time for better readability: YYYY-MM-DD hh:mm:ss
+	dateTimeFormat = "2006-01-02 15:04:05"
 )
 
 type TcsEcsClient interface {
@@ -166,32 +169,35 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context) erro
 		})
 		return err
 	}
-	logger.Info("Connected to TCS endpoint")
+	startTime := time.Now()
+	logger.Info("Connected to TCS endpoint", logger.Fields{
+		"TCSConnectTime":            startTime.Format(dateTimeFormat),
+		"ExpectedTCSDisconnectTime": startTime.Add(session.disconnectTimeout).Format(dateTimeFormat),
+	})
+
+	// newDisconnectTimeoutTimerHandler returns a timer.Afterfunc(timeout, f) which will
+	// call f as goroutine after timeout. The timeout is currently set to 30m+jitter(5m max) to match max duration
+	// of connection with TCS. This timer is meant to handle s.startTCSSession running in blocking mode
+	// beyond 30m+jitter as s.startTCSSession has 2 possible paths: returns with error or continue running
+	// in blocking mode.
+	// Happy path: it returns with error, then timer stops, goroutine to disconnect never starts.
+	// Edge case: it continues to run beyond the maximum duration of TCS connection. Timer starts goroutine
+	// from DisconnectTimeoutTimer to disconnect; guard against hanging connection to unhealthy TCS host.
+	disconnectTimer := session.newDisconnectTimeoutHandler(client, startTime)
+	defer disconnectTimer.Stop()
+
 	// start a timer and listens for tcs heartbeats/acks. The timer is reset when
 	// we receive a heartbeat from the server or when a published metrics message
 	// is acked.
-	timer := time.NewTimer(retry.AddJitter(session.heartbeatTimeout, session.heartbeatJitterMax))
-	defer timer.Stop()
-	client.AddRequestHandler(heartbeatHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
-	client.AddRequestHandler(ackPublishMetricHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
-	client.AddRequestHandler(ackPublishHealthMetricHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
-	client.AddRequestHandler(ackPublishInstanceStatusHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	heartBeatTimer := session.newHeartbeatTimeoutHandler(client, startTime)
+	defer heartBeatTimer.Stop()
+
+	client.AddRequestHandler(heartbeatHandler(heartBeatTimer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	client.AddRequestHandler(ackPublishMetricHandler(heartBeatTimer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	client.AddRequestHandler(ackPublishHealthMetricHandler(heartBeatTimer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	client.AddRequestHandler(ackPublishInstanceStatusHandler(heartBeatTimer, session.heartbeatTimeout, session.heartbeatJitterMax))
 	client.SetAnyRequestHandler(anyMessageHandler(client, wsRWTimeout))
-	serveC := make(chan error, 1)
-	go func() {
-		serveC <- client.Serve(ctx)
-	}()
-	select {
-	case <-ctx.Done():
-		// outer context done, agent is exiting
-		client.Disconnect()
-	case <-timer.C:
-		seelog.Info("TCS Connection hasn't had any activity for too long; disconnecting")
-		client.Disconnect()
-	case err := <-serveC:
-		return err
-	}
-	return nil
+	return client.Serve(ctx)
 }
 
 func (session *telemetrySession) getTelemetryEndpoint() (string, error) {
@@ -204,6 +210,49 @@ func (session *telemetrySession) getTelemetryEndpoint() (string, error) {
 		return "", err
 	}
 	return tcsEndpoint, nil
+}
+
+func (session *telemetrySession) newDisconnectTimeoutHandler(client wsclient.ClientServer, startTime time.Time) *time.Timer {
+	maxConnectionDuration := retry.AddJitter(session.disconnectTimeout, session.disconnectJitterMax)
+	timer := time.AfterFunc(maxConnectionDuration, func() {
+		err := closeTCSClient(client, startTime, maxConnectionDuration)
+		session.metricsFactory.New(metrics.TCSDisconnectTimeoutMetricName).Done(err)
+		if err != nil {
+			logger.Warn("Attempted disconnecting; client already closed", logger.Fields{
+				field.Error: err,
+			})
+		}
+	})
+	return timer
+}
+
+func (session *telemetrySession) newHeartbeatTimeoutHandler(cs wsclient.ClientServer, startTime time.Time) *time.Timer {
+	maxConnectionDuration := retry.AddJitter(session.heartbeatTimeout, session.heartbeatJitterMax)
+	timer := time.AfterFunc(maxConnectionDuration, func() {
+		err := closeTCSClient(cs, startTime, maxConnectionDuration)
+		if err != nil {
+			logger.Warn(fmt.Sprintf("Attempted disconnecting; tcs client already closed. %s", err))
+		}
+	})
+	return timer
+}
+
+// closeTCSClient will attempt to close the provided client, retries are not recommended
+// as failure modes for this are when client is not found or already closed.
+func closeTCSClient(client wsclient.ClientServer, startTime time.Time, timeoutDuration time.Duration) error {
+	logger.Warn("Closing tcs connection", logger.Fields{
+		"ConnectionStartTime":  startTime.Format(dateTimeFormat),
+		"MaxDisconnectionTime": startTime.Add(timeoutDuration).Format(dateTimeFormat),
+	})
+
+	err := client.Disconnect()
+	if err != nil {
+		logger.Warn("Error disconnecting; client already closed", logger.Fields{
+			field.Error: err,
+		})
+	}
+	logger.Info("Disconnected from tcs")
+	return err
 }
 
 // heartbeatHandler resets the heartbeat timer when HeartbeatMessage message is received from tcs.

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs/api.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs/api.go
@@ -233,6 +233,37 @@ func (s Dimension) GoString() string {
 	return s.String()
 }
 
+type EphemeralStorageMetrics struct {
+	_ struct{} `type:"structure"`
+
+	BytesUtilized *ULongStatsSet `type:"structure"`
+}
+
+// String returns the string representation
+func (s EphemeralStorageMetrics) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EphemeralStorageMetrics) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EphemeralStorageMetrics) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EphemeralStorageMetrics"}
+	if s.BytesUtilized != nil {
+		if err := s.BytesUtilized.Validate(); err != nil {
+			invalidParams.AddNested("BytesUtilized", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GeneralMetric struct {
 	_ struct{} `type:"structure"`
 
@@ -991,6 +1022,8 @@ type TaskMetric struct {
 
 	ContainerMetrics []*ContainerMetric `locationName:"containerMetrics" type:"list"`
 
+	EphemeralStorageMetrics *EphemeralStorageMetrics `locationName:"ephemeralStorageMetrics" type:"structure"`
+
 	ServiceConnectMetricsWrapper []*GeneralMetricsWrapper `locationName:"serviceConnectMetricsWrapper" type:"list"`
 
 	TaskArn *string `locationName:"taskArn" type:"string"`
@@ -1021,6 +1054,11 @@ func (s *TaskMetric) Validate() error {
 			if err := v.Validate(); err != nil {
 				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ContainerMetrics", i), err.(request.ErrInvalidParams))
 			}
+		}
+	}
+	if s.EphemeralStorageMetrics != nil {
+		if err := s.EphemeralStorageMetrics.Validate(); err != nil {
+			invalidParams.AddNested("EphemeralStorageMetrics", err.(request.ErrInvalidParams))
 		}
 	}
 

--- a/ecs-agent/metrics/constants.go
+++ b/ecs-agent/metrics/constants.go
@@ -40,4 +40,8 @@ const (
 	credsRefreshNamespace     = "CredentialsRefresh"
 	CredentialsRefreshFailure = credsRefreshNamespace + ".Failure"
 	CredentialsRefreshSuccess = credsRefreshNamespace + ".Success"
+
+	// Agent Availability
+	agentAvailabilityNamespace     = "Availability"
+	TCSDisconnectTimeoutMetricName = agentAvailabilityNamespace + ".TCSDisconnectTimeout"
 )

--- a/ecs-agent/tcs/client/client.go
+++ b/ecs-agent/tcs/client/client.go
@@ -31,7 +31,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 
-	//TODO: ricgang: removethis
 	"github.com/cihub/seelog"
 	"github.com/pborman/uuid"
 )

--- a/ecs-agent/tcs/client/client.go
+++ b/ecs-agent/tcs/client/client.go
@@ -94,7 +94,6 @@ func New(url string,
 			RequestHandlers:    make(map[string]wsclient.RequestHandler),
 		},
 	}
-	//TODO: ricgang: What is this??
 	cs.ServiceError = &tcsError{}
 	return cs
 }
@@ -138,7 +137,7 @@ func (cs *tcsClientServer) publishMessages(ctx context.Context) {
 			logger.Debug("received health message in healthChannel")
 			err := cs.publishHealthOnce(health)
 			if err != nil {
-				logger.Warn("Error publishing metrics", logger.Fields{
+				logger.Warn("Error publishing health", logger.Fields{
 					field.Error: err,
 				})
 			}

--- a/ecs-agent/tcs/client/client.go
+++ b/ecs-agent/tcs/client/client.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 
+	//TODO: ricgang: removethis
 	"github.com/cihub/seelog"
 	"github.com/pborman/uuid"
 )
@@ -93,6 +94,7 @@ func New(url string,
 			RequestHandlers:    make(map[string]wsclient.RequestHandler),
 		},
 	}
+	//TODO: ricgang: What is this??
 	cs.ServiceError = &tcsError{}
 	return cs
 }

--- a/ecs-agent/tcs/handler/handler.go
+++ b/ecs-agent/tcs/handler/handler.go
@@ -46,7 +46,7 @@ type TcsEcsClient interface {
 
 // TelemetrySession defines an interface for handler's long-lived connection with TCS.
 type TelemetrySession interface {
-	StartTelemetrySession(context.Context, string) error
+	StartTelemetrySession(context.Context) error
 	Start(context.Context) error
 }
 
@@ -57,7 +57,6 @@ type telemetrySession struct {
 	agentVersion                  string
 	agentHash                     string
 	containerRuntimeVersion       string
-	endpoint                      string
 	disableMetrics                bool
 	credentialsProvider           *credentials.Credentials
 	cfg                           *wsclient.WSClientMinAgentConfig
@@ -79,7 +78,6 @@ func NewTelemetrySession(
 	agentVersion string,
 	agentHash string,
 	containerRuntimeVersion string,
-	endpoint string,
 	disableMetrics bool,
 	credentialsProvider *credentials.Credentials,
 	cfg *wsclient.WSClientMinAgentConfig,
@@ -100,7 +98,6 @@ func NewTelemetrySession(
 		agentVersion:                  agentVersion,
 		agentHash:                     agentHash,
 		containerRuntimeVersion:       containerRuntimeVersion,
-		endpoint:                      endpoint,
 		disableMetrics:                disableMetrics,
 		credentialsProvider:           credentialsProvider,
 		cfg:                           cfg,
@@ -121,7 +118,7 @@ func NewTelemetrySession(
 func (session *telemetrySession) Start(ctx context.Context) error {
 	backoff := retry.NewExponentialBackoff(time.Second, 1*time.Minute, 0.2, 2)
 	for {
-		tcsError := session.StartTelemetrySession(ctx, session.endpoint)
+		tcsError := session.StartTelemetrySession(ctx)
 		switch tcsError {
 		case context.Canceled, context.DeadlineExceeded:
 			return tcsError
@@ -136,7 +133,7 @@ func (session *telemetrySession) Start(ctx context.Context) error {
 }
 
 // StartTelemetrySession creates a session with the backend and handles requests.
-func (session *telemetrySession) StartTelemetrySession(ctx context.Context, endpoint string) error {
+func (session *telemetrySession) StartTelemetrySession(ctx context.Context) error {
 	wsRWTimeout := 2*session.heartbeatTimeout + session.heartbeatJitterMax
 
 	var containerRuntime string

--- a/ecs-agent/tcs/handler/handler.go
+++ b/ecs-agent/tcs/handler/handler.go
@@ -39,6 +39,10 @@ import (
 const (
 	deregisterContainerInstanceHandler = "TCSDeregisterContainerInstanceHandler"
 	ContainerRuntimeDocker             = "Docker"
+	backoffMin                         = 1 * time.Second
+	backoffMax                         = 1 * time.Minute
+	jitterMultiple                     = 0.2
+	multiple                           = 2
 	// dateTimeFormat is a string format to format time for better readability: YYYY-MM-DD hh:mm:ss
 	dateTimeFormat = "2006-01-02 15:04:05"
 )
@@ -119,7 +123,7 @@ func NewTelemetrySession(
 
 // Start runs in for loop to start telemetry session with exponential backoff
 func (session *telemetrySession) Start(ctx context.Context) error {
-	backoff := retry.NewExponentialBackoff(time.Second, 1*time.Minute, 0.2, 2)
+	backoff := retry.NewExponentialBackoff(backoffMin, backoffMax, jitterMultiple, multiple)
 	for {
 		select {
 		case <-ctx.Done():

--- a/ecs-agent/tcs/handler/handler.go
+++ b/ecs-agent/tcs/handler/handler.go
@@ -121,6 +121,12 @@ func NewTelemetrySession(
 func (session *telemetrySession) Start(ctx context.Context) error {
 	backoff := retry.NewExponentialBackoff(time.Second, 1*time.Minute, 0.2, 2)
 	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("ECS Telemetry service (TCS) session exited cleanly.")
+			return nil
+		default:
+		}
 		tcsError := session.StartTelemetrySession(ctx)
 		switch tcsError {
 		case context.Canceled, context.DeadlineExceeded:

--- a/ecs-agent/tcs/handler/handler.go
+++ b/ecs-agent/tcs/handler/handler.go
@@ -17,6 +17,7 @@ package tcshandler
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/url"
 	"strings"
@@ -38,6 +39,8 @@ import (
 const (
 	deregisterContainerInstanceHandler = "TCSDeregisterContainerInstanceHandler"
 	ContainerRuntimeDocker             = "Docker"
+	// dateTimeFormat is a string format to format time for better readability: YYYY-MM-DD hh:mm:ss
+	dateTimeFormat = "2006-01-02 15:04:05"
 )
 
 type TcsEcsClient interface {
@@ -166,32 +169,35 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context) erro
 		})
 		return err
 	}
-	logger.Info("Connected to TCS endpoint")
+	startTime := time.Now()
+	logger.Info("Connected to TCS endpoint", logger.Fields{
+		"TCSConnectTime":            startTime.Format(dateTimeFormat),
+		"ExpectedTCSDisconnectTime": startTime.Add(session.disconnectTimeout).Format(dateTimeFormat),
+	})
+
+	// newDisconnectTimeoutTimerHandler returns a timer.Afterfunc(timeout, f) which will
+	// call f as goroutine after timeout. The timeout is currently set to 30m+jitter(5m max) to match max duration
+	// of connection with TCS. This timer is meant to handle s.startTCSSession running in blocking mode
+	// beyond 30m+jitter as s.startTCSSession has 2 possible paths: returns with error or continue running
+	// in blocking mode.
+	// Happy path: it returns with error, then timer stops, goroutine to disconnect never starts.
+	// Edge case: it continues to run beyond the maximum duration of TCS connection. Timer starts goroutine
+	// from DisconnectTimeoutTimer to disconnect; guard against hanging connection to unhealthy TCS host.
+	disconnectTimer := session.newDisconnectTimeoutHandler(client, startTime)
+	defer disconnectTimer.Stop()
+
 	// start a timer and listens for tcs heartbeats/acks. The timer is reset when
 	// we receive a heartbeat from the server or when a published metrics message
 	// is acked.
-	timer := time.NewTimer(retry.AddJitter(session.heartbeatTimeout, session.heartbeatJitterMax))
-	defer timer.Stop()
-	client.AddRequestHandler(heartbeatHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
-	client.AddRequestHandler(ackPublishMetricHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
-	client.AddRequestHandler(ackPublishHealthMetricHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
-	client.AddRequestHandler(ackPublishInstanceStatusHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	heartBeatTimer := session.newHeartbeatTimeoutHandler(client, startTime)
+	defer heartBeatTimer.Stop()
+
+	client.AddRequestHandler(heartbeatHandler(heartBeatTimer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	client.AddRequestHandler(ackPublishMetricHandler(heartBeatTimer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	client.AddRequestHandler(ackPublishHealthMetricHandler(heartBeatTimer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	client.AddRequestHandler(ackPublishInstanceStatusHandler(heartBeatTimer, session.heartbeatTimeout, session.heartbeatJitterMax))
 	client.SetAnyRequestHandler(anyMessageHandler(client, wsRWTimeout))
-	serveC := make(chan error, 1)
-	go func() {
-		serveC <- client.Serve(ctx)
-	}()
-	select {
-	case <-ctx.Done():
-		// outer context done, agent is exiting
-		client.Disconnect()
-	case <-timer.C:
-		seelog.Info("TCS Connection hasn't had any activity for too long; disconnecting")
-		client.Disconnect()
-	case err := <-serveC:
-		return err
-	}
-	return nil
+	return client.Serve(ctx)
 }
 
 func (session *telemetrySession) getTelemetryEndpoint() (string, error) {
@@ -204,6 +210,49 @@ func (session *telemetrySession) getTelemetryEndpoint() (string, error) {
 		return "", err
 	}
 	return tcsEndpoint, nil
+}
+
+func (session *telemetrySession) newDisconnectTimeoutHandler(client wsclient.ClientServer, startTime time.Time) *time.Timer {
+	maxConnectionDuration := retry.AddJitter(session.disconnectTimeout, session.disconnectJitterMax)
+	timer := time.AfterFunc(maxConnectionDuration, func() {
+		err := closeTCSClient(client, startTime, maxConnectionDuration)
+		session.metricsFactory.New(metrics.TCSDisconnectTimeoutMetricName).Done(err)
+		if err != nil {
+			logger.Warn("Attempted disconnecting; client already closed", logger.Fields{
+				field.Error: err,
+			})
+		}
+	})
+	return timer
+}
+
+func (session *telemetrySession) newHeartbeatTimeoutHandler(cs wsclient.ClientServer, startTime time.Time) *time.Timer {
+	maxConnectionDuration := retry.AddJitter(session.heartbeatTimeout, session.heartbeatJitterMax)
+	timer := time.AfterFunc(maxConnectionDuration, func() {
+		err := closeTCSClient(cs, startTime, maxConnectionDuration)
+		if err != nil {
+			logger.Warn(fmt.Sprintf("Attempted disconnecting; tcs client already closed. %s", err))
+		}
+	})
+	return timer
+}
+
+// closeTCSClient will attempt to close the provided client, retries are not recommended
+// as failure modes for this are when client is not found or already closed.
+func closeTCSClient(client wsclient.ClientServer, startTime time.Time, timeoutDuration time.Duration) error {
+	logger.Warn("Closing tcs connection", logger.Fields{
+		"ConnectionStartTime":  startTime.Format(dateTimeFormat),
+		"MaxDisconnectionTime": startTime.Add(timeoutDuration).Format(dateTimeFormat),
+	})
+
+	err := client.Disconnect()
+	if err != nil {
+		logger.Warn("Error disconnecting; client already closed", logger.Fields{
+			field.Error: err,
+		})
+	}
+	logger.Info("Disconnected from tcs")
+	return err
 }
 
 // heartbeatHandler resets the heartbeat timer when HeartbeatMessage message is received from tcs.

--- a/ecs-agent/tcs/handler/handler_test.go
+++ b/ecs-agent/tcs/handler/handler_test.go
@@ -405,7 +405,7 @@ func TestClientReconnectsAfterInactiveTimeout(t *testing.T) {
 		TCSurl: server.URL,
 	}
 	ctx := context.Background()
-	deadline := time.Now().Add(1500 * time.Millisecond)
+	deadline := time.Now().Add(5 * time.Second)
 	ctx, cancelCtx := context.WithDeadline(ctx, deadline)
 	defer cancelCtx()
 	deregisterInstanceEventStream := eventstream.NewEventStream("Deregister_Instance", ctx)
@@ -425,7 +425,7 @@ func TestClientReconnectsAfterInactiveTimeout(t *testing.T) {
 		testCfg,
 		deregisterInstanceEventStream,
 		50*time.Millisecond,
-		100*time.Millisecond,
+		10*time.Millisecond,
 		testDisconnectionTimeout,
 		testDisconnectionJitter,
 		nil,
@@ -445,7 +445,7 @@ func TestClientReconnectsAfterInactiveTimeout(t *testing.T) {
 	assert.False(t, websocket.IsCloseError(err, websocket.CloseAbnormalClosure),
 		"Read from closed connection should produce an io.EOF error")
 
-	assert.EqualError(t, err, "context deadline exceeded")
+	assert.NoError(t, err, "No error is expected. The test should exit cleanly when the ctx is done.")
 
 }
 

--- a/ecs-agent/tcs/handler/handler_test.go
+++ b/ecs-agent/tcs/handler/handler_test.go
@@ -623,7 +623,7 @@ func TestPeriodicDisconnectonTCSClient(t *testing.T) {
 		testHeartbeatJitter,
 		10*time.Second,
 		2*time.Second,
-		nil,
+		metrics.NewNopEntryFactory(),
 		telemetryMessages,
 		healthMessages,
 		emptyDoctor,

--- a/ecs-agent/tcs/handler/handler_test.go
+++ b/ecs-agent/tcs/handler/handler_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/doctor"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
 	tcsclient "github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/wsclient"

--- a/ecs-agent/tcs/handler/handler_test.go
+++ b/ecs-agent/tcs/handler/handler_test.go
@@ -154,11 +154,11 @@ func TestStartTelemetrySession(t *testing.T) {
 	// Start test server.
 	closeWS := make(chan []byte)
 	server, serverChan, requestChan, serverErr, err := wsmock.GetMockServer(closeWS)
-	server.StartTLS()
-	defer server.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
+	server.StartTLS()
+	defer server.Close()
 
 	testecsclient := &wsmock.TestECSClient{
 		TCSurl: server.URL,
@@ -252,11 +252,12 @@ func TestSessionConnectionClosedByRemote(t *testing.T) {
 	// Start test server.
 	closeWS := make(chan []byte)
 	server, serverChan, _, serverErr, err := wsmock.GetMockServer(closeWS)
-	server.StartTLS()
-	defer server.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
+	server.StartTLS()
+	defer server.Close()
+
 	go func() {
 		serr := <-serverErr
 		if !websocket.IsCloseError(serr, websocket.CloseNormalClosure) {
@@ -320,11 +321,11 @@ func TestConnectionInactiveTimeout(t *testing.T) {
 	// Start test server.
 	closeWS := make(chan []byte)
 	server, _, requestChan, serverErr, err := wsmock.GetMockServer(closeWS)
-	server.StartTLS()
-	defer server.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
+	server.StartTLS()
+	defer server.Close()
 
 	go func() {
 		for {
@@ -369,12 +370,9 @@ func TestConnectionInactiveTimeout(t *testing.T) {
 
 	// Start a session with the test server.
 	err = session.StartTelemetrySession(ctx)
+	assert.Contains(t, err.Error(), "use of closed network connection")
 
-	// TODO: confirm once. The client would not attempt to reconnect since we are using StartTelemetrySession
-	// instead of Start. Modified the test to just test for connection closed on inactivity.
-	//assert.NoError(t, err, "Close the connection should cause the tcs client return error")
 	msg := <-serverErr
-
 	assert.True(t, websocket.IsCloseError(msg, websocket.CloseAbnormalClosure),
 		"Read from closed connection should produce an io.EOF error")
 
@@ -387,11 +385,11 @@ func TestClientReconnectsAfterInactiveTimeout(t *testing.T) {
 	// Start test server.
 	closeWS := make(chan []byte)
 	server, _, requestChan, _, err := wsmock.GetMockServer(closeWS)
-	server.StartTLS()
-	defer server.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
+	server.StartTLS()
+	defer server.Close()
 
 	go func() {
 		for {
@@ -582,11 +580,11 @@ func TestPeriodicDisconnectonTCSClient(t *testing.T) {
 	// Start test server.
 	closeWS := make(chan []byte)
 	server, _, requestChan, serverErr, err := wsmock.GetMockServer(closeWS)
-	server.StartTLS()
-	defer server.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
+	server.StartTLS()
+	defer server.Close()
 
 	go func() {
 		for {
@@ -608,8 +606,8 @@ func TestPeriodicDisconnectonTCSClient(t *testing.T) {
 	telemetryMessages := make(chan ecstcs.TelemetryMessage, testTelemetryChannelDefaultBufferSize)
 	healthMessages := make(chan ecstcs.HealthMessage, testTelemetryChannelDefaultBufferSize)
 
-	//Setting disconnect timer(10 secs) to be less than heartbeat timer( 1min)
-	//in order disconnect because of periodic timer instead of heartbeat timer due to inactivity.
+	// Setting disconnect timer(10 secs) to be less than heartbeat timer(1min)
+	// in order to disconnect because of periodic timer instead of heartbeat timer due to inactivity.
 	session := NewTelemetrySession(
 		testInstanceArn,
 		testClusterArn,
@@ -633,6 +631,7 @@ func TestPeriodicDisconnectonTCSClient(t *testing.T) {
 
 	// Start a session with the test server.
 	err = session.StartTelemetrySession(ctx)
+	assert.Contains(t, err.Error(), "use of closed network connection")
 
 	msg := <-serverErr
 	assert.True(t, websocket.IsCloseError(msg, websocket.CloseAbnormalClosure),

--- a/ecs-agent/tcs/model/api/api-2.json
+++ b/ecs-agent/tcs/model/api/api-2.json
@@ -28,23 +28,10 @@
       "input":{"shape":"PublishHealthRequest"},
       "output":{"shape":"AckPublishHealth"},
       "errors":[
-        {
-          "shape":"BadRequestException",
-          "exception":true
-        },
-        {
-          "shape":"ResourceValidationException",
-          "exception":true
-        },
-        {
-          "shape":"InvalidParameterException",
-          "exception":true
-        },
-        {
-          "shape":"ServerException",
-          "exception":true,
-          "fault":true
-        }
+        {"shape":"BadRequestException"},
+        {"shape":"ResourceValidationException"},
+        {"shape":"InvalidParameterException"},
+        {"shape":"ServerException"}
       ]
     },
     "PublishInstanceStatus":{
@@ -56,23 +43,10 @@
       "input":{"shape":"PublishInstanceStatusRequest"},
       "output":{"shape":"AckPublishInstanceStatus"},
       "errors":[
-        {
-          "shape":"BadRequestException",
-          "exception":true
-        },
-        {
-          "shape":"ResourceValidationException",
-          "exception":true
-        },
-        {
-          "shape":"InvalidParameterException",
-          "exception":true
-        },
-        {
-          "shape":"ServerException",
-          "exception":true,
-          "fault":true
-        }
+        {"shape":"BadRequestException"},
+        {"shape":"ResourceValidationException"},
+        {"shape":"InvalidParameterException"},
+        {"shape":"ServerException"}
       ]
     },
     "PublishMetrics":{
@@ -84,23 +58,10 @@
       "input":{"shape":"PublishMetricsRequest"},
       "output":{"shape":"AckPublishMetric"},
       "errors":[
-        {
-          "shape":"BadRequestException",
-          "exception":true
-        },
-        {
-          "shape":"ResourceValidationException",
-          "exception":true
-        },
-        {
-          "shape":"InvalidParameterException",
-          "exception":true
-        },
-        {
-          "shape":"ServerException",
-          "exception":true,
-          "fault":true
-        }
+        {"shape":"BadRequestException"},
+        {"shape":"ResourceValidationException"},
+        {"shape":"InvalidParameterException"},
+        {"shape":"ServerException"}
       ]
     },
     "StartTelemetrySession":{
@@ -112,19 +73,9 @@
       "input":{"shape":"StartTelemetrySessionRequest"},
       "output":{"shape":"StopTelemetrySessionMessage"},
       "errors":[
-        {
-          "shape":"BadRequestException",
-          "exception":true
-        },
-        {
-          "shape":"ResourceValidationException",
-          "exception":true
-        },
-        {
-          "shape":"ServerException",
-          "exception":true,
-          "fault":true
-        }
+        {"shape":"BadRequestException"},
+        {"shape":"ResourceValidationException"},
+        {"shape":"ServerException"}
       ]
     }
   },
@@ -203,6 +154,12 @@
       "member":{"shape":"Dimension"}
     },
     "Double":{"type":"double"},
+    "EphemeralStorageMetrics":{
+      "type":"structure",
+      "members":{
+        "BytesUtilized":{"shape":"ULongStatsSet"}
+      }
+    },
     "GeneralMetric":{
       "type":"structure",
       "members":{
@@ -410,6 +367,7 @@
         "taskDefinitionFamily":{"shape":"String"},
         "taskDefinitionVersion":{"shape":"String"},
         "containerMetrics":{"shape":"ContainerMetrics"},
+        "ephemeralStorageMetrics":{"shape":"EphemeralStorageMetrics"},
         "serviceConnectMetricsWrapper":{"shape":"ServiceConnectMetricsWrapper"}
       }
     },

--- a/ecs-agent/tcs/model/ecstcs/api.go
+++ b/ecs-agent/tcs/model/ecstcs/api.go
@@ -233,6 +233,37 @@ func (s Dimension) GoString() string {
 	return s.String()
 }
 
+type EphemeralStorageMetrics struct {
+	_ struct{} `type:"structure"`
+
+	BytesUtilized *ULongStatsSet `type:"structure"`
+}
+
+// String returns the string representation
+func (s EphemeralStorageMetrics) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EphemeralStorageMetrics) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EphemeralStorageMetrics) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EphemeralStorageMetrics"}
+	if s.BytesUtilized != nil {
+		if err := s.BytesUtilized.Validate(); err != nil {
+			invalidParams.AddNested("BytesUtilized", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GeneralMetric struct {
 	_ struct{} `type:"structure"`
 
@@ -991,6 +1022,8 @@ type TaskMetric struct {
 
 	ContainerMetrics []*ContainerMetric `locationName:"containerMetrics" type:"list"`
 
+	EphemeralStorageMetrics *EphemeralStorageMetrics `locationName:"ephemeralStorageMetrics" type:"structure"`
+
 	ServiceConnectMetricsWrapper []*GeneralMetricsWrapper `locationName:"serviceConnectMetricsWrapper" type:"list"`
 
 	TaskArn *string `locationName:"taskArn" type:"string"`
@@ -1021,6 +1054,11 @@ func (s *TaskMetric) Validate() error {
 			if err := v.Validate(); err != nil {
 				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ContainerMetrics", i), err.(request.ErrInvalidParams))
 			}
+		}
+	}
+	if s.EphemeralStorageMetrics != nil {
+		if err := s.EphemeralStorageMetrics.Validate(); err != nil {
+			invalidParams.AddNested("EphemeralStorageMetrics", err.(request.ErrInvalidParams))
 		}
 	}
 

--- a/ecs-agent/wsclient/mock/utils/utils.go
+++ b/ecs-agent/wsclient/mock/utils/utils.go
@@ -14,12 +14,26 @@
 package utils
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"time"
 
 	"github.com/gorilla/websocket"
 )
+
+type TestECSClient struct {
+	TCSurl string
+}
+
+func (client *TestECSClient) DiscoverTelemetryEndpoint(url string) (string, error) {
+	if client.TCSurl == "" {
+		return "", errors.New("No endpoint found.")
+	}
+
+	return client.TCSurl, nil
+
+}
 
 // GetMockServer returns a mock websocket server that can be started up as TLS or not.
 // TODO replace with gomock


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR makes necessary changes in TCS shared library to accommodate integration with agent.

### Implementation details
<!-- How are the changes implemented? -->
1.  Created new ecs client interface named as TcsEcsClient which would allow different agents to pass their ecs clients with one enforcemnt: the ecs client should have DiscoverTelemetryEndpoint() function implemented.
2. Updated mocks, utils and tests to include above change. 
3. Removed passing of endpoint in function StartTelemetrySession(), since the start will invoke the DiscoverTelemetryEndpoint() to poll needed endpoint.
4. Added new disconnectTimeoutHandler() to introduce periodic timeout after disconnectTimeout+ disconnectJitterMax. This functionality was added to ACS connection as part of an COE action item. This PR extends it to TCS connection as well.
5. Introduced new newHeartbeatTimeoutHandler() for appropriate logging on disconnect due to heartbeat timeout.
6. Added new tests for both above functionalities.
7. Updated tcs model to include "EphemeralStorageMetrics" field.
8. Reporter.go now would call Start() instead of StartTelemetrySession() in tcs handler.

### Testing
Unit and integ tests.

New tests cover the changes: yes

### Description for the changelog
TCS client integration

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
