### PR TITLE
Update PR template and enable dependabot for ecs-agent module

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,6 +35,9 @@ You can see our changelog entry style here:
 https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
 -->
 
+**Does this PR include breaking model changes? If so, Have you added transformation functions?**
+<!-- If yes, next release should have a upgraded minor version -->  
+
 ### Licensing
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,15 @@ updates:
     # the bot stuck at trying to upgrade it; (2) sdk change has higher risk of breaking the agent so probably safer to
     # upgrade manually.
     - dependency-name: "github.com/aws/aws-sdk-go"
+- package-ecosystem: gomod
+  directory: "/ecs-agent"
+  schedule:
+    interval: weekly
+    time: "0:00"
+  open-pull-requests-limit: 1
+  target-branch: "dev"
+  ignore:
+    # aws sdk is explicitly excluded from bot auto upgrade because: (1) currently the auto upgrade of it breaks test, and
+    # the bot stuck at trying to upgrade it; (2) sdk change has higher risk of breaking the agent so probably safer to
+    # upgrade manually.
+    - dependency-name: "github.com/aws/aws-sdk-go"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update PR template for model reconciliation change (to remind code author about transformation functions and a new minor version of agent if needed) and enable dependabot for ecs-agent module

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Update PR template and enable dependabot for ecs-agent module

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
