### PR TITLE
Add CSI driver files to copy and sign codebuild jobs

### DIFF
--- a/buildspecs/copy.yml
+++ b/buildspecs/copy.yml
@@ -11,7 +11,7 @@ phases:
       - aws s3 cp $CODEBUILD_SRC_DIR_JSONArtifact/agent.json "$RESULTS_BUCKET_URI/$GIT_COMMIT_SHA/agent.json"
       # Copy the updated agentVersionV2-<branch>.json file
       - aws s3 cp $CODEBUILD_SRC_DIR_JSONArtifact/agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json "$RESULTS_BUCKET_URI/agentVersionV2/agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json"
-      
+
       # since the buildspecs are the primary artifacts, we need to change directory
       - cd $CODEBUILD_SRC_DIR_SignedArtifact
       # list the artifacts that are ready to upload
@@ -26,15 +26,15 @@ phases:
       # copy amd md5 and json files
       - cd $CODEBUILD_SRC_DIR_AmdBuildArtifact
       - |
-        for filename in  *.md5 *.json; do
+        for filename in  *.md5 *.json *.sha256; do
           echo "copying $filename to destination $RESULTS_BUCKET_URI/$GIT_COMMIT_SHA"
           aws s3 cp $filename "$RESULTS_BUCKET_URI/$GIT_COMMIT_SHA/$filename"
         done
- 
+
       # copy amd md5 and json files
       - cd $CODEBUILD_SRC_DIR_ArmBuildArtifact
       - |
-        for filename in  *.md5 *.json; do
+        for filename in  *.md5 *.json *.sha256; do
           echo "copying $filename to destination $RESULTS_BUCKET_URI/$GIT_COMMIT_SHA"
           aws s3 cp $filename "$RESULTS_BUCKET_URI/$GIT_COMMIT_SHA/$filename"
         done

--- a/buildspecs/signing.yml
+++ b/buildspecs/signing.yml
@@ -54,6 +54,14 @@ phases:
       - ECS_AGENT_ARM_RPM="amazon-ecs-init-${INIT_VERSION}.aarch64.rpm"
       - ECS_AGENT_UBUNTU_ARM_DEB="amazon-ecs-init-${INIT_VERSION}.arm64.deb"
 
+      # EBS csi driver image tar files
+      - CSI_DRIVER_AMD_TAR="ebs-csi-driver-v${AGENT_VERSION}.tar"
+      - CSI_DRIVER_AMD_LATEST_TAR="ebs-csi-driver-latest.tar"
+      - CSI_DRIVER_AMD_GITSHORTSHA_TAR="ebs-csi-driver-${GIT_COMMIT_SHORT_SHA}.tar"
+      - CSI_DRIVER_ARM_TAR="ebs-csi-driver-arm64-v${AGENT_VERSION}.tar"
+      - CSI_DRIVER_ARM_LATEST_TAR="ebs-csi-driver-arm64-latest.tar"
+      - CSI_DRIVER_ARM_GITSHORTSHA_TAR="ebs-csi-driver-arm64-${GIT_COMMIT_SHORT_SHA}.tar"
+
       - ECS_ANYWHERE_SCRIPT="ecs-anywhere-install-${INIT_VERSION}.sh"
       - ECS_ANYWHERE_LATEST_SCRIPT="ecs-anywhere-install-latest.sh"
       # Get the private key from secrets manager, jq parse it, turn it into raw output, pipe to file
@@ -71,6 +79,13 @@ phases:
       - source /tmp/functions.sh && sign_file $ECS_AGENT_AMD_GITSHORTSHA_TAR
       - cp "$CODEBUILD_SRC_DIR_AmdBuildArtifact/$ECS_AGENT_AMD_RPM" $ECS_AGENT_AMD_RPM
       - source /tmp/functions.sh && sign_file $ECS_AGENT_AMD_RPM
