### PR TITLE
Revert codebuild image/rpm build job base images

### DIFF
--- a/build-infrastructure/release-pipeline-stack.yml
+++ b/build-infrastructure/release-pipeline-stack.yml
@@ -401,7 +401,7 @@ Resources:
       Description: CodeBuild project to build the ECS Agent Docker image tarball and RPM
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
         ImagePullCredentialsType: CODEBUILD
         PrivilegedMode: true
         Type: LINUX_CONTAINER
@@ -505,7 +505,7 @@ Resources:
       Description: CodeBuild project to build the ECS Agent Docker image tarball
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-aarch64-standard:3.0
+        Image: aws/codebuild/amazonlinux2-aarch64-standard:2.0
         ImagePullCredentialsType: CODEBUILD
         PrivilegedMode: true
         Type: ARM_CONTAINER


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Revert to older codebuild base images after bumping them during CSI driver work. The reason for this is that using the newer codebuild base images causes the RPMs that are built there to require a newer version of GLIBC that is not available on CentOS and SUSE linux.

After bumping the codebuild merge-build.yml job to use the latest Amazon Linux build image, we see a new version of GLIBC getting pulled into our RPM dependencies:

with `aws/codebuild/amazonlinux2-x86_64-standard:5.0`:
```
% rpm -qp ./amazon-ecs-init-latest.x86_64.rpm --requires | grep GLIBC
libc.so.6(GLIBC_2.2.5)(64bit)
libc.so.6(GLIBC_2.3.2)(64bit)
libc.so.6(GLIBC_2.32)(64bit)
libc.so.6(GLIBC_2.34)(64bit)
```

see https://github.com/aws/amazon-ecs-agent/pull/3948/files

with `aws/codebuild/amazonlinux2-x86_64-standard:3.0`:
```
% rpm -qp ./amazon-ecs-init-1.77.0-1.x86_64.rpm --requires | grep GLIBC
libc.so.6(GLIBC_2.2.5)(64bit)
libdl.so.2(GLIBC_2.2.5)(64bit)
libpthread.so.0(GLIBC_2.2.5)(64bit)
libpthread.so.0(GLIBC_2.3.2)(64bit)
libresolv.so.2(GLIBC_2.2.5)(64bit)
```

This causes the ecs-anywhere-install.sh script to fail on CentOS and SLES with this error:

```
Last metadata expiration check: 0:03:23 ago on Mon 16 Oct 2023 05:18:08 PM UTC.
Error: 
 Problem: conflicting requests
  - nothing provides libc.so.6(GLIBC_2.32)(64bit) needed by amazon-ecs-init-1.78.0-1.x86_64 from @commandline
  - nothing provides libc.so.6(GLIBC_2.34)(64bit) needed by amazon-ecs-init-1.78.0-1.x86_64 from @commandline
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

build was run on codebuild and ECS anywhere qualification steps completed.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
