### PR TITLE
Add AcceptInsecureCert method to AgentConfigAccessor

### DIFF
--- a/agent/config/config_accessor.go
+++ b/agent/config/config_accessor.go
@@ -31,6 +31,10 @@ func NewAgentConfigAccessor(cfg *Config) (*agentConfigAccessor, error) {
 	return &agentConfigAccessor{cfg: cfg}, nil
 }
 
+func (aca *agentConfigAccessor) AcceptInsecureCert() bool {
+	return aca.cfg.AcceptInsecureCert
+}
+
 func (aca *agentConfigAccessor) APIEndpoint() string {
 	return aca.cfg.APIEndpoint
 }

--- a/agent/config/config_accessor_test.go
+++ b/agent/config/config_accessor_test.go
@@ -37,6 +37,7 @@ func TestAgentConfigAccessorImplements(t *testing.T) {
 
 func TestAgentConfigAccessorMethods(t *testing.T) {
 	cfg := &Config{
+		AcceptInsecureCert: true,
 		APIEndpoint:        "https://some-endpoint.com",
 		AWSRegion:          "us-east-1",
 		Cluster:            "myCluster",
@@ -50,6 +51,7 @@ func TestAgentConfigAccessorMethods(t *testing.T) {
 
 	configAccessor, err := NewAgentConfigAccessor(cfg)
 	assert.NoError(t, err)
+	assert.Equal(t, cfg.AcceptInsecureCert, configAccessor.AcceptInsecureCert())
 	assert.Equal(t, cfg.APIEndpoint, configAccessor.APIEndpoint())
 	assert.Equal(t, cfg.AWSRegion, configAccessor.AWSRegion())
 	assert.Equal(t, cfg.Cluster, configAccessor.Cluster())

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/config/interface.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/config/interface.go
@@ -15,6 +15,8 @@ package config
 
 // AgentConfigAccessor provides access to an agent config via a set of designated methods (listed below).
 type AgentConfigAccessor interface {
+	// AcceptInsecureCert returns whether clients validate SSL certificates.
+	AcceptInsecureCert() bool
 	// APIEndpoint returns the endpoint to make calls against.
 	// (e.g., "ecs.us-east-1.amazonaws.com")
 	APIEndpoint() string

--- a/ecs-agent/config/interface.go
+++ b/ecs-agent/config/interface.go
@@ -15,6 +15,8 @@ package config
 
 // AgentConfigAccessor provides access to an agent config via a set of designated methods (listed below).
 type AgentConfigAccessor interface {
+	// AcceptInsecureCert returns whether clients validate SSL certificates.
+	AcceptInsecureCert() bool
 	// APIEndpoint returns the endpoint to make calls against.
 	// (e.g., "ecs.us-east-1.amazonaws.com")
 	APIEndpoint() string

--- a/ecs-agent/config/mocks/config_mocks.go
+++ b/ecs-agent/config/mocks/config_mocks.go
@@ -75,6 +75,20 @@ func (mr *MockAgentConfigAccessorMockRecorder) AWSRegion() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AWSRegion", reflect.TypeOf((*MockAgentConfigAccessor)(nil).AWSRegion))
 }
 
+// AcceptInsecureCert mocks base method.
+func (m *MockAgentConfigAccessor) AcceptInsecureCert() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AcceptInsecureCert")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AcceptInsecureCert indicates an expected call of AcceptInsecureCert.
+func (mr *MockAgentConfigAccessorMockRecorder) AcceptInsecureCert() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptInsecureCert", reflect.TypeOf((*MockAgentConfigAccessor)(nil).AcceptInsecureCert))
+}
+
 // Cluster mocks base method.
 func (m *MockAgentConfigAccessor) Cluster() string {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add `AcceptInsecureCert` method to `AgentConfigAccessor` interface (and to agent module's implementation of this interface). This method is required for future changes in the ecs-agent module and was missed being added as part of this previous pull request: https://github.com/aws/amazon-ecs-agent/pull/3928

For clarity, the files that this pull request changes are not currently used by Agent in any meaningful way. These files being "plugged into power" will be done in future pull request(s) and is out of scope of this pull request. 

### Implementation details
<!-- How are the changes implemented? -->
- Add `AcceptInsecureCert` method to `AgentConfigAccessor` interface in ecs-agent module
- Add `AcceptInsecureCert` method to `agentConfigAccessor` struct in agent module, which implements the above interface
- Regenerate mocks for `AgentConfigAccessor` interface

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit, integration, and functional tests.

New tests cover the changes: existing test modified to cover changes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add AcceptInsuranceCert method to AgentConfigAccessor

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
