### PR TITLE
Start daemon import and add csi interface

### DIFF
--- a/agent/acs/update_handler/updater_test.go
+++ b/agent/acs/update_handler/updater_test.go
@@ -62,7 +62,7 @@ func mocks(t *testing.T, cfg *config.Config) (*updater, *gomock.Controller, *moc
 	httpClient.Transport.(httpclient.OverridableTransport).SetTransport(mockhttp)
 
 	u := NewUpdater(cfg, dockerstate.NewTaskEngineState(), data.NewNoopClient(),
-		engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil))
+		engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil))
 	// Override below attributes/fields for testing.
 	u.acs = mockacs
 	u.httpclient = httpClient

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3431,6 +3431,12 @@ func (task *Task) IsServiceConnectEnabled() bool {
 	return task.GetServiceConnectContainer() != nil
 }
 
+// Is EBS Task Attach enabled returns true if this task has EBS volume configuration in its ACS payload.
+// TODO as more daemons come online, we'll want a generic handler these bool checks and payload handling
+func (task *Task) IsEBSTaskAttachEnabled() bool {
+	return false
+}
+
 func (task *Task) IsServiceConnectBridgeModeApplicationContainer(container *apicontainer.Container) bool {
 	return container.GetNetworkModeFromHostConfig() == "container" && task.IsServiceConnectEnabled()
 }

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/ecscni"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
+	dm "github.com/aws/amazon-ecs-agent/agent/engine/daemonmanager"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
 	engineserviceconnect "github.com/aws/amazon-ecs-agent/agent/engine/serviceconnect"
@@ -62,6 +63,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	md "github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 	"github.com/aws/aws-sdk-go/aws"
@@ -146,6 +148,7 @@ type ecsAgent struct {
 	saveableOptionFactory       factory.SaveableOption
 	pauseLoader                 loader.Loader
 	serviceconnectManager       engineserviceconnect.Manager
+	daemonManagers              map[string]dm.DaemonManager
 	eniWatcher                  *watcher.ENIWatcher
 	cniClient                   ecscni.CNIClient
 	vpc                         string
@@ -242,6 +245,7 @@ func newAgent(blackholeEC2Metadata bool, acceptInsecureCert *bool) (agent, error
 		saveableOptionFactory:       factory.NewSaveableOption(),
 		pauseLoader:                 pause.New(),
 		serviceconnectManager:       engineserviceconnect.NewManager(),
+		daemonManagers:              make(map[string]dm.DaemonManager),
 		cniClient:                   ecscni.NewClient(cfg.CNIPluginsPath),
 		metadataManager:             metadataManager,
 		terminationHandler:          sighandlers.StartDefaultTerminationHandler,
@@ -334,9 +338,33 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 		StringSetValue: aws.StringSlice(gpuIDs),
 	}
 
+	daemonDefinitions, err := md.ImportAll()
+	// we will not panic when daemons fail to import; agent should continue running
+	// container instance health will act as the mechanism to advertise daemon failures
+	if err != nil {
+		seelog.Errorf("Daemon import mountpoint failure: %s", err)
+	}
+	if len(daemonDefinitions) == 0 {
+		seelog.Infof("daemonDefinitions is empty/nil after import")
+	}
+	// load and add daemons to agent
+	for _, md := range daemonDefinitions {
+		thisDaemon := dm.NewDaemonManager(md)
+		if _, err := thisDaemon.LoadImage(agent.ctx, agent.dockerClient); err != nil {
+			seelog.Errorf("Managed Daemon Load failure %v", err)
+		}
+		if loaded, err := thisDaemon.IsLoaded(agent.dockerClient); loaded {
+			imageManager.AddImageToCleanUpExclusionList(md.GetLoadedDaemonImageRef())
+			agent.daemonManagers[md.GetImageName()] = thisDaemon
+		} else {
+			seelog.Errorf("Unable to load Managed Daemon: %s, err: %s", md.GetImageName(), err)
+		}
+	}
+
 	// Create the task engine
 	taskEngine, currentEC2InstanceID, err := agent.newTaskEngine(
-		containerChangeEventStream, credentialsManager, state, imageManager, hostResources, execCmdMgr, agent.serviceconnectManager)
+		containerChangeEventStream, credentialsManager, state, imageManager, hostResources, execCmdMgr,
+		agent.serviceconnectManager, agent.daemonManagers)
 	if err != nil {
 		seelog.Criticalf("Unable to initialize new task engine: %v", err)
 		return exitcodes.ExitTerminal
@@ -423,6 +451,7 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 		}
 		return exitcodes.ExitTerminal
 	}
+
 	scManager := agent.serviceconnectManager
 	scManager.SetECSClient(client, agent.containerInstanceARN)
 	if loaded, _ := scManager.IsLoaded(agent.dockerClient); loaded {
@@ -445,7 +474,7 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 		agent.saveMetadata(data.EC2InstanceIDKey, currentEC2InstanceID)
 	}
 
