### PR TITLE
Refactor updater package to remove ACS session's unnecessary dependency

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	acshandler "github.com/aws/amazon-ecs-agent/agent/acs/handler"
+	updater "github.com/aws/amazon-ecs-agent/agent/acs/update_handler"
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/api/ecsclient"
 	"github.com/aws/amazon-ecs-agent/agent/app/factory"
@@ -979,6 +980,7 @@ func (agent *ecsAgent) startACSSession(
 		agent.latestSeqNumberTaskManifest,
 		doctor,
 		acsclient.NewACSClientFactory(),
+		updater.NewUpdater(agent.cfg, state, agent.dataClient, taskEngine).AddAgentUpdateHandlers,
 	)
 	seelog.Info("Beginning Polling for updates")
 	err := acsSession.Start()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request refactors the `updater` package located in `agent/acs/update_handler/` such that ACS session (currently located in `agent/acs/handler/acs_handler.go`) no longer needs to import/take a dependency on the `updater` package.

### Implementation details
<!-- How are the changes implemented? -->
- `agent/acs/update_handler/updater.go`
   - Add `state`, `dataClient`, and `taskEngine` as fields to `updater` struct
   - Update `performUpdateHandler` method to no longer take in  `state`, `dataClient`, and `taskEngine` as parameters and simply use the corresponding `updater` struct fields instead
   - Split current `AddAgentUpdateHandlers` function into two separate functions:
      - `NewUpdater` function which creates/initializes a new `updater`
      - `AddAgentUpdateHandlers` method which adds the necessary agent update request handlers to the passed in ACS `wsclient.ClientServer` such that in place agent updates are supported
   - Use `os.WriteFile` in favor of `ioutil.WriteFile` since the latter is deprecated
- `agent/acs/update_handler/updater_test.go`
   - Update unit tests to take into account the changes made to  `agent/acs/update_handler/updater.go` above
   - Use `os.WriteFile` in favor of `ioutil.WriteFile` since the latter is deprecated
- `agent/acs/handler/acs_handler.go`
   - Add new `addUpdateRequestHandlers` field to `session` struct and struct initialization function `NewSession`
   - Use above in favor of the current usage of `updater.AddAgentUpdateHandlers` function
   - Remove unnecessary import/dependency on `github.com/aws/amazon-ecs-agent/agent/acs/update_handler`
- `agent/acs/handler/acs_handler_test.go`
   - Update unit tests to take into account the changes made to  `agent/acs/handler/acs_handler.go` above
   - Add test that confirms that function contained in session struct field `addUpdateRequestHandlers` is called if not nil
- `agent/app/agent.go`
   - Initialize new `updater` and pass its `AddAgentUpdateHandlers` method to the ACS session via the new struct field `addUpdateRequestHandlers` described above in the changes to `agent/acs/handler/acs_handler.go`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Manually ran ECS Agent team's UpdateContainerAgent API functional test on the changes made to Agent in this pull request for AL2 platform.
```
--- PASS: TestUpdateContainerAgent (86.32s)
PASS
```

Unit, integration, and functional tests.

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Refactor updater package to remove ACS session's unnecessary dependency

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
