### PR TITLE
Process attachment payload message for EBS attach

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_resource_responder.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_resource_responder.go
@@ -91,6 +91,7 @@ func (r *attachResourceResponder) handleAttachMessage(message *ecsacs.ConfirmAtt
 			Status:               status.AttachmentNone,
 		},
 		AttachmentProperties: attachmentProperties,
+		AttachmentType:       aws.StringValue(message.Attachment.AttachmentType),
 	})
 
 	// Send ACK.

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_resource_responder.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_resource_responder.go
@@ -180,9 +180,9 @@ func validateAttachmentAndReturnProperties(message *ecsacs.ConfirmAttachmentMess
 		attachmentProperties[name] = value
 	}
 
-	// For "amazonebs" used by the EBS attach, ACS is using attachmentType to indicate its attachment type.
+	// For "AmazonElasticBlockStorage" used by the EBS attach, ACS is using attachmentType to indicate its attachment type.
 	attachmentType := aws.StringValue(message.Attachment.AttachmentType)
-	if attachmentType == resource.AmazonEBS {
+	if attachmentType == resource.AmazonElasticBlockStorage {
 		err = resource.ValidateRequiredProperties(
 			attachmentProperties,
 			resource.GetVolumeSpecificPropertiesForEBSAttach(),

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery.go
@@ -28,6 +28,8 @@ const (
 )
 
 var (
+	// When confirming an EBS volume is attached to a host, if the expected volume ID does not
+	// match the volume ID found on the host, this error is returned.
 	ErrInvalidVolumeID = errors.New("EBS volume IDs do not match")
 )
 

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_attachment.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_attachment.go
@@ -27,6 +27,8 @@ import (
 
 type ResourceAttachment struct {
 	attachmentinfo.AttachmentInfo
+	// AttachmentType is the type of the resource attachment which can be "amazonebs" for EBS attach tasks.
+	AttachmentType string
 	// AttachmentProperties is a map storing (name, value) representation of attachment properties.
 	// Each pair is a set of property of one resource attachment.
 	// The "FargateResourceId" is a property name that will be present for all resources.
@@ -62,6 +64,14 @@ const (
 
 	// Properties specific to Elastic Block Service Volumes
 	FileSystemTypeName = "filesystemType"
+
+	// Properties specific to volumes for EBS attach.
+	VolumeIdKey             = "volumeId"
+	VolumeSizeGibKey        = "volumeSizeGib"
+	DeviceNameKey           = "deviceName"
+	SourceVolumeHostPathKey = "sourceVolumeHostPath"
+	VolumeNameKey           = "volumeName"
+	FileSystemKey           = "fileSystem"
 )
 
 // getCommonProperties returns the common properties as used for validating a resource.
@@ -77,6 +87,19 @@ func getVolumeSpecificProperties() (volumeSpecificProperties []string) {
 	volumeSpecificProperties = []string{
 		VolumeIdName,
 		DeviceName,
+	}
+	return volumeSpecificProperties
+}
+
+// GetVolumeSpecificPropertiesForEBSAttach returns the properties specific to EBS volume resources which will be used
+// in EBS attach.
+func GetVolumeSpecificPropertiesForEBSAttach() (volumeSpecificProperties []string) {
+	volumeSpecificProperties = []string{
+		VolumeIdKey,
+		VolumeSizeGibKey,
+		DeviceNameKey,
+		SourceVolumeHostPathKey,
+		VolumeNameKey,
 	}
 	return volumeSpecificProperties
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_attachment.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_attachment.go
@@ -27,7 +27,7 @@ import (
 
 type ResourceAttachment struct {
 	attachmentinfo.AttachmentInfo
-	// AttachmentType is the type of the resource attachment which can be "amazonebs" for EBS attach tasks.
+	// AttachmentType is the type of the resource attachment which can be "AmazonElasticBlockStorage" for EBS attach tasks.
 	AttachmentType string
 	// AttachmentProperties is a map storing (name, value) representation of attachment properties.
 	// Each pair is a set of property of one resource attachment.

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_attachment.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_attachment.go
@@ -28,7 +28,7 @@ import (
 type ResourceAttachment struct {
 	attachmentinfo.AttachmentInfo
 	// AttachmentType is the type of the resource attachment which can be "AmazonElasticBlockStorage" for EBS attach tasks.
-	AttachmentType string
+	AttachmentType string `json:"AttachmentType,omitempty"`
 	// AttachmentProperties is a map storing (name, value) representation of attachment properties.
 	// Each pair is a set of property of one resource attachment.
 	// The "FargateResourceId" is a property name that will be present for all resources.

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_type.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_type.go
@@ -20,6 +20,6 @@ const (
 	// ElasticBlockStorage is one of the resource types in the properties list of the attachment payload message for the
 	// EBS volume on firecracker.
 	ElasticBlockStorage = "ElasticBlockStorage"
-	// AmazonElasticBlockStorage is one of the attachment types in the attachment payload message for EBS attach tasks on warmpool.
+	// AmazonElasticBlockStorage is one of the attachment types in the attachment payload message for EBS attach tasks.
 	AmazonElasticBlockStorage = "AmazonElasticBlockStorage"
 )

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_type.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_type.go
@@ -14,6 +14,12 @@
 package resource
 
 const (
-	EphemeralStorage    = "EphemeralStorage"
+	// EphemeralStorage is one of the resource types in the properties list of the attachment payload message for the
+	// ephemeral storage.
+	EphemeralStorage = "EphemeralStorage"
+	// ElasticBlockStorage is one of the resource types in the properties list of the attachment payload message for the
+	// EBS volume on firecracker.
 	ElasticBlockStorage = "ElasticBlockStorage"
+	// AmazonEBS is one of the attachment types in the attachment payload message for EBS attach tasks on warmpool.
+	AmazonEBS = "amazonebs"
 )

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_type.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_type.go
@@ -20,6 +20,6 @@ const (
 	// ElasticBlockStorage is one of the resource types in the properties list of the attachment payload message for the
 	// EBS volume on firecracker.
 	ElasticBlockStorage = "ElasticBlockStorage"
-	// AmazonEBS is one of the attachment types in the attachment payload message for EBS attach tasks on warmpool.
-	AmazonEBS = "amazonebs"
+	// AmazonElasticBlockStorage is one of the attachment types in the attachment payload message for EBS attach tasks on warmpool.
+	AmazonElasticBlockStorage = "AmazonElasticBlockStorage"
 )

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_validation.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_validation.go
@@ -17,9 +17,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ValidateResource checks if the provided resource type is valid, as well as if the attachment
+// ValidateResourceByResourceType checks if the provided resource type is valid, as well as if the attachment
 // properties of the specified resource are valid.
-func ValidateResource(resourceAttachmentProperties map[string]string) error {
+func ValidateResourceByResourceType(resourceAttachmentProperties map[string]string) error {
 	resourceType, ok := resourceAttachmentProperties[ResourceTypeName]
 	if !ok {
 		return errors.New("resource attachment validation: no resourceType found")
@@ -49,28 +49,23 @@ func validateEphemeralStorageProperties(properties map[string]string) error {
 	if err != nil {
 		return err
 	}
-	for _, property := range getExtensibleEphemeralStorageProperties() {
-		if _, ok := properties[property]; !ok {
-			return errors.Errorf("property %s not found in attachment properties", property)
-		}
-	}
-	return nil
+
+	return ValidateRequiredProperties(properties, getExtensibleEphemeralStorageProperties())
 }
 
-// validateCommonAttachmentProperties checks if the required common properties exist for an attachment
+// validateCommonAttachmentProperties checks if all required common properties exist for an attachment
 func validateCommonAttachmentProperties(resourceAttachmentProperties map[string]string) error {
-	for _, property := range getCommonProperties() {
-		if _, ok := resourceAttachmentProperties[property]; !ok {
-			return errors.Errorf("property %s not found in attachment properties", property)
-		}
-	}
-	return nil
+	return ValidateRequiredProperties(resourceAttachmentProperties, getCommonProperties())
 }
 
-// validateVolumeAttachmentProperties checks if the required properties exist for a given volume attachment.
+// validateVolumeAttachmentProperties checks if all required properties exist for a given volume attachment.
 func validateVolumeAttachmentProperties(volumeAttachmentProperties map[string]string) error {
-	for _, property := range getVolumeSpecificProperties() {
-		if _, ok := volumeAttachmentProperties[property]; !ok {
+	return ValidateRequiredProperties(volumeAttachmentProperties, getVolumeSpecificProperties())
+}
+
+func ValidateRequiredProperties(actualProperties map[string]string, requiredProperties []string) error {
+	for _, property := range requiredProperties {
+		if _, ok := actualProperties[property]; !ok {
 			return errors.Errorf("property %s not found in attachment properties", property)
 		}
 	}

--- a/ecs-agent/acs/session/attach_resource_responder.go
+++ b/ecs-agent/acs/session/attach_resource_responder.go
@@ -180,7 +180,7 @@ func validateAttachmentAndReturnProperties(message *ecsacs.ConfirmAttachmentMess
 		attachmentProperties[name] = value
 	}
 
-	// For "amazonebs" used by the EBS attach, ACS is using attachmentType to inform its attachment type.
+	// For "amazonebs" used by the EBS attach, ACS is using attachmentType to indicate its attachment type.
 	attachmentType := aws.StringValue(message.Attachment.AttachmentType)
 	if attachmentType == resource.AmazonEBS {
 		err = resource.ValidateRequiredProperties(
@@ -193,7 +193,7 @@ func validateAttachmentAndReturnProperties(message *ecsacs.ConfirmAttachmentMess
 		return attachmentProperties, nil
 	}
 
-	// For "EphemeralStorage" and "ElasticBlockStorage", ACS is using resourceType to inform its attachment type.
+	// For "EphemeralStorage" and "ElasticBlockStorage", ACS is using resourceType to indicate its attachment type.
 	err = resource.ValidateResourceByResourceType(attachmentProperties)
 	if err != nil {
 		return nil, errors.Wrap(err, "resource attachment validation by resource type failed ")

--- a/ecs-agent/acs/session/attach_resource_responder.go
+++ b/ecs-agent/acs/session/attach_resource_responder.go
@@ -180,9 +180,23 @@ func validateAttachmentAndReturnProperties(message *ecsacs.ConfirmAttachmentMess
 		attachmentProperties[name] = value
 	}
 
-	err = resource.ValidateResource(attachmentProperties)
+	// For "amazonebs" used by the EBS attach, ACS is using attachmentType to inform its attachment type.
+	attachmentType := aws.StringValue(message.Attachment.AttachmentType)
+	if attachmentType == resource.AmazonEBS {
+		err = resource.ValidateRequiredProperties(
+			attachmentProperties,
+			resource.GetVolumeSpecificPropertiesForEBSAttach(),
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "resource attachment validation by attachment type failed")
+		}
+		return attachmentProperties, nil
+	}
+
+	// For "EphemeralStorage" and "ElasticBlockStorage", ACS is using resourceType to inform its attachment type.
+	err = resource.ValidateResourceByResourceType(attachmentProperties)
 	if err != nil {
-		return nil, errors.Wrap(err, "resource attachment validation error")
+		return nil, errors.Wrap(err, "resource attachment validation by resource type failed ")
 	}
 
 	return attachmentProperties, nil

--- a/ecs-agent/acs/session/attach_resource_responder.go
+++ b/ecs-agent/acs/session/attach_resource_responder.go
@@ -91,6 +91,7 @@ func (r *attachResourceResponder) handleAttachMessage(message *ecsacs.ConfirmAtt
 			Status:               status.AttachmentNone,
 		},
 		AttachmentProperties: attachmentProperties,
+		AttachmentType:       aws.StringValue(message.Attachment.AttachmentType),
 	})
 
 	// Send ACK.

--- a/ecs-agent/acs/session/attach_resource_responder.go
+++ b/ecs-agent/acs/session/attach_resource_responder.go
@@ -180,9 +180,9 @@ func validateAttachmentAndReturnProperties(message *ecsacs.ConfirmAttachmentMess
 		attachmentProperties[name] = value
 	}
 
-	// For "amazonebs" used by the EBS attach, ACS is using attachmentType to indicate its attachment type.
+	// For "AmazonElasticBlockStorage" used by the EBS attach, ACS is using attachmentType to indicate its attachment type.
 	attachmentType := aws.StringValue(message.Attachment.AttachmentType)
-	if attachmentType == resource.AmazonEBS {
+	if attachmentType == resource.AmazonElasticBlockStorage {
 		err = resource.ValidateRequiredProperties(
 			attachmentProperties,
 			resource.GetVolumeSpecificPropertiesForEBSAttach(),

--- a/ecs-agent/acs/session/attach_resource_responder_test.go
+++ b/ecs-agent/acs/session/attach_resource_responder_test.go
@@ -38,6 +38,29 @@ const (
 )
 
 var (
+	testAttachmentPropertiesForEBSAttach = []*ecsacs.AttachmentProperty{
+		{
+			Name:  aws.String(resource.SourceVolumeHostPathKey),
+			Value: aws.String("taskarn-vol-id"),
+		},
+		{
+			Name:  aws.String(resource.VolumeIdKey),
+			Value: aws.String("id1"),
+		},
+		{
+			Name:  aws.String(resource.VolumeSizeGibKey),
+			Value: aws.String("size1"),
+		},
+		{
+			Name:  aws.String(resource.VolumeNameKey),
+			Value: aws.String("name"),
+		},
+		{
+			Name:  aws.String(resource.DeviceNameKey),
+			Value: aws.String("device1"),
+		},
+	}
+
 	testAttachmentProperties = []*ecsacs.AttachmentProperty{
 		{
 			Name:  aws.String(resource.FargateResourceIdName),
@@ -83,46 +106,47 @@ func TestValidateAttachResourceMessage(t *testing.T) {
 	defer ctrl.Finish()
 
 	_, err := validateAttachResourceMessage(nil)
-
 	require.Error(t, err)
 
+	// Verify the Attachment is required.
 	confirmAttachmentMessageCopy := *testConfirmAttachmentMessage
 	confirmAttachmentMessageCopy.Attachment = nil
-
 	_, err = validateAttachResourceMessage(&confirmAttachmentMessageCopy)
-
 	require.Error(t, err)
 
+	// Verify the MessageId is required.
 	confirmAttachmentMessageCopy = *testConfirmAttachmentMessage
 	confirmAttachmentMessageCopy.MessageId = aws.String("")
-
 	_, err = validateAttachResourceMessage(&confirmAttachmentMessageCopy)
-
 	require.Error(t, err)
 
+	// Verify the ClusterArn is required.
 	confirmAttachmentMessageCopy = *testConfirmAttachmentMessage
 	confirmAttachmentMessageCopy.ClusterArn = aws.String("")
-
 	_, err = validateAttachResourceMessage(&confirmAttachmentMessageCopy)
-
 	require.Error(t, err)
 
+	// Verify the ContainerInstanceArn is required.
 	confirmAttachmentMessageCopy = *testConfirmAttachmentMessage
 	confirmAttachmentMessageCopy.ContainerInstanceArn = aws.String("")
-
 	_, err = validateAttachResourceMessage(&confirmAttachmentMessageCopy)
-
 	require.Error(t, err)
 
+	// Verify the AttachmentArn is required and is correct format.
 	confirmAttachmentMessageCopy = *testConfirmAttachmentMessage
 	confirmAttachmentMessageCopy.Attachment.AttachmentArn = aws.String("incorrectArn")
-
 	_, err = validateAttachResourceMessage(&confirmAttachmentMessageCopy)
-
 	require.Error(t, err)
 }
 
 func TestValidateAttachmentAndReturnProperties(t *testing.T) {
+	t.Run("with no attachment type", testValidateAttachmentAndReturnPropertiesWithoutAttachmentType)
+	t.Run("with attachment type", testValidateAttachmentAndReturnPropertiesWithAttachmentType)
+}
+
+// testValidateAttachmentAndReturnPropertiesWithoutAttachmentType verifies all required properties for either
+// resource type: "EphemeralStorage" or "ElasticBlockStorage".
+func testValidateAttachmentAndReturnPropertiesWithoutAttachmentType(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -154,6 +178,66 @@ func TestValidateAttachmentAndReturnProperties(t *testing.T) {
 				property.Name = originalPropertyName
 			}
 		})
+	}
+}
+
+// testValidateAttachmentAndReturnPropertiesWithAttachmentType verifies all required properties for attachment
+// type: "amazonebs".
+func testValidateAttachmentAndReturnPropertiesWithAttachmentType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Verify the AttachmentArn is required and uses the correct format.
+	confirmAttachmentMessageCopy := *testConfirmAttachmentMessage
+	confirmAttachmentMessageCopy.Attachment.AttachmentArn = aws.String("incorrectArn")
+	_, err := validateAttachmentAndReturnProperties(&confirmAttachmentMessageCopy)
+	require.Error(t, err)
+	confirmAttachmentMessageCopy.Attachment.AttachmentArn = aws.String(testAttachmentArn)
+
+	// Verify the property name & property value must be non-empty.
+	for _, property := range confirmAttachmentMessageCopy.Attachment.AttachmentProperties {
+		t.Run(property.String(), func(t *testing.T) {
+			originalPropertyName := property.Name
+			property.Name = aws.String("")
+			_, err := validateAttachmentAndReturnProperties(&confirmAttachmentMessageCopy)
+			require.Error(t, err)
+			property.Name = originalPropertyName
+
+			originalPropertyValue := property.Value
+			property.Value = aws.String("")
+			_, err = validateAttachmentAndReturnProperties(&confirmAttachmentMessageCopy)
+			require.Error(t, err)
+			property.Value = originalPropertyValue
+		})
+	}
+
+	// Reset attachment to be a good one.
+	confirmAttachmentMessageCopy.Attachment.AttachmentType = aws.String("amazonebs")
+	confirmAttachmentMessageCopy.Attachment.AttachmentProperties = testAttachmentPropertiesForEBSAttach
+
+	// Verify all required properties for the attachment for EBS attach are present.
+	requiredProperties := []string{
+		"volumeId",
+		"volumeSizeGib",
+		"deviceName",
+		"sourceVolumeHostPath",
+		"volumeName",
+	}
+	for _, requiredProperty := range requiredProperties {
+		verified := false
+		for _, property := range confirmAttachmentMessageCopy.Attachment.AttachmentProperties {
+			if requiredProperty == aws.StringValue(property.Name) {
+				originalPropertyName := property.Name
+				property.Name = aws.String("")
+				_, err := validateAttachmentAndReturnProperties(&confirmAttachmentMessageCopy)
+				require.Error(t, err)
+				property.Name = originalPropertyName
+
+				verified = true
+				break
+			}
+		}
+		require.True(t, verified, "Missing required property: %s", requiredProperty)
 	}
 }
 

--- a/ecs-agent/acs/session/attach_resource_responder_test.go
+++ b/ecs-agent/acs/session/attach_resource_responder_test.go
@@ -182,7 +182,7 @@ func testValidateAttachmentAndReturnPropertiesWithoutAttachmentType(t *testing.T
 }
 
 // testValidateAttachmentAndReturnPropertiesWithAttachmentType verifies all required properties for attachment
-// type: "amazonebs".
+// type: "AmazonElasticBlockStorage".
 func testValidateAttachmentAndReturnPropertiesWithAttachmentType(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -217,7 +217,7 @@ func testValidateAttachmentAndReturnPropertiesWithAttachmentType(t *testing.T) {
 	require.NoError(t, err)
 
 	// Reset attachment to be a good one with valid attachment type.
-	confirmAttachmentMessageCopy.Attachment.AttachmentType = aws.String("amazonebs")
+	confirmAttachmentMessageCopy.Attachment.AttachmentType = aws.String("AmazonElasticBlockStorage")
 	confirmAttachmentMessageCopy.Attachment.AttachmentProperties = testAttachmentPropertiesForEBSAttach
 
 	// Verify all required properties for the attachment for EBS attach are present.

--- a/ecs-agent/acs/session/attach_resource_responder_test.go
+++ b/ecs-agent/acs/session/attach_resource_responder_test.go
@@ -132,7 +132,7 @@ func TestValidateAttachResourceMessage(t *testing.T) {
 	_, err = validateAttachResourceMessage(&confirmAttachmentMessageCopy)
 	require.Error(t, err)
 
-	// Verify the AttachmentArn is required and is correct format.
+	// Verify the AttachmentArn is required and uses correct format.
 	confirmAttachmentMessageCopy = *testConfirmAttachmentMessage
 	confirmAttachmentMessageCopy.Attachment.AttachmentArn = aws.String("incorrectArn")
 	_, err = validateAttachResourceMessage(&confirmAttachmentMessageCopy)
@@ -211,7 +211,12 @@ func testValidateAttachmentAndReturnPropertiesWithAttachmentType(t *testing.T) {
 		})
 	}
 
-	// Reset attachment to be a good one.
+	// Reset attachment to be a good one with invalid attachment type.
+	confirmAttachmentMessageCopy.Attachment.AttachmentType = aws.String("invalid-type")
+	_, err = validateAttachmentAndReturnProperties(&confirmAttachmentMessageCopy)
+	require.NoError(t, err)
+
+	// Reset attachment to be a good one with valid attachment type.
 	confirmAttachmentMessageCopy.Attachment.AttachmentType = aws.String("amazonebs")
 	confirmAttachmentMessageCopy.Attachment.AttachmentProperties = testAttachmentPropertiesForEBSAttach
 

--- a/ecs-agent/api/resource/ebs_discovery.go
+++ b/ecs-agent/api/resource/ebs_discovery.go
@@ -28,6 +28,8 @@ const (
 )
 
 var (
+	// When confirming an EBS volume is attached to a host, if the expected volume ID does not
+	// match the volume ID found on the host, this error is returned.
 	ErrInvalidVolumeID = errors.New("EBS volume IDs do not match")
 )
 

--- a/ecs-agent/api/resource/resource_attachment.go
+++ b/ecs-agent/api/resource/resource_attachment.go
@@ -27,6 +27,8 @@ import (
 
 type ResourceAttachment struct {
 	attachmentinfo.AttachmentInfo
+	// AttachmentType is the type of the resource attachment which can be "amazonebs" for EBS attach tasks.
+	AttachmentType string
 	// AttachmentProperties is a map storing (name, value) representation of attachment properties.
 	// Each pair is a set of property of one resource attachment.
 	// The "FargateResourceId" is a property name that will be present for all resources.
@@ -62,6 +64,14 @@ const (
 
 	// Properties specific to Elastic Block Service Volumes
 	FileSystemTypeName = "filesystemType"
+
+	// Properties specific to volumes for EBS attach.
+	VolumeIdKey             = "volumeId"
+	VolumeSizeGibKey        = "volumeSizeGib"
+	DeviceNameKey           = "deviceName"
+	SourceVolumeHostPathKey = "sourceVolumeHostPath"
+	VolumeNameKey           = "volumeName"
+	FileSystemKey           = "fileSystem"
 )
 
 // getCommonProperties returns the common properties as used for validating a resource.
@@ -77,6 +87,19 @@ func getVolumeSpecificProperties() (volumeSpecificProperties []string) {
 	volumeSpecificProperties = []string{
 		VolumeIdName,
 		DeviceName,
+	}
+	return volumeSpecificProperties
+}
+
+// GetVolumeSpecificPropertiesForEBSAttach returns the properties specific to EBS volume resources which will be used
+// in EBS attach.
+func GetVolumeSpecificPropertiesForEBSAttach() (volumeSpecificProperties []string) {
+	volumeSpecificProperties = []string{
+		VolumeIdKey,
+		VolumeSizeGibKey,
+		DeviceNameKey,
+		SourceVolumeHostPathKey,
+		VolumeNameKey,
 	}
 	return volumeSpecificProperties
 }

--- a/ecs-agent/api/resource/resource_attachment.go
+++ b/ecs-agent/api/resource/resource_attachment.go
@@ -27,7 +27,7 @@ import (
 
 type ResourceAttachment struct {
 	attachmentinfo.AttachmentInfo
-	// AttachmentType is the type of the resource attachment which can be "amazonebs" for EBS attach tasks.
+	// AttachmentType is the type of the resource attachment which can be "AmazonElasticBlockStorage" for EBS attach tasks.
 	AttachmentType string
 	// AttachmentProperties is a map storing (name, value) representation of attachment properties.
 	// Each pair is a set of property of one resource attachment.

--- a/ecs-agent/api/resource/resource_attachment.go
+++ b/ecs-agent/api/resource/resource_attachment.go
@@ -28,7 +28,7 @@ import (
 type ResourceAttachment struct {
 	attachmentinfo.AttachmentInfo
 	// AttachmentType is the type of the resource attachment which can be "AmazonElasticBlockStorage" for EBS attach tasks.
-	AttachmentType string
+	AttachmentType string `json:"AttachmentType,omitempty"`
 	// AttachmentProperties is a map storing (name, value) representation of attachment properties.
 	// Each pair is a set of property of one resource attachment.
 	// The "FargateResourceId" is a property name that will be present for all resources.

--- a/ecs-agent/api/resource/resource_attachment_test.go
+++ b/ecs-agent/api/resource/resource_attachment_test.go
@@ -169,3 +169,17 @@ func TestInitializeExpiredButAlreadySent(t *testing.T) {
 	}
 	assert.NoError(t, attachment.Initialize(func() {}))
 }
+
+// TestGetVolumeSpecificPropertiesForEBSAttach ensures all required properties for EBS attach are correct.
+func TestGetVolumeSpecificPropertiesForEBSAttach(t *testing.T) {
+	expected := []string{
+		"volumeId",
+		"volumeSizeGib",
+		"deviceName",
+		"sourceVolumeHostPath",
+		"volumeName",
+	}
+	actual := GetVolumeSpecificPropertiesForEBSAttach()
+
+	assert.Equal(t, expected, actual)
+}

--- a/ecs-agent/api/resource/resource_type.go
+++ b/ecs-agent/api/resource/resource_type.go
@@ -20,6 +20,6 @@ const (
 	// ElasticBlockStorage is one of the resource types in the properties list of the attachment payload message for the
 	// EBS volume on firecracker.
 	ElasticBlockStorage = "ElasticBlockStorage"
-	// AmazonElasticBlockStorage is one of the attachment types in the attachment payload message for EBS attach tasks on warmpool.
+	// AmazonElasticBlockStorage is one of the attachment types in the attachment payload message for EBS attach tasks.
 	AmazonElasticBlockStorage = "AmazonElasticBlockStorage"
 )

--- a/ecs-agent/api/resource/resource_type.go
+++ b/ecs-agent/api/resource/resource_type.go
@@ -14,6 +14,12 @@
 package resource
 
 const (
-	EphemeralStorage    = "EphemeralStorage"
+	// EphemeralStorage is one of the resource types in the properties list of the attachment payload message for the
+	// ephemeral storage.
+	EphemeralStorage = "EphemeralStorage"
+	// ElasticBlockStorage is one of the resource types in the properties list of the attachment payload message for the
+	// EBS volume on firecracker.
 	ElasticBlockStorage = "ElasticBlockStorage"
+	// AmazonEBS is one of the attachment types in the attachment payload message for EBS attach tasks on warmpool.
+	AmazonEBS = "amazonebs"
 )

--- a/ecs-agent/api/resource/resource_type.go
+++ b/ecs-agent/api/resource/resource_type.go
@@ -20,6 +20,6 @@ const (
 	// ElasticBlockStorage is one of the resource types in the properties list of the attachment payload message for the
 	// EBS volume on firecracker.
 	ElasticBlockStorage = "ElasticBlockStorage"
-	// AmazonEBS is one of the attachment types in the attachment payload message for EBS attach tasks on warmpool.
-	AmazonEBS = "amazonebs"
+	// AmazonElasticBlockStorage is one of the attachment types in the attachment payload message for EBS attach tasks on warmpool.
+	AmazonElasticBlockStorage = "AmazonElasticBlockStorage"
 )

--- a/ecs-agent/api/resource/resource_validation.go
+++ b/ecs-agent/api/resource/resource_validation.go
@@ -17,9 +17,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ValidateResource checks if the provided resource type is valid, as well as if the attachment
+// ValidateResourceByResourceType checks if the provided resource type is valid, as well as if the attachment
 // properties of the specified resource are valid.
-func ValidateResource(resourceAttachmentProperties map[string]string) error {
+func ValidateResourceByResourceType(resourceAttachmentProperties map[string]string) error {
 	resourceType, ok := resourceAttachmentProperties[ResourceTypeName]
 	if !ok {
 		return errors.New("resource attachment validation: no resourceType found")
@@ -49,28 +49,23 @@ func validateEphemeralStorageProperties(properties map[string]string) error {
 	if err != nil {
 		return err
 	}
-	for _, property := range getExtensibleEphemeralStorageProperties() {
-		if _, ok := properties[property]; !ok {
-			return errors.Errorf("property %s not found in attachment properties", property)
-		}
-	}
-	return nil
+
+	return ValidateRequiredProperties(properties, getExtensibleEphemeralStorageProperties())
 }
 
-// validateCommonAttachmentProperties checks if the required common properties exist for an attachment
+// validateCommonAttachmentProperties checks if all required common properties exist for an attachment
 func validateCommonAttachmentProperties(resourceAttachmentProperties map[string]string) error {
-	for _, property := range getCommonProperties() {
-		if _, ok := resourceAttachmentProperties[property]; !ok {
-			return errors.Errorf("property %s not found in attachment properties", property)
-		}
-	}
-	return nil
+	return ValidateRequiredProperties(resourceAttachmentProperties, getCommonProperties())
 }
 
-// validateVolumeAttachmentProperties checks if the required properties exist for a given volume attachment.
+// validateVolumeAttachmentProperties checks if all required properties exist for a given volume attachment.
 func validateVolumeAttachmentProperties(volumeAttachmentProperties map[string]string) error {
-	for _, property := range getVolumeSpecificProperties() {
-		if _, ok := volumeAttachmentProperties[property]; !ok {
+	return ValidateRequiredProperties(volumeAttachmentProperties, getVolumeSpecificProperties())
+}
+
+func ValidateRequiredProperties(actualProperties map[string]string, requiredProperties []string) error {
+	for _, property := range requiredProperties {
+		if _, ok := actualProperties[property]; !ok {
 			return errors.Errorf("property %s not found in attachment properties", property)
 		}
 	}

--- a/ecs-agent/api/resource/resource_validation_test.go
+++ b/ecs-agent/api/resource/resource_validation_test.go
@@ -60,7 +60,7 @@ func TestValidateVolumeResource(t *testing.T) {
 				resourceProperties[property] = testString
 			}
 
-			err := ValidateResource(resourceProperties)
+			err := ValidateResourceByResourceType(resourceProperties)
 			require.NoError(t, err)
 
 			// `requiredProperties` contains all properties required for a resource.
@@ -75,7 +75,7 @@ func TestValidateVolumeResource(t *testing.T) {
 				// Store the current value so that we can add it back when we reset after removing it.
 				val := resourceProperties[property]
 				delete(resourceProperties, property)
-				err := ValidateResource(resourceProperties)
+				err := ValidateResourceByResourceType(resourceProperties)
 				require.Error(t, err)
 				// Make resourceProperties whole again.
 				resourceProperties[property] = val


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR is to update the current attachment payload process to support the `AttachmentType` for EBS attach which will use `AmazonElasticBlockStorage` as the attachment type specifically. `AmazonElasticBlockStorage` is the only one we support so far and all other attachment types will be ignored.

### Implementation details
<!-- How are the changes implemented? -->
- A new field `AttachmentType` is added to the existing `ResourceAttachment`.
- The attachment payload responder will support to parse the `AttachmentType` from ACS and verify all required properties are present.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Feature - support AttachmentType for the attachment payload for EBS Attach

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
