### PR TITLE
Add go mod checker workflow to github CI to assure we ran go mod after a ecs-agent module update

### DIFF
--- a/.github/workflows/gomod.yml
+++ b/.github/workflows/gomod.yml
@@ -1,0 +1,45 @@
+name: Go Mod Check
+
+on: [push, pull_request]
+
+permissions: read-all
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          path: src/github.com/aws/amazon-ecs-agent
+      - name: get GO_VERSION
+        id: get-go-version
+        run: |
+          cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent
+          set -eou pipefail
+          go_version=$(cat -e GO_VERSION)
+          go_version=${go_version%?}
+          go_version_length=${#go_version}
+          go_version_re="^([0-9]+\.){1,2}([0-9]+)$"
+          if ! [[ $go_version_length -le 10 && $go_version =~ $go_version_re ]] ; then
+            echo "invalid GO version"
+            exit 1
+          fi
+          echo "GO_VERSION=$go_version" >> $GITHUB_OUTPUT
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}
+      - name: Run go mod tidy and go mod vendor in ecs-agent module
+        run: |
+          cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent/ecs-agent
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+          go mod vendor
+          git diff --exit-code vendor/
+      - name: Run go mod tidy and go mod vendor in agent module
+        run: |
+          cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent/agent
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+          go mod vendor
+          git diff --exit-code vendor/

--- a/.github/workflows/gomod.yml
+++ b/.github/workflows/gomod.yml
@@ -43,3 +43,10 @@ jobs:
           git diff --exit-code go.mod go.sum
           go mod vendor
           git diff --exit-code vendor/
+      - name: Run go mod tidy and go mod vendor in ecs-init module
+        run: |
+          cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent/ecs-init
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+          go mod vendor
+          git diff --exit-code vendor/

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/eni/eni.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/eni/eni.go
@@ -36,9 +36,9 @@ type ENI struct {
 	// MacAddress is the mac address of the eni
 	MacAddress string
 	// IPV4Addresses is the ipv4 address associated with the eni
-	IPV4Addresses []*IPV4Address
+	IPV4Addresses []*ENIIPV4Address
 	// IPV6Addresses is the ipv6 address associated with the eni
-	IPV6Addresses []*IPV6Address
+	IPV6Addresses []*ENIIPV6Address
 	// SubnetGatewayIPV4Address is the IPv4 address of the subnet gateway of the ENI
 	SubnetGatewayIPV4Address string `json:",omitempty"`
 	// DomainNameServers specifies the nameserver IP addresses for the eni
@@ -272,16 +272,16 @@ func (eni *ENI) String() string {
 		strings.Join(eni.DomainNameSearchList, ","), eni.SubnetGatewayIPV4Address, eniString)
 }
 
-// IPV4Address is the ipv4 information of the eni
-type IPV4Address struct {
+// ENIIPV4Address is the ipv4 information of the eni
+type ENIIPV4Address struct {
 	// Primary indicates whether the ip address is primary
 	Primary bool
 	// Address is the ipv4 address associated with eni
 	Address string
 }
 
-// IPV6Address is the ipv6 information of the eni
-type IPV6Address struct {
+// ENIIPV6Address is the ipv6 information of the eni
+type ENIIPV6Address struct {
 	// Address is the ipv6 address associated with eni
 	Address string
 }
@@ -293,12 +293,12 @@ func ENIFromACS(acsENI *ecsacs.ElasticNetworkInterface) (*ENI, error) {
 		return nil, err
 	}
 
-	var ipv4Addrs []*IPV4Address
-	var ipv6Addrs []*IPV6Address
+	var ipv4Addrs []*ENIIPV4Address
+	var ipv6Addrs []*ENIIPV6Address
 
 	// Read IPv4 address information of the ENI.
 	for _, ec2Ipv4 := range acsENI.Ipv4Addresses {
-		ipv4Addrs = append(ipv4Addrs, &IPV4Address{
+		ipv4Addrs = append(ipv4Addrs, &ENIIPV4Address{
 			Primary: aws.BoolValue(ec2Ipv4.Primary),
 			Address: aws.StringValue(ec2Ipv4.PrivateAddress),
 		})
@@ -306,7 +306,7 @@ func ENIFromACS(acsENI *ecsacs.ElasticNetworkInterface) (*ENI, error) {
 
 	// Read IPv6 address information of the ENI.
 	for _, ec2Ipv6 := range acsENI.Ipv6Addresses {
-		ipv6Addrs = append(ipv6Addrs, &IPV6Address{
+		ipv6Addrs = append(ipv6Addrs, &ENIIPV6Address{
 			Address: aws.StringValue(ec2Ipv6.Address),
 		})
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add go mod checker workflow to github CI to assure we ran go mod after a ecs-agent module update

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> N/A

This is a failed github workflow check that a `go mod tidy && go mod vendor` is missed: https://github.com/Realmonia/amazon-ecs-agent/actions/runs/5931009519/job/16081967368

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
