### PR TITLE
Added the implementation for EBS Watcher for Windows

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_windows.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_windows.go
@@ -43,7 +43,6 @@ func ConfirmEBSVolumeIsAttached(ctx context.Context, deviceName string, volumeID
 	parsedOutput, err := parseExecutableOutput(output)
 	if err != nil {
 		errorMessage := fmt.Sprintf("failed to parse wmic output for volumeID: %s", volumeID)
-		log.Error(err, errorMessage)
 		return errors.Wrap(err, errorMessage)
 	}
 
@@ -51,7 +50,6 @@ func ConfirmEBSVolumeIsAttached(ctx context.Context, deviceName string, volumeID
 
 	if !strings.Contains(parsedOutput, volumeID) {
 		errorMessage := fmt.Sprintf("could not find volume with ID:%s", volumeID)
-		log.Error(errorMessage)
 		return errors.New(errorMessage)
 	}
 

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_windows.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_windows.go
@@ -1,0 +1,72 @@
+//go:build windows
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/pkg/errors"
+)
+
+const (
+	volumeDiscoveryTimeoutDuration = 5 * time.Second
+)
+
+func ConfirmEBSVolumeIsAttached(ctx context.Context, deviceName string, volumeID string) error {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, volumeDiscoveryTimeoutDuration)
+	defer cancel()
+	commandArguments := []string{"diskdrive", "where", fmt.Sprintf("SerialNumber like '%%%s%%'", volumeID), "get", "SerialNumber"}
+	output, err := exec.CommandContext(ctxWithTimeout, "wmic", commandArguments...).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to run wmic: %s", string(output))
+	}
+
+	parsedOutput, err := parseExecutableOutput(output)
+	if err != nil {
+		errorMessage := fmt.Sprintf("failed to parse wmic output for volumeID: %s", volumeID)
+		log.Error(err, errorMessage)
+		return errors.Wrap(err, errorMessage)
+	}
+
+	log.Info(fmt.Sprintf("found volume with parsed information as:%s", parsedOutput))
+
+	if !strings.Contains(parsedOutput, volumeID) {
+		errorMessage := fmt.Sprintf("could not find volume with ID:%s", volumeID)
+		log.Error(errorMessage)
+		return errors.New(errorMessage)
+	}
+
+	return nil
+}
+
+// parseExecutableOutput parses the output of `wmic` and returns the volume SerialNumber.
+func parseExecutableOutput(output []byte) (string, error) {
+	// The output of the wmic diskdrive where "SerialNumber like '%vol0123456789abdcef0%'" get SerialNumber,DeviceID,Description command looks like the following:
+	// SerialNumber
+	// vol0123456789abdcef0_00000001. - There is an 8-digit numeric identifier attached in the results.
+	out := string(output)
+	volumeInfo := strings.Fields(out)
+	if len(volumeInfo) != 2 {
+		return "", errors.New(fmt.Sprintf("cannot find the volume ID. Encountered error message: %s", out))
+	}
+	return volumeInfo[1], nil
+}

--- a/ecs-agent/api/resource/ebs_discovery_windows.go
+++ b/ecs-agent/api/resource/ebs_discovery_windows.go
@@ -1,0 +1,70 @@
+//go:build windows
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/pkg/errors"
+)
+
+const (
+	volumeDiscoveryTimeoutDuration = 5 * time.Second
+)
+
+func ConfirmEBSVolumeIsAttached(ctx context.Context, deviceName string, volumeID string) error {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, volumeDiscoveryTimeoutDuration)
+	defer cancel()
+	commandArguments := []string{"diskdrive", "where", fmt.Sprintf("SerialNumber like '%%%s%%'", volumeID), "get", "SerialNumber"}
+	output, err := exec.CommandContext(ctxWithTimeout, "wmic", commandArguments...).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to run wmic: %s", string(output))
+	}
+
+	parsedOutput, err := parseExecutableOutput(output)
+	if err != nil {
+		errorMessage := fmt.Sprintf("failed to parse wmic output for volumeID: %s", volumeID)
+		return errors.Wrap(err, errorMessage)
+	}
+
+	log.Info(fmt.Sprintf("found volume with parsed information as:%s", parsedOutput))
+
+	if !strings.Contains(parsedOutput, volumeID) {
+		errorMessage := fmt.Sprintf("could not find volume with ID:%s", volumeID)
+		return errors.New(errorMessage)
+	}
+
+	return nil
+}
+
+// parseExecutableOutput parses the output of `wmic` and returns the volume SerialNumber.
+func parseExecutableOutput(output []byte) (string, error) {
+	// The output of the wmic diskdrive where "SerialNumber like '%vol0123456789abdcef0%'" get SerialNumber,DeviceID,Description command looks like the following:
+	// SerialNumber
+	// vol0123456789abdcef0_00000001. - There is an 8-digit numeric identifier attached in the results.
+	out := string(output)
+	volumeInfo := strings.Fields(out)
+	if len(volumeInfo) != 2 {
+		return "", errors.New(fmt.Sprintf("cannot find the volume ID. Encountered error message: %s", out))
+	}
+	return volumeInfo[1], nil
+}

--- a/ecs-agent/api/resource/ebs_discovery_windows_test.go
+++ b/ecs-agent/api/resource/ebs_discovery_windows_test.go
@@ -1,0 +1,44 @@
+//go:build windows && unit
+// +build windows,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package resource
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testVolumeID = "vol-0a1234f3403277890"
+)
+
+func Test_parseExecutableOutput_HappyPath(t *testing.T) {
+	output := fmt.Sprintf("SerialNumber \n	%s_00000001.", testVolumeID)
+	parsedOutput, err := parseExecutableOutput([]byte(output))
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(parsedOutput, testVolumeID))
+}
+
+func Test_parseExecutableOutput_UnexpectedOutput(t *testing.T) {
+	output := "No Instance(s) Available."
+	parsedOutput, err := parseExecutableOutput([]byte(output))
+	require.Error(t, err, "cannot find the volume ID: %s", output)
+	assert.Equal(t, "", parsedOutput)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR adds the feature to detect an attached EBS volume for a EC2 Windows host.

### Implementation details
<!-- How are the changes implemented? -->

We used the `wmic` windows utility to detect the volume based on the volumeID. 

### Testing
<!-- How was this tested? -->
Two additional unit tests were added on how the `wmic` command output is handled by new code.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
Added the ability to detect EBS volumes on Windows.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
