### PR TITLE
Migrate Agent to use vpc-eni plugin for awsvpc mode instead of ecs-eni plugin on Linux

### DIFF
--- a/agent/api/task/task_linux.go
+++ b/agent/api/task/task_linux.go
@@ -275,7 +275,7 @@ func (task *Task) BuildCNIConfigAwsvpc(includeIPAMConfig bool, cniConfig *ecscni
 		// compatibility), consider it a "standard" ENI attachment.
 		case "", ni.DefaultInterfaceAssociationProtocol:
 			cniConfig.ID = eni.MacAddress
-			ifName, netconf, err = ecscni.NewENINetworkConfig(eni, cniConfig)
+			ifName, netconf, err = ecscni.NewVPCENINetworkConfig(eni, cniConfig)
 		case ni.VLANInterfaceAssociationProtocol:
 			cniConfig.ID = eni.MacAddress
 			ifName, netconf, err = ecscni.NewBranchENINetworkConfig(eni, cniConfig)

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -1319,13 +1319,13 @@ func TestBuildCNIConfigRegularENIWithAppMesh(t *testing.T) {
 			// ENI, Bridge and Appmesh
 			require.Len(t, cniConfig.NetworkConfigs, 3)
 			// The first one should be for the ENI.
-			var eniConfig ecscni.ENIConfig
+			var eniConfig ecscni.VPCENIPluginConfig
 			err = json.Unmarshal(cniConfig.NetworkConfigs[0].CNINetworkConfig.Bytes, &eniConfig)
 			require.NoError(t, err)
-			assert.Equal(t, mac, eniConfig.MACAddress, eniConfig)
-			assert.Equal(t, []string{ipv4 + ipv4Block, ipv6 + ipv6Block}, eniConfig.IPAddresses)
+			assert.Equal(t, mac, eniConfig.ENIMACAddress, eniConfig)
+			assert.Equal(t, []string{ipv4 + ipv4Block, ipv6 + ipv6Block}, eniConfig.ENIIPAddresses)
 			assert.Equal(t, []string{ipv4Gateway}, eniConfig.GatewayIPAddresses)
-			assert.Equal(t, blockIMDS, eniConfig.BlockInstanceMetadata)
+			assert.Equal(t, blockIMDS, eniConfig.BlockIMDS)
 			// The second one should be for the Bridge.
 			var bridgeConfig ecscni.BridgeConfig
 			err = json.Unmarshal(cniConfig.NetworkConfigs[1].CNINetworkConfig.Bytes, &bridgeConfig)
@@ -1365,13 +1365,13 @@ func TestBuildCNIConfigRegularENIWithServiceConnect(t *testing.T) {
 			// ENI, Bridge and ServiceConnect
 			require.Len(t, cniConfig.NetworkConfigs, 3)
 			// The first one should be for the ENI.
-			var eniConfig ecscni.ENIConfig
+			var eniConfig ecscni.VPCENIPluginConfig
 			err = json.Unmarshal(cniConfig.NetworkConfigs[0].CNINetworkConfig.Bytes, &eniConfig)
 			require.NoError(t, err)
-			assert.Equal(t, mac, eniConfig.MACAddress, eniConfig)
-			assert.Equal(t, []string{ipv4 + ipv4Block, ipv6 + ipv6Block}, eniConfig.IPAddresses)
+			assert.Equal(t, mac, eniConfig.ENIMACAddress, eniConfig)
+			assert.Equal(t, []string{ipv4 + ipv4Block, ipv6 + ipv6Block}, eniConfig.ENIIPAddresses)
 			assert.Equal(t, []string{ipv4Gateway}, eniConfig.GatewayIPAddresses)
-			assert.Equal(t, blockIMDS, eniConfig.BlockInstanceMetadata)
+			assert.Equal(t, blockIMDS, eniConfig.BlockIMDS)
 			// The second one should be for the Bridge.
 			var bridgeConfig ecscni.BridgeConfig
 			err = json.Unmarshal(cniConfig.NetworkConfigs[1].CNINetworkConfig.Bytes, &bridgeConfig)

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -596,12 +596,12 @@ func TestBuildCNIConfig(t *testing.T) {
 	// For the task ns setup.
 	err = json.Unmarshal(cniConfig.NetworkConfigs[0].CNINetworkConfig.Bytes, &eniConfig)
 	require.NoError(t, err)
-	assert.EqualValues(t, ecscni.ECSVPCENIPluginName, eniConfig.Type)
+	assert.EqualValues(t, ecscni.VPCENIPluginName, eniConfig.Type)
 	assert.False(t, eniConfig.UseExistingNetwork)
 	// For the ecs-bridge setup.
 	err = json.Unmarshal(cniConfig.NetworkConfigs[1].CNINetworkConfig.Bytes, &eniConfig)
 	require.NoError(t, err)
-	assert.EqualValues(t, ecscni.ECSVPCENIPluginName, eniConfig.Type)
+	assert.EqualValues(t, ecscni.VPCENIPluginName, eniConfig.Type)
 	assert.True(t, eniConfig.UseExistingNetwork)
 	assert.EqualValues(t, ecscni.ECSBridgeNetworkName, cniConfig.NetworkConfigs[1].CNINetworkConfig.Network.Name)
 }

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -219,11 +219,11 @@ func (agent *ecsAgent) appendFSxWindowsFileServerCapabilities(capabilities []*ec
 // doesn't contribute to placement decisions and just serves as additional
 // debugging information
 func (agent *ecsAgent) getTaskENIPluginVersionAttribute() (*ecs.Attribute, error) {
-	version, err := agent.cniClient.Version(ecscni.ECSENIPluginName)
+	version, err := agent.cniClient.Version(ecscni.VPCENIPluginName)
 	if err != nil {
 		seelog.Warnf(
 			"Unable to determine the version of the plugin '%s': %v",
-			ecscni.ECSENIPluginName, err)
+			ecscni.VPCENIPluginName, err)
 		return nil, err
 	}
 

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -86,7 +86,7 @@ func TestVolumeDriverCapabilitiesUnix(t *testing.T) {
 			dockerclient.Version_1_18,
 			dockerclient.Version_1_19,
 		}),
-		cniClient.EXPECT().Version(ecscni.ECSENIPluginName).Return("v1", nil),
+		cniClient.EXPECT().Version(ecscni.VPCENIPluginName).Return("v1", nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{"fancyvolumedriver"}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).Return(
@@ -326,7 +326,7 @@ func TestENITrunkingCapabilitiesUnix(t *testing.T) {
 		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 		}),
-		cniClient.EXPECT().Version(ecscni.ECSENIPluginName).Return("v1", nil),
+		cniClient.EXPECT().Version(ecscni.VPCENIPluginName).Return("v1", nil),
 		cniClient.EXPECT().Version(ecscni.ECSBranchENIPluginName).Return("v2", nil),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
@@ -415,7 +415,7 @@ func TestNoENITrunkingCapabilitiesUnix(t *testing.T) {
 		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 		}),
-		cniClient.EXPECT().Version(ecscni.ECSENIPluginName).Return("v1", nil),
+		cniClient.EXPECT().Version(ecscni.VPCENIPluginName).Return("v1", nil),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -117,14 +117,14 @@ func (agent *ecsAgent) appendFSxWindowsFileServerCapabilities(capabilities []*ec
 }
 
 // getTaskENIPluginVersionAttribute returns the version information of the ECS
-// CNI plugins. It just executes the ECSVPCENIPluginName plugin to get the Version information.
+// CNI plugins. It just executes the vpc-eni plugin to get the Version information.
 // Currently, only this plugin is used by ECS Windows for awsvpc mode.
 func (agent *ecsAgent) getTaskENIPluginVersionAttribute() (*ecs.Attribute, error) {
 	version, err := agent.cniClient.Version(ecscni.ECSVPCENIPluginExecutable)
 	if err != nil {
 		seelog.Warnf(
 			"Unable to determine the version of the plugin '%s': %v",
-			ecscni.ECSVPCENIPluginName, err)
+			ecscni.VPCENIPluginName, err)
 		return nil, err
 	}
 

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -44,7 +44,8 @@ const initPID = 1
 
 // awsVPCCNIPlugins is a list of CNI plugins required by the ECS Agent
 // to configure the ENI for a task
-var awsVPCCNIPlugins = []string{ecscni.ECSENIPluginName,
+var awsVPCCNIPlugins = []string{
+	ecscni.VPCENIPluginName,
 	ecscni.ECSBridgePluginName,
 	ecscni.ECSIPAMPluginName,
 	ecscni.ECSAppMeshPluginName,
@@ -100,7 +101,7 @@ func (agent *ecsAgent) initializeTaskENIDependencies(state dockerstate.TaskEngin
 // verifyCNIPluginsCapabilities returns an error if there's an error querying
 // capabilities or if the required capability is absent from the capabilities
 // of the following plugins:
-// a. ecs-eni
+// a. vpc-eni
 // b. ecs-bridge
 // c. ecs-ipam
 // d. aws-appmesh

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -122,7 +122,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 		mockMetadata.EXPECT().PrimaryENIMAC().Return(mac, nil),
 		mockMetadata.EXPECT().VPCID(mac).Return(vpcID, nil),
 		mockMetadata.EXPECT().SubnetID(mac).Return(subnetID, nil),
-		cniClient.EXPECT().Capabilities(ecscni.ECSENIPluginName).Return(cniCapabilities, nil),
+		cniClient.EXPECT().Capabilities(ecscni.VPCENIPluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSBridgePluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSIPAMPluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSAppMeshPluginName).Return(cniCapabilities, nil),
@@ -130,7 +130,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 		mockCredentialsProvider.EXPECT().Retrieve().Return(credentials.Value{}, nil),
 		dockerClient.EXPECT().SupportedVersions().Return(nil),
 		dockerClient.EXPECT().KnownVersions().Return(nil),
-		cniClient.EXPECT().Version(ecscni.ECSENIPluginName).Return("v1", nil),
+		cniClient.EXPECT().Version(ecscni.VPCENIPluginName).Return("v1", nil),
 		cniClient.EXPECT().Version(ecscni.ECSBranchENIPluginName).Return("v2", nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
@@ -288,7 +288,7 @@ func TestQueryCNIPluginsCapabilitiesHappyPath(t *testing.T) {
 	cniCapabilities := []string{ecscni.CapabilityAWSVPCNetworkingMode}
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
 	gomock.InOrder(
-		cniClient.EXPECT().Capabilities(ecscni.ECSENIPluginName).Return(cniCapabilities, nil),
+		cniClient.EXPECT().Capabilities(ecscni.VPCENIPluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSBridgePluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSIPAMPluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSAppMeshPluginName).Return(cniCapabilities, nil),
@@ -308,7 +308,7 @@ func TestQueryCNIPluginsCapabilitiesEmptyCapabilityListFromPlugin(t *testing.T) 
 	defer ctrl.Finish()
 
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
-	cniClient.EXPECT().Capabilities(ecscni.ECSENIPluginName).Return([]string{}, nil)
+	cniClient.EXPECT().Capabilities(ecscni.VPCENIPluginName).Return([]string{}, nil)
 
 	agent := &ecsAgent{
 		cniClient: cniClient,
@@ -324,7 +324,7 @@ func TestQueryCNIPluginsCapabilitiesMissAppMesh(t *testing.T) {
 	cniCapabilities := []string{ecscni.CapabilityAWSVPCNetworkingMode}
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
 	gomock.InOrder(
-		cniClient.EXPECT().Capabilities(ecscni.ECSENIPluginName).Return(cniCapabilities, nil),
+		cniClient.EXPECT().Capabilities(ecscni.VPCENIPluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSBridgePluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSIPAMPluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSAppMeshPluginName).Return(nil, errors.New("error")),
@@ -342,7 +342,7 @@ func TestQueryCNIPluginsCapabilitiesErrorGettingCapabilitiesFromPlugin(t *testin
 	defer ctrl.Finish()
 
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
-	cniClient.EXPECT().Capabilities(ecscni.ECSENIPluginName).Return(nil, errors.New("error"))
+	cniClient.EXPECT().Capabilities(ecscni.VPCENIPluginName).Return(nil, errors.New("error"))
 
 	agent := &ecsAgent{
 		cniClient: cniClient,
@@ -408,7 +408,7 @@ func TestInitializeTaskENIDependenciesQueryCNICapabilitiesError(t *testing.T) {
 		mockMetadata.EXPECT().PrimaryENIMAC().Return(mac, nil),
 		mockMetadata.EXPECT().VPCID(mac).Return(vpcID, nil),
 		mockMetadata.EXPECT().SubnetID(mac).Return(subnetID, nil),
-		cniClient.EXPECT().Capabilities(ecscni.ECSENIPluginName).Return([]string{}, nil),
+		cniClient.EXPECT().Capabilities(ecscni.VPCENIPluginName).Return([]string{}, nil),
 	)
 	agent := &ecsAgent{
 		ec2MetadataClient: mockMetadata,

--- a/agent/ecscni/netconfig_linux.go
+++ b/agent/ecscni/netconfig_linux.go
@@ -112,18 +112,17 @@ func newIPAMConfig(cfg *Config) (IPAMConfig, error) {
 	return ipamConfig, nil
 }
 
-// NewENINetworkConfig creates a new ENI CNI network configuration.
-func NewENINetworkConfig(eni *ni.NetworkInterface, cfg *Config) (string, *libcni.NetworkConfig, error) {
-	eniConf := ENIConfig{
-		Type:                  ECSENIPluginName,
-		ENIID:                 eni.ID,
-		MACAddress:            eni.MacAddress,
-		IPAddresses:           eni.GetIPAddressesWithPrefixLength(),
-		GatewayIPAddresses:    []string{eni.GetSubnetGatewayIPv4Address()},
-		BlockInstanceMetadata: cfg.BlockInstanceMetadata,
+// NewVPCENINetworkConfig creates a new vpc-eni CNI plugin configuration.
+func NewVPCENINetworkConfig(eni *ni.NetworkInterface, cfg *Config) (string, *libcni.NetworkConfig, error) {
+	eniConf := VPCENIPluginConfig{
+		Type:               VPCENIPluginName,
+		ENIMACAddress:      eni.MacAddress,
+		ENIIPAddresses:     eni.GetIPAddressesWithPrefixLength(),
+		GatewayIPAddresses: []string{eni.GetSubnetGatewayIPv4Address()},
+		BlockIMDS:          cfg.BlockInstanceMetadata,
 	}
 
-	networkConfig, err := newNetworkConfig(eniConf, ECSENIPluginName, cfg.MinSupportedCNIVersion)
+	networkConfig, err := newNetworkConfig(eniConf, VPCENIPluginName, cfg.MinSupportedCNIVersion)
 	if err != nil {
 		return "", nil, fmt.Errorf("cni config: failed to create configuration: %w", err)
 	}

--- a/agent/ecscni/netconfig_windows.go
+++ b/agent/ecscni/netconfig_windows.go
@@ -50,7 +50,7 @@ func NewVPCENIPluginConfigForTaskNSSetup(eni *ni.NetworkInterface, cfg *Config) 
 	}
 
 	eniConf := VPCENIPluginConfig{
-		Type:               ECSVPCENIPluginName,
+		Type:               VPCENIPluginName,
 		DNS:                dns,
 		ENIName:            eni.GetLinkName(),
 		ENIMACAddress:      eni.MacAddress,
@@ -72,7 +72,7 @@ func NewVPCENIPluginConfigForTaskNSSetup(eni *ni.NetworkInterface, cfg *Config) 
 // NewVPCENIPluginConfigForECSBridgeSetup creates the configuration required by vpc-eni plugin to setup ecs-bridge endpoint for the task.
 func NewVPCENIPluginConfigForECSBridgeSetup(cfg *Config) (*libcni.NetworkConfig, error) {
 	bridgeConf := VPCENIPluginConfig{
-		Type:               ECSVPCENIPluginName,
+		Type:               VPCENIPluginName,
 		UseExistingNetwork: true,
 		BlockIMDS:          cfg.BlockInstanceMetadata,
 	}

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -30,7 +30,7 @@ const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated.
 	currentECSCNIVersion = "2020.09.0"
 	currentECSCNIGitHash = "53a8481891251e66e35847554d52a13fc7c4fd03"
-	currentVPCCNIGitHash = "a83b66349768e020487a00e31767fc2e6fc88136"
+	currentVPCCNIGitHash = "be5214353252f8315a1341f4df9ffbd8cf69000c"
 )
 
 // Asserts that CNI plugin version matches the expected version

--- a/agent/ecscni/plugin_windows_test.go
+++ b/agent/ecscni/plugin_windows_test.go
@@ -205,7 +205,7 @@ func TestConstructNetworkConfig(t *testing.T) {
 
 	subnet := strings.Split(eniSubnetGatewayIPV4Address, "/")
 	ipv4Addr := fmt.Sprintf("%s/%s", taskENI.GetPrimaryIPv4Address(), subnet[1])
-	assert.Equal(t, ECSVPCENIPluginName, taskENIConfig.Type)
+	assert.Equal(t, VPCENIPluginName, taskENIConfig.Type)
 	assert.Equal(t, TaskHNSNetworkNamePrefix, config.NetworkConfigs[0].CNINetworkConfig.Network.Name)
 	assert.Equal(t, eniID, taskENIConfig.ENIName)
 	assert.EqualValues(t, []string{ipv4Addr}, taskENIConfig.ENIIPAddresses)
@@ -217,7 +217,7 @@ func TestConstructNetworkConfig(t *testing.T) {
 	ecsBridgeConfig := &VPCENIPluginConfig{}
 	err = json.Unmarshal(config.NetworkConfigs[1].CNINetworkConfig.Bytes, ecsBridgeConfig)
 	require.NoError(t, err, "unmarshal ecs-bridge config from bytes failed")
-	assert.Equal(t, ECSVPCENIPluginName, ecsBridgeConfig.Type)
+	assert.Equal(t, VPCENIPluginName, ecsBridgeConfig.Type)
 	assert.Equal(t, ECSBridgeNetworkName, config.NetworkConfigs[1].CNINetworkConfig.Network.Name)
 	assert.True(t, ecsBridgeConfig.UseExistingNetwork)
 }

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -34,6 +34,8 @@ const (
 	// present in the output of the '--capabilities' command of a CNI plugin
 	// indicates that the plugin can support the ECS "awsvpc" network mode
 	CapabilityAWSVPCNetworkingMode = "awsvpc-network-mode"
+	// VPCENIPluginName is the binary of the vpc-eni plugin
+	VPCENIPluginName = "vpc-eni"
 )
 
 // Config contains all the information to set up the container namespace using

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -15,6 +15,7 @@ package ecscni
 
 import (
 	"github.com/containernetworking/cni/libcni"
+	"github.com/containernetworking/cni/pkg/types"
 	cniTypes "github.com/containernetworking/cni/pkg/types"
 )
 
@@ -75,4 +76,26 @@ type NetworkConfig struct {
 	IfName string
 	// CNINetworkConfig is the network configuration required to invoke the CNI plugin
 	CNINetworkConfig *libcni.NetworkConfig
+}
+
+// VPCENIPluginConfig contains all the information required to invoke the vpc-eni plugin.
+type VPCENIPluginConfig struct {
+	// Type is the cni plugin name.
+	Type string `json:"type,omitempty"`
+	// CNIVersion is the cni spec version to use.
+	CNIVersion string `json:"cniVersion,omitempty"`
+	// DNS is used to pass DNS information to the plugin.
+	DNS types.DNS `json:"dns"`
+	// ENIName is the name of the eni on the instance.
+	ENIName string `json:"eniName"`
+	// ENIMACAddress is the MAC address of the eni.
+	ENIMACAddress string `json:"eniMACAddress"`
+	// ENIIPAddresses is the is the ipv4 of eni.
+	ENIIPAddresses []string `json:"eniIPAddresses"`
+	// GatewayIPAddresses specifies the IPv4 address of the subnet gateway for the eni.
+	GatewayIPAddresses []string `json:"gatewayIPAddresses"`
+	// UseExistingNetwork specifies if existing network should be used instead of creating a new one.
+	UseExistingNetwork bool `json:"useExistingNetwork"`
+	// BlockIMDS specifies if the IMDS should be blocked for the created endpoint.
+	BlockIMDS bool `json:"blockInstanceMetadata"`
 }

--- a/agent/ecscni/types_linux.go
+++ b/agent/ecscni/types_linux.go
@@ -38,8 +38,6 @@ const (
 	ECSIPAMPluginName = "ecs-ipam"
 	// ECSBridgePluginName is the binary of the bridge plugin
 	ECSBridgePluginName = "ecs-bridge"
-	// VPCENIPluginName is the binary of the vpc-eni plugin
-	VPCENIPluginName = "vpc-eni"
 	// ECSAppMeshPluginName is the binary of aws-appmesh plugin
 	ECSAppMeshPluginName = "aws-appmesh"
 	// ECSBranchENIPluginName is the binary of the branch-eni plugin

--- a/agent/ecscni/types_linux.go
+++ b/agent/ecscni/types_linux.go
@@ -38,8 +38,8 @@ const (
 	ECSIPAMPluginName = "ecs-ipam"
 	// ECSBridgePluginName is the binary of the bridge plugin
 	ECSBridgePluginName = "ecs-bridge"
-	// ECSENIPluginName is the binary of the eni plugin
-	ECSENIPluginName = "ecs-eni"
+	// VPCENIPluginName is the binary of the vpc-eni plugin
+	VPCENIPluginName = "vpc-eni"
 	// ECSAppMeshPluginName is the binary of aws-appmesh plugin
 	ECSAppMeshPluginName = "aws-appmesh"
 	// ECSBranchENIPluginName is the binary of the branch-eni plugin
@@ -105,24 +105,6 @@ type BridgeConfig struct {
 	HairpinMode bool `json:"hairpinMode"`
 	// IPAM is the configuration to acquire ip/route from ipam plugin
 	IPAM IPAMConfig `json:"ipam,omitempty"`
-}
-
-// ENIConfig contains all the information needed to invoke the eni plugin
-type ENIConfig struct {
-	// Type is the cni plugin name
-	Type string `json:"type,omitempty"`
-	// CNIVersion is the cni spec version to use
-	CNIVersion string `json:"cniVersion,omitempty"`
-	// ENIID is the id of ec2 eni
-	ENIID string `json:"eni"`
-	// MacAddress is the mac address of eni
-	MACAddress string `json:"mac"`
-	// IPAddresses contains the ip addresses of the ENI.
-	IPAddresses []string `json:"ip-addresses"`
-	// GatewayIPAddresses specifies the addresses of the subnet gateway for the ENI.
-	GatewayIPAddresses []string `json:"gateway-ip-addresses"`
-	// BlockInstanceMetadata specifies if InstanceMetadata endpoint should be blocked
-	BlockInstanceMetadata bool `json:"block-instance-metadata"`
 }
 
 // AppMeshConfig contains all the information needed to invoke the app mesh plugin

--- a/agent/ecscni/types_windows.go
+++ b/agent/ecscni/types_windows.go
@@ -18,13 +18,9 @@ package ecscni
 
 import (
 	"time"
-
-	"github.com/containernetworking/cni/pkg/types"
 )
 
 const (
-	// ECSVPCENIPluginName is the name of the vpc-eni plugin.
-	ECSVPCENIPluginName = "vpc-eni"
 	// ECSVPCENIPluginExecutable is the name of vpc-eni executable.
 	ECSVPCENIPluginExecutable = "vpc-eni.exe"
 	// TaskHNSNetworkNamePrefix is the prefix of the HNS network used for task ENI.
@@ -48,26 +44,3 @@ var (
 	setupNSBackoffMultiple = 2.0
 	setupNSMaxRetryCount   = 5
 )
-
-// VPCENIPluginConfig contains all the information required to invoke the vpc-eni plugin.
-type VPCENIPluginConfig struct {
-	// Type is the cni plugin name.
-	Type string `json:"type,omitempty"`
-	// CNIVersion is the cni spec version to use.
-	CNIVersion string `json:"cniVersion,omitempty"`
-	// DNS is used to pass DNS information to the plugin.
-	DNS types.DNS `json:"dns"`
-
-	// ENIName is the name of the eni on the instance.
-	ENIName string `json:"eniName"`
-	// ENIMACAddress is the MAC address of the eni.
-	ENIMACAddress string `json:"eniMACAddress"`
-	// ENIIPAddresses is the is the ipv4 of eni.
-	ENIIPAddresses []string `json:"eniIPAddresses"`
-	// GatewayIPAddresses specifies the IPv4 address of the subnet gateway for the eni.
-	GatewayIPAddresses []string `json:"gatewayIPAddresses"`
-	// UseExistingNetwork specifies if existing network should be used instead of creating a new one.
-	UseExistingNetwork bool `json:"useExistingNetwork"`
-	// BlockIMDS specifies if the IMDS should be blocked for the created endpoint.
-	BlockIMDS bool `json:"blockInstanceMetadata"`
-}

--- a/scripts/build-agent-image
+++ b/scripts/build-agent-image
@@ -45,7 +45,7 @@ if [ "$architecture" == "arm64" ]; then export GOARCH=arm64; fi
 mkdir -p rootfs/amazon-ecs-cni-plugins/
 cp ./misc/plugins/aws-appmesh rootfs/amazon-ecs-cni-plugins/aws-appmesh
 cp ./misc/plugins/ecs-bridge rootfs/amazon-ecs-cni-plugins/ecs-bridge
-cp ./misc/plugins/ecs-eni rootfs/amazon-ecs-cni-plugins/ecs-eni
+cp ./misc/plugins/vpc-eni rootfs/amazon-ecs-cni-plugins/vpc-eni
 cp ./misc/plugins/ecs-ipam rootfs/amazon-ecs-cni-plugins/ecs-ipam
 cp ./misc/plugins/vpc-branch-eni rootfs/amazon-ecs-cni-plugins/vpc-branch-eni
 cp ./misc/plugins/ecs-serviceconnect rootfs/amazon-ecs-cni-plugins/ecs-serviceconnect

--- a/scripts/build-cni-plugins
+++ b/scripts/build-cni-plugins
@@ -61,9 +61,9 @@ make clean
 
 # buildvcs=false excludes version control information in golang >= 1.18. This is required for compiling agent with included repositories
 if [[ $goversion < "1.18" ]]; then
-	cd ${GITPATH}/amazon-vpc-cni-plugins && GO111MODULE=on GOFLAGS="-mod=vendor" make aws-appmesh vpc-branch-eni ecs-serviceconnect
+	cd ${GITPATH}/amazon-vpc-cni-plugins && GO111MODULE=on GOFLAGS="-mod=vendor" make aws-appmesh vpc-branch-eni ecs-serviceconnect vpc-eni
 else
-	cd ${GITPATH}/amazon-vpc-cni-plugins && GO111MODULE=on GOFLAGS="-mod=vendor -buildvcs=false" make aws-appmesh vpc-branch-eni ecs-serviceconnect
+	cd ${GITPATH}/amazon-vpc-cni-plugins && GO111MODULE=on GOFLAGS="-mod=vendor -buildvcs=false" make aws-appmesh vpc-branch-eni ecs-serviceconnect vpc-eni
 fi
 cp -a ./build/linux_${GOARCH}/. ${ROOT}/misc/plugins/
 make clean

--- a/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
@@ -26,4 +26,4 @@ RUN mkdir -p /go/src/github.com/aws/
 
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-plugins
 
-CMD ["make", "aws-appmesh", "vpc-branch-eni", "ecs-serviceconnect"]
+CMD ["make", "vpc-eni", "aws-appmesh", "vpc-branch-eni", "ecs-serviceconnect"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
We recently added Linux support to vpc-eni CNI plugin (https://github.com/aws/amazon-vpc-cni-plugins/pull/101). So, vpc-eni plugin is now capable of setting up network for awsvpc tasks on Linux rendering the currently used ecs-eni plugin redundant. Agent on Windows already uses vpc-eni plugin to set up task network for awsvpc mode.

This PR updates vpc-cni submodule in this repository to [be5214353252f8315a1341f4df9ffbd8cf69000c](https://github.com/aws/amazon-vpc-cni-plugins/commit/be5214353252f8315a1341f4df9ffbd8cf69000c) from [a83b66349768e020487a00e31767fc2e6fc88136](https://github.com/aws/amazon-vpc-cni-plugins/commit/a83b66349768e020487a00e31767fc2e6fc88136) ([diff](https://github.com/aws/amazon-vpc-cni-plugins/compare/a83b66349768e020487a00e31767fc2e6fc88136...be5214353252f8315a1341f4df9ffbd8cf69000c)) and makes Agent use vpc-eni plugin for awsvpc tasks on Linux so that the same plugin is used to setup awsvpc network across Windows and Linux platforms. 

There is no change in functionality.

### Implementation details
<!-- How are the changes implemented? -->
Agent code changes -
* `NewENINetworkConfig` function that is used to create a CNI configuration for ecs-eni plugin for Linux in `agent/ecscni/netconfig_linux.go` file has been replaced with `NewVPCENINetworkConfig` function that creates a CNI configuration for vpc-eni plugin. Function call to build CNI configuration for awsvpc mode for Linux (for environments with ENI Trunking disabled) in `BuildCNIConfigAwsvpc` function in `task_linux.go` file is changed accordingly.
* The configuration for vpc-eni plugin is very similar to that of ecs-eni plugin. Main differences are in the field names.
* Configuration struct for vpc-eni plugin is moved out of Windows specific `ecscni/types_windows.go` file to the more general `ecscni/types.go` file so that the same configuration struct can be used for both Windows and Linux. 
* Constant `ECSVPCENIPluginName` for the name of vpc-eni plugin is removed from `ecscni/types_windows.go` file and is replaced with a new `VPCENIPluginName` constant in `ecscni/types.go` file.
* Configuration struct and constant for the name of for ecs-eni plugin are removed from `ecscni/types_linux.go` file as they are now unused.
* Rest of the changes are just reference and test updates. 

Build script changes - 
* `scripts/build-cni-plugins` script is updated to include building `vpc-eni` plugin.
* `scripts/build-agent-image` script is updated to copy `vpc-eni` plugin instead of `ecs-eni` plugin to Agent image. 
* `scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins` Dockerfile is updated to include building `vpc-eni` plugin.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
A new functional test was added for testing awsvpc mode on Linux for instances with ENI trunking disabled. 

Comprehensive manual testing was done - 
* Tested that security group changes to task ENI are reflected dynamically.
* Tested that IMDS access over IPv4 and IPv6 is blocked for tasks when configuration instructs.
* Tested that containers in the same task are able to communicate with each other over localhost.
* Tested that logs from vpc-eni plugin are collected. 
* Tested that an awsvpc task is reachable over its IPv4 and IPv6 addresses.
* Tested that task is able to reach Agent Task Metadata Endpoint and Credentials Endpoint. 
* Tested that an awsvpc task registered to an Application Load Balancer is reachable through the Load Balancer public IP. 
* Tested that Service Connect ingress and egress metrics are updated in CloudWatch for Service Connect clients and servers. 
* Tested that a test app built with AppMesh works as expected.
* Tested that network metrics are returned by Task Metadata Endpoint for awsvpc tasks. 
* Tested that network metrics for task's ENI are updated in CloudWatch.
* Tested that Agent cleans up task network namespaces. 
* Tested that Agent restarts do not impact network setup and handling.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Migrate Agent to use vpc-eni plugin for awsvpc mode instead of ecs-eni plugin on Linux

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