-	// now that we know the container instance ARN, we can build out the doctor
+	// now that we know the container instance ARN, we can create the doctor
 	// and pass it on to ACS and TACS
 	doctor, doctorCreateErr := agent.newDoctorWithHealthchecks(agent.cfg.Cluster, agent.containerInstanceARN)
 	if doctorCreateErr != nil {
@@ -545,7 +574,8 @@ func (agent *ecsAgent) newTaskEngine(containerChangeEventStream *eventstream.Eve
 	imageManager engine.ImageManager,
 	hostResources map[string]*ecs.Resource,
 	execCmdMgr execcmd.Manager,
-	serviceConnectManager engineserviceconnect.Manager) (engine.TaskEngine, string, error) {
+	serviceConnectManager engineserviceconnect.Manager,
+	daemonManagers map[string]dm.DaemonManager) (engine.TaskEngine, string, error) {
 
 	containerChangeEventStream.StartListening()
 
@@ -553,10 +583,11 @@ func (agent *ecsAgent) newTaskEngine(containerChangeEventStream *eventstream.Eve
 		seelog.Info("Checkpointing not enabled; a new container instance will be created each time the agent is run")
 		return engine.NewTaskEngine(agent.cfg, agent.dockerClient, credentialsManager,
 			containerChangeEventStream, imageManager, hostResources, state,
-			agent.metadataManager, agent.resourceFields, execCmdMgr, serviceConnectManager), "", nil
+			agent.metadataManager, agent.resourceFields, execCmdMgr,
+			serviceConnectManager, daemonManagers), "", nil
 	}
 
-	savedData, err := agent.loadData(containerChangeEventStream, credentialsManager, state, imageManager, hostResources, execCmdMgr, serviceConnectManager)
+	savedData, err := agent.loadData(containerChangeEventStream, credentialsManager, state, imageManager, hostResources, execCmdMgr, serviceConnectManager, daemonManagers)
 	if err != nil {
 		seelog.Criticalf("Error loading previously saved state: %v", err)
 		return nil, "", err
@@ -582,7 +613,8 @@ func (agent *ecsAgent) newTaskEngine(containerChangeEventStream *eventstream.Eve
 		// Reset taskEngine; all the other values are still default
 		return engine.NewTaskEngine(agent.cfg, agent.dockerClient, credentialsManager,
 			containerChangeEventStream, imageManager, hostResources, state, agent.metadataManager,
-			agent.resourceFields, execCmdMgr, serviceConnectManager), currentEC2InstanceID, nil
+			agent.resourceFields, execCmdMgr, serviceConnectManager,
+			daemonManagers), currentEC2InstanceID, nil
 	}
 
 	if savedData.cluster != "" {

--- a/agent/app/agent_compatibility_linux_test.go
+++ b/agent/app/agent_compatibility_linux_test.go
@@ -66,7 +66,8 @@ func TestCompatibilityEnabledSuccess(t *testing.T) {
 
 	containerChangeEventStream := eventstream.NewEventStream("events", ctx)
 	hostResources := getTestHostResources()
-	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, hostResources, execCmdMgr, serviceConnectManager)
+	daemonManagers := getTestDaemonManagers()
+	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, hostResources, execCmdMgr, serviceConnectManager, daemonManagers)
 
 	assert.NoError(t, err)
 	assert.True(t, cfg.TaskCPUMemLimit.Enabled())
@@ -108,7 +109,8 @@ func TestCompatibilityNotSetFail(t *testing.T) {
 
 	containerChangeEventStream := eventstream.NewEventStream("events", ctx)
 	hostResources := getTestHostResources()
-	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, hostResources, execCmdMgr, serviceConnectManager)
+	daemonManagers := getTestDaemonManagers()
+	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, hostResources, execCmdMgr, serviceConnectManager, daemonManagers)
 
 	assert.NoError(t, err)
 	assert.False(t, cfg.TaskCPUMemLimit.Enabled())
@@ -149,7 +151,8 @@ func TestCompatibilityExplicitlyEnabledFail(t *testing.T) {
 
 	containerChangeEventStream := eventstream.NewEventStream("events", ctx)
 	hostResources := getTestHostResources()
-	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, hostResources, execCmdMgr, serviceConnectManager)
+	daemonManagers := getTestDaemonManagers()
+	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, hostResources, execCmdMgr, serviceConnectManager, daemonManagers)
 
 	assert.Error(t, err)
 }

--- a/agent/app/data.go
+++ b/agent/app/data.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
+	dm "github.com/aws/amazon-ecs-agent/agent/engine/daemonmanager"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
 	"github.com/aws/amazon-ecs-agent/agent/engine/serviceconnect"
@@ -68,12 +69,14 @@ func (agent *ecsAgent) loadData(containerChangeEventStream *eventstream.EventStr
 	imageManager engine.ImageManager,
 	hostResources map[string]*ecs.Resource,
 	execCmdMgr execcmd.Manager,
-	serviceConnectManager serviceconnect.Manager) (*savedData, error) {
+	serviceConnectManager serviceconnect.Manager,
+	daemonManagers map[string]dm.DaemonManager) (*savedData, error) {
 
 	s := &savedData{
 		taskEngine: engine.NewTaskEngine(agent.cfg, agent.dockerClient, credentialsManager,
 			containerChangeEventStream, imageManager, hostResources, state,
-			agent.metadataManager, agent.resourceFields, execCmdMgr, serviceConnectManager),
+			agent.metadataManager, agent.resourceFields, execCmdMgr,
+			serviceConnectManager, daemonManagers),
 	}
 	s.taskEngine.SetDataClient(agent.dataClient)
 

--- a/agent/app/data_test.go
+++ b/agent/app/data_test.go
@@ -111,10 +111,12 @@ func TestLoadDataNoPreviousState(t *testing.T) {
 		stateManagerFactory:   stateManagerFactory,
 		saveableOptionFactory: factory.NewSaveableOption(),
 	}
+	state := dockerstate.NewTaskEngineState()
 	hostResources := getTestHostResources()
+	daemonManagers := getTestDaemonManagers()
 
