### PR TITLE
Add missing changes from EBS Task Attach feature branch

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -1041,7 +1041,7 @@ func (agent *ecsAgent) startACSSession(
 		taskComparer,
 		sequenceNumberAccessor,
 		taskStopper,
-		nil,
+		agent.ebsWatcher,
 		updater.NewUpdater(agent.cfg, state, agent.dataClient, taskEngine).AddAgentUpdateHandlers,
 	)
 	logger.Info("Beginning Polling for updates")

--- a/agent/engine/dockerstate/docker_task_engine_state.go
+++ b/agent/engine/dockerstate/docker_task_engine_state.go
@@ -300,7 +300,7 @@ func (state *DockerTaskEngineState) GetAllPendingEBSAttachments() []*apiresource
 func (state *DockerTaskEngineState) allPendingEBSAttachmentsUnsafe() []*apiresource.ResourceAttachment {
 	var pendingEBSAttachments []*apiresource.ResourceAttachment
 	for _, v := range state.ebsAttachments {
-		if !v.IsAttached() && !v.IsSent() {
+		if !v.IsAttached() || !v.IsSent() {
 			pendingEBSAttachments = append(pendingEBSAttachments, v)
 		}
 	}
@@ -319,7 +319,7 @@ func (state *DockerTaskEngineState) GetAllPendingEBSAttachmentsWithKey() map[str
 func (state *DockerTaskEngineState) allPendingEBSAttachmentsWithKeyUnsafe() map[string]*apiresource.ResourceAttachment {
 	pendingEBSAttachments := make(map[string]*apiresource.ResourceAttachment)
 	for k, v := range state.ebsAttachments {
-		if !v.IsAttached() && !v.IsSent() {
+		if !v.IsAttached() || !v.IsSent() {
 			pendingEBSAttachments[k] = v
 		}
 	}

--- a/agent/engine/dockerstate/dockerstate_test.go
+++ b/agent/engine/dockerstate/dockerstate_test.go
@@ -203,6 +203,52 @@ func TestAddPendingEBSAttachment(t *testing.T) {
 
 }
 
+func TestAddPendingEBSAttachmentExclusion(t *testing.T) {
+	state := NewTaskEngineState()
+
+	testSentAttachmentProperties := map[string]string{
+		apiresource.VolumeNameKey:           "myCoolVolume",
+		apiresource.SourceVolumeHostPathKey: "/testpath2",
+		apiresource.VolumeSizeGibKey:        "7",
+		apiresource.DeviceNameKey:           "/dev/nvme1n0",
+		apiresource.VolumeIdKey:             "vol-456",
+		apiresource.FileSystemKey:           "testXFS",
+	}
+
+	// not attached but sent should be included (||)
+	sentAttachment := &apiresource.ResourceAttachment{
+		AttachmentInfo: attachmentinfo.AttachmentInfo{
+			TaskARN:          "taskarn1",
+			AttachmentARN:    "ebs1",
+			AttachStatusSent: true,
+			Status:           status.AttachmentNone,
+		},
+		AttachmentProperties: testAttachmentProperties,
+		AttachmentType:       apiresource.EBSTaskAttach,
+	}
+
+	// attached and sent attachment should be excluded (&&)
+	foundAttachment := &apiresource.ResourceAttachment{
+		AttachmentInfo: attachmentinfo.AttachmentInfo{
+			TaskARN:          "taskarn2",
+			AttachmentARN:    "ebs2",
+			AttachStatusSent: true,
+			Status:           status.AttachmentAttached,
+		},
+		AttachmentProperties: testSentAttachmentProperties,
+		AttachmentType:       apiresource.EBSTaskAttach,
+	}
+
+	state.AddEBSAttachment(foundAttachment)
+	state.AddEBSAttachment(sentAttachment)
+	assert.Len(t, state.(*DockerTaskEngineState).GetAllPendingEBSAttachments(), 1)
+	assert.Len(t, state.(*DockerTaskEngineState).GetAllPendingEBSAttachmentsWithKey(), 1)
+	assert.Len(t, state.(*DockerTaskEngineState).GetAllEBSAttachments(), 2)
+
+	_, ok := state.(*DockerTaskEngineState).GetAllPendingEBSAttachmentsWithKey()["vol-123"]
+	assert.True(t, ok)
+}
+
 func TestTwophaseAddContainer(t *testing.T) {
 	state := NewTaskEngineState()
 	testTask := &apitask.Task{Arn: "test", Containers: []*apicontainer.Container{{

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_attachment.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/resource_attachment.go
@@ -325,3 +325,19 @@ func (ra *ResourceAttachment) GetContainerInstanceARN() string {
 
 	return ra.ContainerInstanceARN
 }
+
+// should attach when not attached, and not sent/not expired
+func (ra *ResourceAttachment) ShouldAttach() bool {
+	ra.guard.RLock()
+	defer ra.guard.RUnlock()
+
+	return !(ra.Status == status.AttachmentAttached) && !ra.AttachStatusSent && !(time.Now().After(ra.ExpiresAt))
+}
+
+// should notify when attached, and not sent/not expired
+func (ra *ResourceAttachment) ShouldNotify() bool {
+	ra.guard.RLock()
+	defer ra.guard.RUnlock()
+
+	return (ra.Status == status.AttachmentAttached) && !ra.AttachStatusSent && !(time.Now().After(ra.ExpiresAt))
+}

--- a/ecs-agent/api/resource/resource_attachment.go
+++ b/ecs-agent/api/resource/resource_attachment.go
@@ -325,3 +325,19 @@ func (ra *ResourceAttachment) GetContainerInstanceARN() string {
 
 	return ra.ContainerInstanceARN
 }
+
+// should attach when not attached, and not sent/not expired
+func (ra *ResourceAttachment) ShouldAttach() bool {
+	ra.guard.RLock()
+	defer ra.guard.RUnlock()
+
+	return !(ra.Status == status.AttachmentAttached) && !ra.AttachStatusSent && !(time.Now().After(ra.ExpiresAt))
+}
+
+// should notify when attached, and not sent/not expired
+func (ra *ResourceAttachment) ShouldNotify() bool {
+	ra.guard.RLock()
+	defer ra.guard.RUnlock()
+
+	return (ra.Status == status.AttachmentAttached) && !ra.AttachStatusSent && !(time.Now().After(ra.ExpiresAt))
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This change bridges the diff between dev and https://github.com/aws/amazon-ecs-agent/tree/feature/EBSTaskAttach 
The main changes are to add the EBS resource handler to the agent, and to update the watcher's state handling.

### Implementation details
The changes came from a rebase of the feature branch against dev, taking dev as desired.   The changes to the watcher and to the task engine state include a couple of bugfixes to our EBS state handling, where previously there was a chance that a notification came before a successful NodeStage.

This change will allow us to start testing from dev branch rather than our feature branch.

### Testing
Ran tests locally to launch 5 successive EBS-backed tasks.  All tasks' EBS volume mounts succeed and tasks are started as expected.

New tests cover the changes: yes

### Description for the changelog
Bugfixes for EBS Task Attach.

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
