### PR TITLE
Redact ECR layer URLs from container pull errors

### DIFF
--- a/agent/dockerclient/dockerapi/errors.go
+++ b/agent/dockerclient/dockerapi/errors.go
@@ -414,11 +414,11 @@ func (err CannotInspectContainerExecError) ErrorName() string {
 // This is done because container runtime's request may sometimes contain security tokens when accessing ECR buckets for image layers.
 // When these requests error out, the URLs with secrets may get bubbled up to Agent logs.
 // So we redact the otherwise hidden URLs for security.
-func redactEcrUrls(str string, err error) error {
+func redactEcrUrls(overrideStr string, err error) error {
 	if err == nil {
 		return nil
 	}
 	urlRegex := regexp.MustCompile(`\"?https[^\s]+starport-layer-bucket[^\s]+`)
-	redactedStr := urlRegex.ReplaceAllString(err.Error(), fmt.Sprintf("REDACTED ECR URL related to %s", str))
+	redactedStr := urlRegex.ReplaceAllString(err.Error(), fmt.Sprintf("REDACTED ECR URL related to %s", overrideStr))
 	return fmt.Errorf(redactedStr)
 }

--- a/agent/dockerclient/dockerapi/errors.go
+++ b/agent/dockerclient/dockerapi/errors.go
@@ -14,6 +14,8 @@
 package dockerapi
 
 import (
+	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
@@ -405,4 +407,18 @@ func (err CannotInspectContainerExecError) Error() string {
 // ErrorName returns name of the CannotCreateContainerExecError.
 func (err CannotInspectContainerExecError) ErrorName() string {
 	return "CannotInspectContainerExecError"
+}
+
+// Redact ECR bucket urls from error string
+// Return a new error with redacted string - replacing ECR bucket (*starport-layer-bucket*) urls with a string.
+// This is done because container runtime's request may sometimes contain security tokens when accessing ECR buckets for image layers.
+// When these requests error out, the URLs with secrets may get bubbled up to Agent logs.
+// So we redact the otherwise hidden URLs for security.
+func redactEcrUrls(str string, err error) error {
+	if err == nil {
+		return nil
+	}
+	urlRegex := regexp.MustCompile(`\"?https[^\s]+starport-layer-bucket[^\s]+`)
+	redactedStr := urlRegex.ReplaceAllString(err.Error(), fmt.Sprintf("REDACTED ECR URL related to %s", str))
+	return fmt.Errorf(redactedStr)
 }

--- a/agent/dockerclient/dockerapi/errors_test.go
+++ b/agent/dockerclient/dockerapi/errors_test.go
@@ -18,6 +18,7 @@ package dockerapi
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,4 +32,65 @@ func TestRetriableErrorReturnsFalseForNoSuchContainer(t *testing.T) {
 func TestRetriableErrorReturnsTrue(t *testing.T) {
 	err := CannotStopContainerError{errors.New("error")}
 	assert.True(t, err.IsRetriableError(), "Non unretriable error treated as unretriable docker error")
+}
+
+func TestRedactEcrUrls(t *testing.T) {
+	testCases := []struct {
+		str         string
+		err         error
+		expectedErr error
+	}{
+		// NO REDACT CASES
+		{
+			str:         "111111111111.dkr.ecr.us-west-2.amazonaws.com/myapp",
+			err:         fmt.Errorf("Error response from daemon: pull access denied for 111111111111.dkr.ecr.us-west-2.amazonaws.com/myapp, repository does not exist or may require 'docker login': denied: User: arn:aws:sts::111111111111:assumed-role/ecsInstanceRole/i-01a01a01a01a01a01a is not authorized to perform: ecr:BatchGetImage on resource: arn:aws:ecr:us-west-2:111111111111:repository/myapp because no resource-based policy allows the ecr:BatchGetImage action"),
+			expectedErr: fmt.Errorf("Error response from daemon: pull access denied for 111111111111.dkr.ecr.us-west-2.amazonaws.com/myapp, repository does not exist or may require 'docker login': denied: User: arn:aws:sts::111111111111:assumed-role/ecsInstanceRole/i-01a01a01a01a01a01a is not authorized to perform: ecr:BatchGetImage on resource: arn:aws:ecr:us-west-2:111111111111:repository/myapp because no resource-based policy allows the ecr:BatchGetImage action"),
+		},
+		{
+			str:         "busybox:latest",
+			err:         fmt.Errorf("invalid reference format"),
+			expectedErr: fmt.Errorf("invalid reference format"),
+		},
+		{
+			str:         "busybox:latest",
+			err:         fmt.Errorf(""),
+			expectedErr: fmt.Errorf(""),
+		},
+		{
+			str:         "busybox:latest",
+			err:         fmt.Errorf("busybox:latest"),
+			expectedErr: fmt.Errorf("busybox:latest"),
+		},
+		{
+			str:         "ubuntu",
+			err:         fmt.Errorf("busybox:latest"),
+			expectedErr: fmt.Errorf("busybox:latest"),
+		},
+		{
+			str:         "111111111111.dkr.ecr.us-west-2.amazonaws.com/myapp",
+			err:         fmt.Errorf("String with https://111111111111.dkr.ecr.us-west-2.amazonaws.com/myapp"),
+			expectedErr: fmt.Errorf("String with https://111111111111.dkr.ecr.us-west-2.amazonaws.com/myapp"),
+		},
+		// REDACT CASES
+		{
+			str:         "111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp",
+			err:         fmt.Errorf("ref pull has been retried 5 time(s): failed to copy: httpReadSeeker: failed open: failed to do request: Get \"https://prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com/d1d1d1-222222222222-11d11d1d-4444-aaaa-bbbb-e4444gg4g4g4/9s9s9s9s9s-2b2b-a2a2-dddd-gg99gg99gg99?X-Amz-Security-Token=mysup3rs3cr3ttok3n\""),
+			expectedErr: fmt.Errorf("ref pull has been retried 5 time(s): failed to copy: httpReadSeeker: failed open: failed to do request: Get REDACTED ECR URL related to 111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp"),
+		},
+		{
+			str:         "111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp",
+			err:         fmt.Errorf("https://prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com/d1d1d1-222222222222-11d11d1d-4444-aaaa-bbbb-e4444gg4g4g4/9s9s9s9s9s-2b2b-a2a2-dddd-gg99gg99gg99?X-Amz-Security-Token=mysup3rs3cr3tt0k3n"),
+			expectedErr: fmt.Errorf("REDACTED ECR URL related to 111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp"),
+		},
+		{
+			str:         "111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp",
+			err:         fmt.Errorf("failed to do request: Get \"https://prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com/d1d1d1-222222222222-11d11d1d-4444-aaaa-bbbb-e4444gg4g4g4/9s9s9s9s9s-2b2b-a2a2-dddd-gg99gg99gg99?X-Amz-Security-Token=mysup3rs3cr3ttok3n\" and another request \"https://prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com/d1d1d1-222222222222-11d11d1d-4444-aaaa-bbbb-e4444gg4g4g4/9s9s9s9s9s-2b2b-a2a2-dddd-gg99gg99gg99?X-Amz-Security-Token=mysup3rs3cr3ttok3n\""),
+			expectedErr: fmt.Errorf("failed to do request: Get REDACTED ECR URL related to 111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp and another request REDACTED ECR URL related to 111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp"),
+		},
+	}
+
+	for _, tc := range testCases {
+		redactedErr := redactEcrUrls(tc.str, tc.err)
+		assert.Equal(t, redactedErr.Error(), tc.expectedErr.Error(), "ECR URL redaction output mismatch")
+	}
 }

--- a/agent/dockerclient/dockerapi/errors_test.go
+++ b/agent/dockerclient/dockerapi/errors_test.go
@@ -36,61 +36,61 @@ func TestRetriableErrorReturnsTrue(t *testing.T) {
 
 func TestRedactEcrUrls(t *testing.T) {
 	testCases := []struct {
-		str         string
+		overrideStr string
 		err         error
 		expectedErr error
 	}{
 		// NO REDACT CASES
 		{
-			str:         "111111111111.dkr.ecr.us-west-2.amazonaws.com/myapp",
+			overrideStr: "111111111111.dkr.ecr.us-west-2.amazonaws.com/myapp",
 			err:         fmt.Errorf("Error response from daemon: pull access denied for 111111111111.dkr.ecr.us-west-2.amazonaws.com/myapp, repository does not exist or may require 'docker login': denied: User: arn:aws:sts::111111111111:assumed-role/ecsInstanceRole/i-01a01a01a01a01a01a is not authorized to perform: ecr:BatchGetImage on resource: arn:aws:ecr:us-west-2:111111111111:repository/myapp because no resource-based policy allows the ecr:BatchGetImage action"),
 			expectedErr: fmt.Errorf("Error response from daemon: pull access denied for 111111111111.dkr.ecr.us-west-2.amazonaws.com/myapp, repository does not exist or may require 'docker login': denied: User: arn:aws:sts::111111111111:assumed-role/ecsInstanceRole/i-01a01a01a01a01a01a is not authorized to perform: ecr:BatchGetImage on resource: arn:aws:ecr:us-west-2:111111111111:repository/myapp because no resource-based policy allows the ecr:BatchGetImage action"),
 		},
 		{
-			str:         "busybox:latest",
+			overrideStr: "busybox:latest",
 			err:         fmt.Errorf("invalid reference format"),
 			expectedErr: fmt.Errorf("invalid reference format"),
 		},
 		{
-			str:         "busybox:latest",
+			overrideStr: "busybox:latest",
 			err:         fmt.Errorf(""),
 			expectedErr: fmt.Errorf(""),
 		},
 		{
-			str:         "busybox:latest",
+			overrideStr: "busybox:latest",
 			err:         fmt.Errorf("busybox:latest"),
 			expectedErr: fmt.Errorf("busybox:latest"),
 		},
 		{
-			str:         "ubuntu",
+			overrideStr: "ubuntu",
 			err:         fmt.Errorf("busybox:latest"),
 			expectedErr: fmt.Errorf("busybox:latest"),
 		},
 		{
-			str:         "111111111111.dkr.ecr.us-west-2.amazonaws.com/myapp",
+			overrideStr: "111111111111.dkr.ecr.us-west-2.amazonaws.com/myapp",
 			err:         fmt.Errorf("String with https://111111111111.dkr.ecr.us-west-2.amazonaws.com/myapp"),
 			expectedErr: fmt.Errorf("String with https://111111111111.dkr.ecr.us-west-2.amazonaws.com/myapp"),
 		},
 		// REDACT CASES
 		{
-			str:         "111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp",
+			overrideStr: "111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp",
 			err:         fmt.Errorf("ref pull has been retried 5 time(s): failed to copy: httpReadSeeker: failed open: failed to do request: Get \"https://prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com/d1d1d1-222222222222-11d11d1d-4444-aaaa-bbbb-e4444gg4g4g4/9s9s9s9s9s-2b2b-a2a2-dddd-gg99gg99gg99?X-Amz-Security-Token=mysup3rs3cr3ttok3n\""),
 			expectedErr: fmt.Errorf("ref pull has been retried 5 time(s): failed to copy: httpReadSeeker: failed open: failed to do request: Get REDACTED ECR URL related to 111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp"),
 		},
 		{
-			str:         "111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp",
+			overrideStr: "111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp",
 			err:         fmt.Errorf("https://prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com/d1d1d1-222222222222-11d11d1d-4444-aaaa-bbbb-e4444gg4g4g4/9s9s9s9s9s-2b2b-a2a2-dddd-gg99gg99gg99?X-Amz-Security-Token=mysup3rs3cr3tt0k3n"),
 			expectedErr: fmt.Errorf("REDACTED ECR URL related to 111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp"),
 		},
 		{
-			str:         "111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp",
+			overrideStr: "111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp",
 			err:         fmt.Errorf("failed to do request: Get \"https://prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com/d1d1d1-222222222222-11d11d1d-4444-aaaa-bbbb-e4444gg4g4g4/9s9s9s9s9s-2b2b-a2a2-dddd-gg99gg99gg99?X-Amz-Security-Token=mysup3rs3cr3ttok3n\" and another request \"https://prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com/d1d1d1-222222222222-11d11d1d-4444-aaaa-bbbb-e4444gg4g4g4/9s9s9s9s9s-2b2b-a2a2-dddd-gg99gg99gg99?X-Amz-Security-Token=mysup3rs3cr3ttok3n\""),
 			expectedErr: fmt.Errorf("failed to do request: Get REDACTED ECR URL related to 111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp and another request REDACTED ECR URL related to 111111111111.dkr.ecr.us-east-1.amazonaws.com/myapp"),
 		},
 	}
 
 	for _, tc := range testCases {
-		redactedErr := redactEcrUrls(tc.str, tc.err)
+		redactedErr := redactEcrUrls(tc.overrideStr, tc.err)
 		assert.Equal(t, redactedErr.Error(), tc.expectedErr.Error(), "ECR URL redaction output mismatch")
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Redact error messages with URLs containing references to string `starport-layer-bucket` (ECR buckets). ECR buckets named as `prod-region-starport-layer-bucket` are used to fetch image layers from.

This redaction is done because container runtime's request may sometimes contain security tokens when accessing ECR buckets for pulling layers. When these requests error out, the URLs with secrets may get bubbled up to Agent logs and ECS logs through `Reason` field in Submit Task State Change calls. So we redact the otherwise hidden URLs for security.

### Implementation details
<!-- How are the changes implemented? -->
Replace regex `\"?https[^\s]+starport-layer-bucket[^\s]+` with a string message containing image reference

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
* Unit tests are added and verified with
* Manually verified this doesn't affect some common Container Pull error messages like

```
DockerGoClient: failed to pull image <acc id>.dkr.ecr.us-west-2.amazonaws.com/benchmark-app:latest: [CannotPullContainerError] Error response from daemon: pull access denied for <acc id>.dkr.ecr.us-west-2.amazonaws.com/benchmark-app, repository does not exist or may require 'docker login': denied: User: arn:aws:sts::<acc id>:assumed-role/ecsInstanceRole/<inst id> is not authorized to perform....
```
New tests cover the changes: <!-- yes|no -->
Yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Redact ECR layer URLs from container pull errors
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