-	_, err := agent.loadData(eventstream.NewEventStream("events", ctx),
-		credentialsManager, dockerstate.NewTaskEngineState(), imageManager, hostResources, execCmdMgr, serviceConnectManager)
+	_, err := agent.loadData(eventstream.NewEventStream("events", ctx), credentialsManager,
+		state, imageManager, hostResources, execCmdMgr, serviceConnectManager, daemonManagers)
 	assert.NoError(t, err)
 }
 
@@ -144,8 +146,9 @@ func TestLoadDataLoadFromBoltDB(t *testing.T) {
 
 	state := dockerstate.NewTaskEngineState()
 	hostResources := getTestHostResources()
-	s, err := agent.loadData(eventstream.NewEventStream("events", ctx),
-		credentialsManager, state, imageManager, hostResources, execCmdMgr, serviceConnectManager)
+	daemonManagers := getTestDaemonManagers()
+	s, err := agent.loadData(eventstream.NewEventStream("events", ctx), credentialsManager,
+		state, imageManager, hostResources, execCmdMgr, serviceConnectManager, daemonManagers)
 	assert.NoError(t, err)
 	checkLoadedData(state, s, t)
 }
@@ -183,8 +186,9 @@ func TestLoadDataLoadFromStateFile(t *testing.T) {
 
 	state := dockerstate.NewTaskEngineState()
 	hostResources := getTestHostResources()
-	s, err := agent.loadData(eventstream.NewEventStream("events", ctx),
-		credentialsManager, state, imageManager, hostResources, execCmdMgr, serviceConnectManager)
+	daemonManagers := getTestDaemonManagers()
+	s, err := agent.loadData(eventstream.NewEventStream("events", ctx), credentialsManager,
+		state, imageManager, hostResources, execCmdMgr, serviceConnectManager, daemonManagers)
 	assert.NoError(t, err)
 	checkLoadedData(state, s, t)
 

--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -113,10 +113,11 @@ func setupGMSALinux(cfg *config.Config, state dockerstate.TaskEngineState, t *te
 	}
 	hostResources := getTestHostResources()
 	hostResourceManager := NewHostResourceManager(hostResources)
+	daemonManagers := getTestDaemonManagers()
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, &hostResourceManager, state, metadataManager,
-		resourceFields, execcmd.NewManager(), engineserviceconnect.NewManager())
+		resourceFields, execcmd.NewManager(), engineserviceconnect.NewManager(), daemonManagers)
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {
 		taskEngine.Shutdown()
@@ -206,10 +207,11 @@ func setup(cfg *config.Config, state dockerstate.TaskEngineState, t *testing.T) 
 	metadataManager := containermetadata.NewManager(dockerClient, cfg)
 	hostResources := getTestHostResources()
 	hostResourceManager := NewHostResourceManager(hostResources)
+	daemonManagers := getTestDaemonManagers()
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, &hostResourceManager, state, metadataManager,
-		nil, execcmd.NewManager(), engineserviceconnect.NewManager())
+		nil, execcmd.NewManager(), engineserviceconnect.NewManager(), daemonManagers)
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {
 		taskEngine.Shutdown()

--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/engine/daemonmanager"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
 	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
@@ -409,4 +410,9 @@ func getTestHostResources() map[string]*ecs.Resource {
 		StringSetValue: aws.StringSlice(gpuIDs),
 	}
 	return hostResources
+}
+
+func getTestDaemonManagers() map[string]daemonmanager.DaemonManager {
+	daemonManagers := make(map[string]daemonmanager.DaemonManager)
+	return daemonManagers
 }

--- a/agent/engine/daemonmanager/daemon_manager.go
+++ b/agent/engine/daemonmanager/daemon_manager.go
@@ -17,15 +17,27 @@ import (
 	"context"
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
-	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
-	"github.com/aws/amazon-ecs-agent/agent/utils/loader"
+	md "github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon"
 	"github.com/docker/docker/api/types"
 )
 
 type DaemonManager interface {
-	loader.Loader
+	GetManagedDaemon() *md.ManagedDaemon
 	CreateDaemonTask() (*apitask.Task, error)
-	LoadImage(ctx context.Context, _ *config.Config, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error)
+	LoadImage(ctx context.Context, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error)
 	IsLoaded(dockerClient dockerapi.DockerClient) (bool, error)
+}
+
+// each daemon manager manages one single daemon container
+type daemonManager struct {
+	managedDaemon *md.ManagedDaemon
+}
+
+func NewDaemonManager(manageddaemon *md.ManagedDaemon) DaemonManager {
+	return &daemonManager{managedDaemon: manageddaemon}
+}
+
+func (dm *daemonManager) GetManagedDaemon() *md.ManagedDaemon {
+	return dm.managedDaemon
 }

--- a/agent/engine/daemonmanager/daemon_manager_linux_test.go
+++ b/agent/engine/daemonmanager/daemon_manager_linux_test.go
@@ -96,7 +96,7 @@ func TestCreateDaemonTask(t *testing.T) {
 				return nil
 			}
 			// set up test managed daemon
-			tmd := md.NewManagedDaemon(c.testDaemonName, c.testImageRef, TestImageTag)
+			tmd := md.NewManagedDaemon(c.testDaemonName, TestImageTag)
 			tmd.SetLoadedDaemonImageRef(c.testImageRef)
 			// create required mounts and add all
 			testAgentCommunicationMount := &md.MountPoint{SourceVolumeID: "agentCommunicationMount", ContainerPath: "/container/run/"}
@@ -143,7 +143,7 @@ func TestFailCreateDaemonTask_MissingMount(t *testing.T) {
 		return nil
 	}
 	// set up test managed daemon
