### PR TITLE
further revert all acs related eni usage

### DIFF
--- a/agent/acs/handler/attach_eni_handler_common.go
+++ b/agent/acs/handler/attach_eni_handler_common.go
@@ -15,13 +15,12 @@ package handler
 
 import (
 	"fmt"
-
 	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
+	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
-	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/arn"
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
@@ -48,7 +47,7 @@ func NewENIHandler(state dockerstate.TaskEngineState, dataClient data.Client) *e
 // 2. Otherwise add the attachment to state, start its ack timer, and save the state
 // These are common tasks for handling a task ENI attachment and an instance ENI attachment, so they are put
 // into this function to be shared by both attachment handlers
-func (eniHandler *eniHandler) HandleENIAttachment(ea *ni.ENIAttachment) error {
+func (eniHandler *eniHandler) HandleENIAttachment(ea *apieni.ENIAttachment) error {
 	attachmentType := ea.AttachmentType
 	attachmentARN := ea.AttachmentARN
 	taskARN := ea.TaskARN
@@ -70,7 +69,7 @@ func (eniHandler *eniHandler) HandleENIAttachment(ea *ni.ENIAttachment) error {
 }
 
 // addENIAttachmentToState adds an ENI attachment to state, and start its ack timer
-func (eniHandler *eniHandler) addENIAttachmentToState(ea *ni.ENIAttachment) error {
+func (eniHandler *eniHandler) addENIAttachmentToState(ea *apieni.ENIAttachment) error {
 	attachmentType := ea.AttachmentType
 	attachmentARN := ea.AttachmentARN
 	taskARN := ea.TaskARN
@@ -82,14 +81,14 @@ func (eniHandler *eniHandler) addENIAttachmentToState(ea *ni.ENIAttachment) erro
 	}
 
 	switch attachmentType {
-	case ni.ENIAttachmentTypeTaskENI:
+	case apieni.ENIAttachmentTypeTaskENI:
 		taskId, _ := arn.TaskIdFromArn(taskARN)
 		logger.Info("Adding eni attachment info to state for task", logger.Fields{
 			field.TaskID:    taskId,
 			"attachmentARN": attachmentARN,
 			"mac":           mac,
 		})
-	case ni.ENIAttachmentTypeInstanceENI:
+	case apieni.ENIAttachmentTypeInstanceENI:
 		logger.Info("Adding instance eni attachment info to state", logger.Fields{
 			"attachmentARN": attachmentARN,
 			"mac":           mac,

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -23,8 +23,8 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
+	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
-	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/pkg/errors"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -73,7 +73,7 @@ type ManagedAgentStateChange struct {
 // SubmitTaskStateChange API
 type TaskStateChange struct {
 	// Attachment is the eni attachment object to send
-	Attachment *ni.ENIAttachment
+	Attachment *apieni.ENIAttachment
 	// TaskArn is the unique identifier for the task
 	TaskARN string
 	// Status is the status to send
@@ -99,7 +99,7 @@ type TaskStateChange struct {
 // SubmitAttachmentStateChanges API
 type AttachmentStateChange struct {
 	// Attachment is the eni attachment object to send
-	Attachment *ni.ENIAttachment
+	Attachment *apieni.ENIAttachment
 }
 
 type ErrShouldNotSendEvent struct {
@@ -218,7 +218,7 @@ func NewManagedAgentChangeEvent(task *apitask.Task, cont *apicontainer.Container
 }
 
 // NewAttachmentStateChangeEvent creates a new attachment state change event
-func NewAttachmentStateChangeEvent(eniAttachment *ni.ENIAttachment) AttachmentStateChange {
+func NewAttachmentStateChangeEvent(eniAttachment *apieni.ENIAttachment) AttachmentStateChange {
 	return AttachmentStateChange{
 		Attachment: eniAttachment,
 	}

--- a/agent/data/client.go
+++ b/agent/data/client.go
@@ -20,7 +20,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -77,11 +77,11 @@ type Client interface {
 	GetImageStates() ([]*image.ImageState, error)
 
 	// SaveENIAttachment saves the data of an ENI attachment.
-	SaveENIAttachment(*networkinterface.ENIAttachment) error
+	SaveENIAttachment(*apieni.ENIAttachment) error
 	// DeleteENIAttachment deletes the data of an ENI atttachment.
 	DeleteENIAttachment(string) error
 	// GetENIAttachments gets the data of all the ENI attachment.
-	GetENIAttachments() ([]*networkinterface.ENIAttachment, error)
+	GetENIAttachments() ([]*apieni.ENIAttachment, error)
 
 	// SaveMetadata saves a key value pair of metadata.
 	SaveMetadata(string, string) error

--- a/agent/data/eniattachment_client.go
+++ b/agent/data/eniattachment_client.go
@@ -17,13 +17,13 @@ import (
 	"encoding/json"
 
 	"github.com/aws/amazon-ecs-agent/agent/utils"
-	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 
 	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 )
 
-func (c *client) SaveENIAttachment(eni *ni.ENIAttachment) error {
+func (c *client) SaveENIAttachment(eni *apieni.ENIAttachment) error {
 	id, err := utils.GetENIAttachmentId(eni.AttachmentARN)
 	if err != nil {
 		return errors.Wrap(err, "failed to generate database id")
@@ -41,12 +41,12 @@ func (c *client) DeleteENIAttachment(id string) error {
 	})
 }
 
-func (c *client) GetENIAttachments() ([]*ni.ENIAttachment, error) {
-	var eniAttachments []*ni.ENIAttachment
+func (c *client) GetENIAttachments() ([]*apieni.ENIAttachment, error) {
+	var eniAttachments []*apieni.ENIAttachment
 	err := c.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(eniAttachmentsBucketName))
 		return walk(bucket, func(id string, data []byte) error {
-			eniAttachment := ni.ENIAttachment{}
+			eniAttachment := apieni.ENIAttachment{}
 			if err := json.Unmarshal(data, &eniAttachment); err != nil {
 				return err
 			}

--- a/agent/data/noop_client.go
+++ b/agent/data/noop_client.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 )
 
 type noopClient struct{}
@@ -68,7 +68,7 @@ func (c *noopClient) GetImageStates() ([]*image.ImageState, error) {
 	return nil, nil
 }
 
-func (c *noopClient) SaveENIAttachment(*networkinterface.ENIAttachment) error {
+func (c *noopClient) SaveENIAttachment(*apieni.ENIAttachment) error {
 	return nil
 }
 
@@ -76,7 +76,7 @@ func (c *noopClient) DeleteENIAttachment(string) error {
 	return nil
 }
 
-func (c *noopClient) GetENIAttachments() ([]*networkinterface.ENIAttachment, error) {
+func (c *noopClient) GetENIAttachments() ([]*apieni.ENIAttachment, error) {
 	return nil, nil
 }
 

--- a/agent/engine/dockerstate/json.go
+++ b/agent/engine/dockerstate/json.go
@@ -20,7 +20,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
-	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 )
 
 // These bits of information should be enough to reconstruct the entire
@@ -30,8 +30,8 @@ type savedState struct {
 	IdToContainer  map[string]*apicontainer.DockerContainer `json:"IdToContainer"` // DockerId -> apicontainer.DockerContainer
 	IdToTask       map[string]string                        `json:"IdToTask"`      // DockerId -> taskarn
 	ImageStates    []*image.ImageState
-	ENIAttachments []*ni.ENIAttachment `json:"ENIAttachments"`
-	IPToTask       map[string]string   `json:"IPToTask"`
+	ENIAttachments []*apieni.ENIAttachment `json:"ENIAttachments"`
+	IPToTask       map[string]string       `json:"IPToTask"`
 }
 
 func (state *DockerTaskEngineState) MarshalJSON() ([]byte, error) {

--- a/agent/eni/watcher/watcher.go
+++ b/agent/eni/watcher/watcher.go
@@ -27,8 +27,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
-	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 )
 
@@ -142,7 +142,7 @@ func (eniWatcher *ENIWatcher) sendENIStateChange(mac string) error {
 
 	// We found an ENI, which has the expiration time set in future and
 	// needs to be acknowledged as having been 'attached' to the Instance
-	if eni.AttachmentType == ni.ENIAttachmentTypeInstanceENI {
+	if eni.AttachmentType == apieni.ENIAttachmentTypeInstanceENI {
 		go eniWatcher.emitInstanceENIAttachedEvent(eni)
 	} else {
 		go eniWatcher.emitTaskENIAttachedEvent(eni)
@@ -152,7 +152,7 @@ func (eniWatcher *ENIWatcher) sendENIStateChange(mac string) error {
 
 // emitTaskENIChangeEvent sends a state change event for a task ENI attachment to the event channel with eni status as
 // attached
-func (eniWatcher *ENIWatcher) emitTaskENIAttachedEvent(eni *ni.ENIAttachment) {
+func (eniWatcher *ENIWatcher) emitTaskENIAttachedEvent(eni *apieni.ENIAttachment) {
 	eni.Status = status.AttachmentAttached
 	log.Infof("Emitting task ENI attached event for: %s", eni.String())
 	eniWatcher.eniChangeEvent <- api.TaskStateChange{
@@ -163,7 +163,7 @@ func (eniWatcher *ENIWatcher) emitTaskENIAttachedEvent(eni *ni.ENIAttachment) {
 
 // emitInstanceENIChangeEvent sends a state change event for an instance ENI attachment to the event channel with eni
 // status as attached
-func (eniWatcher *ENIWatcher) emitInstanceENIAttachedEvent(eni *ni.ENIAttachment) {
+func (eniWatcher *ENIWatcher) emitInstanceENIAttachedEvent(eni *apieni.ENIAttachment) {
 	eni.Status = status.AttachmentAttached
 	log.Infof("Emitting instance ENI attached event for: %s", eni.String())
 	eniWatcher.eniChangeEvent <- api.NewAttachmentStateChangeEvent(eni)

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_eni_common.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_eni_common.go
@@ -13,8 +13,8 @@
 
 package session
 
-import ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+import apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 
 type ENIHandler interface {
-	HandleENIAttachment(eniAttachment *ni.ENIAttachment) error
+	HandleENIAttachment(eniAttachment *apieni.ENIAttachment) error
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_instance_eni_responder.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_instance_eni_responder.go
@@ -15,6 +15,7 @@ package session
 
 import (
 	"fmt"
+	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -98,7 +99,7 @@ func (r *attachInstanceENIResponder) handleAttachMessage(message *ecsacs.AttachI
 func (r *attachInstanceENIResponder) handleInstanceENIFromMessage(eni *ecsacs.ElasticNetworkInterface,
 	messageID, clusterARN, containerInstanceARN string, receivedAt time.Time, waitTimeoutMs int64) {
 	expiresAt := receivedAt.Add(time.Duration(waitTimeoutMs) * time.Millisecond)
-	err := r.eniHandler.HandleENIAttachment(&ni.ENIAttachment{
+	err := r.eniHandler.HandleENIAttachment(&apieni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			AttachmentARN:        aws.StringValue(eni.AttachmentArn),
 			Status:               status.AttachmentNone,

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_task_eni_responder.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_task_eni_responder.go
@@ -15,6 +15,7 @@ package session
 
 import (
 	"fmt"
+	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -99,7 +100,7 @@ func (r *attachTaskENIResponder) handleAttachMessage(message *ecsacs.AttachTaskN
 func (r *attachTaskENIResponder) handleTaskENIFromMessage(eni *ecsacs.ElasticNetworkInterface,
 	messageID, taskARN, clusterARN, containerInstanceARN string, receivedAt time.Time, waitTimeoutMs int64) {
 	expiresAt := receivedAt.Add(time.Duration(waitTimeoutMs) * time.Millisecond)
-	err := r.eniHandler.HandleENIAttachment(&ni.ENIAttachment{
+	err := r.eniHandler.HandleENIAttachment(&apieni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			TaskARN:              taskARN,
 			AttachmentARN:        aws.StringValue(eni.AttachmentArn),

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/eni/eni.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/eni/eni.go
@@ -36,9 +36,9 @@ type ENI struct {
 	// MacAddress is the mac address of the eni
 	MacAddress string
 	// IPV4Addresses is the ipv4 address associated with the eni
-	IPV4Addresses []*IPV4Address
+	IPV4Addresses []*ENIIPV4Address
 	// IPV6Addresses is the ipv6 address associated with the eni
-	IPV6Addresses []*IPV6Address
+	IPV6Addresses []*ENIIPV6Address
 	// SubnetGatewayIPV4Address is the IPv4 address of the subnet gateway of the ENI
 	SubnetGatewayIPV4Address string `json:",omitempty"`
 	// DomainNameServers specifies the nameserver IP addresses for the eni
@@ -272,16 +272,16 @@ func (eni *ENI) String() string {
 		strings.Join(eni.DomainNameSearchList, ","), eni.SubnetGatewayIPV4Address, eniString)
 }
 
-// IPV4Address is the ipv4 information of the eni
-type IPV4Address struct {
+// ENIIPV4Address is the ipv4 information of the eni
+type ENIIPV4Address struct {
 	// Primary indicates whether the ip address is primary
 	Primary bool
 	// Address is the ipv4 address associated with eni
 	Address string
 }
 
-// IPV6Address is the ipv6 information of the eni
-type IPV6Address struct {
+// ENIIPV6Address is the ipv6 information of the eni
+type ENIIPV6Address struct {
 	// Address is the ipv6 address associated with eni
 	Address string
 }
@@ -293,12 +293,12 @@ func ENIFromACS(acsENI *ecsacs.ElasticNetworkInterface) (*ENI, error) {
 		return nil, err
 	}
 
-	var ipv4Addrs []*IPV4Address
-	var ipv6Addrs []*IPV6Address
+	var ipv4Addrs []*ENIIPV4Address
+	var ipv6Addrs []*ENIIPV6Address
 
 	// Read IPv4 address information of the ENI.
 	for _, ec2Ipv4 := range acsENI.Ipv4Addresses {
-		ipv4Addrs = append(ipv4Addrs, &IPV4Address{
+		ipv4Addrs = append(ipv4Addrs, &ENIIPV4Address{
 			Primary: aws.BoolValue(ec2Ipv4.Primary),
 			Address: aws.StringValue(ec2Ipv4.PrivateAddress),
 		})
@@ -306,7 +306,7 @@ func ENIFromACS(acsENI *ecsacs.ElasticNetworkInterface) (*ENI, error) {
 
 	// Read IPv6 address information of the ENI.
 	for _, ec2Ipv6 := range acsENI.Ipv6Addresses {
-		ipv6Addrs = append(ipv6Addrs, &IPV6Address{
+		ipv6Addrs = append(ipv6Addrs, &ENIIPV6Address{
 			Address: aws.StringValue(ec2Ipv6.Address),
 		})
 	}

--- a/ecs-agent/acs/session/attach_eni_common.go
+++ b/ecs-agent/acs/session/attach_eni_common.go
@@ -13,8 +13,8 @@
 
 package session
 
-import ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+import apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 
 type ENIHandler interface {
-	HandleENIAttachment(eniAttachment *ni.ENIAttachment) error
+	HandleENIAttachment(eniAttachment *apieni.ENIAttachment) error
 }

--- a/ecs-agent/acs/session/attach_instance_eni_responder.go
+++ b/ecs-agent/acs/session/attach_instance_eni_responder.go
@@ -15,6 +15,7 @@ package session
 
 import (
 	"fmt"
+	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -98,7 +99,7 @@ func (r *attachInstanceENIResponder) handleAttachMessage(message *ecsacs.AttachI
 func (r *attachInstanceENIResponder) handleInstanceENIFromMessage(eni *ecsacs.ElasticNetworkInterface,
 	messageID, clusterARN, containerInstanceARN string, receivedAt time.Time, waitTimeoutMs int64) {
 	expiresAt := receivedAt.Add(time.Duration(waitTimeoutMs) * time.Millisecond)
-	err := r.eniHandler.HandleENIAttachment(&ni.ENIAttachment{
+	err := r.eniHandler.HandleENIAttachment(&apieni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			AttachmentARN:        aws.StringValue(eni.AttachmentArn),
 			Status:               status.AttachmentNone,

--- a/ecs-agent/acs/session/attach_task_eni_responder.go
+++ b/ecs-agent/acs/session/attach_task_eni_responder.go
@@ -15,6 +15,7 @@ package session
 
 import (
 	"fmt"
+	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -99,7 +100,7 @@ func (r *attachTaskENIResponder) handleAttachMessage(message *ecsacs.AttachTaskN
 func (r *attachTaskENIResponder) handleTaskENIFromMessage(eni *ecsacs.ElasticNetworkInterface,
 	messageID, taskARN, clusterARN, containerInstanceARN string, receivedAt time.Time, waitTimeoutMs int64) {
 	expiresAt := receivedAt.Add(time.Duration(waitTimeoutMs) * time.Millisecond)
-	err := r.eniHandler.HandleENIAttachment(&ni.ENIAttachment{
+	err := r.eniHandler.HandleENIAttachment(&apieni.ENIAttachment{
 		AttachmentInfo: attachmentinfo.AttachmentInfo{
 			TaskARN:              taskARN,
 			AttachmentARN:        aws.StringValue(eni.AttachmentArn),

--- a/ecs-agent/acs/session/mocks/session_mock.go
+++ b/ecs-agent/acs/session/mocks/session_mock.go
@@ -22,8 +22,8 @@ import (
 	reflect "reflect"
 
 	ecsacs "github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
 	resource "github.com/aws/amazon-ecs-agent/ecs-agent/api/resource"
-	networkinterface "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -51,7 +51,7 @@ func (m *MockENIHandler) EXPECT() *MockENIHandlerMockRecorder {
 }
 
 // HandleENIAttachment mocks base method.
-func (m *MockENIHandler) HandleENIAttachment(arg0 *networkinterface.ENIAttachment) error {
+func (m *MockENIHandler) HandleENIAttachment(arg0 *apieni.ENIAttachment) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleENIAttachment", arg0)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This further revert more acs interface changes that breaks current Fargate integration

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
further revert all acs related eni usage (no need to be in release note)

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
