### PR TITLE
Account GPUs as list of GPU IDs for resource accounting

### DIFF
--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -4855,7 +4855,7 @@ func TestInitializeAndGetCredentialSpecResource(t *testing.T) {
 	assert.True(t, ok)
 }
 
-func getTestTaskResourceMap(cpu int64, mem int64, ports []*string, portsUdp []*string, numGPUs int64) map[string]*ecs.Resource {
+func getTestTaskResourceMap(cpu int64, mem int64, ports []*string, portsUdp []*string, gpuIDs []*string) map[string]*ecs.Resource {
 	taskResources := make(map[string]*ecs.Resource)
 	taskResources["CPU"] = &ecs.Resource{
 		Name:         utils.Strptr("CPU"),
@@ -4882,9 +4882,9 @@ func getTestTaskResourceMap(cpu int64, mem int64, ports []*string, portsUdp []*s
 	}
 
 	taskResources["GPU"] = &ecs.Resource{
-		Name:         utils.Strptr("GPU"),
-		Type:         utils.Strptr("INTEGER"),
-		IntegerValue: &numGPUs,
+		Name:           utils.Strptr("GPU"),
+		Type:           utils.Strptr("STRINGSET"),
+		StringSetValue: gpuIDs,
 	}
 
 	return taskResources
@@ -5076,6 +5076,7 @@ func TestToHostResources(t *testing.T) {
 
 	portsTCP := []uint16{10, 11}
 	portsUDP := []uint16{20, 21}
+	taskGpus := aws.StringSlice([]string{"gpu1", "gpu2"})
 
 	testCases := []struct {
 		task              *Task
@@ -5083,27 +5084,27 @@ func TestToHostResources(t *testing.T) {
 	}{
 		{
 			task:              testTask1,
-			expectedResources: getTestTaskResourceMap(int64(1024), int64(512), []*string{}, []*string{}, int64(2)),
+			expectedResources: getTestTaskResourceMap(int64(1024), int64(512), []*string{}, []*string{}, taskGpus),
 		},
 		{
 			task:              testTask2,
-			expectedResources: getTestTaskResourceMap(int64(2400), int64(1000), []*string{}, []*string{}, int64(0)),
+			expectedResources: getTestTaskResourceMap(int64(2400), int64(1000), []*string{}, []*string{}, []*string{}),
 		},
 		{
 			task:              testTask3,
-			expectedResources: getTestTaskResourceMap(int64(2400), int64(1700), []*string{}, []*string{}, int64(0)),
+			expectedResources: getTestTaskResourceMap(int64(2400), int64(1700), []*string{}, []*string{}, []*string{}),
 		},
 		{
 			task:              testTask4,
-			expectedResources: getTestTaskResourceMap(int64(1024), int64(512), utils.Uint16SliceToStringSlice(portsTCP), utils.Uint16SliceToStringSlice(portsUDP), int64(0)),
+			expectedResources: getTestTaskResourceMap(int64(1024), int64(512), utils.Uint16SliceToStringSlice(portsTCP), utils.Uint16SliceToStringSlice(portsUDP), []*string{}),
 		},
 		{
 			task:              testTask5,
-			expectedResources: getTestTaskResourceMap(int64(600), int64(1800), []*string{}, []*string{}, int64(0)),
+			expectedResources: getTestTaskResourceMap(int64(600), int64(1800), []*string{}, []*string{}, []*string{}),
 		},
 		{
 			task:              testTask6,
-			expectedResources: getTestTaskResourceMap(int64(1024), int64(512), []*string{}, []*string{}, int64(0)),
+			expectedResources: getTestTaskResourceMap(int64(1024), int64(512), []*string{}, []*string{}, []*string{}),
 		},
 	}
 
@@ -5121,7 +5122,17 @@ func TestToHostResources(t *testing.T) {
 		assert.Equal(t, *tc.expectedResources["MEMORY"].IntegerValue, *calcResources["MEMORY"].IntegerValue, "Error converting task Memory resources")
 
 		//GPU
-		assert.Equal(t, *tc.expectedResources["GPU"].IntegerValue, *calcResources["GPU"].IntegerValue, "Error converting task GPU resources")
+		for _, expectedGpu := range tc.expectedResources["GPU"].StringSetValue {
+			found := false
+			for _, calcGpu := range calcResources["GPU"].StringSetValue {
+				if *expectedGpu == *calcGpu {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "Could not convert GPU port resources")
+		}
+		assert.Equal(t, len(tc.expectedResources["GPU"].StringSetValue), len(calcResources["GPU"].StringSetValue), "Error converting task GPU resources")
 
 		//PORTS
 		for _, expectedPort := range tc.expectedResources["PORTS_TCP"].StringSetValue {
@@ -5134,7 +5145,7 @@ func TestToHostResources(t *testing.T) {
 			}
 			assert.True(t, found, "Could not convert TCP port resources")
 		}
-		assert.Equal(t, len(tc.expectedResources["PORTS_TCP"].StringSetValue), len(calcResources["PORTS_TCP"].StringSetValue), "Error converting task TCP port tesources")
+		assert.Equal(t, len(tc.expectedResources["PORTS_TCP"].StringSetValue), len(calcResources["PORTS_TCP"].StringSetValue), "Error converting task TCP port resources")
 
 		//PORTS_UDP
 		for _, expectedPort := range tc.expectedResources["PORTS_UDP"].StringSetValue {
@@ -5147,6 +5158,6 @@ func TestToHostResources(t *testing.T) {
 			}
 			assert.True(t, found, "Could not convert UDP port resources")
 		}
-		assert.Equal(t, len(tc.expectedResources["PORTS_UDP"].StringSetValue), len(calcResources["PORTS_UDP"].StringSetValue), "Error converting task UDP port tesources")
+		assert.Equal(t, len(tc.expectedResources["PORTS_UDP"].StringSetValue), len(calcResources["PORTS_UDP"].StringSetValue), "Error converting task UDP port resources")
 	}
 }

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -311,26 +311,26 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 		seelog.Critical("Unable to fetch host resources")
 		return exitcodes.ExitError
 	}
-	numGPUs := int64(0)
+	gpuIDs := []string{}
 	if agent.cfg.GPUSupportEnabled {
 		err := agent.initializeGPUManager()
 		if err != nil {
 			seelog.Criticalf("Could not initialize Nvidia GPU Manager: %v", err)
 			return exitcodes.ExitError
 		}
-		// Find number of GPUs instance has
+		// Find GPUs (if any) on the instance
 		platformDevices := agent.getPlatformDevices()
 		for _, device := range platformDevices {
 			if *device.Type == ecs.PlatformDeviceTypeGpu {
-				numGPUs++
+				gpuIDs = append(gpuIDs, *device.Id)
 			}
 		}
 	}
 
 	hostResources["GPU"] = &ecs.Resource{
-		Name:         utils.Strptr("GPU"),
-		Type:         utils.Strptr("INTEGER"),
-		IntegerValue: &numGPUs,
+		Name:           utils.Strptr("GPU"),
+		Type:           utils.Strptr("STRINGSET"),
+		StringSetValue: aws.StringSlice(gpuIDs),
 	}
 
 	// Create the task engine

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -1691,7 +1691,6 @@ func getTestHostResources() map[string]*ecs.Resource {
 		Type:           utils.Strptr("STRINGSET"),
 		StringSetValue: ports_tcp,
 	}
-
 	//PORTS_UDP
 	ports_udp := []*string{}
 	hostResources["PORTS_UDP"] = &ecs.Resource{
@@ -1700,11 +1699,11 @@ func getTestHostResources() map[string]*ecs.Resource {
 		StringSetValue: ports_udp,
 	}
 	//GPUs
-	numGPUs := int64(3)
+	gpuIDs := []string{"gpu1", "gpu2", "gpu3", "gpu4"}
 	hostResources["GPU"] = &ecs.Resource{
-		Name:         utils.Strptr("GPU"),
-		Type:         utils.Strptr("INTEGER"),
-		IntegerValue: &numGPUs,
+		Name:           utils.Strptr("GPU"),
+		Type:           utils.Strptr("STRINGSET"),
+		StringSetValue: aws.StringSlice(gpuIDs),
 	}
 	return hostResources
 }

--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ecs_client/model/ecs"
 	mock_ttime "github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime/mocks"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/cihub/seelog"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/golang/mock/gomock"
@@ -393,7 +394,6 @@ func getTestHostResources() map[string]*ecs.Resource {
 		Type:           utils.Strptr("STRINGSET"),
 		StringSetValue: ports_tcp,
 	}
-
 	//PORTS_UDP
 	ports_udp := []*string{}
 	hostResources["PORTS_UDP"] = &ecs.Resource{
@@ -402,11 +402,11 @@ func getTestHostResources() map[string]*ecs.Resource {
 		StringSetValue: ports_udp,
 	}
 	//GPUs
-	numGPUs := int64(3)
+	gpuIDs := []string{"gpu1", "gpu2", "gpu3", "gpu4"}
 	hostResources["GPU"] = &ecs.Resource{
-		Name:         utils.Strptr("GPU"),
-		Type:         utils.Strptr("INTEGER"),
-		IntegerValue: &numGPUs,
+		Name:           utils.Strptr("GPU"),
+		Type:           utils.Strptr("STRINGSET"),
+		StringSetValue: aws.StringSlice(gpuIDs),
 	}
 	return hostResources
 }

--- a/agent/engine/host_resource_manager_test.go
+++ b/agent/engine/host_resource_manager_test.go
@@ -1,3 +1,19 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package engine
 
 import (
@@ -5,10 +21,11 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ecs_client/model/ecs"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 )
 
-func getTestHostResourceManager(cpu int64, mem int64, ports []*string, portsUdp []*string, numGPUs int64) *HostResourceManager {
+func getTestHostResourceManager(cpu int64, mem int64, ports []*string, portsUdp []*string, gpuIDs []*string) *HostResourceManager {
 	hostResources := make(map[string]*ecs.Resource)
 	hostResources["CPU"] = &ecs.Resource{
 		Name:         utils.Strptr("CPU"),
@@ -35,9 +52,9 @@ func getTestHostResourceManager(cpu int64, mem int64, ports []*string, portsUdp 
 	}
 
 	hostResources["GPU"] = &ecs.Resource{
-		Name:         utils.Strptr("PORTS_UDP"),
-		Type:         utils.Strptr("STRINGSET"),
-		IntegerValue: &numGPUs,
+		Name:           utils.Strptr("PORTS_UDP"),
+		Type:           utils.Strptr("STRINGSET"),
+		StringSetValue: gpuIDs,
 	}
 
 	hostResourceManager := NewHostResourceManager(hostResources)
@@ -45,7 +62,7 @@ func getTestHostResourceManager(cpu int64, mem int64, ports []*string, portsUdp 
 	return &hostResourceManager
 }
 
-func getTestTaskResourceMap(cpu int64, mem int64, ports []*string, portsUdp []*string, numGPUs int64) map[string]*ecs.Resource {
+func getTestTaskResourceMap(cpu int64, mem int64, ports []*string, portsUdp []*string, gpuIDs []*string) map[string]*ecs.Resource {
 	taskResources := make(map[string]*ecs.Resource)
 	taskResources["CPU"] = &ecs.Resource{
 		Name:         utils.Strptr("CPU"),
@@ -72,23 +89,26 @@ func getTestTaskResourceMap(cpu int64, mem int64, ports []*string, portsUdp []*s
 	}
 
 	taskResources["GPU"] = &ecs.Resource{
-		Name:         utils.Strptr("GPU"),
-		Type:         utils.Strptr("INTEGER"),
-		IntegerValue: &numGPUs,
+		Name:           utils.Strptr("GPU"),
+		Type:           utils.Strptr("STRINGSET"),
+		StringSetValue: gpuIDs,
 	}
 
 	return taskResources
 }
+
 func TestHostResourceConsumeSuccess(t *testing.T) {
 	hostResourcePort1 := "22"
 	hostResourcePort2 := "1000"
-	numGPUs := 4
-	h := getTestHostResourceManager(int64(2048), int64(2048), []*string{&hostResourcePort1}, []*string{&hostResourcePort2}, int64(numGPUs))
+	gpuIDs := []string{"gpu1", "gpu2", "gpu3", "gpu4"}
+	h := getTestHostResourceManager(int64(2048), int64(2048), []*string{&hostResourcePort1}, []*string{&hostResourcePort2}, aws.StringSlice(gpuIDs))
 
 	testTaskArn := "arn:aws:ecs:us-east-1:<aws_account_id>:task/cluster-name/11111"
 	taskPort1 := "23"
 	taskPort2 := "1001"
-	taskResources := getTestTaskResourceMap(int64(512), int64(768), []*string{&taskPort1}, []*string{&taskPort2}, 1)
+	taskGpuId1 := "gpu2"
+	taskGpuId2 := "gpu3"
+	taskResources := getTestTaskResourceMap(int64(512), int64(768), []*string{&taskPort1}, []*string{&taskPort2}, []*string{&taskGpuId1, &taskGpuId2})
 
 	consumed, _ := h.consume(testTaskArn, taskResources)
 	assert.Equal(t, consumed, true, "Incorrect consumed status")
@@ -100,18 +120,23 @@ func TestHostResourceConsumeSuccess(t *testing.T) {
 	assert.Equal(t, *h.consumedResource["PORTS_UDP"].StringSetValue[0], "1000", "Incorrect udp port resource accounting during consume")
 	assert.Equal(t, *h.consumedResource["PORTS_UDP"].StringSetValue[1], "1001", "Incorrect udp port resource accounting during consume")
 	assert.Equal(t, len(h.consumedResource["PORTS_UDP"].StringSetValue), 2, "Incorrect port resource accounting during consume")
-	assert.Equal(t, *h.consumedResource["GPU"].IntegerValue, int64(1), "Incorrect gpu resource accounting during consume")
+	assert.Equal(t, *h.consumedResource["GPU"].StringSetValue[0], "gpu2", "Incorrect gpu resource accounting during consume")
+	assert.Equal(t, *h.consumedResource["GPU"].StringSetValue[1], "gpu3", "Incorrect gpu resource accounting during consume")
+	assert.Equal(t, len(h.consumedResource["GPU"].StringSetValue), 2, "Incorrect gpu resource accounting during consume")
 }
+
 func TestHostResourceConsumeFail(t *testing.T) {
 	hostResourcePort1 := "22"
 	hostResourcePort2 := "1000"
-	numGPUs := 4
-	h := getTestHostResourceManager(int64(2048), int64(2048), []*string{&hostResourcePort1}, []*string{&hostResourcePort2}, int64(numGPUs))
+	gpuIDs := []string{"gpu1", "gpu2", "gpu3", "gpu4"}
+	h := getTestHostResourceManager(int64(2048), int64(2048), []*string{&hostResourcePort1}, []*string{&hostResourcePort2}, aws.StringSlice(gpuIDs))
 
 	testTaskArn := "arn:aws:ecs:us-east-1:<aws_account_id>:task/cluster-name/11111"
 	taskPort1 := "22"
 	taskPort2 := "1001"
-	taskResources := getTestTaskResourceMap(int64(512), int64(768), []*string{&taskPort1}, []*string{&taskPort2}, 1)
+	taskGpuId1 := "gpu2"
+	taskGpuId2 := "gpu3"
+	taskResources := getTestTaskResourceMap(int64(512), int64(768), []*string{&taskPort1}, []*string{&taskPort2}, []*string{&taskGpuId1, &taskGpuId2})
 
 	consumed, _ := h.consume(testTaskArn, taskResources)
 	assert.Equal(t, consumed, false, "Incorrect consumed status")
@@ -121,19 +146,21 @@ func TestHostResourceConsumeFail(t *testing.T) {
 	assert.Equal(t, len(h.consumedResource["PORTS_TCP"].StringSetValue), 1, "Incorrect port resource accounting during consume")
 	assert.Equal(t, *h.consumedResource["PORTS_UDP"].StringSetValue[0], "1000", "Incorrect udp port resource accounting during consume")
 	assert.Equal(t, len(h.consumedResource["PORTS_UDP"].StringSetValue), 1, "Incorrect port resource accounting during consume")
-	assert.Equal(t, *h.consumedResource["GPU"].IntegerValue, int64(0), "Incorrect gpu resource accounting during consume")
+	assert.Equal(t, len(h.consumedResource["GPU"].StringSetValue), 0, "Incorrect gpu resource accounting during consume")
 }
 
 func TestHostResourceRelease(t *testing.T) {
 	hostResourcePort1 := "22"
 	hostResourcePort2 := "1000"
-	numGPUs := 4
-	h := getTestHostResourceManager(int64(2048), int64(2048), []*string{&hostResourcePort1}, []*string{&hostResourcePort2}, int64(numGPUs))
+	gpuIDs := []string{"gpu1", "gpu2", "gpu3", "gpu4"}
+	h := getTestHostResourceManager(int64(2048), int64(2048), []*string{&hostResourcePort1}, []*string{&hostResourcePort2}, aws.StringSlice(gpuIDs))
 
 	testTaskArn := "arn:aws:ecs:us-east-1:<aws_account_id>:task/cluster-name/11111"
 	taskPort1 := "23"
 	taskPort2 := "1001"
-	taskResources := getTestTaskResourceMap(int64(512), int64(768), []*string{&taskPort1}, []*string{&taskPort2}, 1)
+	taskGpuId1 := "gpu2"
+	taskGpuId2 := "gpu3"
+	taskResources := getTestTaskResourceMap(int64(512), int64(768), []*string{&taskPort1}, []*string{&taskPort2}, []*string{&taskGpuId1, &taskGpuId2})
 
 	h.consume(testTaskArn, taskResources)
 	h.release(testTaskArn, taskResources)
@@ -144,21 +171,21 @@ func TestHostResourceRelease(t *testing.T) {
 	assert.Equal(t, len(h.consumedResource["PORTS_TCP"].StringSetValue), 1, "Incorrect port resource accounting during release")
 	assert.Equal(t, *h.consumedResource["PORTS_UDP"].StringSetValue[0], "1000", "Incorrect udp port resource accounting during release")
 	assert.Equal(t, len(h.consumedResource["PORTS_UDP"].StringSetValue), 1, "Incorrect udp port resource accounting during release")
-	assert.Equal(t, *h.consumedResource["GPU"].IntegerValue, int64(0), "Incorrect gpu resource accounting during release")
+	assert.Equal(t, len(h.consumedResource["GPU"].StringSetValue), 0, "Incorrect gpu resource accounting during release")
 }
 
 func TestConsumable(t *testing.T) {
 	hostResourcePort1 := "22"
 	hostResourcePort2 := "1000"
-	numGPUs := 4
-	h := getTestHostResourceManager(int64(2048), int64(2048), []*string{&hostResourcePort1}, []*string{&hostResourcePort2}, int64(numGPUs))
+	gpuIDs := []string{"gpu1", "gpu2", "gpu3", "gpu4"}
+	h := getTestHostResourceManager(int64(2048), int64(2048), []*string{&hostResourcePort1}, []*string{&hostResourcePort2}, aws.StringSlice(gpuIDs))
 
 	testCases := []struct {
 		cpu           int64
 		mem           int64
 		ports         []uint16
 		portsUdp      []uint16
-		gpus          int64
+		gpus          []string
 		canBeConsumed bool
 	}{
 		{
@@ -166,7 +193,7 @@ func TestConsumable(t *testing.T) {
 			mem:           int64(1024),
 			ports:         []uint16{25},
 			portsUdp:      []uint16{1003},
-			gpus:          int64(2),
+			gpus:          []string{"gpu1", "gpu2"},
 			canBeConsumed: true,
 		},
 		{
@@ -174,7 +201,7 @@ func TestConsumable(t *testing.T) {
 			mem:           int64(1024),
 			ports:         []uint16{},
 			portsUdp:      []uint16{},
-			gpus:          int64(0),
+			gpus:          []string{},
 			canBeConsumed: false,
 		},
 		{
@@ -182,7 +209,7 @@ func TestConsumable(t *testing.T) {
 			mem:           int64(2500),
 			ports:         []uint16{},
 			portsUdp:      []uint16{},
-			gpus:          int64(0),
+			gpus:          []string{},
 			canBeConsumed: false,
 		},
 		{
@@ -190,7 +217,7 @@ func TestConsumable(t *testing.T) {
 			mem:           int64(1024),
 			ports:         []uint16{22},
 			portsUdp:      []uint16{},
-			gpus:          int64(0),
+			gpus:          []string{},
 			canBeConsumed: false,
 		},
 		{
@@ -198,23 +225,80 @@ func TestConsumable(t *testing.T) {
 			mem:           int64(1024),
 			ports:         []uint16{},
 			portsUdp:      []uint16{1000},
-			gpus:          int64(0),
-			canBeConsumed: false,
-		},
-		{
-			cpu:           int64(1024),
-			mem:           int64(1024),
-			ports:         []uint16{},
-			portsUdp:      []uint16{1000},
-			gpus:          int64(5),
+			gpus:          []string{},
 			canBeConsumed: false,
 		},
 	}
 
 	for _, tc := range testCases {
-		resources := getTestTaskResourceMap(tc.cpu, tc.mem, utils.Uint16SliceToStringSlice(tc.ports), utils.Uint16SliceToStringSlice(tc.portsUdp), tc.gpus)
+		resources := getTestTaskResourceMap(tc.cpu, tc.mem, utils.Uint16SliceToStringSlice(tc.ports), utils.Uint16SliceToStringSlice(tc.portsUdp), aws.StringSlice(tc.gpus))
 		canBeConsumed, err := h.consumable(resources)
 		assert.Equal(t, canBeConsumed, tc.canBeConsumed, "Error in checking if resources can be successfully consumed")
 		assert.Equal(t, err, nil, "Error in checking if resources can be successfully consumed, error returned from consumable")
 	}
+}
+
+func TestResourceHealthTrue(t *testing.T) {
+	hostResourcePort1 := "22"
+	hostResourcePort2 := "1000"
+	gpuIDs := []string{"gpu1", "gpu2", "gpu3", "gpu4"}
+	h := getTestHostResourceManager(int64(2048), int64(2048), []*string{&hostResourcePort1}, []*string{&hostResourcePort2}, aws.StringSlice(gpuIDs))
+
+	resources := getTestTaskResourceMap(1024, 1024, utils.Uint16SliceToStringSlice([]uint16{22}), utils.Uint16SliceToStringSlice([]uint16{1000}), aws.StringSlice([]string{"gpu1", "gpu2"}))
+	err := h.checkResourcesHealth(resources)
+	assert.NoError(t, err, "Error in checking healthy resource map status")
+}
+
+// Verify Resource health status checks gpu status properly from valid pool of gpus and returns error
+func TestResourceHealthGPUFalse(t *testing.T) {
+	hostResourcePort1 := "22"
+	hostResourcePort2 := "1000"
+	gpuIDs := []string{"gpu1", "gpu2", "gpu3", "gpu4"}
+	h := getTestHostResourceManager(int64(2048), int64(2048), []*string{&hostResourcePort1}, []*string{&hostResourcePort2}, aws.StringSlice(gpuIDs))
+
+	resources := getTestTaskResourceMap(1024, 1024, utils.Uint16SliceToStringSlice([]uint16{22}), utils.Uint16SliceToStringSlice([]uint16{1000}), aws.StringSlice([]string{"gpu1", "gpu5"}))
+	err := h.checkResourcesHealth(resources)
+	assert.Error(t, err, "Error in checking unhealthy resource map status")
+}
+
+func TestResourceHealthIntegerFalse(t *testing.T) {
+	hostResourcePort1 := "22"
+	hostResourcePort2 := "1000"
+	gpuIDs := []string{"gpu1", "gpu2", "gpu3", "gpu4"}
+	h := getTestHostResourceManager(int64(2048), int64(2048), []*string{&hostResourcePort1}, []*string{&hostResourcePort2}, aws.StringSlice(gpuIDs))
+
+	// Create unhealthy resource map, nil value for IntegerValue field
+	resources := make(map[string]*ecs.Resource)
+	resources["CPU"] = &ecs.Resource{
+		Name: utils.Strptr("CPU"),
+		Type: utils.Strptr("INTEGER"),
+	}
+	resources["MEMORY"] = &ecs.Resource{
+		Name: utils.Strptr("MEMORY"),
+		Type: utils.Strptr("INTEGER"),
+	}
+
+	err := h.checkResourcesHealth(resources)
+	assert.Error(t, err, "Error in checking unhealthy resource map status")
+}
+
+func TestResourceHealthStringSetFalse(t *testing.T) {
+	hostResourcePort1 := "22"
+	hostResourcePort2 := "1000"
+	gpuIDs := []string{"gpu1", "gpu2", "gpu3", "gpu4"}
+	h := getTestHostResourceManager(int64(2048), int64(2048), []*string{&hostResourcePort1}, []*string{&hostResourcePort2}, aws.StringSlice(gpuIDs))
+
+	// Create unhealthy resource map, nil value for StringSetValue field
+	resources := make(map[string]*ecs.Resource)
+	resources["PORTS"] = &ecs.Resource{
+		Name: utils.Strptr("PORTS"),
+		Type: utils.Strptr("STRINGSET"),
+	}
+	resources["PORTS_UDP"] = &ecs.Resource{
+		Name: utils.Strptr("PORTS_UDP"),
+		Type: utils.Strptr("STRINGSET"),
+	}
+
+	err := h.checkResourcesHealth(resources)
+	assert.Error(t, err, "Error in checking unhealthy resource map status")
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
In the current implementation of [task resource accounting](https://github.com/aws/amazon-ecs-agent/pull/3819) in ECS Agent, the way we account GPUs is by counting the number of consumed GPUs on the host at any given time. But in ACS payload Agent receives, Agent gets the exact GPU ID on the instance on which to schedule the containers. Consider a scenario when a task is running on a multi-GPU machine, and using a GPU (say `gpu1`). If it gets in stopping state (desiredStatus=`stopped`) by an ACS StopTask, `gpu1` gets released by ECS backend, and a new task can get scheduled on `gpu1`, and agent can start the task on the `gpu1` if it just considers GPU accounting using counts - as available GPUs can be >= 1 on multi GPU machine. This may cause GPU OOM issues in application when
- both tasks end up on same GPU (for single GPU, the count acts as a boolean so the issue is not reproducible on single GPU machine)
- if stopping task GPU memory + new running task GPU memory > available GPU memory

To fix this, in host resource manager, and when accounting a task's resources, GPU accounting must be accounted as list of individual GPU IDs which the task consumes/will consume.

### Implementation details
<!-- How are the changes implemented? -->
* `agent/engine/host_resource_manager.go` - Changed resource type of `GPU` from `INTEGER` to `STRINGSET`
* `agent/api/task/task.go` - Changed resource type of `GPU` from `INTEGER` to `STRINGSET` for each task's resources
* `agent/app/agent.go` - When initializing host_resource_manager, initialize with list of host gpu ids instead of count

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
* Made unit test changes to test for the required changes
* End to end manual testing - On multi gpu machine, start a gpu task with long stopTimeout and which occupies 90% of gpu memory and stop it. Immediately start a new gpu task
    * If new task ends up on different gpu, the task immediately begins
    * If new task ends on same gpu, the task waits until the first task stops (desired change here)

Redacted Agent debug logs for 2nd case from above manual testing
`T1(e2332bb033774dbbbc7fc5b9566dd229) on (GPU-72371e2b-be81-46d5-d4b4-e3406546ae6b):`
```
level=debug time=2023-08-16T23:51:44Z msg="Enqueued task in Waiting Task Queue" taskARN="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/e2332bb033774dbbbc7fc5b9566dd229"
level=debug time=2023-08-16T23:51:44Z msg="Waiting for task event" task="e2332bb033774dbbbc7fc5b9566dd229"
level=debug time=2023-08-16T23:51:44Z msg="Task host resources to account for" PORTS_UDP=[] GPU=[GPU-72371e2b-be81-46d5-d4b4-e3406546ae6b] taskArn="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/e2332bb033774dbbbc7fc5b9566dd229" CPU=1024 MEMORY=8000 PORTS_TCP=[]
level=info time=2023-08-16T23:51:44Z msg="Resources successfully consumed, continue to task creation" taskArn="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/e2332bb033774dbbbc7fc5b9566dd229"
level=debug time=2023-08-16T23:51:44Z msg="Consumed resources after task consume call" taskArn="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/e2332bb033774dbbbc7fc5b9566dd229" CPU=2048 MEMORY=16000 PORTS_TCP=[22 2375 2376 51678 51679] PORTS_UDP=[] GPU=[GPU-7e35a581-c6b0-dafd-7d55-22dbe796a93c GPU-72371e2b-be81-46d5-d4b4-e3406546ae6b]
level=debug time=2023-08-16T23:51:44Z msg="Dequeued task from Waiting Task Queue" taskARN="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/e2332bb033774dbbbc7fc5b9566dd229"
level=info time=2023-08-16T23:51:44Z msg="Host resources consumed, progressing task" taskARN="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/e2332bb033774dbbbc7fc5b9566dd229"
```

`T2(1fa908d7dd6449878e0f9a1efa31764b) on same GPU (GPU-72371e2b-be81-46d5-d4b4-e3406546ae6b), task stays in PENDING until first stops:`
```
level=debug time=2023-08-16T23:52:52Z msg="Enqueued task in Waiting Task Queue" taskARN="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/1fa908d7dd6449878e0f9a1efa31764b"
level=debug time=2023-08-16T23:52:52Z msg="Waiting for task event" task="1fa908d7dd6449878e0f9a1efa31764b"
level=debug time=2023-08-16T23:52:52Z msg="Task host resources to account for" PORTS_TCP=[] PORTS_UDP=[] GPU=[GPU-72371e2b-be81-46d5-d4b4-e3406546ae6b] taskArn="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/1fa908d7dd6449878e0f9a1efa31764b" CPU=1024 MEMORY=8000
level=info time=2023-08-16T23:52:52Z msg="Resources not consumed, enough resources not available" taskArn="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/1fa908d7dd6449878e0f9a1efa31764b"
level=debug time=2023-08-16T23:52:52Z msg="Consumed resources after task consume call" PORTS_TCP=[22 2375 2376 51678 51679] PORTS_UDP=[] GPU=[GPU-72371e2b-be81-46d5-d4b4-e3406546ae6b] taskArn="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/1fa908d7dd6449878e0f9a1efa31764b" CPU=1024 MEMORY=8000
```

`After first task Stops and GPU is freed up, T2 starts up:`
```
level=debug time=2023-08-16T23:54:11Z msg="Task host resources to account for" PORTS_TCP=[] PORTS_UDP=[] GPU=[GPU-72371e2b-be81-46d5-d4b4-e3406546ae6b] taskArn="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/1fa908d7dd6449878e0f9a1efa31764b" CPU=1024 MEMORY=8000
level=info time=2023-08-16T23:54:11Z msg="Resources successfully consumed, continue to task creation" taskArn="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/1fa908d7dd6449878e0f9a1efa31764b"
level=debug time=2023-08-16T23:54:11Z msg="Consumed resources after task consume call" MEMORY=8000 PORTS_TCP=[22 2375 2376 51678 51679] PORTS_UDP=[] GPU=[GPU-72371e2b-be81-46d5-d4b4-e3406546ae6b] taskArn="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/1fa908d7dd6449878e0f9a1efa31764b" CPU=1024
level=debug time=2023-08-16T23:54:11Z msg="Dequeued task from Waiting Task Queue" taskARN="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/1fa908d7dd6449878e0f9a1efa31764b"
level=info time=2023-08-16T23:54:11Z msg="Host resources consumed, progressing task" taskARN="arn:aws:ecs:us-west-2:<acc>:task/external-memcheck/1fa908d7dd6449878e0f9a1efa31764b"
level=debug time=2023-08-16T23:54:11Z msg="Skipping event emission for task" task="1fa908d7dd6449878e0f9a1efa31764b" error="status not recognized by ECS"
level=debug time=2023-08-16T23:54:11Z msg="Task not steady state or terminal; progressing it" task="1fa908d7dd6449878e0f9a1efa31764b"
```
New tests cover the changes: <!-- yes|no -->
Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug - Fixed gpu resource accounting by maintaining list of used gpu ids instead of count of used gpus, to prevent possible gpu OOM in some situations

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
