### PR TITLE
Implement AgentConfigAccessor interface in agent/

### DIFF
--- a/agent/config/config_accessor.go
+++ b/agent/config/config_accessor.go
@@ -1,0 +1,84 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"errors"
+)
+
+// agentConfigAccessor struct implements AgentConfigAccessor interface defined in ecs-agent module.
+type agentConfigAccessor struct {
+	cfg *Config
+}
+
+// NewAgentConfigAccessor creates a new agentConfigAccessor.
+func NewAgentConfigAccessor(cfg *Config) (*agentConfigAccessor, error) {
+	if cfg == nil {
+		return nil, errors.New("unable to create new agent config accessor due to passed in config value being nil")
+	}
+
+	return &agentConfigAccessor{cfg: cfg}, nil
+}
+
+func (aca *agentConfigAccessor) APIEndpoint() string {
+	return aca.cfg.APIEndpoint
+}
+
+func (aca *agentConfigAccessor) AWSRegion() string {
+	return aca.cfg.AWSRegion
+}
+
+func (aca *agentConfigAccessor) Cluster() string {
+	return aca.cfg.Cluster
+}
+
+func (aca *agentConfigAccessor) DefaultClusterName() string {
+	return DefaultClusterName
+}
+
+func (aca *agentConfigAccessor) External() bool {
+	return aca.cfg.External.Enabled()
+}
+
+func (aca *agentConfigAccessor) InstanceAttributes() map[string]string {
+	return aca.cfg.InstanceAttributes
+}
+
+func (aca *agentConfigAccessor) NoInstanceIdentityDocument() bool {
+	return aca.cfg.NoIID
+}
+
+func (aca *agentConfigAccessor) OSFamily() string {
+	return GetOSFamily()
+}
+
+func (aca *agentConfigAccessor) OSType() string {
+	return OSType
+}
+
+func (aca *agentConfigAccessor) ReservedMemory() uint16 {
+	return aca.cfg.ReservedMemory
+}
+
+func (aca *agentConfigAccessor) ReservedPorts() []uint16 {
+	return aca.cfg.ReservedPorts
+}
+
+func (aca *agentConfigAccessor) ReservedPortsUDP() []uint16 {
+	return aca.cfg.ReservedPortsUDP
+}
+
+func (aca *agentConfigAccessor) UpdateCluster(cluster string) {
+	aca.cfg.Cluster = cluster
+}

