### PR TITLE
Validate file system type for EBS-backed task attachment payload

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_resource_responder.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/attach_resource_responder.go
@@ -202,6 +202,10 @@ func validateAttachmentAndReturnProperties(message *ecsacs.ConfirmAttachmentMess
 		if err != nil {
 			return nil, errors.Wrap(err, "resource attachment validation by attachment type failed")
 		}
+		err = resource.ValidateFileSystemType(attachmentProperties[resource.FileSystemKey])
+		if err != nil {
+			return nil, errors.Wrap(err, "resource attachment validation by file system property failed")
+		}
 		return attachmentProperties, nil
 	}
 

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_attachment.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_attachment.go
@@ -74,6 +74,16 @@ const (
 	FileSystemKey           = "fileSystem"
 )
 
+var (
+	allowedFSTypes = map[string]bool{
+		"xfs":  true,
+		"ext2": true,
+		"ext3": true,
+		"ext4": true,
+		"ntfs": true,
+	}
+)
+
 // getCommonProperties returns the common properties as used for validating a resource.
 func getCommonProperties() (commonProperties []string) {
 	commonProperties = []string{

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_validation.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_validation.go
@@ -71,3 +71,12 @@ func ValidateRequiredProperties(actualProperties map[string]string, requiredProp
 	}
 	return nil
 }
+
+// For EBS-backed task attachment payload, the file system type is optional. If we do receive a file system type value,
+// we want to validate what we receive is one of the following types [xfs, ext2, ext3, ext4, ntfs].
+func ValidateFileSystemType(filesystemType string) error {
+	if filesystemType != "" && !allowedFSTypes[filesystemType] {
+		return errors.Errorf("invalid file system type: %s", filesystemType)
+	}
+	return nil
+}

--- a/ecs-agent/acs/session/attach_resource_responder.go
+++ b/ecs-agent/acs/session/attach_resource_responder.go
@@ -202,6 +202,10 @@ func validateAttachmentAndReturnProperties(message *ecsacs.ConfirmAttachmentMess
 		if err != nil {
 			return nil, errors.Wrap(err, "resource attachment validation by attachment type failed")
 		}
+		err = resource.ValidateFileSystemType(attachmentProperties[resource.FileSystemKey])
+		if err != nil {
+			return nil, errors.Wrap(err, "resource attachment validation by file system property failed")
+		}
 		return attachmentProperties, nil
 	}
 

--- a/ecs-agent/api/resource/resource_attachment.go
+++ b/ecs-agent/api/resource/resource_attachment.go
@@ -74,6 +74,16 @@ const (
 	FileSystemKey           = "fileSystem"
 )
 
+var (
+	allowedFSTypes = map[string]bool{
+		"xfs":  true,
+		"ext2": true,
+		"ext3": true,
+		"ext4": true,
+		"ntfs": true,
+	}
+)
+
 // getCommonProperties returns the common properties as used for validating a resource.
 func getCommonProperties() (commonProperties []string) {
 	commonProperties = []string{

--- a/ecs-agent/api/resource/resource_validation.go
+++ b/ecs-agent/api/resource/resource_validation.go
@@ -71,3 +71,12 @@ func ValidateRequiredProperties(actualProperties map[string]string, requiredProp
 	}
 	return nil
 }
+
+// For EBS-backed task attachment payload, the file system type is optional. If we do receive a file system type value,
+// we want to validate what we receive is one of the following types [xfs, ext2, ext3, ext4, ntfs].
+func ValidateFileSystemType(filesystemType string) error {
+	if filesystemType != "" && !allowedFSTypes[filesystemType] {
+		return errors.Errorf("invalid file system type: %s", filesystemType)
+	}
+	return nil
+}

--- a/ecs-agent/api/resource/resource_validation_test.go
+++ b/ecs-agent/api/resource/resource_validation_test.go
@@ -83,3 +83,15 @@ func TestValidateVolumeResource(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateVolumeFileSystem(t *testing.T) {
+	validFileSystems := []string{"xfs", "ext2", "ext3", "ext4", "ntfs"}
+
+	for _, fs := range validFileSystems {
+		err := ValidateFileSystemType(fs)
+		require.NoError(t, err)
+	}
+
+	err := ValidateFileSystemType("someFilesystem")
+	require.Error(t, err)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will introduce a new validation check for the attachment payload of EBS-backed task. Specifically if the file system type is included within the attachment payload then we want to ensure that they are of the following types:
* xfs
* ext2
* ext3
* ext4
* ntfs

### Implementation details
Implemented a new functionality called `ValidateFileSystemType` that checks if the filesystem value is one of the specified types listed above. These types are essentially stored as a set called `AllowedFSTypes`.

### Testing
Modified the existing unit tests within the attachment resource responder to now also check if we receive any errors if the file system type is some invalid value as well as empty.

New tests cover the changes: Yes

### Description for the changelog
Validate file system type within attachment payload of EBS-backed tasks

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
