### PR TITLE
Rename methods of ACS CredentialsMetadataSetter interface

### DIFF
--- a/agent/acs/handler/refresh_credentials_responder.go
+++ b/agent/acs/handler/refresh_credentials_responder.go
@@ -42,7 +42,7 @@ func NewCredentialsMetadataSetter(taskEngine engine.TaskEngine) *credentialsMeta
 	}
 }
 
-func (cmSetter *credentialsMetadataSetter) SetTaskRoleMetadata(
+func (cmSetter *credentialsMetadataSetter) SetTaskRoleCredentialsMetadata(
 	message *ecsacs.IAMRoleCredentialsMessage) error {
 	task, err := cmSetter.getCredentialsMessageTask(message)
 	if err != nil {
@@ -52,7 +52,7 @@ func (cmSetter *credentialsMetadataSetter) SetTaskRoleMetadata(
 	return nil
 }
 
-func (cmSetter *credentialsMetadataSetter) SetExecRoleMetadata(
+func (cmSetter *credentialsMetadataSetter) SetExecRoleCredentialsMetadata(
 	message *ecsacs.IAMRoleCredentialsMessage) error {
 	task, err := cmSetter.getCredentialsMessageTask(message)
 	if err != nil {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/refresh_credentials_responder.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/refresh_credentials_responder.go
@@ -32,8 +32,8 @@ const (
 )
 
 type CredentialsMetadataSetter interface {
-	SetTaskRoleMetadata(message *ecsacs.IAMRoleCredentialsMessage) error
-	SetExecRoleMetadata(message *ecsacs.IAMRoleCredentialsMessage) error
+	SetTaskRoleCredentialsMetadata(message *ecsacs.IAMRoleCredentialsMessage) error
+	SetExecRoleCredentialsMetadata(message *ecsacs.IAMRoleCredentialsMessage) error
 }
 
 // refreshCredentialsResponder implements the wsclient.RequestResponder interface for responding
@@ -136,12 +136,12 @@ func (r *refreshCredentialsResponder) setCredentialsMetadata(message *ecsacs.IAM
 	roleType := aws.StringValue(message.RoleType)
 	switch roleType {
 	case credentials.ApplicationRoleType:
-		err := r.credsMetadataSetter.SetTaskRoleMetadata(message)
+		err := r.credsMetadataSetter.SetTaskRoleCredentialsMetadata(message)
 		if err != nil {
 			return errors.Wrap(err, "failed to set task role metadata")
 		}
 	case credentials.ExecutionRoleType:
-		err := r.credsMetadataSetter.SetExecRoleMetadata(message)
+		err := r.credsMetadataSetter.SetExecRoleCredentialsMetadata(message)
 		if err != nil {
 			return errors.Wrap(err, "failed to set execution role metadata")
 		}

--- a/ecs-agent/acs/session/mocks/session_mock.go
+++ b/ecs-agent/acs/session/mocks/session_mock.go
@@ -122,32 +122,32 @@ func (m *MockCredentialsMetadataSetter) EXPECT() *MockCredentialsMetadataSetterM
 	return m.recorder
 }
 
-// SetExecRoleMetadata mocks base method.
-func (m *MockCredentialsMetadataSetter) SetExecRoleMetadata(arg0 *ecsacs.IAMRoleCredentialsMessage) error {
+// SetExecRoleCredentialsMetadata mocks base method.
+func (m *MockCredentialsMetadataSetter) SetExecRoleCredentialsMetadata(arg0 *ecsacs.IAMRoleCredentialsMessage) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetExecRoleMetadata", arg0)
+	ret := m.ctrl.Call(m, "SetExecRoleCredentialsMetadata", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SetExecRoleMetadata indicates an expected call of SetExecRoleMetadata.
-func (mr *MockCredentialsMetadataSetterMockRecorder) SetExecRoleMetadata(arg0 interface{}) *gomock.Call {
+// SetExecRoleCredentialsMetadata indicates an expected call of SetExecRoleCredentialsMetadata.
+func (mr *MockCredentialsMetadataSetterMockRecorder) SetExecRoleCredentialsMetadata(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExecRoleMetadata", reflect.TypeOf((*MockCredentialsMetadataSetter)(nil).SetExecRoleMetadata), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExecRoleCredentialsMetadata", reflect.TypeOf((*MockCredentialsMetadataSetter)(nil).SetExecRoleCredentialsMetadata), arg0)
 }
 
-// SetTaskRoleMetadata mocks base method.
-func (m *MockCredentialsMetadataSetter) SetTaskRoleMetadata(arg0 *ecsacs.IAMRoleCredentialsMessage) error {
+// SetTaskRoleCredentialsMetadata mocks base method.
+func (m *MockCredentialsMetadataSetter) SetTaskRoleCredentialsMetadata(arg0 *ecsacs.IAMRoleCredentialsMessage) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetTaskRoleMetadata", arg0)
+	ret := m.ctrl.Call(m, "SetTaskRoleCredentialsMetadata", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SetTaskRoleMetadata indicates an expected call of SetTaskRoleMetadata.
-func (mr *MockCredentialsMetadataSetterMockRecorder) SetTaskRoleMetadata(arg0 interface{}) *gomock.Call {
+// SetTaskRoleCredentialsMetadata indicates an expected call of SetTaskRoleCredentialsMetadata.
+func (mr *MockCredentialsMetadataSetterMockRecorder) SetTaskRoleCredentialsMetadata(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTaskRoleMetadata", reflect.TypeOf((*MockCredentialsMetadataSetter)(nil).SetTaskRoleMetadata), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTaskRoleCredentialsMetadata", reflect.TypeOf((*MockCredentialsMetadataSetter)(nil).SetTaskRoleCredentialsMetadata), arg0)
 }
 
 // MockPayloadMessageHandler is a mock of PayloadMessageHandler interface.

--- a/ecs-agent/acs/session/refresh_credentials_responder.go
+++ b/ecs-agent/acs/session/refresh_credentials_responder.go
@@ -32,8 +32,8 @@ const (
 )
 
 type CredentialsMetadataSetter interface {
-	SetTaskRoleMetadata(message *ecsacs.IAMRoleCredentialsMessage) error
-	SetExecRoleMetadata(message *ecsacs.IAMRoleCredentialsMessage) error
+	SetTaskRoleCredentialsMetadata(message *ecsacs.IAMRoleCredentialsMessage) error
+	SetExecRoleCredentialsMetadata(message *ecsacs.IAMRoleCredentialsMessage) error
 }
 
 // refreshCredentialsResponder implements the wsclient.RequestResponder interface for responding
@@ -136,12 +136,12 @@ func (r *refreshCredentialsResponder) setCredentialsMetadata(message *ecsacs.IAM
 	roleType := aws.StringValue(message.RoleType)
 	switch roleType {
 	case credentials.ApplicationRoleType:
-		err := r.credsMetadataSetter.SetTaskRoleMetadata(message)
+		err := r.credsMetadataSetter.SetTaskRoleCredentialsMetadata(message)
 		if err != nil {
 			return errors.Wrap(err, "failed to set task role metadata")
 		}
 	case credentials.ExecutionRoleType:
-		err := r.credsMetadataSetter.SetExecRoleMetadata(message)
+		err := r.credsMetadataSetter.SetExecRoleCredentialsMetadata(message)
 		if err != nil {
 			return errors.Wrap(err, "failed to set execution role metadata")
 		}

--- a/ecs-agent/acs/session/refresh_credentials_responder_test.go
+++ b/ecs-agent/acs/session/refresh_credentials_responder_test.go
@@ -164,12 +164,12 @@ func TestRefreshCredentialsAckHappyPath(t *testing.T) {
 			case credentials.ApplicationRoleType:
 				testMessage.RoleType = aws.String(credentials.ApplicationRoleType)
 				mockCredsMetadataSetter.EXPECT().
-					SetTaskRoleMetadata(gomock.Any()).
+					SetTaskRoleCredentialsMetadata(gomock.Any()).
 					Return(nil)
 			case credentials.ExecutionRoleType:
 				testMessage.RoleType = aws.String(credentials.ExecutionRoleType)
 				mockCredsMetadataSetter.EXPECT().
-					SetExecRoleMetadata(gomock.Any()).
+					SetExecRoleCredentialsMetadata(gomock.Any()).
 					Return(nil)
 			default:
 				t.Fatal("invalid role type used in happy path test, role type should be valid for happy path")
@@ -217,7 +217,7 @@ func TestRefreshCredentialsWhenUnableToSetCredentialsMetadata(t *testing.T) {
 	credentialsManager := credentials.NewManager()
 	mockCredsMetadataSetter := mock_session.NewMockCredentialsMetadataSetter(ctrl)
 	mockCredsMetadataSetter.EXPECT().
-		SetTaskRoleMetadata(gomock.Any()).
+		SetTaskRoleCredentialsMetadata(gomock.Any()).
 		Return(errors.Errorf("unable to set credentials metadata"))
 	mockMetricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
 	mockEntry := mock_metrics.NewMockEntry(ctrl)


### PR DESCRIPTION
### Summary
Changing the names of `CredentialsMetadataSetter` interface methods to be more specific in what they are doing.

### Implementation details
in `refresh_credentials_responder.go`: 
`SetTaskRoleMetadata` renamed to `SetTaskRoleCredentialsMetadata`
`SetExecRoleMetadata` renamed to `SetExecRoleCredentialsMetadata`

### Testing
`go mod tidy && go mod vendor` run in agent module
`make test` ran to completion with no failures.

New tests cover the changes: N/A

### Description for the changelog

Update interface naming in ACS refresh credentials responder 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
