### PR TITLE
Return CSI client interface

### DIFF
--- a/ecs-agent/csiclient/csi_client.go
+++ b/ecs-agent/csiclient/csi_client.go
@@ -57,8 +57,8 @@ type csiClient struct {
 }
 
 // NewCSIClient creates a CSI client for the communication with CSI driver daemon.
-func NewCSIClient(socketIn string) csiClient {
-	return csiClient{csiSocket: socketIn}
+func NewCSIClient(socketIn string) CSIClient {
+	return &csiClient{csiSocket: socketIn}
 }
 
 func (cc *csiClient) NodeStageVolume(ctx context.Context,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR is to return the CSI client interface instead of the csiClient struct which is not exported.

### Implementation details
<!-- How are the changes implemented? -->
Update the `NewCSIClient` to return `CSIClient`.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug - return CSI client interface for external callers' uses.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
