### PR TITLE
Add new network data structures

### DIFF
--- a/ecs-agent/netlib/model/status/network_status.go
+++ b/ecs-agent/netlib/model/status/network_status.go
@@ -1,0 +1,42 @@
+package status
+
+// NetworkStatus represents the status of a network resource.
+type NetworkStatus string
+
+const (
+	// NetworkNone is the initial status of the ENI.
+	NetworkNone NetworkStatus = "NONE"
+	// NetworkReadyPull indicates that the ENI is ready for downloading resources associated with
+	// the execution role. This includes container images, task secrets and configs.
+	NetworkReadyPull NetworkStatus = "READY_PULL"
+	// NetworkReady indicates that the ENI is ready for use by containers in the task.
+	NetworkReady NetworkStatus = "READY"
+	// NetworkDeleted indicates that the ENI is deleted.
+	NetworkDeleted NetworkStatus = "DELETED"
+)
+
+var (
+	eniStatusOrder = map[NetworkStatus]int{
+		NetworkNone:      0,
+		NetworkReadyPull: 1,
+		NetworkReady:     2,
+		NetworkDeleted:   3,
+	}
+)
+
+func (es NetworkStatus) String() string {
+	return string(es)
+}
+
+func (es NetworkStatus) ENIStatusBackwards(es2 NetworkStatus) bool {
+	return eniStatusOrder[es] < eniStatusOrder[es2]
+}
+
+func GetAllENIStatuses() []NetworkStatus {
+	return []NetworkStatus{
+		NetworkNone,
+		NetworkReadyPull,
+		NetworkReady,
+		NetworkDeleted,
+	}
+}

--- a/ecs-agent/netlib/model/status/network_status_test.go
+++ b/ecs-agent/netlib/model/status/network_status_test.go
@@ -46,4 +46,3 @@ func TestNetworkStatusOrder(t *testing.T) {
 	assert.False(t, NetworkReady.ENIStatusBackwards(NetworkReadyPull))
 	assert.False(t, NetworkDeleted.ENIStatusBackwards(NetworkReady))
 }
-

