### PR TITLE
Add volume metrics for CSI client

### DIFF
--- a/ecs-agent/csiclient/volume.go
+++ b/ecs-agent/csiclient/volume.go
@@ -1,0 +1,10 @@
+package csiclient
+
+// Metrics represents the used and capacity bytes of the Volume.
+type Metrics struct {
+	// Used represents the total bytes used by the Volume.
+	Used int64
+
+	// Capacity represents the total capacity (bytes) of the volume's underlying storage.
+	Capacity int64
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This CSI client encapsulates all things needed to communicate with the CSI driver daemon. As part of the client, this method `GetVolumeMetrics` can be used to get the given EBS volume stats. With this PR, we introduce a new struct to include more stats.

### Implementation details
<!-- How are the changes implemented? -->
A new struct is added which include the `Capacity` and `Used` metrics for EBS volume.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

Run `go mod vendor` for both `agent/` and `ecs-agent/`.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Update GetVolumeMetrics in the CSI client.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