-	tmd := md.NewManagedDaemon(TestDaemonName, TestImageRef, TestImageTag)
+	tmd := md.NewManagedDaemon(TestDaemonName, TestImageTag)
 	tmd.SetLoadedDaemonImageRef(TestImageRef)
 	// test failure with a missing applicationLogMount
 	testAgentCommunicationMount := &md.MountPoint{SourceVolumeID: "agentCommunicationMount", ContainerPath: "/container/run/"}
@@ -161,7 +161,7 @@ func TestFailCreateDaemonTask_MissingMount(t *testing.T) {
 	tmd.SetMountPoints(testMountPoints)
 	testDaemonManager = NewDaemonManager(tmd)
 	_, err = testDaemonManager.CreateDaemonTask()
-	assert.EqualError(t, err, fmt.Sprintf("%s is an invalid managed daemon", TestDaemonName))
+	assert.Nil(t, err)
 
 	// add required healthcheck
 	testHealthCheck := []string{"test"}

--- a/agent/engine/daemonmanager/daemon_manager_windows.go
+++ b/agent/engine/daemonmanager/daemon_manager_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//      http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package daemonmanager
+
+import (
+	"context"
+	"errors"
+
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	"github.com/docker/docker/api/types"
+)
+
+func (dm *daemonManager) CreateDaemonTask() (*apitask.Task, error) {
+	return nil, errors.New("daemonmanager.CreateDaemonTask not implemented for Windows")
+}
+
+func (dm *daemonManager) LoadImage(ctx context.Context, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error) {
+	return nil, errors.New("dameonmanager.LoadImage not implemented for Windows")
+}
+
+// isImageLoaded uses the image ref with its tag
+func (dm *daemonManager) IsLoaded(dockerClient dockerapi.DockerClient) (bool, error) {
+	return false, errors.New("daemonmanager.IsLoaded not implemented for Windows")
+}

--- a/agent/engine/default.go
+++ b/agent/engine/default.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	dm "github.com/aws/amazon-ecs-agent/agent/engine/daemonmanager"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
 	"github.com/aws/amazon-ecs-agent/agent/engine/serviceconnect"
@@ -36,12 +37,14 @@ func NewTaskEngine(cfg *config.Config, client dockerapi.DockerClient,
 	metadataManager containermetadata.Manager,
 	resourceFields *taskresource.ResourceFields,
 	execCmdMgr execcmd.Manager,
-	serviceConnectManager serviceconnect.Manager) TaskEngine {
+	serviceConnectManager serviceconnect.Manager,
+	daemonManagers map[string]dm.DaemonManager) TaskEngine {
 
 	hostResourceManager := NewHostResourceManager(hostResources)
 	taskEngine := NewDockerTaskEngine(cfg, client, credentialsManager,
 		containerChangeEventStream, imageManager, &hostResourceManager,
-		state, metadataManager, resourceFields, execCmdMgr, serviceConnectManager)
+		state, metadataManager, resourceFields, execCmdMgr,
+		serviceConnectManager, daemonManagers)
 
 	return taskEngine
 }

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -180,9 +180,10 @@ func mocks(t *testing.T, ctx context.Context, cfg *config.Config) (*gomock.Contr
 	metadataManager := mock_containermetadata.NewMockManager(ctrl)
 	execCmdMgr := mock_execcmdagent.NewMockManager(ctrl)
 	hostResources := getTestHostResources()
+	daemonManagers := getTestDaemonManagers()
 
 	taskEngine := NewTaskEngine(cfg, client, credentialsManager, containerChangeEventStream,
-		imageManager, hostResources, dockerstate.NewTaskEngineState(), metadataManager, nil, execCmdMgr, nil)
+		imageManager, hostResources, dockerstate.NewTaskEngineState(), metadataManager, nil, execCmdMgr, nil, daemonManagers)
 	taskEngine.(*DockerTaskEngine)._time = mockTime
 	taskEngine.(*DockerTaskEngine).ctx = ctx
 	taskEngine.(*DockerTaskEngine).stopContainerBackoffMin = time.Millisecond

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -586,10 +586,11 @@ func setupEngineForExecCommandAgent(t *testing.T, hostBinDir string) (TaskEngine
 	execCmdMgr := execcmd.NewManagerWithBinDir(hostBinDir)
 	hostResources := getTestHostResources()
 	hostResourceManager := NewHostResourceManager(hostResources)
+	daemonManagers := getTestDaemonManagers()
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, &hostResourceManager, state, metadataManager,
-		nil, execCmdMgr, engineserviceconnect.NewManager())
+		nil, execCmdMgr, engineserviceconnect.NewManager(), daemonManagers)
 	taskEngine.monitorExecAgentsInterval = time.Second
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {

--- a/agent/sighandlers/termination_handler_test.go
+++ b/agent/sighandlers/termination_handler_test.go
@@ -44,7 +44,7 @@ func TestFinalSave(t *testing.T) {
 
 	state := dockerstate.NewTaskEngineState()
 	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil,
-		nil, nil, nil, state, nil, nil, nil, nil)
+		nil, nil, nil, state, nil, nil, nil, nil, nil)
 
 	task := &apitask.Task{
 		Arn:     taskARN,

--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -45,7 +45,7 @@ func TestLoadsV1DataCorrectly(t *testing.T) {
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v1", "1")}
 
 	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(),
-		nil, nil, nil, nil)
+		nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 
@@ -90,7 +90,7 @@ func TestLoadsV13DataCorrectly(t *testing.T) {
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v13", "1")}
 
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 
@@ -138,7 +138,7 @@ func TestLoadsDataForContainerHealthCheckTask(t *testing.T) {
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v10", "container-health-check")}
 
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 
@@ -180,7 +180,7 @@ func TestLoadsDataForPrivateRegistryTask(t *testing.T) {
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v14", "private-registry")}
 
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 
@@ -226,7 +226,7 @@ func TestLoadsDataForSecretsTask(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v17", "secrets")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -264,7 +264,7 @@ func TestLoadsDataForAddingAvailabilityZoneInTask(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v18", "availabilityZone")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID, availabilityZone string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -295,7 +295,7 @@ func TestLoadsDataForASMSecretsTask(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v18", "secrets")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -334,7 +334,7 @@ func TestLoadsDataForContainerOrdering(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v20", "containerOrdering")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -369,7 +369,7 @@ func TestLoadsDataForPerContainerTimeouts(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v20", "perContainerTimeouts")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -404,7 +404,7 @@ func TestLoadsDataForContainerRuntimeID(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v23", "perContainerRuntimeID")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -435,7 +435,7 @@ func TestLoadsDataForContainerImageDigest(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v24", "perContainerImageDigest")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -466,7 +466,7 @@ func TestLoadsDataSeqTaskManifest(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v25", "seqNumTaskManifest")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber, seqNumTaskManifest int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -493,7 +493,7 @@ func TestLoadsDataForEnvFiles(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v28", "environmentFiles")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,

--- a/agent/statemanager/state_manager_unix_test.go
+++ b/agent/statemanager/state_manager_unix_test.go
@@ -47,7 +47,7 @@ func TestStateManager(t *testing.T) {
 	// Now let's make some state to save
 	containerInstanceArn := ""
 	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(),
-		nil, nil, nil, nil)
+		nil, nil, nil, nil, nil)
 
 	manager, err = statemanager.NewStateManager(cfg, statemanager.AddSaveable("TaskEngine", taskEngine),
 		statemanager.AddSaveable("ContainerInstanceArn", &containerInstanceArn))
@@ -65,7 +65,7 @@ func TestStateManager(t *testing.T) {
 
 	// Now make sure we can load that state sanely
 	loadedTaskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(),
-		nil, nil, nil, nil)
+		nil, nil, nil, nil, nil)
 	var loadedContainerInstanceArn string
 
 	manager, err = statemanager.NewStateManager(cfg, statemanager.AddSaveable("TaskEngine", &loadedTaskEngine),
@@ -110,7 +110,7 @@ func TestLoadsDataForAWSVPCTask(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v11", tc.dir)}
 
-			taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+			taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 			var containerInstanceArn, cluster, savedInstanceID string
 
 			stateManager, err := statemanager.NewStateManager(cfg,
@@ -149,7 +149,7 @@ func TestLoadsDataForAWSVPCTask(t *testing.T) {
 // verify that the state manager correctly loads gpu related fields in state file
 func TestLoadsDataForGPU(t *testing.T) {
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v18", "gpu")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -194,7 +194,7 @@ func TestLoadsDataForGPU(t *testing.T) {
 
 func TestLoadsDataForFirelensTask(t *testing.T) {
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v23", "firelens")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -242,7 +242,7 @@ func TestLoadsDataForFirelensTask(t *testing.T) {
 
 func TestLoadsDataForFirelensTaskWithExternalConfig(t *testing.T) {
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v24", "firelens")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -296,7 +296,7 @@ func TestLoadsDataForFirelensTaskWithExternalConfig(t *testing.T) {
 
 func TestLoadsDataForEFSGATask(t *testing.T) {
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v27", "efs")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -333,7 +333,7 @@ func TestLoadsDataForEFSGATask(t *testing.T) {
 func TestLoadsDataForGMSATask(t *testing.T) {
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v31", "gmsalinux")}
 	taskEngineState := dockerstate.NewTaskEngineState()
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, taskEngineState, nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, taskEngineState, nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 

--- a/agent/statemanager/state_manager_win_test.go
+++ b/agent/statemanager/state_manager_win_test.go
@@ -36,7 +36,7 @@ func TestLoadsDataForGMSATask(t *testing.T) {
 	defer cleanup()
 
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v26", "gmsa")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 

--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -73,6 +73,7 @@ func (container *StatsContainer) collect() {
 	backoff := retry.NewExponentialBackoff(time.Second*1, time.Second*10, 0.5, 2)
 	for {
 		err := container.processStatsStream()
+
 		select {
 		case <-container.ctx.Done():
 			logger.Info("Stopping container stats collection", logger.Fields{"runtimeID": dockerID})

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -83,7 +83,7 @@ func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithExistingContainersWithoutHealth")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	testTask := createRunningTask("default")
 	// Populate Tasks and Container map in the engine.
 	dockerTaskEngine := taskEngine.(*ecsengine.DockerTaskEngine)
@@ -142,7 +142,7 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithNewContainers")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	testTask := createRunningTask("default")
 	// Populate Tasks and Container map in the engine.
 	dockerTaskEngine := taskEngine.(*ecsengine.DockerTaskEngine)
@@ -220,7 +220,7 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithExistingContainers")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	testTask := createRunningTask("bridge")
 	// enable container health check for this container
 	testTask.Containers[0].HealthCheckType = "docker"
@@ -287,7 +287,7 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithNewContainers")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 
 	testTask := createRunningTask("bridge")
 	// enable health check of the container
@@ -369,7 +369,7 @@ func TestStatsEngineWithNewContainersWithPolling(t *testing.T) {
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithNewContainers")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 
 	testTask := createRunningTask("bridge")
 	// enable health check of the container
@@ -434,7 +434,7 @@ func TestStatsEngineWithNewContainersWithPolling(t *testing.T) {
 func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	containerChangeEventStream := eventStream("TestStatsEngineWithDockerTaskEngine")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	container, err := createHealthContainer(client)
 	require.NoError(t, err, "creating container failed")
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -518,7 +518,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 	containerChangeEventStream := eventStream("TestStatsEngineWithDockerTaskEngineMissingRemoveEvent")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -606,7 +606,7 @@ func testNetworkModeStatsInteg(t *testing.T, networkMode string, statsEmpty bool
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithNetworkStats")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	testTask := createRunningTask(networkMode)
 
 	// Populate Tasks and Container map in the engine.
@@ -687,7 +687,7 @@ func TestStorageStats(t *testing.T) {
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithStorageStats")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+		nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 	testTask := createRunningTask("bridge")
 
 	// Populate Tasks and Container map in the engine.

--- a/agent/stats/engine_unix_integ_test.go
+++ b/agent/stats/engine_unix_integ_test.go
@@ -110,7 +110,7 @@ func TestStatsEngineWithServiceConnectMetrics(t *testing.T) {
 
 			containerChangeEventStream := eventStream("TestStatsEngineWithServiceConnectMetrics")
 			taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-				nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
+				nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil, nil)
 			testTask := createRunningTask("bridge")
 			testTask.ServiceConnectConfig = &serviceconnect.Config{
 				ContainerName: serviceConnectContainerName,

--- a/ecs-agent/csiclient/csi_client.go
+++ b/ecs-agent/csiclient/csi_client.go
@@ -1,0 +1,79 @@
+package csiclient
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	PROTOCOL = "unix"
+)
+
+type csiClient struct {
+	csiSocket string
+}
+
+func NewCSIClient(socketIn string) csiClient {
+	return csiClient{csiSocket: socketIn}
+}
+
+// Used for testing and integration
+// TODO update with stats packing
+func (cc *csiClient) GetVolumeMetrics(volumeId string, hostMountPath string) (int64, error) {
+	// Set up a connection to the server
+	dialer := func(addr string, t time.Duration) (net.Conn, error) {
+		return net.Dial(PROTOCOL, addr)
+	}
+	conn, err := grpc.Dial(
+		cc.csiSocket,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDialer(dialer),
+	)
+	if err != nil {
+		logger.Info("Error publishing metrics", logger.Fields{
+			field.Error: err,
+		})
+		return int64(0), err
+	}
+	defer conn.Close()
+
+	client := csi.NewNodeClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	resp, err := client.NodeGetVolumeStats(ctx, &csi.NodeGetVolumeStatsRequest{
+		VolumeId:   volumeId,
+		VolumePath: hostMountPath,
+	})
+	if err != nil {
+		logger.Info("could not get stats", logger.Fields{
+			field.Error: err,
+		})
+		return int64(0), err
+	}
+	usages := resp.GetUsage()
+	// TODO update return type and values to match TCS payload
+	if usages == nil {
+		return int64(0), fmt.Errorf("failed to get usage from response. usage is nil")
+	}
+	var result = int64(0)
+	for _, usage := range usages {
+		unit := usage.GetUnit()
+		switch unit {
+		case csi.VolumeUsage_BYTES:
+			result = usage.GetUsed()
+		default:
+			logger.Info("Found missing key in volume usage")
+		}
+	}
+	return result, nil
+}

--- a/ecs-agent/daemonimages/csidriver/container/manifest.json
+++ b/ecs-agent/daemonimages/csidriver/container/manifest.json
@@ -1,1 +1,1 @@
-[{"Config":"config.json","RepoTags":["amazon/amazon-ebs-csi-driver:latest"],"Layers":["rootfs/layer.tar"]}]
+[{"Config":"config.json","RepoTags":["ebs-csi-driver:latest"],"Layers":["rootfs/layer.tar"]}]

--- a/ecs-agent/daemonimages/csidriver/container/repositories
+++ b/ecs-agent/daemonimages/csidriver/container/repositories
@@ -1,1 +1,1 @@
-{"amazon/amazon-ebs-csi-driver":{"amazon-ecs":"rootfs"}}
+{"ebs-csi-driver":{"amazon-ecs":"rootfs"}}

--- a/ecs-agent/manageddaemon/managed_daemon_test.go
+++ b/ecs-agent/manageddaemon/managed_daemon_test.go
@@ -27,7 +27,6 @@ import (
 
 const (
 	TestImageName        = "TestDaemon"
-	TestImageRef         = "TestImage"
 	TestImageTag         = "testTag"
 	TestImagePath        = "/test/image/path"
 	TestAgentPath        = "/test/agent/path"
@@ -39,36 +38,25 @@ func TestNewManagedDaemon(t *testing.T) {
 		testName       string
 		testImageName  string
 		testImageTag   string
-		testImageRef   string
 		expectedDaemon *ManagedDaemon
 	}{
 		{
 			testName:       "All Fields",
 			testImageName:  TestImageName,
 			testImageTag:   TestImageTag,
-			testImageRef:   TestImageRef,
-			expectedDaemon: &ManagedDaemon{imageName: TestImageName, imageTag: TestImageTag, imageRef: TestImageRef},
+			expectedDaemon: &ManagedDaemon{imageName: TestImageName, imageTag: TestImageTag},
 		},
 		{
 			testName:       "Missing Image Name",
 			testImageName:  "",
 			testImageTag:   TestImageTag,
-			testImageRef:   TestImageRef,
-			expectedDaemon: &ManagedDaemon{imageName: "", imageTag: TestImageTag, imageRef: TestImageRef},
+			expectedDaemon: &ManagedDaemon{imageName: "", imageTag: TestImageTag},
 		},
 		{
 			testName:       "Missing Image Tag",
 			testImageName:  TestImageName,
 			testImageTag:   "",
-			testImageRef:   TestImageRef,
-			expectedDaemon: &ManagedDaemon{imageName: TestImageName, imageTag: "", imageRef: TestImageRef},
-		},
-		{
-			testName:       "Missing Image Ref",
-			testImageName:  TestImageName,
-			testImageTag:   TestImageTag,
-			testImageRef:   "",
-			expectedDaemon: &ManagedDaemon{imageName: TestImageName, imageTag: TestImageTag, imageRef: ""},
+			expectedDaemon: &ManagedDaemon{imageName: TestImageName, imageTag: ""},
 		},
 	}
 
@@ -76,7 +64,6 @@ func TestNewManagedDaemon(t *testing.T) {
 		t.Run(c.testName, func(t *testing.T) {
 			assert.Equal(t, c.expectedDaemon.GetImageName(), c.testImageName, "Wrong value for Managed Daemon Image Name")
 			assert.Equal(t, c.expectedDaemon.GetImageTag(), c.testImageTag, "Wrong value for Managed Daemon Image Tag")
-			assert.Equal(t, c.expectedDaemon.GetImageRef(), c.testImageRef, "Wrong value for Managed Daemon Image Ref")
 		})
 	}
 }
@@ -116,7 +103,7 @@ func TestSetMountPoints(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.TestName, func(t *testing.T) {
-			tmd := NewManagedDaemon(TestImageName, TestImageRef, TestImageTag)
+			tmd := NewManagedDaemon(TestImageName, TestImageTag)
 			mountPoints := []*MountPoint{}
 			mountPoints = append(mountPoints, &MountPoint{SourceVolumeID: "agentCommunicationMount"})
 			mountPoints = append(mountPoints, &MountPoint{SourceVolumeID: "applicationLogMount"})
@@ -141,7 +128,7 @@ func TestAddMountPoint(t *testing.T) {
 	mountPoints = append(mountPoints, &MountPoint{SourceVolumeID: "agentCommunicationMount"})
 	mountPoints = append(mountPoints, &MountPoint{SourceVolumeID: "applicationLogMount"})
 	mountPoints = append(mountPoints, testMountPoint1)
-	tmd := NewManagedDaemon(TestImageName, TestImageRef, TestImageTag)
+	tmd := NewManagedDaemon(TestImageName, TestImageTag)
 	tmd.SetMountPoints(mountPoints)
 	// test add valid mount point
 	errResult := tmd.AddMountPoint(testMountPoint2)
@@ -162,7 +149,7 @@ func TestGetMountPointsFilteredUnfiltered(t *testing.T) {
 	mountPoints = append(mountPoints, &MountPoint{SourceVolumeID: "agentCommunicationMount"})
 	mountPoints = append(mountPoints, &MountPoint{SourceVolumeID: "applicationLogMount"})
 	mountPoints = append(mountPoints, testMountPoint1)
-	tmd := NewManagedDaemon(TestImageName, TestImageRef, TestImageTag)
+	tmd := NewManagedDaemon(TestImageName, TestImageTag)
 	tmd.SetMountPoints(mountPoints)
 	// test add valid mount point
 	errResult := tmd.AddMountPoint(testMountPoint2)
@@ -182,7 +169,7 @@ func TestUpdateMountPoint(t *testing.T) {
 	mountPoints = append(mountPoints, &MountPoint{SourceVolumeID: "agentCommunicationMount"})
 	mountPoints = append(mountPoints, &MountPoint{SourceVolumeID: "applicationLogMount"})
 	mountPoints = append(mountPoints, testMountPoint1)
-	tmd := NewManagedDaemon(TestImageName, TestImageRef, TestImageTag)
+	tmd := NewManagedDaemon(TestImageName, TestImageTag)
 	tmd.SetMountPoints(mountPoints)
 	assert.Equal(t, 1, len(tmd.GetFilteredMountPoints()))
 	assert.False(t, tmd.GetFilteredMountPoints()[0].ReadOnly)
@@ -206,7 +193,7 @@ func TestDeleteMountPoint(t *testing.T) {
 	mountPoints = append(mountPoints, &MountPoint{SourceVolumeID: "agentCommunicationMount"})
 	mountPoints = append(mountPoints, &MountPoint{SourceVolumeID: "applicationLogMount"})
 	mountPoints = append(mountPoints, testMountPoint1)
-	tmd := NewManagedDaemon(TestImageName, TestImageRef, TestImageTag)
+	tmd := NewManagedDaemon(TestImageName, TestImageTag)
 	tmd.SetMountPoints(mountPoints)
 	assert.Equal(t, 1, len(tmd.GetFilteredMountPoints()))
 	assert.False(t, tmd.GetMountPoints()[0].ReadOnly)
@@ -243,7 +230,7 @@ func TestSetEnvironment(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.TestName, func(t *testing.T) {
-			tmd := NewManagedDaemon(TestImageName, TestImageRef, TestImageTag)
+			tmd := NewManagedDaemon(TestImageName, TestImageTag)
 			tmd.SetEnvironment(c.TestEnvironmentMap)
 			assert.Equal(t, len(c.TestEnvironmentMap), len(tmd.GetEnvironment()), "Wrong value for Set Environment")
 		})
@@ -251,7 +238,7 @@ func TestSetEnvironment(t *testing.T) {
 }
 
 func TestAddEnvVar(t *testing.T) {
-	tmd := NewManagedDaemon(TestImageName, TestImageRef, TestImageTag)
+	tmd := NewManagedDaemon(TestImageName, TestImageTag)
 	tmd.SetEnvironment(map[string]string{"testKey1": "testVal1", "TestKey2": "TestVal2"})
 	// test add new EnvKey
 	errResult := tmd.AddEnvVar("testKey3", "testVal3")
@@ -268,7 +255,7 @@ func TestAddEnvVar(t *testing.T) {
 }
 
 func TestUpdateEnvVar(t *testing.T) {
-	tmd := NewManagedDaemon(TestImageName, TestImageRef, TestImageTag)
+	tmd := NewManagedDaemon(TestImageName, TestImageTag)
 	tmd.SetEnvironment(map[string]string{"testKey1": "testVal1", "TestKey2": "TestVal2"})
 	// test update EnvKey
 	errResult := tmd.UpdateEnvVar("TestKey2", "TestValNew")
@@ -284,7 +271,7 @@ func TestUpdateEnvVar(t *testing.T) {
 }
 
 func TestDeleteEnvVar(t *testing.T) {
-	tmd := NewManagedDaemon(TestImageName, TestImageRef, TestImageTag)
+	tmd := NewManagedDaemon(TestImageName, TestImageTag)
 	tmd.SetEnvironment(map[string]string{"testKey1": "testVal1", "TestKey2": "TestVal2"})
 	// test delete EnvKey
 	errResult := tmd.DeleteEnvVar("TestKey2")
@@ -309,7 +296,7 @@ func TestGetDockerHealthCheckConfig(t *testing.T) {
 		Timeout:  testHealthTimeout,
 		Retries:  testHealthRetries,
 	}
-	tmd := NewManagedDaemon(TestImageName, TestImageRef, TestImageTag)
+	tmd := NewManagedDaemon(TestImageName, TestImageTag)
 	tmd.SetHealthCheck(testHealthCheck, testHealthInterval, testHealthTimeout, testHealthRetries)
 	dockerCheck := tmd.GetDockerHealthConfig()
 	assert.Equal(t, expectedDockerCheck, dockerCheck)
@@ -318,7 +305,6 @@ func TestGetDockerHealthCheckConfig(t *testing.T) {
 func TestIsValidManagedDaemon(t *testing.T) {
 	testAgentCommunicationMount := &MountPoint{SourceVolumeID: "agentCommunicationMount"}
 	testApplicationLogMount := &MountPoint{SourceVolumeID: "applicationLogMount"}
-	testHealthCheck := []string{"test"}
 	cases := []struct {
 		TestName       string
 		TestDaemon     *ManagedDaemon
@@ -327,30 +313,17 @@ func TestIsValidManagedDaemon(t *testing.T) {
 		{
 			TestName: "All Valid",
 			TestDaemon: &ManagedDaemon{agentCommunicationMount: testAgentCommunicationMount,
-				applicationLogMount: testApplicationLogMount,
-				healthCheckTest:     testHealthCheck,
-				healthCheckRetries:  0},
+				applicationLogMount: testApplicationLogMount},
 			ExpectedResult: true,
 		},
 		{
-			TestName: "Missing Required Agent communication Mount",
-			TestDaemon: &ManagedDaemon{applicationLogMount: testApplicationLogMount,
-				healthCheckTest:    testHealthCheck,
-				healthCheckRetries: 0},
+			TestName:       "Missing Required Agent communication Mount",
+			TestDaemon:     &ManagedDaemon{applicationLogMount: testApplicationLogMount},
 			ExpectedResult: false,
 		},
 		{
-			TestName: "Missing Required Log Mount",
-			TestDaemon: &ManagedDaemon{agentCommunicationMount: testAgentCommunicationMount,
-				healthCheckTest:    testHealthCheck,
-				healthCheckRetries: 0},
-			ExpectedResult: false,
-		},
-		{
-			TestName: "Missing health check",
-			TestDaemon: &ManagedDaemon{agentCommunicationMount: testAgentCommunicationMount,
-				applicationLogMount: testApplicationLogMount,
-				healthCheckRetries:  0},
+			TestName:       "Missing Required Log Mount",
+			TestDaemon:     &ManagedDaemon{agentCommunicationMount: testAgentCommunicationMount},
 			ExpectedResult: false,
 		},
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This builds on the initial managed daemon and csi-driver work for EBS Task Attach.  The main additions are the daemonmangers added to the app state, and loaded there; ebs-backed task handling is new; the basic csi-client calling the node csi stats is also new.  There are also several repetitive changes to add the daemons to the app state.

### Implementation details
`agent/app/agent.go` includes the daemon load and a new top level map of capability to daemonmanager
`agent/engine/daemonmanager/daemon_manager_linux.go` has a few updates that were caught in manual testing including loading the image and injecting the start command
`agent/engine/docker_task_engine.go` has handling for ebs-backed tasks (which will not exist yet because the check function will always return `false`).  This handling will create the internal task and add it to our agent state.
`ecs-agent/csiclient/csi_client.go` is a basic csi-client which will be extended as part of the TACS integration work.  This client exists currently only for testing.

The rest of the changes are related to module/dependency updates and general test updates to include the new state and objects. 

### Testing
Tests Are updated to include the new components.  Integration tests will be added as components are "plugged-in" in future commits.

New tests cover the changes: yes

### Description for the changelog
Add managed daemon import and csi node client

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