--- a/ecs-agent/netlib/model/status/network_status_test.go
+++ b/ecs-agent/netlib/model/status/network_status_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 package status
 
 import (
@@ -19,15 +22,15 @@ func TestNetworkStatus(t *testing.T) {
 		},
 		{
 			status: NetworkReadyPull,
-			str:    "NONE",
+			str:    "READY_PULL",
 		},
 		{
 			status: NetworkReady,
-			str:    "NONE",
+			str:    "READY",
 		},
 		{
 			status: NetworkDeleted,
-			str:    "NONE",
+			str:    "DELETED",
 		},
 	}
 	for _, tc := range testCases {

--- a/ecs-agent/netlib/model/status/network_status_test.go
+++ b/ecs-agent/netlib/model/status/network_status_test.go
@@ -1,8 +1,9 @@
 package status
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestNetworkStatus verifies the corresponding string values of each status

--- a/ecs-agent/netlib/model/status/network_status_test.go
+++ b/ecs-agent/netlib/model/status/network_status_test.go
@@ -46,3 +46,4 @@ func TestNetworkStatusOrder(t *testing.T) {
 	assert.False(t, NetworkReady.ENIStatusBackwards(NetworkReadyPull))
 	assert.False(t, NetworkDeleted.ENIStatusBackwards(NetworkReady))
 }
+

--- a/ecs-agent/netlib/model/status/network_status_test.go
+++ b/ecs-agent/netlib/model/status/network_status_test.go
@@ -1,0 +1,48 @@
+package status
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// TestNetworkStatus verifies the corresponding string values of each status
+// is appropriate.
+func TestNetworkStatus(t *testing.T) {
+	testCases := []struct {
+		status NetworkStatus
+		str    string
+	}{
+		{
+			status: NetworkNone,
+			str:    "NONE",
+		},
+		{
+			status: NetworkReadyPull,
+			str:    "NONE",
+		},
+		{
+			status: NetworkReady,
+			str:    "NONE",
+		},
+		{
+			status: NetworkDeleted,
+			str:    "NONE",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.str, func(t *testing.T) {
+			assert.Equal(t, tc.str, (&tc.status).String())
+		})
+	}
+}
+
+// TestNetworkStatusOrder verifies that order of statuses are as required.
+func TestNetworkStatusOrder(t *testing.T) {
+	assert.True(t, NetworkNone.ENIStatusBackwards(NetworkReadyPull))
+	assert.True(t, NetworkReadyPull.ENIStatusBackwards(NetworkReady))
+	assert.True(t, NetworkReady.ENIStatusBackwards(NetworkDeleted))
+
+	assert.False(t, NetworkReadyPull.ENIStatusBackwards(NetworkNone))
+	assert.False(t, NetworkReady.ENIStatusBackwards(NetworkReadyPull))
+	assert.False(t, NetworkDeleted.ENIStatusBackwards(NetworkReady))
+}

--- a/ecs-agent/netlib/model/tasknetworkconfig/common_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/common_test.go
@@ -1,0 +1,44 @@
+package tasknetworkconfig
+
+import ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+
+const (
+	primaryNetNSName       = "primary-netns"
+	secondaryNetNSName     = "secondary-netns"
+	primaryInterfaceName   = "primary-interface"
+	secondaryInterfaceName = "secondary-interface"
+)
+
+func getTestTaskNetworkConfig() *TaskNetworkConfig {
+	return &TaskNetworkConfig{
+		NetworkNamespaces: getTestNetworkNamespaces(),
+	}
+}
+
+func getTestNetworkNamespaces() []*NetworkNamespace {
+	return []*NetworkNamespace{
+		{
+			Name:              secondaryNetNSName,
+			Index:             1,
+			NetworkInterfaces: getTestNetworkInterfaces(),
+		},
+		{
+			Name:              primaryNetNSName,
+			Index:             0,
+			NetworkInterfaces: getTestNetworkInterfaces(),
+		},
+	}
+}
+
+func getTestNetworkInterfaces() []*ni.NetworkInterface {
+	return []*ni.NetworkInterface{
+		{
+			Name:  secondaryInterfaceName,
+			Index: 1,
+		},
+		{
+			Name:  primaryInterfaceName,
+			Index: 0,
+		},
+	}
+}

--- a/ecs-agent/netlib/model/tasknetworkconfig/network_namespace.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/network_namespace.go
@@ -1,0 +1,35 @@
+package tasknetworkconfig
+
+import (
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+)
+
+// NetworkNamespace is model representing each network namespace.
+type NetworkNamespace struct {
+	Name  string
+	Path  string
+	Index int
+
+	// NetworkInterfaces represents ENIs or any kind of network interface associated the particular netns.
+	NetworkInterfaces []*networkinterface.NetworkInterface
+
+	// AppMeshConfig holds AppMesh related parameters for the particular netns.
+	AppMeshConfig *appmesh.AppMesh
+
+	// TODO: Add Service Connect model here once it is moved under the netlib package.
+
+	KnownState   string
+	DesiredState string
+}
+
+// GetPrimaryInterface returns the network interface that has the index value of 0 within
+// the network namespace.
+func (ns NetworkNamespace) GetPrimaryInterface() *networkinterface.NetworkInterface {
+	for _, ni := range ns.NetworkInterfaces {
+		if ni.Index == 0 {
+			return ni
+		}
+	}
+	return nil
+}

--- a/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
@@ -36,4 +36,3 @@ func TestNetworkNamespace_GetPrimaryInterface(t *testing.T) {
 		assert.Equal(t, tc.primaryNI, tc.netns.GetPrimaryInterface())
 	}
 }
-

--- a/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
@@ -37,7 +37,6 @@ func TestNetworkNamespace_GetPrimaryInterface(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		assert.Equal(t, tc.primaryNI, tc.netns.GetPrimaryInterface().Name)
-	}
+	assert.Equal(t, tc.primaryNI, testCases[0].netns.GetPrimaryInterface().Name)
+	assert.Nil(t, testCases[1].netns.GetPrimaryInterface())
 }

--- a/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 package tasknetworkconfig
 
 import (
@@ -35,6 +38,6 @@ func TestNetworkNamespace_GetPrimaryInterface(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		assert.Equal(t, tc.primaryNI, tc.netns.GetPrimaryInterface())
+		assert.Equal(t, tc.primaryNI, tc.netns.GetPrimaryInterface().Name)
 	}
 }

