### PR TITLE
Support NodeUnstageVolume in csi driver

### DIFF
--- a/ecs-agent/csiclient/csi_client.go
+++ b/ecs-agent/csiclient/csi_client.go
@@ -20,8 +20,6 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -48,7 +46,8 @@ type CSIClient interface {
 		mountOptions []string,
 		fsGroup *int64,
 	) error
-	GetVolumeMetrics(volumeId string, hostMountPath string) (*Metrics, error)
+	NodeUnstageVolume(ctx context.Context, volumeId, stagingTargetPath string) error
+	GetVolumeMetrics(ctx context.Context, volumeId string, hostMountPath string) (*Metrics, error)
 }
 
 // csiClient encapsulates all CSI methods.
@@ -61,6 +60,10 @@ func NewCSIClient(socketIn string) csiClient {
 	return csiClient{csiSocket: socketIn}
 }
 
+// NodeStageVolume will do following things for the given volume:
+// 1. format the device if it does not have any,
+// 2. mount the device to given stagingTargetPath,
+// 3. resize the fs if its size is smaller than the device size.
 func (cc *csiClient) NodeStageVolume(ctx context.Context,
 	volID string,
 	publishContext map[string]string,
@@ -72,17 +75,13 @@ func (cc *csiClient) NodeStageVolume(ctx context.Context,
 	mountOptions []string,
 	fsGroup *int64,
 ) error {
-	conn, err := cc.grpcDialConnect()
+	conn, err := cc.grpcDialConnect(ctx)
 	if err != nil {
-		logger.Error("NodeStage: CSI Connection Error", logger.Fields{
-			field.Error: err,
-		})
-		return err
+		return fmt.Errorf("NodeStageVolume: failed to establish CSI connection: %w", err)
 	}
 	defer conn.Close()
 
 	client := csi.NewNodeClient(conn)
-
 	defaultVolumeCapability := &csi.VolumeCapability{
 		AccessType: &csi.VolumeCapability_Mount{
 			Mount: &csi.VolumeCapability_MountVolume{},
@@ -115,39 +114,46 @@ func (cc *csiClient) NodeStageVolume(ctx context.Context,
 	}
 
 	_, err = client.NodeStageVolume(ctx, &req)
-
 	if err != nil {
-		logger.Error("Error staging volume via CSI driver", logger.Fields{
-			field.Error: err,
-		})
-		return err
+		return fmt.Errorf("failed to stage volume via CSI driver: %w", err)
+	}
+	return nil
+}
+
+// NodeUnstageVolume will unstage/umount the given volume from the stagingTargetPath.
+func (cc *csiClient) NodeUnstageVolume(ctx context.Context, volumeId, stagingTargetPath string) error {
+	conn, err := cc.grpcDialConnect(ctx)
+	if err != nil {
+		return fmt.Errorf("NodeUnstageVolume: failed to establish CSI connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := csi.NewNodeClient(conn)
+	_, err = client.NodeUnstageVolume(ctx, &csi.NodeUnstageVolumeRequest{
+		VolumeId:          volumeId,
+		StagingTargetPath: stagingTargetPath,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to unstage volume via CSI driver: %w", err)
 	}
 	return nil
 }
 
 // GetVolumeMetrics returns volume usage.
-func (cc *csiClient) GetVolumeMetrics(volumeId string, hostMountPath string) (*Metrics, error) {
-	conn, err := cc.grpcDialConnect()
+func (cc *csiClient) GetVolumeMetrics(ctx context.Context, volumeId string, hostMountPath string) (*Metrics, error) {
+	conn, err := cc.grpcDialConnect(ctx)
 	if err != nil {
-		logger.Error("GetVolumeMetrics: CSI Connection Error")
-		return nil, err
+		return nil, fmt.Errorf("GetVolumeMetrics: failed to establish CSI connection: %w", err)
 	}
 	defer conn.Close()
 
 	client := csi.NewNodeClient(conn)
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
 	resp, err := client.NodeGetVolumeStats(ctx, &csi.NodeGetVolumeStatsRequest{
 		VolumeId:   volumeId,
 		VolumePath: hostMountPath,
 	})
 	if err != nil {
-		logger.Error("Could not get stats", logger.Fields{
-			field.Error: err,
-		})
-		return nil, err
+		return nil, fmt.Errorf("failed to get stats via CSI driver: %w", err)
 	}
 
 	usages := resp.GetUsage()
@@ -180,21 +186,19 @@ func (cc *csiClient) GetVolumeMetrics(volumeId string, hostMountPath string) (*M
 	}, nil
 }
 
-func (cc *csiClient) grpcDialConnect() (*grpc.ClientConn, error) {
+func (cc *csiClient) grpcDialConnect(ctx context.Context) (*grpc.ClientConn, error) {
 	dialer := func(addr string, t time.Duration) (net.Conn, error) {
 		return net.Dial(protocol, addr)
 	}
-	conn, err := grpc.Dial(
+	conn, err := grpc.DialContext(
+		ctx,
 		cc.csiSocket,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDialer(dialer),
 	)
 	if err != nil {
-		logger.Error("Error building a connection to CSI driver", logger.Fields{
-			field.Error: err,
-			"Socket":    cc.csiSocket,
-		})
-		return nil, err
+		return nil, fmt.Errorf(
+			"error building a connection to CSI driver with socket %s: %w", cc.csiSocket, err)
 	}
 	return conn, nil
 }

--- a/ecs-agent/csiclient/dummy_csiclient.go
+++ b/ecs-agent/csiclient/dummy_csiclient.go
@@ -25,7 +25,7 @@ const gibToBytes = 1024 * 1024 * 1024
 type dummyCSIClient struct {
 }
 
-func (c *dummyCSIClient) GetVolumeMetrics(volumeId string, hostMountPath string) (*Metrics, error) {
+func (c *dummyCSIClient) GetVolumeMetrics(ctx context.Context, volumeId string, hostMountPath string) (*Metrics, error) {
 	return &Metrics{
 		Used:     15 * gibToBytes,
 		Capacity: 20 * gibToBytes,
@@ -43,6 +43,10 @@ func (c *dummyCSIClient) NodeStageVolume(ctx context.Context,
 	mountOptions []string,
 	fsGroup *int64,
 ) error {
+	return nil
+}
+
+func (c *dummyCSIClient) NodeUnstageVolume(ctx context.Context, volumeId, stagingTargetPath string) error {
 	return nil
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR is to support `NodeUnstageVolume` operation in the csi driver.

### Implementation details
<!-- How are the changes implemented? -->
- Add an implementation for `NodeUnstageVolume` in `node.go` by copying the existing implementation - https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/pkg/driver/node.go#L288-L336.
- Add the new method in the csi client which will be used by Agent to communicate with the csi driver daemon.
- Switch to use `grpc.DialContext` so that caller can set the timeout by using `context.WithTimeout`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

Manually tested this can umount the EBS volume on the host.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - add new volume operation - NodeUnstageVolume.

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