+      # Sign the amd csi driver tar (this is a secondary source so we have to do some copying)
+      - cp "$CODEBUILD_SRC_DIR_AmdBuildArtifact/$CSI_DRIVER_AMD_TAR" $CSI_DRIVER_AMD_TAR
+      - source /tmp/functions.sh && sign_file $CSI_DRIVER_AMD_TAR
+      - cp "$CODEBUILD_SRC_DIR_AmdBuildArtifact/$CSI_DRIVER_AMD_LATEST_TAR" $CSI_DRIVER_AMD_LATEST_TAR
+      - source /tmp/functions.sh && sign_file $CSI_DRIVER_AMD_LATEST_TAR
+      - cp "$CODEBUILD_SRC_DIR_AmdBuildArtifact/$CSI_DRIVER_AMD_GITSHORTSHA_TAR" $CSI_DRIVER_AMD_GITSHORTSHA_TAR
+      - source /tmp/functions.sh && sign_file $CSI_DRIVER_AMD_GITSHORTSHA_TAR
       # Sign ECS Anywhere Script
       - cp "$CODEBUILD_SRC_DIR_AmdBuildArtifact/scripts/ecs-anywhere-install.sh" $ECS_ANYWHERE_SCRIPT
       - source /tmp/functions.sh && sign_file $ECS_ANYWHERE_SCRIPT
@@ -85,6 +100,13 @@ phases:
       - source /tmp/functions.sh && sign_file $ECS_AGENT_ARM_GITSHORTSHA_TAR
       - cp "$CODEBUILD_SRC_DIR_ArmBuildArtifact/$ECS_AGENT_ARM_RPM" $ECS_AGENT_ARM_RPM
       - source /tmp/functions.sh && sign_file $ECS_AGENT_ARM_RPM
+      # Sign the arm csi driver tar (this is a secondary source so we have to do some copying)
+      - cp "$CODEBUILD_SRC_DIR_ArmBuildArtifact/$CSI_DRIVER_ARM_TAR" $CSI_DRIVER_ARM_TAR
+      - source /tmp/functions.sh && sign_file $CSI_DRIVER_ARM_TAR
+      - cp "$CODEBUILD_SRC_DIR_ArmBuildArtifact/$CSI_DRIVER_ARM_LATEST_TAR" $CSI_DRIVER_ARM_LATEST_TAR
+      - source /tmp/functions.sh && sign_file $CSI_DRIVER_ARM_LATEST_TAR
+      - cp "$CODEBUILD_SRC_DIR_ArmBuildArtifact/$CSI_DRIVER_ARM_GITSHORTSHA_TAR" $CSI_DRIVER_ARM_GITSHORTSHA_TAR
+      - source /tmp/functions.sh && sign_file $CSI_DRIVER_ARM_GITSHORTSHA_TAR
       # Sign the amd deb (this is a secondary source so we have to do some copying)
       - cp "$CODEBUILD_SRC_DIR_UbuntuAmdBuildArtifact/$ECS_AGENT_UBUNTU_AMD_DEB" $ECS_AGENT_UBUNTU_AMD_DEB
       - source /tmp/functions.sh && sign_file $ECS_AGENT_UBUNTU_AMD_DEB
@@ -122,3 +144,15 @@ artifacts:
     - '$ECS_ANYWHERE_SCRIPT.asc'
     - $ECS_ANYWHERE_LATEST_SCRIPT
     - '$ECS_ANYWHERE_LATEST_SCRIPT.asc'
+    - $CSI_DRIVER_AMD_TAR
+    - '$CSI_DRIVER_AMD_TAR.asc'
+    - $CSI_DRIVER_AMD_LATEST_TAR
+    - '$CSI_DRIVER_AMD_LATEST_TAR.asc'
+    - $CSI_DRIVER_AMD_GITSHORTSHA_TAR
+    - '$CSI_DRIVER_AMD_GITSHORTSHA_TAR.asc'
+    - $CSI_DRIVER_ARM_TAR
+    - '$CSI_DRIVER_ARM_TAR.asc'
+    - $CSI_DRIVER_ARM_LATEST_TAR
+    - '$CSI_DRIVER_ARM_LATEST_TAR.asc'
+    - $CSI_DRIVER_ARM_GITSHORTSHA_TAR
+    - '$CSI_DRIVER_ARM_GITSHORTSHA_TAR.asc'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

- CSI driver uses sha256 hashes so add these to the glob match on copied files in copy.yml codebuild job
- Add CSI driver to signing.yml, which will sign x86_64 and arm64 csi driver container image artifacts
- signed csi driver artifacts are added to list of outputted artifacts at the end of the codebuild job

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

commands were spot-checked and run manually, will also be shadowing the next release to check for correctness

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
