### PR TITLE
add more container metadata to the introspection response

### DIFF
--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -14,6 +14,8 @@
 package v1
 
 import (
+	"time"
+
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
@@ -49,6 +51,10 @@ type ContainerResponse struct {
 	DockerID   string                        `json:"DockerId"`
 	DockerName string                        `json:"DockerName"`
 	Name       string                        `json:"Name"`
+	Image      string                        `json:"Image"`
+	ImageID    string                        `json:"ImageID"`
+	CreatedAt  *time.Time                    `json:"CreatedAt,omitempty"`
+	StartedAt  *time.Time                    `json:"StartedAt,omitempty"`
 	Ports      []tmdsresponse.PortResponse   `json:"Ports,omitempty"`
 	Networks   []tmdsresponse.Network        `json:"Networks,omitempty"`
 	Volumes    []tmdsresponse.VolumeResponse `json:"Volumes,omitempty"`
@@ -89,6 +95,8 @@ func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *ni
 	container := dockerContainer.Container
 	resp := ContainerResponse{
 		Name:       container.Name,
+		Image:      container.Image,
+		ImageID:    container.ImageID,
 		DockerID:   dockerContainer.DockerID,
 		DockerName: dockerContainer.DockerName,
 	}
@@ -104,6 +112,14 @@ func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *ni
 				IPv6Addresses: eni.GetIPV6Addresses(),
 			},
 		}
+	}
+	if createdAt := container.GetCreatedAt(); !createdAt.IsZero() {
+		createdAt = createdAt.UTC()
+		resp.CreatedAt = &createdAt
+	}
+	if startedAt := container.GetStartedAt(); !startedAt.IsZero() {
+		startedAt = startedAt.UTC()
+		resp.StartedAt = &startedAt
 	}
 	return resp
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR has been previously reviewed in https://github.com/aws/amazon-ecs-agent/pull/3788. We're now ready to stage this for release.

It adds the following container metadata to the introspection response:

- Container ImageName
- Container ImageID
- Container CreatedAt
- Container StartedAt

The above metadata is available via task metadata endpoint. This change fills the gap in the introspection response.

### Implementation details
<!-- How are the changes implemented? -->
Updated the v1 handler container response. Note that this doesn't alter task metadata endpoint v1 since that has been moved to the ecs-agent directory.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

- Updated the unit tests for task and container response.
- Tested a custom ECS agent build and verified that the introspection response now has the new metadata.


New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

enhancement: adding new container metadata to the introspection response

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
