### PR TITLE
Build the csi driver image tar in codebuild pr-build job

### DIFF
--- a/build-infrastructure/codebuild-devbuild-stack.yml
+++ b/build-infrastructure/codebuild-devbuild-stack.yml
@@ -142,9 +142,9 @@ Resources:
       Description: A CodeBuild project to build artifacts (ARM). Builds are triggered by PR creation and updates, and artifacts are saved in S3
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: 'aws/codebuild/amazonlinux2-aarch64-standard:2.0'
+        Image: 'aws/codebuild/amazonlinux2-aarch64-standard:3.0'
         ImagePullCredentialsType: CODEBUILD
-        PrivilegedMode: false
+        PrivilegedMode: true
         Type: ARM_CONTAINER
       Name: !Sub '${BuildProjectName}-arm'
       QueuedTimeoutInMinutes: 60
@@ -196,9 +196,9 @@ Resources:
       Description: A CodeBuild project to build artifacts (AMD/x86_64). Builds are triggered by PR creation and updates, and artifacts are saved in S3
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: 'aws/codebuild/amazonlinux2-x86_64-standard:3.0'
+        Image: 'aws/codebuild/amazonlinux2-x86_64-standard:5.0'
         ImagePullCredentialsType: CODEBUILD
-        PrivilegedMode: false
+        PrivilegedMode: true
         Type: LINUX_CONTAINER
       Name: !Sub '${BuildProjectName}-amd'
       QueuedTimeoutInMinutes: 60

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -45,6 +45,7 @@ phases:
       - echo "Building agent image" 2>&1 | tee -a $BUILD_LOG
       - AGENT_VERSION=$(cat VERSION)
       - ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
+      - CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
       - ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
@@ -62,13 +63,16 @@ phases:
       - GO111MODULE=auto
       - make release-agent 2>&1 | tee -a $BUILD_LOG
       - make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
+      - make -C ./ecs-agent/daemonimages/csidriver 2>&1 | tee -a $BUILD_LOG
       - ls
       # Rename artifacts for architecture
       - |
         if [[ $architecture == "arm64" ]] ; then
           mv $ECS_AGENT_TAR "ecs-agent-arm64-v${AGENT_VERSION}.tar"
+          mv $CSI_DRIVER_TAR "./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
           ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
           ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
+          CSI_DRIVER_TAR="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver-arm64.tar"
         fi
 
   post_build:
@@ -79,5 +83,6 @@ artifacts:
     - $ECS_AGENT_TAR
     - $ECS_AGENT_RPM
     - $BUILD_LOG
+    - $CSI_DRIVER_TAR
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

- Build the CSI driver container in codebuild PR build job and upload to artifacts bucket.
- Modify pr-build codebuild cloudformation to be in privileged mode. This is so that docker containers can run within the job, as the CSI driver container is built with docker.
- Update to latest container image versions from codebuild for housekeeping.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Ran pr-build codebuild jobs with the changes in this PR.

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
