### PR TITLE
Adding support for ebs volumes within task handler

### DIFF
--- a/agent/api/task/task_attachment_handler.go
+++ b/agent/api/task/task_attachment_handler.go
@@ -17,7 +17,9 @@ import (
 	"fmt"
 
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	apiresource "github.com/aws/amazon-ecs-agent/ecs-agent/api/resource"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/aws-sdk-go/aws"
 )
@@ -76,10 +78,13 @@ func (scAttachment *ServiceConnectAttachmentHandler) validateAttachment(acsTask 
 func handleTaskAttachments(acsTask *ecsacs.Task, task *Task) error {
 	if acsTask.Attachments != nil {
 		var serviceConnectAttachment *ecsacs.Attachment
+		var ebsVolumeAttachments []*ecsacs.Attachment
 		for _, attachment := range acsTask.Attachments {
 			switch aws.StringValue(attachment.AttachmentType) {
 			case serviceConnectAttachmentType:
 				serviceConnectAttachment = attachment
+			case apiresource.AmazonElasticBlockStorage:
+				ebsVolumeAttachments = append(ebsVolumeAttachments, attachment)
 			default:
 				logger.Debug("Received an attachment type", logger.Fields{
 					"attachmentType": attachment.AttachmentType,
@@ -103,6 +108,20 @@ func handleTaskAttachments(acsTask *ecsacs.Task, task *Task) error {
 				return fmt.Errorf("service connect config validation failed: %w", err)
 			}
 			task.ServiceConnectConfig = scHandler.(*ServiceConnectAttachmentHandler).scConfig
+		}
+		if len(ebsVolumeAttachments) > 0 {
+			for _, attachment := range ebsVolumeAttachments {
+				ebs, err := taskresourcevolume.ParseEBSTaskVolumeAttachment(attachment)
+				if err != nil {
+					return fmt.Errorf("unable to parse and validate EBS volume: %w", err)
+				}
+				taskVolume := TaskVolume{
+					Name:   ebs.VolumeName,
+					Type:   apiresource.AmazonElasticBlockStorage,
+					Volume: ebs,
+				}
+				task.Volumes = append(task.Volumes, taskVolume)
+			}
 		}
 	}
 	return nil

--- a/agent/taskresource/volume/dockervolume.go
+++ b/agent/taskresource/volume/dockervolume.go
@@ -41,6 +41,7 @@ const (
 	resourceProvisioningError = "VolumeError: Agent could not create task's volume resources"
 	EFSVolumeType             = "efs"
 	netNSFormat               = "/proc/%s/ns/net"
+	EBSSourcePrefix           = "/mnt/ecs/ebs/"
 )
 
 // VolumeResource represents volume resource
@@ -154,6 +155,11 @@ func (cfg *EFSVolumeConfig) Source() string {
 // Source returns the name of the volume resource which is used as the source of the volume mount
 func (cfg *DockerVolumeConfig) Source() string {
 	return cfg.DockerVolumeName
+}
+
+// Source returns the source volume host mount point for an EBS volume
+func (cfg *EBSTaskVolumeConfig) Source() string {
+	return EBSSourcePrefix + cfg.SourceVolumeHostPath
 }
 
 // GetName returns the name of the volume resource

--- a/agent/taskresource/volume/dockervolume_ebs.go
+++ b/agent/taskresource/volume/dockervolume_ebs.go
@@ -1,0 +1,96 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volume
+
+import (
+	"fmt"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	apiresource "github.com/aws/amazon-ecs-agent/ecs-agent/api/resource"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+const (
+	missingEbsEntryFormart = `missing %s in the EBS config`
+)
+
+type EBSTaskVolumeConfig struct {
+	VolumeId             string `json:"volumeId"`
+	VolumeName           string `json:"volumeName"`
+	VolumeSizeGib        string `json:"volumeSizeGib"`
+	SourceVolumeHostPath string `json:"sourceVolumeHostPath"`
+	DeviceName           string `json:"deviceName"`
+	// FileSystem is optional and will be present if customers explicitly set this in their task definition
+	FileSystem string `json:"fileSystem"`
+	// DockerVolumeName is internal docker name for this volume.
+	DockerVolumeName string `json:"dockerVolumeName"`
+}
+
+// ParseEBSTaskVolumeAttachment parses the ebs task volume config value
+// from the given attachment.
+func ParseEBSTaskVolumeAttachment(ebsAttachment *ecsacs.Attachment) (*EBSTaskVolumeConfig, error) {
+	ebsTaskVolumeConfig := &EBSTaskVolumeConfig{}
+	for _, property := range ebsAttachment.AttachmentProperties {
+		if property == nil {
+			return nil, fmt.Errorf("failed to parse task ebs attachment, encountered nil property")
+		}
+		if aws.StringValue(property.Value) == "" {
+			return nil, fmt.Errorf("failed to parse task ebs attachment, encountered empty value for property: %s", aws.StringValue(property.Name))
+		}
+		switch aws.StringValue(property.Name) {
+		case apiresource.VolumeIdKey:
+			ebsTaskVolumeConfig.VolumeId = aws.StringValue(property.Value)
+		case apiresource.VolumeSizeGibKey:
+			ebsTaskVolumeConfig.VolumeSizeGib = aws.StringValue(property.Value)
+		case apiresource.DeviceNameKey:
+			ebsTaskVolumeConfig.DeviceName = aws.StringValue(property.Value)
+		case apiresource.SourceVolumeHostPathKey:
+			ebsTaskVolumeConfig.SourceVolumeHostPath = aws.StringValue(property.Value)
+		case apiresource.VolumeNameKey:
+			ebsTaskVolumeConfig.VolumeName = aws.StringValue(property.Value)
+		case apiresource.FileSystemKey:
+			ebsTaskVolumeConfig.FileSystem = aws.StringValue(property.Value)
+		default:
+			logger.Warn("Received an unrecognized attachment property", logger.Fields{
+				"attachmentProperty": property.String(),
+			})
+		}
+	}
+	err := validateEBSTaskVolumeAttachment(ebsTaskVolumeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return ebsTaskVolumeConfig, nil
+}
+
+// validateEBSTaskVolumeAttachment validates that none of the following required attachment properties
+// are missing from the EBS configuration after parsing.
+// Required Properties: VolumeId, VolumeName, and SourceVolumeHostPath
+func validateEBSTaskVolumeAttachment(cfg *EBSTaskVolumeConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("empty EBS task volume configuration")
+	}
+	if cfg.VolumeId == "" {
+		return fmt.Errorf(missingEbsEntryFormart, apiresource.VolumeIdKey)
+	}
+	if cfg.VolumeName == "" {
+		return fmt.Errorf(missingEbsEntryFormart, apiresource.VolumeNameKey)
+	}
+	if cfg.SourceVolumeHostPath == "" {
+		return fmt.Errorf(missingEbsEntryFormart, apiresource.SourceVolumeHostPathKey)
+	}
+	return nil
+}

--- a/agent/taskresource/volume/dockervolume_ebs_test.go
+++ b/agent/taskresource/volume/dockervolume_ebs_test.go
@@ -1,0 +1,242 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package volume
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	apiresource "github.com/aws/amazon-ecs-agent/ecs-agent/api/resource"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testAttachmentArn = "att-arn-1"
+)
+
+func TestParseEBSTaskVolumeAttachmentHappyCase(t *testing.T) {
+	attachment := &ecsacs.Attachment{
+		AttachmentArn:  aws.String(testAttachmentArn),
+		AttachmentType: aws.String(apiresource.AmazonElasticBlockStorage),
+		AttachmentProperties: []*ecsacs.AttachmentProperty{
+			{
+				Name:  aws.String(apiresource.VolumeIdKey),
+				Value: aws.String(TestVolumeId),
+			},
+			{
+				Name:  aws.String(apiresource.VolumeSizeGibKey),
+				Value: aws.String(TestVolumeSizeGib),
+			},
+			{
+				Name:  aws.String(apiresource.SourceVolumeHostPathKey),
+				Value: aws.String(TestSourceVolumeHostPath),
+			},
+			{
+				Name:  aws.String(apiresource.VolumeNameKey),
+				Value: aws.String(TestVolumeName),
+			},
+			{
+				Name:  aws.String(apiresource.FileSystemKey),
+				Value: aws.String(TestFileSystem),
+			},
+			{
+				Name:  aws.String(apiresource.DeviceNameKey),
+				Value: aws.String(TestDeviceName),
+			},
+		},
+	}
+
+	expectedEBSCfg := &EBSTaskVolumeConfig{
+		VolumeId:             "vol-12345",
+		VolumeName:           "test-volume",
+		VolumeSizeGib:        "10",
+		SourceVolumeHostPath: "taskarn_vol-12345",
+		DeviceName:           "/dev/nvme1n1",
+		FileSystem:           "ext4",
+	}
+
+	parsedEBSCfg, err := ParseEBSTaskVolumeAttachment(attachment)
+	assert.NoError(t, err, "unable to parse attachment")
+	assert.Equal(t, expectedEBSCfg, parsedEBSCfg)
+}
+
+func TestParseEBSTaskVolumeAttachmentNilProperty(t *testing.T) {
+	attachment := &ecsacs.Attachment{
+		AttachmentArn:  aws.String(testAttachmentArn),
+		AttachmentType: aws.String(apiresource.AmazonElasticBlockStorage),
+		AttachmentProperties: []*ecsacs.AttachmentProperty{
+			nil,
+		},
+	}
+
+	_, err := ParseEBSTaskVolumeAttachment(attachment)
+	assert.Error(t, err)
+}
+
+func TestParseEBSTaskVolumeAttachmentNilPropertyValue(t *testing.T) {
+	attachment := &ecsacs.Attachment{
+		AttachmentArn:  aws.String(testAttachmentArn),
+		AttachmentType: aws.String(apiresource.AmazonElasticBlockStorage),
+		AttachmentProperties: []*ecsacs.AttachmentProperty{
+			{
+				Name:  aws.String(apiresource.VolumeIdKey),
+				Value: nil,
+			},
+			{
+				Name:  aws.String(apiresource.VolumeSizeGibKey),
+				Value: aws.String(TestVolumeSizeGib),
+			},
+			{
+				Name:  aws.String(apiresource.SourceVolumeHostPathKey),
+				Value: aws.String(TestSourceVolumeHostPath),
+			},
+			{
+				Name:  aws.String(apiresource.VolumeNameKey),
+				Value: aws.String(TestVolumeName),
+			},
+			{
+				Name:  aws.String(apiresource.FileSystemKey),
+				Value: aws.String(TestFileSystem),
+			},
+			{
+				Name:  aws.String(apiresource.DeviceNameKey),
+				Value: aws.String(TestDeviceName),
+			},
+		},
+	}
+
+	_, err := ParseEBSTaskVolumeAttachment(attachment)
+	assert.Error(t, err)
+}
+
+func TestParseEBSTaskVolumeAttachmentEmptyPropertyValue(t *testing.T) {
+	attachment := &ecsacs.Attachment{
+		AttachmentArn:  aws.String(testAttachmentArn),
+		AttachmentType: aws.String(apiresource.AmazonElasticBlockStorage),
+		AttachmentProperties: []*ecsacs.AttachmentProperty{
+			{
+				Name:  aws.String(apiresource.VolumeIdKey),
+				Value: aws.String(""),
+			},
+			{
+				Name:  aws.String(apiresource.VolumeSizeGibKey),
+				Value: aws.String(TestVolumeSizeGib),
+			},
+			{
+				Name:  aws.String(apiresource.SourceVolumeHostPathKey),
+				Value: aws.String(TestSourceVolumeHostPath),
+			},
+			{
+				Name:  aws.String(apiresource.VolumeNameKey),
+				Value: aws.String(TestVolumeName),
+			},
+			{
+				Name:  aws.String(apiresource.FileSystemKey),
+				Value: aws.String(TestFileSystem),
+			},
+			{
+				Name:  aws.String(apiresource.DeviceNameKey),
+				Value: aws.String(TestDeviceName),
+			},
+		},
+	}
+
+	_, err := ParseEBSTaskVolumeAttachment(attachment)
+	assert.Error(t, err)
+}
+
+func TestParseEBSTaskVolumeAttachmentUnknownProperty(t *testing.T) {
+	attachment := &ecsacs.Attachment{
+		AttachmentArn:  aws.String(testAttachmentArn),
+		AttachmentType: aws.String(apiresource.AmazonElasticBlockStorage),
+		AttachmentProperties: []*ecsacs.AttachmentProperty{
+			{
+				Name:  aws.String(apiresource.VolumeIdKey),
+				Value: aws.String(TestVolumeId),
+			},
+			{
+				Name:  aws.String(apiresource.VolumeSizeGibKey),
+				Value: aws.String(TestVolumeSizeGib),
+			},
+			{
+				Name:  aws.String(apiresource.SourceVolumeHostPathKey),
+				Value: aws.String(TestSourceVolumeHostPath),
+			},
+			{
+				Name:  aws.String(apiresource.VolumeNameKey),
+				Value: aws.String(TestVolumeName),
+			},
+			{
+				Name:  aws.String(apiresource.FileSystemKey),
+				Value: aws.String(TestFileSystem),
+			},
+			{
+				Name:  aws.String(apiresource.DeviceNameKey),
+				Value: aws.String(TestDeviceName),
+			},
+			{
+				Name:  aws.String("someProperty"),
+				Value: aws.String("foo"),
+			},
+		},
+	}
+
+	expectedEBSCfg := &EBSTaskVolumeConfig{
+		VolumeId:             "vol-12345",
+		VolumeName:           "test-volume",
+		VolumeSizeGib:        "10",
+		SourceVolumeHostPath: "taskarn_vol-12345",
+		DeviceName:           "/dev/nvme1n1",
+		FileSystem:           "ext4",
+	}
+
+	parsedEBSCfg, err := ParseEBSTaskVolumeAttachment(attachment)
+	assert.NoError(t, err, "unable to parse attachment")
+	assert.Equal(t, expectedEBSCfg, parsedEBSCfg)
+}
+
+func TestParseEBSTaskVolumeAttachmentMissingProperty(t *testing.T) {
+	// The following attachment will be missing the SourceVolumeHostPath property
+	attachment := &ecsacs.Attachment{
+		AttachmentArn:  aws.String(testAttachmentArn),
+		AttachmentType: aws.String(apiresource.AmazonElasticBlockStorage),
+		AttachmentProperties: []*ecsacs.AttachmentProperty{
+			{
+				Name:  aws.String(apiresource.VolumeIdKey),
+				Value: aws.String(TestVolumeId),
+			},
+			{
+				Name:  aws.String(apiresource.VolumeSizeGibKey),
+				Value: aws.String(TestVolumeSizeGib),
+			},
+			{
+				Name:  aws.String(apiresource.VolumeNameKey),
+				Value: aws.String(TestVolumeName),
+			},
+			{
+				Name:  aws.String(apiresource.FileSystemKey),
+				Value: aws.String(TestFileSystem),
+			},
+			{
+				Name:  aws.String(apiresource.DeviceNameKey),
+				Value: aws.String(TestDeviceName),
+			},
+		},
+	}
+	_, err := ParseEBSTaskVolumeAttachment(attachment)
+	assert.Error(t, err)
+}

--- a/agent/taskresource/volume/testconst.go
+++ b/agent/taskresource/volume/testconst.go
@@ -1,0 +1,26 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volume
+
+// This file contains constants that are commonly used when testing with EBS volumes for tasks. These constants
+// should only be called in test files.
+const (
+	TestAttachmentType       = "AmazonElasticBlockStorage"
+	TestVolumeId             = "vol-12345"
+	TestVolumeSizeGib        = "10"
+	TestSourceVolumeHostPath = "taskarn_vol-12345"
+	TestVolumeName           = "test-volume"
+	TestFileSystem           = "ext4"
+	TestDeviceName           = "/dev/nvme1n1"
+)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
The goal of this PR is to add functionality to handle and process task payload with EBS volume attachments. Once the payload has been processed, agent will spin up the task docker container and mount the EBS volume within the host instance.

### Implementation details
* Minor changes to `task.go`
  * Added a new attachment type for EBS Volumes
* Modified `task_attachment_handler.go`
  * Modified `handleTaskAttachments`: The functionality will now be parsing the list of attachment that's within the task payload (in the form of the shared Task struct). If there are any attachments of type `AmazonElasticBlockStorage` then we'll parse + validate it into an object of type  `EBSTaskVolumeConfig` via the `ParseEBSTaskVolumeAttachment`  function. At the end, we'll append each new `EBSTaskVolumeConfig` object to the list of volumes for the managed task.
* Modified `taskvolume.go`
  * Added new functionality to `unmarshalEBSVolume`: This function will unmarshal raw data (in JSON form) and convert into an object of type `EBSTaskVolumeConfig`. This is used for saving to state.
* Minor changes to `dockervolume.go`: 
  * Added new functionality to `Source`: Returns the complete source host path that's used to bind mount with the task docker container
* Added `dockervolume_ebs.go` to `taskresource/volume`
  * Added new functionality to `ParseEBSTaskVolumeAttachment`: Parses and validates an EBS volume attachment from the task payload sent from ACS. Returns a new object of typed `EBSTaskVolumeConfig` 
  * Added new functionality `validateEBSTaskVolumeAttachment`: Validates that the parsed `EBSTaskVolumeConfig` has VolumeId, VolumeName, and SourceVolumeHostPath set and non-empty which is required for task start and stop.
  * New struct `EBSTaskVolumeConfig`which is used to store all of the attachment information of the EBS volume for a managed task

### Testing
Unit tests

New tests cover the changes: Yes

### Description for the changelog
Add support to handle task payload with EBS volume attachments.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
