### PR TITLE
Update SSM Agent version to 3.2.1630.0 for ECS exec

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -637,7 +637,7 @@ find-copy-certs-exec() {
 }
 
 download-ssm-binaries-exec() {
-    BINARY_VERSION="3.1.804.0"
+    BINARY_VERSION="3.2.1630.0"
     BINARY_PATH="/var/lib/ecs/deps/execute-command/bin/${BINARY_VERSION}"
     BINARY_DOWNLOAD_PATH="ssm-binaries"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Upgrade Amazon SSM Agent version to[ 3.2.1630.0](https://github.com/aws/amazon-ssm-agent/releases/tag/3.2.1630.0), which is the latest stable version, to address security issues. Find CVE listed below, and a similar PR in [amazon-ecs-ami](https://github.com/aws/amazon-ecs-ami/pull/150) as reference .

1. [Important] https://alas.aws.amazon.com/ALAS-2023-1825.html
2. [Important] https://alas.aws.amazon.com/AL2/ALAS-2023-2238.html
3. [Important] https://alas.aws.amazon.com/AL2023/ALAS-2023-373.html
4. [Important] https://alas.aws.amazon.com/AL2023/ALAS-2023-339.html

### Implementation details
Update SSM Agent binary version to `3.2.1630.0` in scripts/ecs-anywhere-install.sh

### Testing
1. Use updated ecs-anywhere-install.sh and run e2e functional tests on following ECS Anywhere supported platforms, 
 * al2generic-amd64, al2generic-arm64
 * centos7-amd64, centos7-arm64, centos7-gpu
 * centos8-amd64, centos8-arm64
 * debian10-gpu, debian10-amd64, debian10-arm64
 * sles15-amd64
 * untu18-gpu, ubuntu18-amd64, ubuntu18-arm64
 * ubuntu20-gpu, ubuntu20-amd64, ubuntu20-arm64
2. Confirmed the version of SSM Agent version (for the ECS exec feature) and feature tests passed.
```
$ ssm_command_id=$(aws ssm send-command \
--region us-west-2 \
--instance-ids mi-xxx \
--document-name "AWS-RunShellScript" \
--comment "ls binary path" \
--parameters '{"executionTimeout":["30"],"commands":["sudo ls /var/lib/ecs/deps/execute-command/bin/"]}' \
--output text \
--query "Command.CommandId")
```

```
$ aws ssm get-command-invocation \
--region us-west-2 \
--command-id $ssm_command_id \
--instance-id mi-xxx
{
    "Comment": "ls binary path", 
    "ExecutionElapsedTime": "PT0.051S", 
    "ExecutionEndDateTime": "2023-10-06T22:55:16.381Z", 
    "StandardErrorContent": "", 
    "CloudWatchOutputConfig": {
        "CloudWatchLogGroupName": "", 
        "CloudWatchOutputEnabled": false
    }, 
    "InstanceId": "mi-xxx", 
    "StandardErrorUrl": "", 
    "DocumentName": "AWS-RunShellScript", 
    "DocumentVersion": "$DEFAULT", 
    "Status": "Success", 
    "StatusDetails": "Success", 
    "PluginName": "aws:runShellScript", 
    "StandardOutputContent": "3.2.1630.0\n", 
    "ResponseCode": 0, 
    "ExecutionStartDateTime": "2023-10-06T22:55:16.381Z", 
    "CommandId": "xxx", 
    "StandardOutputUrl": ""
}
```


New tests cover the changes: no

### Description for the changelog
[Enhancement] Update SSM Agent version to 3.2.1630.0 for ECS exec.

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No breaking change is introduced by this PR.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
