### PR TITLE
Build CSI driver in production merge-build codebuild job

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/csi_client_linux.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/csi_client_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+// +build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package csiclient
+
+import "path/filepath"
+
+const (
+	defaultImageName      = "ebs-csi-driver"
+	defaultSocketName     = "csi-driver.sock"
+	defaultSocketHostPath = "/var/run/ecs/"
+)
+
+func DefaultSocketFilePath() string {
+	return filepath.Join(defaultSocketHostPath, defaultImageName, defaultSocketName)
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/csi_client_windows.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/csi_client_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package csiclient
+
+func DefaultSocketFilePath() string {
+	return "unimplemented" // TODO: Windows implementation
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/dummy_csiclient.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/dummy_csiclient.go
@@ -16,6 +16,7 @@ package csiclient
 import (
 	"context"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -48,6 +49,10 @@ func (c *dummyCSIClient) NodeStageVolume(ctx context.Context,
 
 func (c *dummyCSIClient) NodeUnstageVolume(ctx context.Context, volumeId, stagingTargetPath string) error {
 	return nil
+}
+
+func (c *dummyCSIClient) NodeGetCapabilities(ctx context.Context) (*csi.NodeGetCapabilitiesResponse, error) {
+	return &csi.NodeGetCapabilitiesResponse{}, nil
 }
 
 func NewDummyCSIClient() CSIClient {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/generate_mocks.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/generate_mocks.go
@@ -1,0 +1,15 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package csiclient
+
+//go:generate mockgen -destination=mocks/mocks.go -copyright_file=../../scripts/copyright_file github.com/aws/amazon-ecs-agent/ecs-agent/csiclient CSIClient

--- a/build-infrastructure/release-pipeline-stack.yml
+++ b/build-infrastructure/release-pipeline-stack.yml
@@ -401,9 +401,9 @@ Resources:
       Description: CodeBuild project to build the ECS Agent Docker image tarball and RPM
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
         ImagePullCredentialsType: CODEBUILD
-        PrivilegedMode: false
+        PrivilegedMode: true
         Type: LINUX_CONTAINER
       LogsConfig:
         CloudWatchLogs:
@@ -505,9 +505,9 @@ Resources:
       Description: CodeBuild project to build the ECS Agent Docker image tarball
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-aarch64-standard:2.0
+        Image: aws/codebuild/amazonlinux2-aarch64-standard:3.0
         ImagePullCredentialsType: CODEBUILD
-        PrivilegedMode: false
+        PrivilegedMode: true
         Type: ARM_CONTAINER
       LogsConfig:
         CloudWatchLogs:

--- a/buildspecs/merge-build.yml
+++ b/buildspecs/merge-build.yml
@@ -99,7 +99,7 @@ phases:
       - md5sum $ECS_AGENT_LATEST_TAR | awk '{print $1}' > $ECS_AGENT_LATEST_TAR_MD5
       - md5sum $ECS_AGENT_GITSHORTSHA_TAR | awk '{print $1}' > $ECS_AGENT_GITSHORTSHA_TAR_MD5
 
-      # json file names 
+      # json file names
       - ECS_AGENT_TAR_JSON="${ECS_AGENT_TAR}.json"
       - ECS_AGENT_LATEST_TAR_JSON="${ECS_AGENT_LATEST_TAR}.json"
       - ECS_AGENT_GITSHORTSHA_TAR_JSON="${ECS_AGENT_GITSHORTSHA_TAR}.json"
@@ -107,6 +107,25 @@ phases:
       # Create jsons
       - echo "{\"agentVersion\":\"v${AGENT_VERSION}\"}" | tee $ECS_AGENT_TAR_JSON $ECS_AGENT_LATEST_TAR_JSON $ECS_AGENT_GITSHORTSHA_TAR_JSON
 
+      # Build CSI driver image
+      - echo "Build CSI driver image"
+      - ARCH_TAG=""
+      - |
+        if [[ $architecture == "arm64" ]] ; then
+          ARCH_TAG="-arm64"
+        fi
+      - CSI_DRIVER_TAR_SOURCE="./ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar"
+      - CSI_DRIVER_TAR="ebs-csi-driver${ARCH_TAG}-v${AGENT_VERSION}.tar"
+      - CSI_DRIVER_LATEST_TAR="ebs-csi-driver${ARCH_TAG}-latest.tar"
+      - CSI_DRIVER_GITSHORTSHA_TAR="ebs-csi-driver${ARCH_TAG}-${GIT_COMMIT_SHORT_SHA}.tar"
+      - make -C ./ecs-agent/daemonimages/csidriver
+      - cp "$CSI_DRIVER_TAR_SOURCE" "$CSI_DRIVER_TAR"
+      - cp "$CSI_DRIVER_TAR_SOURCE" "$CSI_DRIVER_LATEST_TAR"
+      - cp "$CSI_DRIVER_TAR_SOURCE" "$CSI_DRIVER_GITSHORTSHA_TAR"
+      # csi driver sha256 file checksums
+      - sha256sum $CSI_DRIVER_TAR | awk '{print $1}' > "${CSI_DRIVER_TAR}.sha256"
+      - sha256sum $CSI_DRIVER_LATEST_TAR | awk '{print $1}' > "${CSI_DRIVER_LATEST_TAR}.sha256"
+      - sha256sum $CSI_DRIVER_GITSHORTSHA_TAR | awk '{print $1}' > "${CSI_DRIVER_GITSHORTSHA_TAR}.sha256"
 
 artifacts:
   files:
@@ -127,6 +146,14 @@ artifacts:
 
     # rpm
     - $ECS_AGENT_RPM
+
+    # csi driver
+    - "$CSI_DRIVER_TAR"
+    - "$CSI_DRIVER_LATEST_TAR"
+    - "$CSI_DRIVER_GITSHORTSHA_TAR"
+    - "${CSI_DRIVER_TAR}.sha256"
+    - "${CSI_DRIVER_LATEST_TAR}.sha256"
+    - "${CSI_DRIVER_GITSHORTSHA_TAR}.sha256"
 
     # ECS Anywhere install script
     - 'scripts/ecs-anywhere-install.sh'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This change builds the CSI driver in the production codebuild "merge-build" job. This is similar to https://github.com/aws/amazon-ecs-agent/pull/3933

In addition to building, we also create artifacts in a similar format to the ecs-agent artifacts, with a "latest", "vX.XX.X", and "git hash" versioned artifacts. Lastly we make sha256 checksum hashes to be published.

Also bump up the version number of the codebuild image and change to privileged mode, to allow docker to run inside the codebuild container.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

This job was tested using a temporary codebuild job running merge-build.yml within the dev codebuild stack: https://github.com/aws/amazon-ecs-agent/pull/3947/files


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
