### PR TITLE
Log error if handling task manifest message fails

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/task_manifest_responder.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/task_manifest_responder.go
@@ -80,9 +80,18 @@ func (tmr *taskManifestResponder) HandlerFunc() wsclient.RequestHandler {
 // handleTaskManifestMessage is the high level caller to handle a task manifest message from ACS.
 // It will kick off the call stack of processTaskManifestMessage calling ack and send TaskManifestMessage
 func (tmr *taskManifestResponder) handleTaskManifestMessage(message *ecsacs.TaskManifestMessage) {
-	logger.Debug(fmt.Sprintf("Processing %s", TaskManifestMessageName), logger.Fields{field.MessageID: message.MessageId})
+	messageID := aws.StringValue(message.MessageId)
+	logger.Debug(fmt.Sprintf("Processing %s", TaskManifestMessageName), logger.Fields{
+		field.MessageID: messageID,
+	})
 	m := tmr.metricsFactory.New(metrics.TaskManifestHandlingDuration)
 	err := tmr.processTaskManifestMessage(message)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Unable to handle %s", TaskManifestMessageName), logger.Fields{
+			field.MessageID: messageID,
+			field.Error:     err,
+		})
+	}
 	m.Done(err)
 }
 

--- a/ecs-agent/acs/session/task_manifest_responder.go
+++ b/ecs-agent/acs/session/task_manifest_responder.go
@@ -80,9 +80,18 @@ func (tmr *taskManifestResponder) HandlerFunc() wsclient.RequestHandler {
 // handleTaskManifestMessage is the high level caller to handle a task manifest message from ACS.
 // It will kick off the call stack of processTaskManifestMessage calling ack and send TaskManifestMessage
 func (tmr *taskManifestResponder) handleTaskManifestMessage(message *ecsacs.TaskManifestMessage) {
-	logger.Debug(fmt.Sprintf("Processing %s", TaskManifestMessageName), logger.Fields{field.MessageID: message.MessageId})
+	messageID := aws.StringValue(message.MessageId)
+	logger.Debug(fmt.Sprintf("Processing %s", TaskManifestMessageName), logger.Fields{
+		field.MessageID: messageID,
+	})
 	m := tmr.metricsFactory.New(metrics.TaskManifestHandlingDuration)
 	err := tmr.processTaskManifestMessage(message)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Unable to handle %s", TaskManifestMessageName), logger.Fields{
+			field.MessageID: messageID,
+			field.Error:     err,
+		})
+	}
 	m.Done(err)
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Currently if Agent fails to handle a task manifest message fail (i.e., call to `processTaskManifestMessage` returns an error), we do not log any meaningful error. Thus, right now there would be no indication in the logs if handling a task manifest message failed for any reason (which is also not consistent with the behavior of other ACS message responders).

This pull request simply adds an informative log statement with level `ERROR` in the event that the call to `processTaskManifestMessage` returns an error.

### Implementation details
<!-- How are the changes implemented? -->
See Summary above.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit, integration, and functional tests.

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Log error if handling task manifest message fails

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
