### PR TITLE
Add interface for csi client

### DIFF
--- a/ecs-agent/csiclient/csi_client.go
+++ b/ecs-agent/csiclient/csi_client.go
@@ -31,7 +31,9 @@ const (
 	PROTOCOL = "unix"
 )
 
-// CSIClient is an interface that specifies all supported operations for Agent uses.
+// CSIClient is an interface that specifies all supported operations in the Container Storage Interface(CSI)
+// driver for Agent uses. The CSI driver provides many volume related operations to manage the lifecycle of
+// Amazon EBS volumes, including mounting, umounting, resizing and volume stats.
 type CSIClient interface {
 	GetVolumeMetrics(volumeId string, hostMountPath string) (*Metrics, error)
 }

--- a/ecs-agent/csiclient/csi_client.go
+++ b/ecs-agent/csiclient/csi_client.go
@@ -31,6 +31,7 @@ const (
 	PROTOCOL = "unix"
 )
 
+// CSIClient is an interface that specifies all supported operations for Agent uses.
 type CSIClient interface {
 	GetVolumeMetrics(volumeId string, hostMountPath string) (*Metrics, error)
 }
@@ -40,6 +41,7 @@ type csiClient struct {
 	csiSocket string
 }
 
+// NewCSIClient creates a CSI client for the communication with CSI driver daemon.
 func NewCSIClient(socketIn string) CSIClient {
 	return &csiClient{csiSocket: socketIn}
 }

--- a/ecs-agent/csiclient/csi_client.go
+++ b/ecs-agent/csiclient/csi_client.go
@@ -1,3 +1,16 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package csiclient
 
 import (
@@ -18,13 +31,17 @@ const (
 	PROTOCOL = "unix"
 )
 
+type CSIClient interface {
+	GetVolumeMetrics(volumeId string, hostMountPath string) (*Metrics, error)
+}
+
 // csiClient encapsulates all CSI methods.
 type csiClient struct {
 	csiSocket string
 }
 
-func NewCSIClient(socketIn string) csiClient {
-	return csiClient{csiSocket: socketIn}
+func NewCSIClient(socketIn string) CSIClient {
+	return &csiClient{csiSocket: socketIn}
 }
 
 // GetVolumeMetrics returns volume usage.

--- a/ecs-agent/csiclient/dummy_csiclient.go
+++ b/ecs-agent/csiclient/dummy_csiclient.go
@@ -13,7 +13,7 @@
 
 package csiclient
 
-const volumeSizeGib = 1024 * 1024 * 1024
+const gibToBytes = 1024 * 1024 * 1024
 
 // dummyCSIClient can be used to test the behaviour of csi client.
 type dummyCSIClient struct {
@@ -21,8 +21,8 @@ type dummyCSIClient struct {
 
 func (c *dummyCSIClient) GetVolumeMetrics(volumeId string, hostMountPath string) (*Metrics, error) {
 	return &Metrics{
-		Used:     15 * volumeSizeGib,
-		Capacity: 20 * volumeSizeGib,
+		Used:     15 * gibToBytes,
+		Capacity: 20 * gibToBytes,
 	}, nil
 }
 

--- a/ecs-agent/csiclient/dummy_csiclient.go
+++ b/ecs-agent/csiclient/dummy_csiclient.go
@@ -15,6 +15,7 @@ package csiclient
 
 const volumeSizeGib = 1024 * 1024 * 1024
 
+// dummyCSIClient can be used to test the behaviour of csi client.
 type dummyCSIClient struct {
 }
 

--- a/ecs-agent/csiclient/dummy_csiclient.go
+++ b/ecs-agent/csiclient/dummy_csiclient.go
@@ -13,11 +13,18 @@
 
 package csiclient
 
-// Metrics represents the used and capacity bytes of the Volume.
-type Metrics struct {
-	// Used represents the total bytes used by the Volume.
-	Used int64 `json:"Used"`
+const volumeSizeGib = 1024 * 1024 * 1024
 
-	// Capacity represents the total capacity (bytes) of the volume's underlying storage.
-	Capacity int64 `json:"Capacity"`
+type dummyCSIClient struct {
+}
+
+func (c *dummyCSIClient) GetVolumeMetrics(volumeId string, hostMountPath string) (*Metrics, error) {
+	return &Metrics{
+		Used:     15 * volumeSizeGib,
+		Capacity: 20 * volumeSizeGib,
+	}, nil
+}
+
+func NewDummyCSIClient() CSIClient {
+	return &dummyCSIClient{}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR is to add an interface for the csi client which can be used by Agent to communicate with the CSI driver daemon.

### Implementation details
<!-- How are the changes implemented? -->
1. the new interface are from the existing implementation of the method `GetVolumeMetrics`
2. change `NewCSIClient` to return a pointer.
3. add a new dummy csi client for testing only.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add interface for csi client.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
