### PR TITLE
Managed Daemon fixup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _bin/
 *.swp
 *.orig
 /agent/version/_version.go
+/ecs-agent/daemonimages/csidriver/tarfiles
 /ecs-init/version/version.go
 .agignore
 *.sublime-*

--- a/agent/engine/daemonmanager/daemon_manager_linux.go
+++ b/agent/engine/daemonmanager/daemon_manager_linux.go
@@ -37,6 +37,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
+	dockermount "github.com/docker/docker/api/types/mount"
 	"github.com/pborman/uuid"
 )
 
@@ -55,24 +56,46 @@ func (dm *daemonManager) CreateDaemonTask() (*apitask.Task, error) {
 	imageName := dm.managedDaemon.GetImageName()
 	loadedImageRef := dm.managedDaemon.GetLoadedDaemonImageRef()
 	containerRunning := apicontainerstatus.ContainerRunning
+	stringCaps := []string{}
+	if dm.managedDaemon.GetLinuxParameters() != nil {
+		caps := dm.managedDaemon.GetLinuxParameters().Capabilities.Add
+		for _, cap := range caps {
+			stringCaps = append(stringCaps, *cap)
+		}
+	}
 	dockerHostConfig := dockercontainer.HostConfig{
+		Mounts:      []dockermount.Mount{},
 		NetworkMode: apitask.HostNetworkMode,
 		// the default value of 0 for MaximumRetryCount means retry indefinitely
 		RestartPolicy: dockercontainer.RestartPolicy{
 			Name:              "on-failure",
 			MaximumRetryCount: 0,
 		},
+		Privileged: dm.managedDaemon.GetPrivileged(),
+		CapAdd:     stringCaps,
 	}
 	if !dm.managedDaemon.IsValidManagedDaemon() {
 		return nil, fmt.Errorf("%s is an invalid managed daemon", imageName)
 	}
-	for _, mount := range dm.managedDaemon.GetMountPoints() {
-		err := mkdirAllAndChown(mount.SourceVolumeHostPath, daemonMountPermission, daemonUID, os.Getegid())
+
+	for _, mp := range dm.managedDaemon.GetMountPoints() {
+		err := mkdirAllAndChown(mp.SourceVolumeHostPath, daemonMountPermission, daemonUID, os.Getegid())
 		if err != nil {
 			return nil, err
 		}
-		dockerHostConfig.Binds = append(dockerHostConfig.Binds,
-			fmt.Sprintf("%s:%s", mount.SourceVolumeHostPath, mount.ContainerPath))
+		var bindOptions = dockermount.BindOptions{}
+
+		if mp.PropagationShared {
+			// https://github.com/moby/moby/blob/master/api/types/mount/mount.go#L52
+			bindOptions.Propagation = dockermount.PropagationShared
+		}
+		mountPoint := dockermount.Mount{
+			Type:        dockermount.TypeBind,
+			Source:      mp.SourceVolumeHostPath,
+			Target:      mp.ContainerPath,
+			BindOptions: &bindOptions,
+		}
+		dockerHostConfig.Mounts = append(dockerHostConfig.Mounts, mountPoint)
 	}
 	rawHostConfig, err := json.Marshal(&dockerHostConfig)
 	if err != nil {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs/api.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs/api.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
@@ -509,6 +510,8 @@ type Container struct {
 
 	Links []*string `locationName:"links" type:"list"`
 
+	LinuxParameters *LinuxParameters `locationName:"linuxParameters" type:"structure"`
+
 	LogsAuthStrategy *string `locationName:"logsAuthStrategy" type:"string" enum:"AuthStrategy"`
 
 	ManagedAgents []*ManagedAgent `locationName:"managedAgents" type:"list"`
@@ -524,6 +527,8 @@ type Container struct {
 	Overrides *string `locationName:"overrides" type:"string"`
 
 	PortMappings []*PortMapping `locationName:"portMappings" type:"list"`
+
+	Privileged *bool `locationName:"privileged" type:"boolean"`
 
 	RegistryAuthentication *RegistryAuthenticationData `locationName:"registryAuthentication" type:"structure"`
 
@@ -550,6 +555,21 @@ func (s Container) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Container) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Container"}
+	if s.LinuxParameters != nil {
+		if err := s.LinuxParameters.Validate(); err != nil {
+			invalidParams.AddNested("LinuxParameters", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ContainerDependency struct {
 	_ struct{} `type:"structure"`
 
@@ -566,6 +586,40 @@ func (s ContainerDependency) String() string {
 // GoString returns the string representation
 func (s ContainerDependency) GoString() string {
 	return s.String()
+}
+
+type Device struct {
+	_ struct{} `type:"structure"`
+
+	ContainerPath *string `locationName:"containerPath" type:"string"`
+
+	// HostPath is a required field
+	HostPath *string `locationName:"hostPath" type:"string" required:"true"`
+
+	Permissions []*string `locationName:"permissions" type:"list"`
+}
+
+// String returns the string representation
+func (s Device) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Device) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Device) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Device"}
+	if s.HostPath == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostPath"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DockerConfig struct {
@@ -1233,6 +1287,66 @@ func (s *InvalidInstanceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
+type KernelCapabilities struct {
+	_ struct{} `type:"structure"`
+
+	Add []*string `locationName:"add" type:"list"`
+
+	Drop []*string `locationName:"drop" type:"list"`
+}
+
+// String returns the string representation
+func (s KernelCapabilities) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s KernelCapabilities) GoString() string {
+	return s.String()
+}
+
+type LinuxParameters struct {
+	_ struct{} `type:"structure"`
+
+	Capabilities *KernelCapabilities `locationName:"capabilities" type:"structure"`
+
+	Devices []*Device `locationName:"devices" type:"list"`
+
+	InitProcessEnabled *bool `locationName:"initProcessEnabled" type:"boolean"`
+
+	SharedMemorySize *int64 `locationName:"sharedMemorySize" type:"integer"`
+}
+
+// String returns the string representation
+func (s LinuxParameters) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LinuxParameters) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LinuxParameters) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LinuxParameters"}
+	if s.Devices != nil {
+		for i, v := range s.Devices {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Devices", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ManagedAgent struct {
 	_ struct{} `type:"structure"`
 
@@ -1371,6 +1485,26 @@ func (s PayloadInput) String() string {
 // GoString returns the string representation
 func (s PayloadInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PayloadInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PayloadInput"}
+	if s.Tasks != nil {
+		for i, v := range s.Tasks {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tasks", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PayloadMessage struct {
@@ -1870,6 +2004,26 @@ func (s Task) String() string {
 // GoString returns the string representation
 func (s Task) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Task) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Task"}
+	if s.Containers != nil {
+		for i, v := range s.Containers {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Containers", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type TaskIdentifier struct {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon/managed_daemon.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon/managed_daemon.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+
 	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
@@ -55,6 +57,9 @@ type ManagedDaemon struct {
 
 	loadedDaemonImageRef string
 	command              []string
+
+	linuxParameters *ecsacs.LinuxParameters
+	privileged      bool
 }
 
 // A valid managed daemon will require
@@ -82,16 +87,12 @@ func ImportAll() ([]*ManagedDaemon, error) {
 	return []*ManagedDaemon{}, nil
 }
 
-func (md *ManagedDaemon) SetHealthCheck(
-	healthCheckTest []string,
-	healthCheckInterval time.Duration,
-	healthCheckTimeout time.Duration,
-	healthCheckRetries int) {
-	md.healthCheckInterval = healthCheckInterval
-	md.healthCheckTimeout = healthCheckTimeout
-	md.healthCheckRetries = healthCheckRetries
-	md.healthCheckTest = make([]string, len(healthCheckTest))
-	copy(md.healthCheckTest, healthCheckTest)
+func (md *ManagedDaemon) GetLinuxParameters() *ecsacs.LinuxParameters {
+	return md.linuxParameters
+}
+
+func (md *ManagedDaemon) GetPrivileged() bool {
+	return md.privileged
 }
 
 func (md *ManagedDaemon) GetImageName() string {
@@ -147,6 +148,18 @@ func (md *ManagedDaemon) GetEnvironment() map[string]string {
 
 func (md *ManagedDaemon) GetLoadedDaemonImageRef() string {
 	return md.loadedDaemonImageRef
+}
+
+func (md *ManagedDaemon) SetHealthCheck(
+	healthCheckTest []string,
+	healthCheckInterval time.Duration,
+	healthCheckTimeout time.Duration,
+	healthCheckRetries int) {
+	md.healthCheckInterval = healthCheckInterval
+	md.healthCheckTimeout = healthCheckTimeout
+	md.healthCheckRetries = healthCheckRetries
+	md.healthCheckTest = make([]string, len(healthCheckTest))
+	copy(md.healthCheckTest, healthCheckTest)
 }
 
 // filter mount points for agentCommunicationMount
@@ -205,6 +218,10 @@ func (md *ManagedDaemon) SetEnvironment(environment map[string]string) {
 
 func (md *ManagedDaemon) SetLoadedDaemonImageRef(loadedImageRef string) {
 	md.loadedDaemonImageRef = loadedImageRef
+}
+
+func (md *ManagedDaemon) SetPrivileged(isPrivileged bool) {
+	md.privileged = isPrivileged
 }
 
 // AddMountPoint will add by MountPoint.SourceVolume

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon/mountpoint.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon/mountpoint.go
@@ -26,4 +26,7 @@ type MountPoint struct {
 	ContainerPath        string `json:"ContainerPath,omitempty"`
 	ReadOnly             bool   `json:"ReadOnly,omitempty"`
 	Internal             bool   `json:"Internal,omitempty"`
+	// BindOptions.Propagation comes from:
+	// https://github.com/moby/moby/blob/master/api/types/mount/mount.go#L46-L56
+	PropagationShared bool `json:"PropagationShared,omitempty"`
 }

--- a/ecs-agent/acs/model/api/api-2.json
+++ b/ecs-agent/acs/model/api/api-2.json
@@ -251,6 +251,14 @@
       "exception":true
     },
     "Boolean":{"type":"boolean"},
+    "BoxedBoolean":{
+      "type":"boolean",
+      "box":true
+    },
+    "BoxedInteger":{
+      "type":"integer",
+      "box":true
+    },
     "CloseMessage":{
       "type":"structure",
       "members":{
@@ -290,6 +298,8 @@
         "portMappings":{"shape":"PortMappingList"},
         "managedAgents":{"shape":"ManagedAgentList"},
         "mountPoints":{"shape":"MountPointList"},
+        "linuxParameters":{"shape":"LinuxParameters"},
+        "privileged":{"shape":"BoxedBoolean"},
         "networkInterfaceNames":{"shape":"StringList"},
         "volumesFrom":{"shape":"VolumeFromList"},
         "dockerConfig":{"shape":"DockerConfig"},
@@ -618,6 +628,48 @@
       "type":"list",
       "member":{"shape":"MountPoint"}
     },
+    "KernelCapabilities":{
+      "type":"structure",
+      "members":{
+        "add":{"shape":"StringList"},
+        "drop":{"shape":"StringList"}
+      }
+    },
+    "Device":{
+      "type":"structure",
+      "required":["hostPath"],
+      "members":{
+        "hostPath":{"shape":"String"},
+        "containerPath":{"shape":"String"},
+        "permissions":{"shape":"DeviceCgroupPermissions"}
+      }
+    },
+    "DeviceCgroupPermission":{
+      "type":"string",
+      "enum":[
+        "read",
+        "write",
+        "mknod"
+      ]
+    },
+    "DeviceCgroupPermissions":{
+      "type":"list",
+      "member":{"shape":"DeviceCgroupPermission"}
+    },
+    "DevicesList":{
+      "type":"list",
+      "member":{"shape":"Device"}
+    },
+    "LinuxParameters":{
+      "type":"structure",
+      "members":{
+        "capabilities":{"shape":"KernelCapabilities"},
+        "devices":{"shape":"DevicesList"},
+        "initProcessEnabled":{"shape":"BoxedBoolean"},
+        "sharedMemorySize":{"shape":"BoxedInteger"}
+      }
+    },
+
     "NackRequest":{
       "type":"structure",
       "members":{

--- a/ecs-agent/acs/model/ecsacs/api.go
+++ b/ecs-agent/acs/model/ecsacs/api.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
@@ -509,6 +510,8 @@ type Container struct {
 
 	Links []*string `locationName:"links" type:"list"`
 
+	LinuxParameters *LinuxParameters `locationName:"linuxParameters" type:"structure"`
+
 	LogsAuthStrategy *string `locationName:"logsAuthStrategy" type:"string" enum:"AuthStrategy"`
 
 	ManagedAgents []*ManagedAgent `locationName:"managedAgents" type:"list"`
@@ -524,6 +527,8 @@ type Container struct {
 	Overrides *string `locationName:"overrides" type:"string"`
 
 	PortMappings []*PortMapping `locationName:"portMappings" type:"list"`
+
+	Privileged *bool `locationName:"privileged" type:"boolean"`
 
 	RegistryAuthentication *RegistryAuthenticationData `locationName:"registryAuthentication" type:"structure"`
 
@@ -550,6 +555,21 @@ func (s Container) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Container) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Container"}
+	if s.LinuxParameters != nil {
+		if err := s.LinuxParameters.Validate(); err != nil {
+			invalidParams.AddNested("LinuxParameters", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ContainerDependency struct {
 	_ struct{} `type:"structure"`
 
@@ -566,6 +586,40 @@ func (s ContainerDependency) String() string {
 // GoString returns the string representation
 func (s ContainerDependency) GoString() string {
 	return s.String()
+}
+
+type Device struct {
+	_ struct{} `type:"structure"`
+
+	ContainerPath *string `locationName:"containerPath" type:"string"`
+
+	// HostPath is a required field
+	HostPath *string `locationName:"hostPath" type:"string" required:"true"`
+
+	Permissions []*string `locationName:"permissions" type:"list"`
+}
+
+// String returns the string representation
+func (s Device) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Device) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Device) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Device"}
+	if s.HostPath == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostPath"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DockerConfig struct {
@@ -1233,6 +1287,66 @@ func (s *InvalidInstanceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
+type KernelCapabilities struct {
+	_ struct{} `type:"structure"`
+
+	Add []*string `locationName:"add" type:"list"`
+
+	Drop []*string `locationName:"drop" type:"list"`
+}
+
+// String returns the string representation
+func (s KernelCapabilities) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s KernelCapabilities) GoString() string {
+	return s.String()
+}
+
+type LinuxParameters struct {
+	_ struct{} `type:"structure"`
+
+	Capabilities *KernelCapabilities `locationName:"capabilities" type:"structure"`
+
+	Devices []*Device `locationName:"devices" type:"list"`
+
+	InitProcessEnabled *bool `locationName:"initProcessEnabled" type:"boolean"`
+
+	SharedMemorySize *int64 `locationName:"sharedMemorySize" type:"integer"`
+}
+
+// String returns the string representation
+func (s LinuxParameters) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LinuxParameters) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LinuxParameters) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LinuxParameters"}
+	if s.Devices != nil {
+		for i, v := range s.Devices {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Devices", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ManagedAgent struct {
 	_ struct{} `type:"structure"`
 
@@ -1371,6 +1485,26 @@ func (s PayloadInput) String() string {
 // GoString returns the string representation
 func (s PayloadInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PayloadInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PayloadInput"}
+	if s.Tasks != nil {
+		for i, v := range s.Tasks {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tasks", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PayloadMessage struct {
@@ -1870,6 +2004,26 @@ func (s Task) String() string {
 // GoString returns the string representation
 func (s Task) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Task) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Task"}
+	if s.Containers != nil {
+		for i, v := range s.Containers {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Containers", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type TaskIdentifier struct {

--- a/ecs-agent/manageddaemon/managed_daemon.go
+++ b/ecs-agent/manageddaemon/managed_daemon.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+
 	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
@@ -55,6 +57,9 @@ type ManagedDaemon struct {
 
 	loadedDaemonImageRef string
 	command              []string
+
+	linuxParameters *ecsacs.LinuxParameters
+	privileged      bool
 }
 
 // A valid managed daemon will require
@@ -82,16 +87,12 @@ func ImportAll() ([]*ManagedDaemon, error) {
 	return []*ManagedDaemon{}, nil
 }
 
-func (md *ManagedDaemon) SetHealthCheck(
-	healthCheckTest []string,
-	healthCheckInterval time.Duration,
-	healthCheckTimeout time.Duration,
-	healthCheckRetries int) {
-	md.healthCheckInterval = healthCheckInterval
-	md.healthCheckTimeout = healthCheckTimeout
-	md.healthCheckRetries = healthCheckRetries
-	md.healthCheckTest = make([]string, len(healthCheckTest))
-	copy(md.healthCheckTest, healthCheckTest)
+func (md *ManagedDaemon) GetLinuxParameters() *ecsacs.LinuxParameters {
+	return md.linuxParameters
+}
+
+func (md *ManagedDaemon) GetPrivileged() bool {
+	return md.privileged
 }
 
 func (md *ManagedDaemon) GetImageName() string {
@@ -147,6 +148,18 @@ func (md *ManagedDaemon) GetEnvironment() map[string]string {
 
 func (md *ManagedDaemon) GetLoadedDaemonImageRef() string {
 	return md.loadedDaemonImageRef
+}
+
+func (md *ManagedDaemon) SetHealthCheck(
+	healthCheckTest []string,
+	healthCheckInterval time.Duration,
+	healthCheckTimeout time.Duration,
+	healthCheckRetries int) {
+	md.healthCheckInterval = healthCheckInterval
+	md.healthCheckTimeout = healthCheckTimeout
+	md.healthCheckRetries = healthCheckRetries
+	md.healthCheckTest = make([]string, len(healthCheckTest))
+	copy(md.healthCheckTest, healthCheckTest)
 }
 
 // filter mount points for agentCommunicationMount
@@ -205,6 +218,10 @@ func (md *ManagedDaemon) SetEnvironment(environment map[string]string) {
 
 func (md *ManagedDaemon) SetLoadedDaemonImageRef(loadedImageRef string) {
 	md.loadedDaemonImageRef = loadedImageRef
+}
+
+func (md *ManagedDaemon) SetPrivileged(isPrivileged bool) {
+	md.privileged = isPrivileged
 }
 
 // AddMountPoint will add by MountPoint.SourceVolume

--- a/ecs-agent/manageddaemon/mountpoint.go
+++ b/ecs-agent/manageddaemon/mountpoint.go
@@ -26,4 +26,7 @@ type MountPoint struct {
 	ContainerPath        string `json:"ContainerPath,omitempty"`
 	ReadOnly             bool   `json:"ReadOnly,omitempty"`
 	Internal             bool   `json:"Internal,omitempty"`
+	// BindOptions.Propagation comes from:
+	// https://github.com/moby/moby/blob/master/api/types/mount/mount.go#L46-L56
+	PropagationShared bool `json:"PropagationShared,omitempty"`
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
CSI Managed Daemon requires both privilege and mount propagation.  This adds them to the Managed Daemon config and integrates this with `CreateDaemonTask`

### Testing
Added unit tests and also tested
Tested via [fierlion/NodeStageAltogether](https://github.com/fierlion/amazon-ecs-agent/blob/fierlion/NodeStageAltogether/agent/api/task/task.go#L837-L846) which includes CSI Client changes from https://github.com/aws/amazon-ecs-agent/pull/3905 and CSI Driver updates from https://github.com/aws/amazon-ecs-agent/pull/3900 as well as hard-coded volume parameters in the task.go

New tests cover the changes: yes

### Description for the changelog
Update Managed Daemon to allow for privilege and mount propagation.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
