### PR TITLE
Use float64 for network rate stats

### DIFF
--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -131,8 +131,8 @@ func (queue *Queue) add(rawStat *ContainerStats) {
 
 		if stat.NetworkStats != nil {
 			networkStatPerSec := &stats.NetworkStatsPerSec{
-				RxBytesPerSecond: stat.NetworkStats.RxBytesPerSecond,
-				TxBytesPerSecond: stat.NetworkStats.TxBytesPerSecond,
+				RxBytesPerSecond: float64(stat.NetworkStats.RxBytesPerSecond),
+				TxBytesPerSecond: float64(stat.NetworkStats.TxBytesPerSecond),
 			}
 			queue.lastNetworkStatPerSec = networkStatPerSec
 		}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/stats/types.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/stats/types.go
@@ -13,6 +13,6 @@
 package stats
 
 type NetworkStatsPerSec struct {
-	RxBytesPerSecond float32 `json:"rx_bytes_per_sec"`
-	TxBytesPerSecond float32 `json:"tx_bytes_per_sec"`
+	RxBytesPerSecond float64 `json:"rx_bytes_per_sec"`
+	TxBytesPerSecond float64 `json:"tx_bytes_per_sec"`
 }

--- a/ecs-agent/stats/types.go
+++ b/ecs-agent/stats/types.go
@@ -13,6 +13,6 @@
 package stats
 
 type NetworkStatsPerSec struct {
-	RxBytesPerSecond float32 `json:"rx_bytes_per_sec"`
-	TxBytesPerSecond float32 `json:"tx_bytes_per_sec"`
+	RxBytesPerSecond float64 `json:"rx_bytes_per_sec"`
+	TxBytesPerSecond float64 `json:"tx_bytes_per_sec"`
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Changing the type of network rate stats `RxBytesPerSecond` and `TxBytesPerSecond` in ecs-agent module from `float32` to `float64` to match Fargate Agent. 

The change in behavior for TMDS v4 is that `network_rate_stats` field in stats response will now have more precision.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Called TMDS v4 task stats endpoint. The results are shown below.
Before
```
{
  "rx_bytes_per_sec": 44802.4609375,
  "tx_bytes_per_sec": 119103.296875
}
```

After (only the precision is important, values from different tests won't match as a lot of factors determine the stats).
```
{
  "rx_bytes_per_sec": 44806.56,
  "tx_bytes_per_sec": 119114.195
}
```

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Use float64 for network rate stats

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
