### PR TITLE
Add dev mount to csi driver daemon

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon/managed_daemon.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon/managed_daemon.go
@@ -120,6 +120,14 @@ func defaultImportAll() ([]*ManagedDaemon, error) {
 			ContainerPath:        "/mnt/ecs/ebs",
 			PropagationShared:    true,
 		},
+		&MountPoint{
+			SourceVolumeID:       "devMount",
+			SourceVolume:         "devMount",
+			SourceVolumeType:     "host",
+			SourceVolumeHostPath: "/dev",
+			ContainerPath:        "/dev",
+			PropagationShared:    true,
+		},
 	}
 	if err := ebsManagedDaemon.SetMountPoints(ebsMounts); err != nil {
 		return nil, fmt.Errorf("Unable to import EBS ManagedDaemon: %s", err)

--- a/ecs-agent/manageddaemon/managed_daemon.go
+++ b/ecs-agent/manageddaemon/managed_daemon.go
@@ -120,6 +120,14 @@ func defaultImportAll() ([]*ManagedDaemon, error) {
 			ContainerPath:        "/mnt/ecs/ebs",
 			PropagationShared:    true,
 		},
+		&MountPoint{
+			SourceVolumeID:       "devMount",
+			SourceVolume:         "devMount",
+			SourceVolumeType:     "host",
+			SourceVolumeHostPath: "/dev",
+			ContainerPath:        "/dev",
+			PropagationShared:    true,
+		},
 	}
 	if err := ebsManagedDaemon.SetMountPoints(ebsMounts); err != nil {
 		return nil, fmt.Errorf("Unable to import EBS ManagedDaemon: %s", err)


### PR DESCRIPTION
### Summary
We discovered a bug in the running CSI managed daemon container where host-level symlinks for newly attached volumes are not showing up inside the privileged-mode container.  An explicit mount of the `/dev` directory fixes the issue and was recommended by the EBS team who own the EBS CSI driver.

### Implementation details
A new mount is added to the existing managed daemon CSI definition.

### Testing
manual testing -- run agent and start up EBS CSI Managed Daemon, then Docker Inspect the CSI container to verify that the mount is created.

New tests cover the changes: no

### Description for the changelog
Bugfix for EBS CSI Driver device discovery.

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
