### PR TITLE
Collect volume metrics and volume clean up for EBS-backed tasks

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -43,6 +43,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
+	apiresource "github.com/aws/amazon-ecs-agent/ecs-agent/api/resource"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ecs_client/model/ecs"
@@ -331,7 +332,37 @@ func TaskFromACS(acsTask *ecsacs.Task, envelope *ecsacs.PayloadMessage) (*Task, 
 	return task, nil
 }
 
+// TODO: Add unit test
+func (task *Task) RemoveVolume(index int) {
+	task.lock.Lock()
+	defer task.lock.Unlock()
+	task.removeVolumeUnsafe(index)
+}
+
+func (task *Task) removeVolumeUnsafe(index int) {
+	if index < 0 || index >= len(task.Volumes) {
+		return
+	}
+	// temp := task.Volumes[:1]
+	out := make([]TaskVolume, 0)
+	out = append(out, task.Volumes[:index]...)
+	out = append(out, task.Volumes[index+1:]...)
+	task.Volumes = out
+}
+
 func (task *Task) initializeVolumes(cfg *config.Config, dockerClient dockerapi.DockerClient, ctx context.Context) error {
+	// TODO: Have EBS volumes use the DockerVolumeConfig to create the mountpoint
+	if task.IsEBSTaskAttachEnabled() {
+		ebsVolumes := task.GetEBSVolumeNames()
+		for index, tv := range task.Volumes {
+			volumeName := tv.Name
+			volumeType := tv.Type
+			if ebsVolumes[volumeName] && volumeType != apiresource.EBSTaskAttach {
+				task.RemoveVolume(index)
+			}
+		}
+	}
+
 	err := task.initializeDockerLocalVolumes(dockerClient, ctx)
 	if err != nil {
 		return apierrors.NewResourceInitError(task.Arn, err)
@@ -3435,7 +3466,45 @@ func (task *Task) IsServiceConnectEnabled() bool {
 // Is EBS Task Attach enabled returns true if this task has EBS volume configuration in its ACS payload.
 // TODO as more daemons come online, we'll want a generic handler these bool checks and payload handling
 func (task *Task) IsEBSTaskAttachEnabled() bool {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+	return task.isEBSTaskAttachEnabledUnsafe()
+}
+
+func (task *Task) isEBSTaskAttachEnabledUnsafe() bool {
+	logger.Debug("Checking if there are any ebs volume configs")
+	for _, tv := range task.Volumes {
+		switch tv.Volume.(type) {
+		case *taskresourcevolume.EBSTaskVolumeConfig:
+			logger.Debug("found ebs volume config")
+			return true
+		default:
+			continue
+		}
+	}
 	return false
+}
+
+// TODO: Add unit tests
+func (task *Task) GetEBSVolumeNames() map[string]bool {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+	return task.getEBSVolumeNamesUnsafe()
+}
+
+func (task *Task) getEBSVolumeNamesUnsafe() map[string]bool {
+	volNames := map[string]bool{}
+	for _, tv := range task.Volumes {
+		switch tv.Volume.(type) {
+		case *taskresourcevolume.EBSTaskVolumeConfig:
+			logger.Debug("found ebs volume config")
+			ebsCfg := tv.Volume.(*taskresourcevolume.EBSTaskVolumeConfig)
+			volNames[ebsCfg.VolumeName] = true
+		default:
+			continue
+		}
+	}
+	return volNames
 }
 
 func (task *Task) IsServiceConnectBridgeModeApplicationContainer(container *apicontainer.Container) bool {

--- a/agent/engine/dockerstate/docker_task_engine_state.go
+++ b/agent/engine/dockerstate/docker_task_engine_state.go
@@ -334,7 +334,7 @@ func (state *DockerTaskEngineState) AddEBSAttachment(ebsAttachment *apiresource.
 	}
 	state.lock.Lock()
 	defer state.lock.Unlock()
-	volumeId := ebsAttachment.AttachmentProperties[apiresource.VolumeIdName]
+	volumeId := ebsAttachment.AttachmentProperties[apiresource.VolumeIdKey]
 	if _, ok := state.ebsAttachments[volumeId]; !ok {
 		state.ebsAttachments[volumeId] = ebsAttachment
 		seelog.Debugf("Successfully added EBS attachment: %v", ebsAttachment.EBSToString())

--- a/agent/engine/dockerstate/dockerstate_test.go
+++ b/agent/engine/dockerstate/dockerstate_test.go
@@ -31,12 +31,12 @@ import (
 
 var (
 	testAttachmentProperties = map[string]string{
-		apiresource.ResourceTypeName:    apiresource.ElasticBlockStorage,
-		apiresource.RequestedSizeName:   "5",
-		apiresource.VolumeSizeInGiBName: "7",
-		apiresource.DeviceName:          "/dev/nvme0n0",
-		apiresource.VolumeIdName:        "vol-123",
-		apiresource.FileSystemTypeName:  "testXFS",
+		apiresource.VolumeNameKey:           "myCoolVolume",
+		apiresource.SourceVolumeHostPathKey: "/testpath",
+		apiresource.VolumeSizeGibKey:        "7",
+		apiresource.DeviceNameKey:           "/dev/nvme0n0",
+		apiresource.VolumeIdKey:             "vol-123",
+		apiresource.FileSystemKey:           "testXFS",
 	}
 )
 
@@ -138,6 +138,7 @@ func TestAddRemoveEBSAttachment(t *testing.T) {
 			AttachmentARN: "ebs1",
 		},
 		AttachmentProperties: testAttachmentProperties,
+		AttachmentType:       apiresource.EBSTaskAttach,
 	}
 
 	state.AddEBSAttachment(attachment)
@@ -150,7 +151,7 @@ func TestAddRemoveEBSAttachment(t *testing.T) {
 	assert.False(t, ok)
 	assert.Nil(t, ebs)
 
-	state.RemoveEBSAttachment(attachment.AttachmentProperties[apiresource.VolumeIdName])
+	state.RemoveEBSAttachment(attachment.AttachmentProperties[apiresource.VolumeIdKey])
 	assert.Len(t, state.(*DockerTaskEngineState).GetAllEBSAttachments(), 0)
 	ebs, ok = state.GetEBSByVolumeId("vol-123")
 	assert.False(t, ok)
@@ -168,15 +169,16 @@ func TestAddPendingEBSAttachment(t *testing.T) {
 			Status:           status.AttachmentNone,
 		},
 		AttachmentProperties: testAttachmentProperties,
+		AttachmentType:       apiresource.EBSTaskAttach,
 	}
 
 	testSentAttachmentProperties := map[string]string{
-		apiresource.ResourceTypeName:    apiresource.ElasticBlockStorage,
-		apiresource.RequestedSizeName:   "3",
-		apiresource.VolumeSizeInGiBName: "9",
-		apiresource.DeviceName:          "/dev/nvme1n0",
-		apiresource.VolumeIdName:        "vol-456",
-		apiresource.FileSystemTypeName:  "testXFS2",
+		apiresource.VolumeNameKey:           "myCoolVolume",
+		apiresource.SourceVolumeHostPathKey: "/testpath2",
+		apiresource.VolumeSizeGibKey:        "7",
+		apiresource.DeviceNameKey:           "/dev/nvme1n0",
+		apiresource.VolumeIdKey:             "vol-456",
+		apiresource.FileSystemKey:           "testXFS",
 	}
 
 	foundAttachment := &apiresource.ResourceAttachment{
@@ -187,6 +189,7 @@ func TestAddPendingEBSAttachment(t *testing.T) {
 			Status:           status.AttachmentAttached,
 		},
 		AttachmentProperties: testSentAttachmentProperties,
+		AttachmentType:       apiresource.EBSTaskAttach,
 	}
 
 	state.AddEBSAttachment(pendingAttachment)

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -31,6 +31,7 @@ import (
 	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/csiclient"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
 	"github.com/aws/aws-sdk-go/aws"
@@ -62,6 +63,9 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	resolver.EXPECT().ResolveTask("c1").AnyTimes().Return(t1, nil)
 	resolver.EXPECT().ResolveTask("c2").AnyTimes().Return(t1, nil)
 	resolver.EXPECT().ResolveTask("c3").AnyTimes().Return(t2, nil)
+	resolver.EXPECT().ResolveTaskByARN("t1").AnyTimes().Return(t1, nil)
+	resolver.EXPECT().ResolveTaskByARN("t2").AnyTimes().Return(t2, nil)
+	resolver.EXPECT().ResolveTaskByARN("t3").AnyTimes().Return(t3, nil)
 	resolver.EXPECT().ResolveTask("c4").AnyTimes().Return(nil, fmt.Errorf("unmapped container"))
 	resolver.EXPECT().ResolveTask("c5").AnyTimes().Return(t2, nil)
 	resolver.EXPECT().ResolveTask("c6").AnyTimes().Return(t3, nil)
@@ -82,6 +86,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	engine.client = mockDockerClient
 	engine.cluster = defaultCluster
 	engine.containerInstanceArn = defaultContainerInstance
+	engine.csiClient = csiclient.NewDummyCSIClient()
 	defer engine.removeAll()
 
 	engine.addAndStartStatsContainer("c1")

--- a/agent/stats/engine_unix.go
+++ b/agent/stats/engine_unix.go
@@ -1,0 +1,106 @@
+//go:build linux
+// +build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//      http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/csiclient"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+func (engine *DockerStatsEngine) getEBSVolumeMetrics(taskArn string) []*ecstcs.VolumeMetric {
+	task, err := engine.resolver.ResolveTaskByARN(taskArn)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Unable to get corresponding task from dd with task arn: %s", taskArn))
+		return nil
+	}
+
+	if !task.IsEBSTaskAttachEnabled() {
+		logger.Debug("Task not EBS-backed, skip gathering EBS volume metrics.", logger.Fields{
+			"taskArn": taskArn,
+		})
+		return nil
+	}
+
+	// TODO: Remove the CSI client from the stats engine and just always have the CSI client created
+	// since a new connection is created regardless and it'll make the stats engine less stateful
+	if engine.csiClient == nil {
+		client := csiclient.NewCSIClient(filepath.Join(csiclient.DefaultSocketHostPath, csiclient.DefaultImageName, csiclient.DefaultSocketName))
+		engine.csiClient = &client
+	}
+	return engine.fetchEBSVolumeMetrics(task, taskArn)
+}
+
+func (engine *DockerStatsEngine) fetchEBSVolumeMetrics(task *apitask.Task, taskArn string) []*ecstcs.VolumeMetric {
+	var metrics []*ecstcs.VolumeMetric
+	for _, tv := range task.Volumes {
+		// TODO: Include Getters within the TaskVolume interface so that we don't need to have these type casts.
+		// (i.e. getVolumeId())
+		switch tv.Volume.(type) {
+		case *taskresourcevolume.EBSTaskVolumeConfig:
+			ebsCfg := tv.Volume.(*taskresourcevolume.EBSTaskVolumeConfig)
+			volumeId := ebsCfg.VolumeId
+			hostPath := ebsCfg.Source()
+			metric, err := engine.getVolumeMetricsWithTimeout(volumeId, hostPath)
+			if err != nil {
+				logger.Error("Failed to gather metrics for EBS volume", logger.Fields{
+					"VolumeId":             volumeId,
+					"SourceVolumeHostPath": hostPath,
+					"Error":                err,
+				})
+				continue
+			}
+			usedBytes := aws.Float64((float64)(metric.Used))
+			totalBytes := aws.Float64((float64)(metric.Capacity))
+			metrics = append(metrics, &ecstcs.VolumeMetric{
+				VolumeId:   aws.String(volumeId),
+				VolumeName: aws.String(ebsCfg.VolumeName),
+				Utilized: &ecstcs.UDoubleCWStatsSet{
+					Max:         usedBytes,
+					Min:         usedBytes,
+					SampleCount: aws.Int64(1),
+					Sum:         usedBytes,
+				},
+				Size: &ecstcs.UDoubleCWStatsSet{
+					Max:         totalBytes,
+					Min:         totalBytes,
+					SampleCount: aws.Int64(1),
+					Sum:         totalBytes,
+				},
+			})
+		default:
+			continue
+		}
+	}
+	return metrics
+}
+
+func (engine *DockerStatsEngine) getVolumeMetricsWithTimeout(volumeId, hostPath string) (*csiclient.Metrics, error) {
+	derivedCtx, cancel := context.WithTimeout(engine.ctx, time.Second*1)
+	// releases resources if GetVolumeMetrics finishes before timeout
+	defer cancel()
+	return engine.csiClient.GetVolumeMetrics(derivedCtx, volumeId, hostPath)
+}

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -26,8 +26,13 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
 	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
+	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
+	apiresource "github.com/aws/amazon-ecs-agent/ecs-agent/api/resource"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/csiclient"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -165,4 +170,68 @@ func TestServiceConnectWithDisabledMetrics(t *testing.T) {
 	assert.Len(t, engine.tasksToContainers, 0, "No containers should be tracked if metrics is disabled")
 	assert.Len(t, engine.tasksToHealthCheckContainers, 1)
 	assert.Len(t, engine.taskToServiceConnectStats, 1)
+}
+
+// TODO: Add a unhappy case in the near future
+func TestFetchEBSVolumeMetrics(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
+	mockDockerClient := mock_dockerapi.NewMockDockerClient(mockCtrl)
+	t1 := &apitask.Task{
+		Arn: "t1",
+		Volumes: []apitask.TaskVolume{
+			{
+				Name: "1",
+				Type: apiresource.EBSTaskAttach,
+				Volume: &taskresourcevolume.EBSTaskVolumeConfig{
+					VolumeId:             "vol-12345",
+					VolumeName:           "test-volume",
+					VolumeSizeGib:        "10",
+					SourceVolumeHostPath: "taskarn_vol-12345",
+					DeviceName:           "/dev/nvme1n1",
+					FileSystem:           "ext4",
+				},
+			},
+		},
+	}
+
+	resolver.EXPECT().ResolveTaskByARN("t1").AnyTimes().Return(t1, nil)
+	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestFetchEBSVolumeMetrics"), nil, nil)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	engine.ctx = ctx
+	engine.resolver = resolver
+	engine.cluster = defaultCluster
+	engine.containerInstanceArn = defaultContainerInstance
+	engine.client = mockDockerClient
+	engine.csiClient = csiclient.NewDummyCSIClient()
+
+	expectedUsedBytes := aws.Float64(15 * 1024 * 1024 * 1024)
+	expectedTotalBytes := aws.Float64(20 * 1024 * 1024 * 1024)
+	expectedMetrics := []*ecstcs.VolumeMetric{
+		{
+			VolumeId:   aws.String("vol-12345"),
+			VolumeName: aws.String("test-volume"),
+			Utilized: &ecstcs.UDoubleCWStatsSet{
+				Max:         expectedUsedBytes,
+				Min:         expectedUsedBytes,
+				SampleCount: aws.Int64(1),
+				Sum:         expectedUsedBytes,
+			},
+			Size: &ecstcs.UDoubleCWStatsSet{
+				Max:         expectedTotalBytes,
+				Min:         expectedTotalBytes,
+				SampleCount: aws.Int64(1),
+				Sum:         expectedTotalBytes,
+			},
+		},
+	}
+
+	actualMetrics := engine.fetchEBSVolumeMetrics(t1, "t1")
+
+	assert.Len(t, actualMetrics, 1)
+	assert.Equal(t, actualMetrics, expectedMetrics)
 }

--- a/agent/stats/engine_windows.go
+++ b/agent/stats/engine_windows.go
@@ -13,14 +13,13 @@
 // on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
-package csiclient
 
-const (
-	DefaultImageName      = ""
-	DefaultSocketName     = ""
-	DefaultSocketHostPath = ""
+package stats
+
+import (
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
 )
 
-func DefaultSocketFilePath() string {
-	return "unimplemented" // TODO: Windows implementation
+func (engine *DockerStatsEngine) getEBSVolumeMetrics(taskArn string) []*ecstcs.VolumeMetric {
+	return nil
 }

--- a/agent/taskresource/volume/testconst.go
+++ b/agent/taskresource/volume/testconst.go
@@ -16,7 +16,7 @@ package volume
 // This file contains constants that are commonly used when testing with EBS volumes for tasks. These constants
 // should only be called in test files.
 const (
-	TestAttachmentType       = "EBSTaskAttach"
+	TestAttachmentType       = "amazonebs"
 	TestVolumeId             = "vol-12345"
 	TestVolumeSizeGib        = "10"
 	TestSourceVolumeHostPath = "taskarn_vol-12345"

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/csi_client_linux.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/csi_client_linux.go
@@ -22,11 +22,11 @@ import (
 )
 
 const (
-	defaultImageName      = md.EbsCsiDriver
-	defaultSocketName     = "csi-driver.sock"
-	defaultSocketHostPath = "/var/run/ecs/"
+	DefaultImageName      = md.EbsCsiDriver
+	DefaultSocketName     = "csi-driver.sock"
+	DefaultSocketHostPath = "/var/run/ecs/"
 )
 
 func DefaultSocketFilePath() string {
-	return filepath.Join(defaultSocketHostPath, defaultImageName, defaultSocketName)
+	return filepath.Join(DefaultSocketHostPath, DefaultImageName, DefaultSocketName)
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/csi_client_windows.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/csi_client_windows.go
@@ -15,6 +15,12 @@
 // permissions and limitations under the License.
 package csiclient
 
+const (
+	DefaultImageName      = ""
+	DefaultSocketName     = ""
+	DefaultSocketHostPath = ""
+)
+
 func DefaultSocketFilePath() string {
 	return "unimplemented" // TODO: Windows implementation
 }

--- a/ecs-agent/csiclient/csi_client_linux.go
+++ b/ecs-agent/csiclient/csi_client_linux.go
@@ -22,11 +22,11 @@ import (
 )
 
 const (
-	defaultImageName      = md.EbsCsiDriver
-	defaultSocketName     = "csi-driver.sock"
-	defaultSocketHostPath = "/var/run/ecs/"
+	DefaultImageName      = md.EbsCsiDriver
+	DefaultSocketName     = "csi-driver.sock"
+	DefaultSocketHostPath = "/var/run/ecs/"
 )
 
 func DefaultSocketFilePath() string {
-	return filepath.Join(defaultSocketHostPath, defaultImageName, defaultSocketName)
+	return filepath.Join(DefaultSocketHostPath, DefaultImageName, DefaultSocketName)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will introduce the functionality to collect volume metrics for EBS-backed tasks via the CSI driver as well as task clean up for EBS-backed task.

### Implementation details
#### Changes made to collect Volume metrics in EBS-backed Tasks
Implemented `getEBSVolumeMetrics()` and `fetchEBSVolumeMetrics()` where it'll collect the volume metrics via `NodeGetVolumeStats` from the CSI driver for each EBS-backed tasks. The `getEBSVolumeMetrics()` will be invoked when getting all of the other task and instance metrics in `GetInstanceMetrics()`. 

`IsEBSTaskAttachEnabled()` has also been implemented and will scan for any EBS volume configuration within the list of volumes of a task. Although it's being called in `AddTask()` within a check, it will temporarily always return false for all tasks (i.e. consider it not EBS-backed task) in order to avoid invoking the CSI driver functionality. This will be fixed and addressed in another PR.

List of files changed:
* agent/api/task/task.go: Added functionality to `IsEBSTaskAttachEnabled()`
* agent/engine/docker_task_engine.go: Temporarily assume that all tasks are not EBS-backed, Will be fixed in a future PR
* agent/stats/engine.go
* agent/stats/engine_test.go
* agent/stats/engine_unix.go: Essentially calls upon the CSI driver to run `NodeGetVolumeStats` on all EBS volumes attached to EBS-backed tasks
* agent/stats/engine_unix_test.go
* agent/stats/engine_windows.go
* ecs-agent/csiclient/csi_client.go

#### Changes made to clean up EBS-backed tasks
Implemented `UnstageVolumes` to unmount the host mountpoint for all EBS volumes on a EBS-backed task. This will happen on task clean up.

List of files changed:
* agent/engine/task_manager.go



### Testing
Added new unit test.

`TestFetchEBSVolumeMetrics`: Test that the new `fetchEBSVolumeMetrics` function is working as intended. As a TODO, we'll need to add a unhappy test case as well.

TODO: Add unit test for `NodeUnstage` in a follow up PR.

Manual testing:
We've manually mounted/staged an EBS volume onto a testing EC2 instance with agent running and tried calling the `getEBSVolumeMetrics` functionality. 
Agent logs to get volume metrics
```
level=debug time=2023-09-26T04:14:54Z msg="Fetching EBS volume metrics..."
level=debug time=2023-09-26T04:14:54Z msg="Is an ebs volume configuration"
level=debug time=2023-09-26T04:14:54Z msg="Found volume usage" UsedBytes=108707840 TotalBytes=10726932480
level=debug time=2023-09-26T04:14:54Z msg="Ignore inodes key"
level=debug time=2023-09-26T04:14:54Z msg="EBS TACS Metrics collected! UsedBytes: 1.0870784e+08 TotalBytes: 1.072693248e+10"
level=debug time=2023-09-26T04:14:54Z msg="sent telemetry message" module=engine.go
```

CSI driver container NodeGetVolumeStats logs
```
I1009 18:49:17.146637       1 node.go:303] "NodeGetVolumeStats: called" args={"volume_id":"vol-0f00d7ebcc1c0993f","volume_path":"/mnt/ecs/ebs/mocktaskID_vol-0f00d7ebcc1c0993f"}
I1009 18:49:37.145296       1 node.go:303] "NodeGetVolumeStats: called" args={"volume_id":"vol-0f00d7ebcc1c0993f","volume_path":"/mnt/ecs/ebs/mocktaskID_vol-0f00d7ebcc1c0993f"}
```

Agent logs to unstage volume
```
level=debug time=2023-10-09T18:17:16Z msg="No more tasks could be started at this moment, waiting"
level=debug time=2023-10-09T18:17:16Z msg="Successfully unstaged volume" Task="web-app:2 arn:aws:ecs:us-west-2:113424923516:task/evm-test-gamma/20b60545e5214c43818e73aa8f95550a, TaskStatus: (STOPPED->STOPPED) N Containers: 1, N ENIs 0"
```

CSI driver container NodeUnstageVolume logs
```
I1009 18:49:39.828644       1 node.go:253] "NodeUnstageVolume: called" args={"volume_id":"vol-0f00d7ebcc1c0993f","staging_target_path":"/mnt/ecs/ebs/mocktaskID_vol-0f00d7ebcc1c0993f"}
I1009 18:49:39.828876       1 node.go:293] "NodeUnstageVolume: unmounting" target="/mnt/ecs/ebs/mocktaskID_vol-0f00d7ebcc1c0993f"
I1009 18:49:39.828894       1 mount_helper_common.go:93] unmounting "/mnt/ecs/ebs/mocktaskID_vol-0f00d7ebcc1c0993f" (corruptedMount: false, mounterCanSkipMountPointChecks: true)
I1009 18:49:39.828908       1 mount_linux.go:360] Unmounting /mnt/ecs/ebs/mocktaskID_vol-0f00d7ebcc1c0993f
I1009 18:49:39.855136       1 mount_helper_common.go:150] Warning: deleting path "/mnt/ecs/ebs/mocktaskID_vol-0f00d7ebcc1c0993f"
I1009 18:49:39.855207       1 node.go:298] "NodeUnStageVolume: successfully unstaged volume" volumeID="vol-0f00d7ebcc1c0993f" target="/mnt/ecs/ebs/mocktaskID_vol-0f00d7ebcc1c0993f"
I1009 18:49:39.855226       1 node.go:268] "NodeUnStageVolume: volume operation finished" volumeID="vol-0f00d7ebcc1c0993f"
```

New tests cover the changes: Yes

### Description for the changelog
* Collect volume metrics for EBS-backed tasks and clean up EBS-backed tasks

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
