### PR TITLE
Skip Task resource accounting for Fargate 1.3.0 launch type

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3509,6 +3509,10 @@ func (task *Task) IsServiceConnectConnectionDraining() bool {
 	return task.ServiceConnectConnectionDrainingUnsafe
 }
 
+func (task *Task) IsLaunchTypeFargate() bool {
+	return strings.ToUpper(task.LaunchType) == "FARGATE"
+}
+
 // ToHostResources will convert a task to a map of resources which ECS takes into account when scheduling tasks on instances
 // * CPU
 //   - If task level CPU is set, use that

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -1453,16 +1453,16 @@ func TestHostResourceManagerLaunchTypeBehavior(t *testing.T) {
 
 		// goroutine to verify task running order and verify assertions
 		go func() {
-			// 1st task goes to RUNNING
+			// Task goes to RUNNING
 			verifyContainerRunningStateChange(t, taskEngine)
 			verifyTaskIsRunning(stateChangeEvents, testTask)
 
 			time.Sleep(2500 * time.Millisecond)
 
-			// At this time, task stopTask is received, and SIGTERM sent to task
+			// At this time, stopTask is received, and SIGTERM sent to task
 			// but the task is still RUNNING due to trap handler
-			assert.Equal(t, apitaskstatus.TaskRunning, testTask.GetKnownStatus(), "fargate task known status should be RUNNING")
-			assert.Equal(t, apitaskstatus.TaskStopped, testTask.GetDesiredStatus(), "fargate task desired status should be STOPPED")
+			assert.Equal(t, apitaskstatus.TaskRunning, testTask.GetKnownStatus(), "task known status should be RUNNING")
+			assert.Equal(t, apitaskstatus.TaskStopped, testTask.GetDesiredStatus(), "task desired status should be STOPPED")
 			// Verify resources are properly consumed in host resource manager, and not consumed for Fargate
 			if tc.LaunchType == "FARGATE" {
 				assert.False(t, taskEngine.(*DockerTaskEngine).hostResourceManager.checkTaskConsumed(testTask.Arn), "fargate task resources should not be consumed")

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -285,7 +285,7 @@ func (mtask *managedTask) waitForHostResources() {
 		return
 	}
 
-	if !mtask.IsInternal && !mtask.engine.hostResourceManager.checkTaskConsumed(mtask.Arn) {
+	if !mtask.IsLaunchTypeFargate() && !mtask.IsInternal && !mtask.engine.hostResourceManager.checkTaskConsumed(mtask.Arn) {
 		// Internal tasks are started right away as their resources are not accounted for
 		mtask.engine.enqueueTask(mtask)
 		for !mtask.waitEvent(mtask.consumedHostResourceEvent) {

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -287,7 +287,7 @@ func (mtask *managedTask) waitForHostResources() {
 
 	if !mtask.IsLaunchTypeFargate() && !mtask.IsInternal && !mtask.engine.hostResourceManager.checkTaskConsumed(mtask.Arn) {
 		// Internal tasks are started right away as their resources are not accounted for
-		// Fargate (1.3.0) only ever run a single task, rely on backend instance placement and skip resource accounting
+		// Fargate (1.3.0) - rely on backend instance placement and skip resource accounting
 		mtask.engine.enqueueTask(mtask)
 		for !mtask.waitEvent(mtask.consumedHostResourceEvent) {
 			if mtask.GetDesiredStatus().Terminal() {

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -287,6 +287,7 @@ func (mtask *managedTask) waitForHostResources() {
 
 	if !mtask.IsLaunchTypeFargate() && !mtask.IsInternal && !mtask.engine.hostResourceManager.checkTaskConsumed(mtask.Arn) {
 		// Internal tasks are started right away as their resources are not accounted for
+		// Fargate (1.3.0) only ever run a single task, rely on backend instance placement and skip resource accounting
 		mtask.engine.enqueueTask(mtask)
 		for !mtask.waitEvent(mtask.consumedHostResourceEvent) {
 			if mtask.GetDesiredStatus().Terminal() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
ECS backend resource accounting can be different for Fargate (1.3.0) than for ECS/EC2 or ECS-Anywhere. This can cause issues with task resource accounting in ECS Agent, if it is not in sync with backend accounting. This behavior can be turned off for Fargate tasks and all resource availability can be delegated to Fargate backend instead.

### Implementation details
<!-- How are the changes implemented? -->
* ACS Payload has field `LaunchType` which takes value `FARGATE` for Fargate tasks. For such tasks, do not queue them up and launch them up straightaway. Their resources never get accounted in HostResourceManager.
* HostResourceManager release resources is not a problem as it is an idempotent release. If a task does not exist in HostResourceManager's accounting, this operation will be a no-op.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
* Added Integ tests to validate HostResourceManager still consumes resources for non fargate tasks, and does not consume resources for fargate tasks
* Manual testing
Both `EC2 and External` -
	- Queued 1 task after the other, enough memory available for 2nd task
		- 2nd task starts without waiting for 1st task to stopped

	- Queued 1 task, Stopped it with stop timeout of 30s, started new task with conflicted resource (CPU)
		- 2nd task starts after 1st task goes to stopped

New tests cover the changes: <!-- yes|no -->
Yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Skip Task resource accounting for Fargate 1.3.0 launch type
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