--- a/agent/config/config_accessor_test.go
+++ b/agent/config/config_accessor_test.go
@@ -1,0 +1,69 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	ecsagentconfig "github.com/aws/amazon-ecs-agent/ecs-agent/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAgentConfigAccessorErrorsWhenConfigIsNil(t *testing.T) {
+	configAccessor, err := NewAgentConfigAccessor(nil)
+	assert.Error(t, err)
+	assert.Nil(t, configAccessor)
+}
+
+func TestAgentConfigAccessorImplements(t *testing.T) {
+	configAccessor, err := NewAgentConfigAccessor(&Config{})
+	assert.NoError(t, err)
+	assert.Implements(t, (*ecsagentconfig.AgentConfigAccessor)(nil), configAccessor)
+}
+
+func TestAgentConfigAccessorMethods(t *testing.T) {
+	cfg := &Config{
+		APIEndpoint:        "https://some-endpoint.com",
+		AWSRegion:          "us-east-1",
+		Cluster:            "myCluster",
+		External:           BooleanDefaultFalse{Value: ExplicitlyEnabled},
+		InstanceAttributes: map[string]string{"attribute1": "value1"},
+		NoIID:              true,
+		ReservedMemory:     uint16(20),
+		ReservedPorts:      []uint16{22, 2375, 2376, 51678},
+		ReservedPortsUDP:   []uint16{},
+	}
+
+	configAccessor, err := NewAgentConfigAccessor(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, cfg.APIEndpoint, configAccessor.APIEndpoint())
+	assert.Equal(t, cfg.AWSRegion, configAccessor.AWSRegion())
+	assert.Equal(t, cfg.Cluster, configAccessor.Cluster())
+	assert.Equal(t, DefaultClusterName, configAccessor.DefaultClusterName())
+	assert.Equal(t, cfg.External.Enabled(), configAccessor.External())
+	assert.Equal(t, cfg.NoIID, configAccessor.NoInstanceIdentityDocument())
+	assert.Equal(t, GetOSFamily(), configAccessor.OSFamily())
+	assert.Equal(t, OSType, configAccessor.OSType())
+	assert.Equal(t, cfg.ReservedMemory, configAccessor.ReservedMemory())
+	assert.Equal(t, cfg.ReservedPorts, configAccessor.ReservedPorts())
+	assert.Equal(t, cfg.ReservedPortsUDP, configAccessor.ReservedPortsUDP())
+	newCluster := "arn:aws:ecs:us-east-1:123456789012:cluster/my-cluster"
+	configAccessor.UpdateCluster(newCluster)
+	assert.Equal(t, newCluster, cfg.Cluster)
+	assert.Equal(t, newCluster, configAccessor.Cluster())
+	assert.Equal(t, cfg.Cluster, configAccessor.Cluster())
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/config/generate_mocks.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/config/generate_mocks.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+//go:generate mockgen -destination=mocks/config_mocks.go -copyright_file=../../scripts/copyright_file github.com/aws/amazon-ecs-agent/ecs-agent/config AgentConfigAccessor

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/config/interface.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/config/interface.go
@@ -1,0 +1,65 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+// AgentConfigAccessor provides access to an agent config via a set of designated methods (listed below).
+type AgentConfigAccessor interface {
+	// APIEndpoint returns the endpoint to make calls against.
+	// (e.g., "ecs.us-east-1.amazonaws.com")
+	APIEndpoint() string
+	// AWSRegion returns the region to run in.
+	// (e.g., "us-east-1")
+	AWSRegion() string
+	// Cluster returns the name or full ARN of the cluster that the Agent
+	// should register the container instance into.
+	Cluster() string
+	// DefaultClusterName returns the name of the cluster that the container
+	// instance should be registered into by default (i.e., if no cluster is
+	// specified).
+	// (e.g., "default")
+	DefaultClusterName() string
+	// External returns whether the Agent is running on external compute
+	// capacity (i.e., outside of AWS).
+	External() bool
+	// InstanceAttributes returns a map of key/value pairs representing
+	// attributes to be associated with the instance within the ECS service.
+	// They are used to influence behavior such as launch placement.
+	InstanceAttributes() map[string]string
+	// NoInstanceIdentityDocument returns whether the Agent should register
+	// the instance with instance identity document. When this method returns true,
+	// it means that the Agent should not register the instance with instance identity document.
+	// This is used to accommodate scenarios where the instance identity document is not
+	// available or needed (e.g., when Agent is running on external compute capacity).
+	NoInstanceIdentityDocument() bool
+	// OSFamily returns the operating system family of the instance.
+	// (e.g., "WINDOWS_SERVER_2019_CORE")
+	OSFamily() string
+	// OSType returns the operating system type of the instance.
+	// (e.g., "windows")
+	OSType() string
+	// ReservedMemory returns the reduction (in MiB) of the memory
+	// capacity of the instance that is reported to Amazon ECS.
+	// It is used by ECS service to influence task placement and does NOT reserve
+	// memory usage on the instance.
+	ReservedMemory() uint16
+	// ReservedPorts returns an array of ports which should be registered as
+	// unavailable.
+	ReservedPorts() []uint16
+	// ReservedPortsUDP returns an array of UDP ports which should be registered
+	// as unavailable.
+	ReservedPortsUDP() []uint16
+	// UpdateCluster updates the cluster that the Agent should register the
+	// container instance into.
+	UpdateCluster(cluster string)
+}

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -24,6 +24,7 @@ github.com/aws/amazon-ecs-agent/ecs-agent/api/resource
 github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/mocks
 github.com/aws/amazon-ecs-agent/ecs-agent/api/status
 github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status
+github.com/aws/amazon-ecs-agent/ecs-agent/config
 github.com/aws/amazon-ecs-agent/ecs-agent/credentials
 github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks
 github.com/aws/amazon-ecs-agent/ecs-agent/data


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Create struct `agentConfigAccessor` in agent module that implements `AgentConfigAccessor` interface defined in ecs-agent module. The aforementioned interface was introduced in this previous pull request: https://github.com/aws/amazon-ecs-agent/pull/3928

For clarity, this pull request adds files to the agent module but Agent does NOT currently use them in any meaningful way. These files being "plugged into power" will be done in future pull request(s) and is out of scope of this pull request. 

### Implementation details
<!-- How are the changes implemented? -->
* Add `agentConfigAccessor` struct to `agent/config/config_accessor.go` such that `agentConfigAccessor` struct implements the `AgentConfigAccessor` interface defined in ecs-agent module
* Add tests for the above to `agent/config/config_accessor_test.go`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit, integration, and functional tests.

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Implement AgentConfigAccessor interface in agent/

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
