### PR TITLE
Model transformer: model reconciliation for agent upgrades

### DIFF
--- a/agent/data/client.go
+++ b/agent/data/client.go
@@ -135,7 +135,7 @@ func setup(dataDir string) (*client, error) {
 	})
 
 	// create transformer
-	transformer := modeltransformer.NewTransFormer()
+	transformer := modeltransformer.NewTransformer()
 
 	// registering task transformation functions
 	transformationfunctions.RegisterTaskTransformationFunctions(transformer)

--- a/agent/data/client.go
+++ b/agent/data/client.go
@@ -19,7 +19,9 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/data/transformationfunctions"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/modeltransformer"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	bolt "go.etcd.io/bbolt"
 )
@@ -33,6 +35,7 @@ const (
 	imagesBucketName         = "images"
 	eniAttachmentsBucketName = "eniattachments"
 	metadataBucketName       = "metadata"
+	emptyAgentVersionMsg     = "No version info available in boltDB. Either this is a fresh instance, or we were using state file to persist data. Transformer not applicable."
 )
 
 var (
@@ -94,7 +97,8 @@ type Client interface {
 
 // client implements the Client interface using boltdb as the backing data store.
 type client struct {
-	db *bolt.DB
+	db          *bolt.DB
+	transformer *modeltransformer.Transformer
 }
 
 // New returns a data client that implements the Client interface with boltdb.
@@ -115,7 +119,8 @@ func NewWithSetup(dataDir string) (Client, error) {
 	return setup(dataDir)
 }
 
-// setup initiates the boltdb client and makes sure the buckets we use are created.
+// setup initiates the boltdb client and makes sure the buckets we use and transformer are created, and
+// registers transformation functions to transformer.
 func setup(dataDir string) (*client, error) {
 	db, err := bolt.Open(filepath.Join(dataDir, dbName), dbMode, nil)
 	err = db.Update(func(tx *bolt.Tx) error {
@@ -128,11 +133,19 @@ func setup(dataDir string) (*client, error) {
 
 		return nil
 	})
+
+	// create transformer
+	transformer := modeltransformer.NewTransFormer()
+
+	// registering task transformation functions
+	transformationfunctions.RegisterTaskTransformationFunctions(transformer)
+
 	if err != nil {
 		return nil, err
 	}
 	return &client{
-		db: db,
+		db:          db,
+		transformer: transformer,
 	}, nil
 }
 

--- a/agent/data/client_test.go
+++ b/agent/data/client_test.go
@@ -30,7 +30,7 @@ func newTestClient(t *testing.T) Client {
 	testDir := t.TempDir()
 
 	testDB, err := bolt.Open(filepath.Join(testDir, dbName), dbMode, nil)
-	transformer := modeltransformer.NewTransFormer()
+	transformer := modeltransformer.NewTransformer()
 	require.NoError(t, err)
 	require.NoError(t, testDB.Update(func(tx *bolt.Tx) error {
 		for _, b := range buckets {

--- a/agent/data/models/task_models.go
+++ b/agent/data/models/task_models.go
@@ -1,0 +1,115 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//lint:file-ignore U1000 Ignore unused fields as some of them are only used by Fargate
+
+package models
+
+import (
+	"sync"
+	"time"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+	"github.com/aws/amazon-ecs-agent/agent/api/task"
+	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	resourcetype "github.com/aws/amazon-ecs-agent/agent/taskresource/types"
+	nlappmesh "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
+)
+
+// Task_1_0_0 is "the original model" before model transformer is created.
+type Task_1_0_0 struct {
+	Arn                                    string
+	id                                     string
+	Overrides                              task.TaskOverrides `json:"-"`
+	Family                                 string
+	Version                                string
+	ServiceName                            string
+	Containers                             []*apicontainer.Container
+	Associations                           []task.Association        `json:"associations"`
+	ResourcesMapUnsafe                     resourcetype.ResourcesMap `json:"resources"`
+	Volumes                                []task.TaskVolume         `json:"volumes"`
+	CPU                                    float64                   `json:"Cpu,omitempty"`
+	Memory                                 int64                     `json:"Memory,omitempty"`
+	DesiredStatusUnsafe                    apitaskstatus.TaskStatus  `json:"DesiredStatus"`
+	KnownStatusUnsafe                      apitaskstatus.TaskStatus  `json:"KnownStatus"`
+	KnownStatusTimeUnsafe                  time.Time                 `json:"KnownTime"`
+	PullStartedAtUnsafe                    time.Time                 `json:"PullStartedAt"`
+	PullStoppedAtUnsafe                    time.Time                 `json:"PullStoppedAt"`
+	ExecutionStoppedAtUnsafe               time.Time                 `json:"ExecutionStoppedAt"`
+	SentStatusUnsafe                       apitaskstatus.TaskStatus  `json:"SentStatus"`
+	ExecutionCredentialsID                 string                    `json:"executionCredentialsID"`
+	credentialsID                          string
+	credentialsRelativeURIUnsafe           string
+	ENIs                                   task.TaskENIs `json:"ENI"`
+	AppMesh                                *nlappmesh.AppMesh
+	MemoryCPULimitsEnabled                 bool                `json:"MemoryCPULimitsEnabled,omitempty"`
+	PlatformFields                         task.PlatformFields `json:"PlatformFields,omitempty"`
+	terminalReason                         string
+	terminalReasonOnce                     sync.Once
+	PIDMode                                string `json:"PidMode,omitempty"`
+	IPCMode                                string `json:"IpcMode,omitempty"`
+	NvidiaRuntime                          string `json:"NvidiaRuntime,omitempty"`
+	LocalIPAddressUnsafe                   string `json:"LocalIPAddress,omitempty"`
+	LaunchType                             string `json:"LaunchType,omitempty"`
+	lock                                   sync.RWMutex
+	setIdOnce                              sync.Once
+	ServiceConnectConfig                   *serviceconnect.Config `json:"ServiceConnectConfig,omitempty"`
+	ServiceConnectConnectionDrainingUnsafe bool                   `json:"ServiceConnectConnectionDraining,omitempty"`
+	NetworkMode                            string                 `json:"NetworkMode,omitempty"`
+	IsInternal                             bool                   `json:"IsInternal,omitempty"`
+}
+
+// Task_1_x_0 is an example new model with breaking change. Latest Task_1_x_0 should be the same as current Task model.
+// TODO: update this model when introducing first actual transformation function
+type Task_1_x_0 struct {
+	Arn                                    string
+	id                                     string
+	Overrides                              task.TaskOverrides `json:"-"`
+	Family                                 string
+	Version                                string
+	ServiceName                            string
+	Containers                             []*apicontainer.Container
+	Associations                           []task.Association        `json:"associations"`
+	ResourcesMapUnsafe                     resourcetype.ResourcesMap `json:"resources"`
+	Volumes                                []task.TaskVolume         `json:"volumes"`
+	CPU                                    float64                   `json:"Cpu,omitempty"`
+	Memory                                 int64                     `json:"Memory,omitempty"`
+	DesiredStatusUnsafe                    apitaskstatus.TaskStatus  `json:"DesiredStatus"`
+	KnownStatusUnsafe                      apitaskstatus.TaskStatus  `json:"KnownStatus"`
+	KnownStatusTimeUnsafe                  time.Time                 `json:"KnownTime"`
+	PullStartedAtUnsafe                    time.Time                 `json:"PullStartedAt"`
+	PullStoppedAtUnsafe                    time.Time                 `json:"PullStoppedAt"`
+	ExecutionStoppedAtUnsafe               time.Time                 `json:"ExecutionStoppedAt"`
+	SentStatusUnsafe                       apitaskstatus.TaskStatus  `json:"SentStatus"`
+	ExecutionCredentialsID                 string                    `json:"executionCredentialsID"`
+	credentialsID                          string
+	credentialsRelativeURIUnsafe           string
+	NetworkInterfaces                      task.TaskENIs `json:"NetworkInterfaces"`
+	AppMesh                                *nlappmesh.AppMesh
+	MemoryCPULimitsEnabled                 bool                `json:"MemoryCPULimitsEnabled,omitempty"`
+	PlatformFields                         task.PlatformFields `json:"PlatformFields,omitempty"`
+	terminalReason                         string
+	terminalReasonOnce                     sync.Once
+	PIDMode                                string `json:"PidMode,omitempty"`
+	IPCMode                                string `json:"IpcMode,omitempty"`
+	NvidiaRuntime                          string `json:"NvidiaRuntime,omitempty"`
+	LocalIPAddressUnsafe                   string `json:"LocalIPAddress,omitempty"`
+	LaunchType                             string `json:"LaunchType,omitempty"`
+	lock                                   sync.RWMutex
+	setIdOnce                              sync.Once
+	ServiceConnectConfig                   *serviceconnect.Config `json:"ServiceConnectConfig,omitempty"`
+	ServiceConnectConnectionDrainingUnsafe bool                   `json:"ServiceConnectConnectionDraining,omitempty"`
+	NetworkMode                            string                 `json:"NetworkMode,omitempty"`
+	IsInternal                             bool                   `json:"IsInternal,omitempty"`
+}

--- a/agent/data/transformationfunctions/tasktf.go
+++ b/agent/data/transformationfunctions/tasktf.go
@@ -1,0 +1,69 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package transformationfunctions
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/amazon-ecs-agent/agent/data/models"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/modeltransformer"
+)
+
+// RegisterTaskTransformationFunctions calls all registerTaskTransformationFunctions<x_y_z> in ascending order.
+// (from lower threshold version to higher threshold version) thresholdVersion is the version we introduce a breaking change in.
+// All versions below threshold version need to go through that specific transformation function
+func RegisterTaskTransformationFunctions(t *modeltransformer.Transformer) {
+	registerTaskTransformationFunction1_x_0(t)
+}
+
+// registerTaskTransformationFunction1_x_0 is a template RegisterTaskTransformation function.
+// It registers the transformation functions that translate the task model from models.Task_1_0_0 to models.Task_1_x_0
+// Future addition to transformation functions should follow the same pattern. This current performs noop
+// TODO: edit this function when introducing first actual transformation function, and add unit test
+func registerTaskTransformationFunction1_x_0(t *modeltransformer.Transformer) {
+	thresholdVersion := "1.0.0" // this assures it never actually gets executed
+	t.AddTaskTransformationFunctions(thresholdVersion, func(dataIn []byte) ([]byte, error) {
+		logger.Info(fmt.Sprintf("Executing transformation function with threshold %s.", thresholdVersion))
+		oldModel := models.Task_1_0_0{}
+		newModel := models.Task_1_x_0{}
+		var intermediate map[string]interface{}
+
+		// Load json to old model (so that we can capture some fields before it is deleted)
+		err := json.Unmarshal(dataIn, &oldModel)
+		if err != nil {
+			return nil, err
+		}
+
+		// Load json to intermediate model to process
+		err = json.Unmarshal(dataIn, &intermediate)
+		if err != nil {
+			return nil, err
+		}
+
+		// Actual process to process
+		delete(intermediate, "ENIs")
+		modifiedJSON, err := json.Marshal(intermediate)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(modifiedJSON, &newModel)
+		newModel.NetworkInterfaces = oldModel.ENIs
+		dataOut, err := json.Marshal(&newModel)
+		logger.Info(fmt.Sprintf("Transform associated with version %s finished.", thresholdVersion))
+		return dataOut, err
+	})
+	logger.Info(fmt.Sprintf("Registered transformation function with threshold %s.", thresholdVersion))
+}

--- a/agent/data/transformationfunctions/tasktf_test.go
+++ b/agent/data/transformationfunctions/tasktf_test.go
@@ -14,41 +14,22 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package data
+package transformationfunctions
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/modeltransformer"
 
-	"github.com/stretchr/testify/require"
-	bolt "go.etcd.io/bbolt"
+	"github.com/stretchr/testify/assert"
 )
 
-func newTestClient(t *testing.T) Client {
-	testDir := t.TempDir()
+const (
+	expectedTaskTransformationChainLength = 1
+)
 
-	testDB, err := bolt.Open(filepath.Join(testDir, dbName), dbMode, nil)
+func TestRegisterTaskTransformationFunctions(t *testing.T) {
 	transformer := modeltransformer.NewTransFormer()
-	require.NoError(t, err)
-	require.NoError(t, testDB.Update(func(tx *bolt.Tx) error {
-		for _, b := range buckets {
-			_, err = tx.CreateBucketIfNotExists([]byte(b))
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}))
-	testClient := &client{
-		db:          testDB,
-		transformer: transformer,
-	}
-
-	t.Cleanup(func() {
-		require.NoError(t, testClient.Close())
-	})
-	return testClient
+	RegisterTaskTransformationFunctions(transformer)
+	assert.Equal(t, expectedTaskTransformationChainLength, transformer.GetNumberOfTransformationFunctions("Task"))
 }

--- a/agent/data/transformationfunctions/tasktf_test.go
+++ b/agent/data/transformationfunctions/tasktf_test.go
@@ -29,7 +29,7 @@ const (
 )
 
 func TestRegisterTaskTransformationFunctions(t *testing.T) {
-	transformer := modeltransformer.NewTransFormer()
+	transformer := modeltransformer.NewTransformer()
 	RegisterTaskTransformationFunctions(transformer)
 	assert.Equal(t, expectedTaskTransformationChainLength, transformer.GetNumberOfTransformationFunctions("Task"))
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/modeltransformer/transformer.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/modeltransformer/transformer.go
@@ -1,0 +1,108 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package modeltransformer
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+)
+
+const (
+	modelTypeTask = "Task"
+)
+
+// Transformer stores transformation functions for all types of objects.
+// Transform<type> will execute a series of transformation functions to make it compatible with current agent version.
+// add<type>TransformationFunctions will add more <type> transformation functions to the transformation functions chain.
+// Add other transformation functions as needed. e.g. ContainerTransformationFunctions.
+// Add corresponding Transform<Type> and Add<Type>TransformationFunctions while adding other transformation functions.
+type Transformer struct {
+	taskTransformFunctions []*TransformFunc
+}
+
+// TransformFunc contains the threshold version string for transformation function and the transformationFunction itself.
+// During upgrade, all models from versions below threshold version should execute the transformation function.
+type TransformFunc struct {
+	version  string
+	function interface{}
+}
+
+func NewTransFormer() *Transformer {
+	t := &Transformer{}
+	return t
+}
+
+// GetNumberOfTransformationFunctions returns the number of transformation functions given a model type
+func (t *Transformer) GetNumberOfTransformationFunctions(modelType string) int {
+	switch modelType {
+	case modelTypeTask:
+		return len(t.taskTransformFunctions)
+	default:
+		return 0
+	}
+}
+
+// TransformTask executes the transformation functions when version associated with model in boltdb is below the
+func (t *Transformer) TransformTask(version string, data []byte) ([]byte, error) {
+	var err error
+	// execute transformation functions sequentially and skip those not applicable
+	for _, transformFunc := range t.taskTransformFunctions {
+		if closure, ok := transformFunc.function.(func([]byte) ([]byte, error)); ok {
+			if checkVersionSmaller(version, transformFunc.version) {
+				logger.Info(fmt.Sprintf("Agent version associated with task model in boltdb %s is below threshold %s. Transformation needed.", version, transformFunc.version))
+				data, err = closure(data)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				logger.Info(fmt.Sprintf("Agent version associated with task model in boltdb %s is bigger or equal to threshold %s. Skipping transformation.", version, transformFunc.version))
+				continue
+			}
+		} else {
+			return nil, fmt.Errorf("transformation function for version %s is not valid", transformFunc.version)
+		}
+	}
+	return data, err
+}
+
+// AddTaskTransformationFunctions adds the transformationFunction to the handling chain
+func (t *Transformer) AddTaskTransformationFunctions(version string, transformationFunc interface{}) {
+	t.taskTransformFunctions = append(t.taskTransformFunctions, &TransformFunc{
+		version:  version,
+		function: transformationFunc,
+	})
+}
+
+// IsUpgrade checks whether the load of a persisted model to running agent is an upgrade
+func (t *Transformer) IsUpgrade(runningAgentVersion, persistedAgentVersion string) bool {
+	return checkVersionSmaller(persistedAgentVersion, runningAgentVersion)
+}
+
+func checkVersionSmaller(version, threshold string) bool {
+	versionParams := strings.Split(version, ".")
+	thresholdParams := strings.Split(threshold, ".")
+
+	for i := 0; i < len(versionParams); i++ {
+		versionNumber, _ := strconv.Atoi(versionParams[i])
+		thresholdNumber, _ := strconv.Atoi(thresholdParams[i])
+
+		if thresholdNumber > versionNumber {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/modeltransformer/transformer.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/modeltransformer/transformer.go
@@ -41,7 +41,7 @@ type TransformFunc struct {
 	function interface{}
 }
 
-func NewTransFormer() *Transformer {
+func NewTransformer() *Transformer {
 	t := &Transformer{}
 	return t
 }
@@ -56,7 +56,7 @@ func (t *Transformer) GetNumberOfTransformationFunctions(modelType string) int {
 	}
 }
 
-// TransformTask executes the transformation functions when version associated with model in boltdb is below the
+// TransformTask executes the transformation functions when version associated with model in boltdb is below the threshold
 func (t *Transformer) TransformTask(version string, data []byte) ([]byte, error) {
 	var err error
 	// execute transformation functions sequentially and skip those not applicable

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -32,6 +32,7 @@ github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/request
 github.com/aws/amazon-ecs-agent/ecs-agent/logger/field
 github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon
 github.com/aws/amazon-ecs-agent/ecs-agent/metrics
+github.com/aws/amazon-ecs-agent/ecs-agent/modeltransformer
 github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh
 github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface
 github.com/aws/amazon-ecs-agent/ecs-agent/stats

--- a/ecs-agent/modeltransformer/transformer.go
+++ b/ecs-agent/modeltransformer/transformer.go
@@ -1,0 +1,108 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package modeltransformer
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+)
+
+const (
+	modelTypeTask = "Task"
+)
+
+// Transformer stores transformation functions for all types of objects.
+// Transform<type> will execute a series of transformation functions to make it compatible with current agent version.
+// add<type>TransformationFunctions will add more <type> transformation functions to the transformation functions chain.
+// Add other transformation functions as needed. e.g. ContainerTransformationFunctions.
+// Add corresponding Transform<Type> and Add<Type>TransformationFunctions while adding other transformation functions.
+type Transformer struct {
+	taskTransformFunctions []*TransformFunc
+}
+
+// TransformFunc contains the threshold version string for transformation function and the transformationFunction itself.
+// During upgrade, all models from versions below threshold version should execute the transformation function.
+type TransformFunc struct {
+	version  string
+	function interface{}
+}
+
+func NewTransFormer() *Transformer {
+	t := &Transformer{}
+	return t
+}
+
+// GetNumberOfTransformationFunctions returns the number of transformation functions given a model type
+func (t *Transformer) GetNumberOfTransformationFunctions(modelType string) int {
+	switch modelType {
+	case modelTypeTask:
+		return len(t.taskTransformFunctions)
+	default:
+		return 0
+	}
+}
+
+// TransformTask executes the transformation functions when version associated with model in boltdb is below the
+func (t *Transformer) TransformTask(version string, data []byte) ([]byte, error) {
+	var err error
+	// execute transformation functions sequentially and skip those not applicable
+	for _, transformFunc := range t.taskTransformFunctions {
+		if closure, ok := transformFunc.function.(func([]byte) ([]byte, error)); ok {
+			if checkVersionSmaller(version, transformFunc.version) {
+				logger.Info(fmt.Sprintf("Agent version associated with task model in boltdb %s is below threshold %s. Transformation needed.", version, transformFunc.version))
+				data, err = closure(data)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				logger.Info(fmt.Sprintf("Agent version associated with task model in boltdb %s is bigger or equal to threshold %s. Skipping transformation.", version, transformFunc.version))
+				continue
+			}
+		} else {
+			return nil, fmt.Errorf("transformation function for version %s is not valid", transformFunc.version)
+		}
+	}
+	return data, err
+}
+
+// AddTaskTransformationFunctions adds the transformationFunction to the handling chain
+func (t *Transformer) AddTaskTransformationFunctions(version string, transformationFunc interface{}) {
+	t.taskTransformFunctions = append(t.taskTransformFunctions, &TransformFunc{
+		version:  version,
+		function: transformationFunc,
+	})
+}
+
+// IsUpgrade checks whether the load of a persisted model to running agent is an upgrade
+func (t *Transformer) IsUpgrade(runningAgentVersion, persistedAgentVersion string) bool {
+	return checkVersionSmaller(persistedAgentVersion, runningAgentVersion)
+}
+
+func checkVersionSmaller(version, threshold string) bool {
+	versionParams := strings.Split(version, ".")
+	thresholdParams := strings.Split(threshold, ".")
+
+	for i := 0; i < len(versionParams); i++ {
+		versionNumber, _ := strconv.Atoi(versionParams[i])
+		thresholdNumber, _ := strconv.Atoi(thresholdParams[i])
+
+		if thresholdNumber > versionNumber {
+			return true
+		}
+	}
+	return false
+}

--- a/ecs-agent/modeltransformer/transformer.go
+++ b/ecs-agent/modeltransformer/transformer.go
@@ -41,7 +41,7 @@ type TransformFunc struct {
 	function interface{}
 }
 
-func NewTransFormer() *Transformer {
+func NewTransformer() *Transformer {
 	t := &Transformer{}
 	return t
 }
@@ -56,7 +56,7 @@ func (t *Transformer) GetNumberOfTransformationFunctions(modelType string) int {
 	}
 }
 
-// TransformTask executes the transformation functions when version associated with model in boltdb is below the
+// TransformTask executes the transformation functions when version associated with model in boltdb is below the threshold
 func (t *Transformer) TransformTask(version string, data []byte) ([]byte, error) {
 	var err error
 	// execute transformation functions sequentially and skip those not applicable

--- a/ecs-agent/modeltransformer/transformer_test.go
+++ b/ecs-agent/modeltransformer/transformer_test.go
@@ -1,0 +1,177 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package modeltransformer
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	firstThresholdVersion  = "1.10.0"
+	secondThresholdVersion = "1.20.0"
+)
+
+type Test_task_1_0_0 struct {
+	TestFieldId          string
+	TestFieldContainerId string
+	TestFieldTaskVCpu    string
+}
+
+type Test_task_1_10_0 struct {
+	TestFieldId           string
+	TestFieldContainerIds []string // breaking change introduced in 1.10.0
+	TestFieldTaskVCpu     string
+}
+
+type Test_task_1_20_0 struct {
+	TestFieldId           string
+	TestFieldContainerIds []string
+	TestFieldTaskVCpu     int // breaking change introduced in 1.20.0
+}
+
+func testTransformationFunction1100(dataIn []byte) ([]byte, error) {
+	oldModel := Test_task_1_0_0{}
+	newModel := Test_task_1_10_0{}
+
+	err := json.Unmarshal(dataIn, &oldModel)
+	if err != nil {
+		return nil, err
+	}
+
+	newModel.TestFieldId = oldModel.TestFieldId
+	newModel.TestFieldContainerIds = []string{oldModel.TestFieldContainerId}
+	newModel.TestFieldTaskVCpu = oldModel.TestFieldTaskVCpu
+	dataOut, err := json.Marshal(&newModel)
+	return dataOut, err
+}
+
+func testTransformationFunction1200(dataIn []byte) ([]byte, error) {
+	oldModel := Test_task_1_10_0{}
+	newModel := Test_task_1_20_0{}
+
+	err := json.Unmarshal(dataIn, &oldModel)
+	if err != nil {
+		return nil, err
+	}
+
+	newModel.TestFieldId = oldModel.TestFieldId
+	newModel.TestFieldContainerIds = oldModel.TestFieldContainerIds
+	newModel.TestFieldTaskVCpu, _ = strconv.Atoi(oldModel.TestFieldTaskVCpu)
+	dataOut, err := json.Marshal(&newModel)
+	return dataOut, err
+}
+
+func TestAddTaskTransformationFunctionsAndTransformTask(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		boltDbMetadataVersion string
+		dataIn                interface{}
+	}{
+		{
+			name:                  "upgrade skip all transformations",
+			boltDbMetadataVersion: "1.20.0",
+			dataIn: Test_task_1_20_0{
+				TestFieldId:           "id",
+				TestFieldContainerIds: []string{"cid"},
+				TestFieldTaskVCpu:     1,
+			},
+		},
+		{
+			name:                  "upgrade skip first transformation",
+			boltDbMetadataVersion: "1.19.0",
+			dataIn: Test_task_1_10_0{
+				TestFieldId:           "id",
+				TestFieldContainerIds: []string{"cid"},
+				TestFieldTaskVCpu:     "1",
+			},
+		},
+		{
+			name:                  "upgrade skip first transformation test 2",
+			boltDbMetadataVersion: "1.10.0",
+			dataIn: Test_task_1_10_0{
+				TestFieldId:           "id",
+				TestFieldContainerIds: []string{"cid"},
+				TestFieldTaskVCpu:     "1",
+			},
+		},
+		{
+			name:                  "upgrade go through all transformations",
+			boltDbMetadataVersion: "1.9.0",
+			dataIn: Test_task_1_0_0{
+				TestFieldId:          "id",
+				TestFieldContainerId: "cid",
+				TestFieldTaskVCpu:    "1",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expectedOut, _ := json.Marshal(&Test_task_1_20_0{
+				TestFieldId:           "id",
+				TestFieldContainerIds: []string{"cid"},
+				TestFieldTaskVCpu:     1,
+			})
+			dataIn, _ := json.Marshal(&tc.dataIn)
+			transformer := NewTransFormer()
+			transformer.AddTaskTransformationFunctions(firstThresholdVersion, testTransformationFunction1100)
+			transformer.AddTaskTransformationFunctions(secondThresholdVersion, testTransformationFunction1200)
+			dataOut, err := transformer.TransformTask(tc.boltDbMetadataVersion, dataIn)
+			assert.NoError(t, err, "Expected no error from transform, but there is.")
+			assert.Equal(t, expectedOut, dataOut)
+		})
+	}
+}
+
+func TestCheckIsUpgrade(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		runningAgentVersion   string
+		persistedAgentVersion string
+		expect                bool
+	}{
+		{
+			name:                  "runningAgentVersion equals to persistedAgentVersion",
+			runningAgentVersion:   "1.0.0",
+			persistedAgentVersion: "1.0.0",
+			expect:                false,
+		},
+		{
+			name:                  "runningAgentVersion greater than persistedAgentVersion",
+			runningAgentVersion:   "1.1.0",
+			persistedAgentVersion: "1.0.0",
+			expect:                true,
+		},
+		{
+			name:                  "runningAgentVersion smaller than persistedAgentVersion",
+			runningAgentVersion:   "1.0.0",
+			persistedAgentVersion: "1.1.0",
+			expect:                false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			transformer := NewTransFormer()
+			assert.Equal(t, tc.expect, transformer.IsUpgrade(tc.runningAgentVersion, tc.persistedAgentVersion))
+		})
+	}
+}

--- a/ecs-agent/modeltransformer/transformer_test.go
+++ b/ecs-agent/modeltransformer/transformer_test.go
@@ -131,7 +131,7 @@ func TestAddTaskTransformationFunctionsAndTransformTask(t *testing.T) {
 				TestFieldTaskVCpu:     1,
 			})
 			dataIn, _ := json.Marshal(&tc.dataIn)
-			transformer := NewTransFormer()
+			transformer := NewTransformer()
 			transformer.AddTaskTransformationFunctions(firstThresholdVersion, testTransformationFunction1100)
 			transformer.AddTaskTransformationFunctions(secondThresholdVersion, testTransformationFunction1200)
 			dataOut, err := transformer.TransformTask(tc.boltDbMetadataVersion, dataIn)
@@ -170,7 +170,7 @@ func TestCheckIsUpgrade(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			transformer := NewTransFormer()
+			transformer := NewTransformer()
 			assert.Equal(t, tc.expect, transformer.IsUpgrade(tc.runningAgentVersion, tc.persistedAgentVersion))
 		})
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This adds the functionality of model transformer to agent, which detects model incompatibility between the running agent version and the data we persists in boltDB. 

**Note 1: the transformation functions and models introduced in this PR is example/template change and will never be executed!**
**Note 2: this is only for agent upgrades. Support for agent downgrades is not in scope.**


A version check (using `version.Version` in "running" agent and `agent-version` in boltDB metadata bucket) is performed before we load boltDB data to agent state. If a version difference is detected, the loaded json will go through a series of transformation functions, apply those applicable transformation functions, then reach a state that it is compatible with current running agent version then loaded into agent state.

Here, "applicable" transformation functions means that the model is older than the version we introduce a new model (and as a result, anew transformation function). We check the model version against transformation function's threshold version, if it is older (smaller version number), it will go through the transformation function.

### Implementation details
<!-- How are the changes implemented? -->
- `transformer` in `ecs-agent` module
  - `transformer` stores transformation functions registered by agent (during data client initialization), and expose method to actually execute transformation functions in a loop (through a slice of function closure).
- `model` and `transtf` in `agent` module
  - `model` contains different models we introduced that are mutually incompatible. `transtf` contains corresponding transformation functions we introduced with models.

I also included a template task transformation function which will never get executed now.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> Yes

New unit tests are added. Manual testing done: manually verified following:
- Transformation function executed if a model compatibility is detected and there is a version upgrade
- Transformation function skipped if no model compatibility is detected and there is a version upgrade
- Transformation function skipped if there is no version upgrade

**Log from manual testing**

BoltDB stored agent version is 1.75.0

```
sudo systemctl restart ecs

level=info time=2023-08-30T00:12:52Z msg="Starting Amazon ECS Agent" version="1.75.2" commit="UNKNOWN"
level=info time=2023-08-30T00:12:52Z msg="Registered transformation function with threshold 1.99.0."
level=info time=2023-08-30T00:12:52Z msg="Agent version associated with task model in boltdb 1.75.0 is below threshold 1.99.0. Transformation needed."
level=info time=2023-08-30T00:12:52Z msg="Executing transformation function with threshold 1.99.0."
level=info time=2023-08-30T00:12:52Z msg="Transform associated with version 1.99.0 finished."
```
transformation functions registered and executed, since 1.75.0 < 1.75.2 and a breaking change introduced. 
```
sudo systemctl restart ecs

level=info time=2023-08-30T00:24:23Z msg="Starting Amazon ECS Agent" version="1.75.2" commit="UNKNOWN"
level=info time=2023-08-30T00:24:23Z msg="Registered transformation function with threshold 1.99.0."
```
transformation functions registered but not executed, since it's 1.75.2 = 1.75.2, and models have been updated since last load.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Model transformer: model reconciliation for agent upgrades

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