--- a/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
@@ -2,8 +2,10 @@ package tasknetworkconfig
 
 import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
-	"github.com/stretchr/testify/assert"
+
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNetworkNamespace_GetPrimaryInterface(t *testing.T) {

--- a/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
@@ -36,3 +36,4 @@ func TestNetworkNamespace_GetPrimaryInterface(t *testing.T) {
 		assert.Equal(t, tc.primaryNI, tc.netns.GetPrimaryInterface())
 	}
 }
+

--- a/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
@@ -27,5 +27,5 @@ func TestNetworkNamespace_GetPrimaryInterface(t *testing.T) {
 	assert.Equal(t, primaryInterfaceName, netns.GetPrimaryInterface().Name)
 
 	netns = &NetworkNamespace{}
-	assert.Equal(t, netns)
+	assert.Empty(t, netns.GetPrimaryInterface())
 }

--- a/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
@@ -12,31 +12,20 @@ import (
 )
 
 func TestNetworkNamespace_GetPrimaryInterface(t *testing.T) {
-	testCases := []struct {
-		netns     *NetworkNamespace
-		primaryNI string
-	}{
-		{
-			netns: &NetworkNamespace{
-				NetworkInterfaces: []*networkinterface.NetworkInterface{
-					{
-						Index: 1,
-						Name:  secondaryInterfaceName,
-					},
-					{
-						Index: 0,
-						Name:  primaryInterfaceName,
-					},
-				},
+	netns := &NetworkNamespace{
+		NetworkInterfaces: []*networkinterface.NetworkInterface{
+			{
+				Index: 1,
+				Name:  secondaryInterfaceName,
 			},
-			primaryNI: primaryInterfaceName,
-		},
-		{
-			netns:     &NetworkNamespace{},
-			primaryNI: "",
+			{
+				Index: 0,
+				Name:  primaryInterfaceName,
+			},
 		},
 	}
+	assert.Equal(t, primaryInterfaceName, netns.GetPrimaryInterface().Name)
 
-	assert.Equal(t, tc.primaryNI, testCases[0].netns.GetPrimaryInterface().Name)
-	assert.Nil(t, testCases[1].netns.GetPrimaryInterface())
+	netns = &NetworkNamespace{}
+	assert.Equal(t, netns)
 }

--- a/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
@@ -1,0 +1,38 @@
+package tasknetworkconfig
+
+import (
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNetworkNamespace_GetPrimaryInterface(t *testing.T) {
+	testCases := []struct {
+		netns     *NetworkNamespace
+		primaryNI string
+	}{
+		{
+			netns: &NetworkNamespace{
+				NetworkInterfaces: []*networkinterface.NetworkInterface{
+					{
+						Index: 1,
+						Name:  secondaryInterfaceName,
+					},
+					{
+						Index: 0,
+						Name:  primaryInterfaceName,
+					},
+				},
+			},
+			primaryNI: primaryInterfaceName,
+		},
+		{
+			netns:     &NetworkNamespace{},
+			primaryNI: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.primaryNI, tc.netns.GetPrimaryInterface())
+	}
+}

--- a/ecs-agent/netlib/model/tasknetworkconfig/task_network_config.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/task_network_config.go
@@ -11,7 +11,10 @@ type TaskNetworkConfig struct {
 // GetPrimaryInterface returns the interface with index 0 inside the network namespace
 // with index 0 associated with the task's network config.
 func (tnc *TaskNetworkConfig) GetPrimaryInterface() *ni.NetworkInterface {
-	return tnc.GetPrimaryNetNS().GetPrimaryInterface()
+	if tnc != nil && tnc.GetPrimaryNetNS() != nil {
+		return tnc.GetPrimaryNetNS().GetPrimaryInterface()
+	}
+	return nil
 }
 
 // GetPrimaryNetNS returns the netns with index 0 associated with the task's network config.

--- a/ecs-agent/netlib/model/tasknetworkconfig/task_network_config.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/task_network_config.go
@@ -2,15 +2,19 @@ package tasknetworkconfig
 
 import ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 
+// TaskNetworkConfig is the top level network data structure associated with a task.
 type TaskNetworkConfig struct {
 	NetworkNamespaces []*NetworkNamespace
 	NetworkMode       string
 }
 
+// GetPrimaryInterface returns the interface with index 0 inside the network namespace
+// with index 0 associated with the task's network config.
 func (tnc *TaskNetworkConfig) GetPrimaryInterface() *ni.NetworkInterface {
 	return tnc.GetPrimaryNetNS().GetPrimaryInterface()
 }
 
+// GetPrimaryNetNS returns the netns with index 0 associated with the task's network config.
 func (tnc *TaskNetworkConfig) GetPrimaryNetNS() *NetworkNamespace {
 	for _, netns := range tnc.NetworkNamespaces {
 		if netns.Index == 0 {

--- a/ecs-agent/netlib/model/tasknetworkconfig/task_network_config.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/task_network_config.go
@@ -1,0 +1,22 @@
+package tasknetworkconfig
+
+import ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+
+type TaskNetworkConfig struct {
+	NetworkNamespaces []*NetworkNamespace
+	NetworkMode       string
+}
+
+func (tnc *TaskNetworkConfig) GetPrimaryInterface() *ni.NetworkInterface {
+	return tnc.GetPrimaryNetNS().GetPrimaryInterface()
+}
+
+func (tnc *TaskNetworkConfig) GetPrimaryNetNS() *NetworkNamespace {
+	for _, netns := range tnc.NetworkNamespaces {
+		if netns.Index == 0 {
+			return netns
+		}
+	}
+
+	return nil
+}

--- a/ecs-agent/netlib/model/tasknetworkconfig/task_network_config_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/task_network_config_test.go
@@ -1,0 +1,25 @@
+package tasknetworkconfig
+
+import (
+	"github.com/stretchr/testify/assert"
+	
+	"testing"
+)
+
+func TestTaskNetworkConfig_GetPrimaryInterface(t *testing.T) {
+	testNetConfig := getTestTaskNetworkConfig()
+	assert.Equal(t, primaryInterfaceName, testNetConfig.GetPrimaryInterface().Name)
+
+	testNetConfig = &TaskNetworkConfig{
+		NetworkNamespaces: []*NetworkNamespace{},
+	}
+	assert.Nil(t, testNetConfig.GetPrimaryInterface())
+}
+
+func TestTaskNetworkConfig_GetPrimaryNetNS(t *testing.T) {
+	testNetConfig := getTestTaskNetworkConfig()
+	assert.Equal(t, primaryNetNSName, testNetConfig.GetPrimaryNetNS().Name)
+
+	testNetConfig = &TaskNetworkConfig{}
+	assert.Nil(t, testNetConfig.GetPrimaryNetNS())
+}

--- a/ecs-agent/netlib/model/tasknetworkconfig/task_network_config_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/task_network_config_test.go
@@ -2,7 +2,7 @@ package tasknetworkconfig
 
 import (
 	"github.com/stretchr/testify/assert"
-	
+
 	"testing"
 )
 
@@ -23,4 +23,3 @@ func TestTaskNetworkConfig_GetPrimaryNetNS(t *testing.T) {
 	testNetConfig = &TaskNetworkConfig{}
 	assert.Nil(t, testNetConfig.GetPrimaryNetNS())
 }
-

--- a/ecs-agent/netlib/model/tasknetworkconfig/task_network_config_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/task_network_config_test.go
@@ -23,3 +23,4 @@ func TestTaskNetworkConfig_GetPrimaryNetNS(t *testing.T) {
 	testNetConfig = &TaskNetworkConfig{}
 	assert.Nil(t, testNetConfig.GetPrimaryNetNS())
 }
+

--- a/ecs-agent/netlib/model/tasknetworkconfig/task_network_config_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/task_network_config_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 package tasknetworkconfig
 
 import (


### PR DESCRIPTION
### Summary
This change adds a new task level network data structure and a network
    namespace level data structure into the shared network library. This
    enables the path to having a unified network library for ECS data plane.

### Implementation details
New data structures as agreed in design are added under the `ecs-agent/netlib/model` package.

### Testing
`make test` and `make run-integ-tests` passed on local environment.

New tests cover the changes: Yes

Passed Github workflow.
### Description for the changelog
Add `TaskNetworkConfig` and `NetworkNamespace` models to shared network library.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
