### PR TITLE
fixing an edge case for 'START' container dependency

### DIFF
--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -187,6 +187,16 @@ func verifyContainerStoppedStateChangeWithRuntimeID(t *testing.T, taskEngine Tas
 		"Expected container runtimeID should not empty")
 }
 
+// verifySpecificContainerStateChange verifies that a specific container (identified by the containerName parameter),
+// has a specific status (identified by the containerStatus parameter)
+func verifySpecificContainerStateChange(t *testing.T, taskEngine TaskEngine, containerName string,
+	containerStatus apicontainerstatus.ContainerStatus) {
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	event := <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).ContainerName, containerName)
+	assert.Equal(t, event.(api.ContainerStateChange).Status, containerStatus)
+}
+
 func setup(cfg *config.Config, state dockerstate.TaskEngineState, t *testing.T) (TaskEngine, func(), credentials.Manager) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()

--- a/agent/engine/dependencygraph/graph.go
+++ b/agent/engine/dependencygraph/graph.go
@@ -426,11 +426,17 @@ func containerOrderingDependenciesIsResolved(target *apicontainer.Container,
 	case createCondition:
 		// The 'target' container desires to be moved to 'Created' or the 'steady' state.
 		// Allow this only if the known status of the dependency container state is already started
-		// i.e it's state is any of 'Created', 'steady state' or 'Stopped'
+		// i.e. it's state is any of 'Created', 'steady state' or 'Stopped'
 		return dependsOnContainerKnownStatus >= apicontainerstatus.ContainerCreated
 
 	case startCondition:
-		if targetDesiredStatus == apicontainerstatus.ContainerCreated {
+		if dependsOnContainerKnownStatus == apicontainerstatus.ContainerStopped {
+			// The 'dependsOn' container has already transitioned to STOPPED state.
+			// A container's known status is updated to STOPPED when the container transitions from
+			// RUNNING -> STOPPED. We let the 'target' container to move to its next desired state,
+			// since the START dependency has been fulfilled.
+			return true
+		} else if targetDesiredStatus == apicontainerstatus.ContainerCreated {
 			// The 'target' container desires to be moved to 'Created' state.
 			// Allow this only if the known status of the linked container is
 			// 'Created' or if the dependency container is in 'steady state'

--- a/agent/engine/dependencygraph/graph_test.go
+++ b/agent/engine/dependencygraph/graph_test.go
@@ -932,6 +932,30 @@ func TestContainerOrderingIsResolved(t *testing.T) {
 			Resolved:            false,
 		},
 		{
+			TargetDesired:       apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerStopped,
+			DependencyCondition: startCondition,
+			Resolved:            true,
+		},
+		{
+			TargetDesired:       apicontainerstatus.ContainerPulled,
+			DependencyKnown:     apicontainerstatus.ContainerStopped,
+			DependencyCondition: startCondition,
+			Resolved:            true,
+		},
+		{
+			TargetDesired:       apicontainerstatus.ContainerCreated,
+			DependencyKnown:     apicontainerstatus.ContainerStopped,
+			DependencyCondition: startCondition,
+			Resolved:            true,
+		},
+		{
+			TargetDesired:       apicontainerstatus.ContainerRunning,
+			DependencyKnown:     apicontainerstatus.ContainerStopped,
+			DependencyCondition: startCondition,
+			Resolved:            true,
+		},
+		{
 			TargetDesired:       apicontainerstatus.ContainerRunning,
 			DependencyKnown:     apicontainerstatus.ContainerStopped,
 			DependencyCondition: successCondition,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
ECS supports specifying container ordering dependencies in task definitions. [documentation](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDependency.html)

This PR fixes an edge case with the START container ordering dependency. Consider the following customer use case:
- An ECS task definition specifies 2 containers - A and B.
- ctr A is essential and it depends on ctr B to "START".
- ctr B is non-essential. It can be a sidecar that shouldn't impact the task's uptime, for example, a logging sidecar like firelens or a miscellaneous cleanup job runner.

The edge case we're trying to solve here becomes apparent when ctr B starts and stops even before the ctr A has reached >= PULLED state. By definition of the START dependency condition, ctr A should proceed to run as long as ctr B has started (it shouldn't matter when/how ctr B stops. Other dependency checks like COMPLETE, SUCCESS, HEALTHY let customers control the stop behaviors).

### Implementation details
<!-- How are the changes implemented? -->
Updated the start condition checks with the following: return true (i.e. dependency is resolved) when the dependency container's known status is stopped.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

1. Added new unit test cases when dependency container known status is stopped.
2. Added a new integration test for testing the START condition. We seem to have integration tests for all other conditions except start. I ran this integration test on an AL2 instance about a 100 times to ensure its not flaky.
3. Manually tested that this change fixes the corner case, while not breaking existing use-cases. This case is reproducible by using 2 different container images; ctr A depends on START of B; ctr image for A is considerably larger than that of B; B exits even before A's image was finished pulling. The task stays in pending forever. If the images are cached then it runs fine, exhibiting two different inconsistent task behaviors.
4. Also verified that a container's known status is STOPPED only when it has transitioned from RUNNING -> STOPPED. This implies that since it reached RUNNING, the START dependency condition has been fulfilled.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

bugfix: fixing an edge case for 'START' container dependency

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
