### PR TITLE
Minor refactor of TTL cache (allow nil TTL + get TTL)

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -96,7 +96,7 @@ func NewECSClient(
 		standardClient:          standardClient,
 		submitStateChangeClient: submitStateChangeClient,
 		ec2metadata:             ec2MetadataClient,
-		pollEndpointCache:       async.NewTTLCache(pollEndpointCacheTTL),
+		pollEndpointCache:       async.NewTTLCache(&async.TTL{Duration: pollEndpointCacheTTL}),
 	}
 }
 

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -1029,7 +1029,7 @@ func TestDiscoverTelemetryEndpointAfterPollEndpointCacheHit(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockSDK := mock_api.NewMockECSSDK(mockCtrl)
-	pollEndpointCache := async.NewTTLCache(10 * time.Minute)
+	pollEndpointCache := async.NewTTLCache(&async.TTL{Duration: 10 * time.Minute})
 	client := &APIECSClient{
 		credentialProvider: credentials.AnonymousCredentials,
 		config: &config.Config{

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/async/mocks/async_mocks.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/async/mocks/async_mocks.go
@@ -20,7 +20,6 @@ package mock_async
 
 import (
 	reflect "reflect"
-	time "time"
 
 	async "github.com/aws/amazon-ecs-agent/ecs-agent/async"
 	gomock "github.com/golang/mock/gomock"
@@ -139,6 +138,20 @@ func (mr *MockTTLCacheMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockTTLCache)(nil).Get), arg0)
 }
 
+// GetTTL mocks base method.
+func (m *MockTTLCache) GetTTL() *async.TTL {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTTL")
+	ret0, _ := ret[0].(*async.TTL)
+	return ret0
+}
+
+// GetTTL indicates an expected call of GetTTL.
+func (mr *MockTTLCacheMockRecorder) GetTTL() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTTL", reflect.TypeOf((*MockTTLCache)(nil).GetTTL))
+}
+
 // Set mocks base method.
 func (m *MockTTLCache) Set(arg0 string, arg1 interface{}) {
 	m.ctrl.T.Helper()
@@ -152,7 +165,7 @@ func (mr *MockTTLCacheMockRecorder) Set(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // SetTTL mocks base method.
-func (m *MockTTLCache) SetTTL(arg0 time.Duration) {
+func (m *MockTTLCache) SetTTL(arg0 *async.TTL) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetTTL", arg0)
 }

--- a/ecs-agent/async/mocks/async_mocks.go
+++ b/ecs-agent/async/mocks/async_mocks.go
@@ -20,7 +20,6 @@ package mock_async
 
 import (
 	reflect "reflect"
-	time "time"
 
 	async "github.com/aws/amazon-ecs-agent/ecs-agent/async"
 	gomock "github.com/golang/mock/gomock"
@@ -139,6 +138,20 @@ func (mr *MockTTLCacheMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockTTLCache)(nil).Get), arg0)
 }
 
+// GetTTL mocks base method.
+func (m *MockTTLCache) GetTTL() *async.TTL {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTTL")
+	ret0, _ := ret[0].(*async.TTL)
+	return ret0
+}
+
+// GetTTL indicates an expected call of GetTTL.
+func (mr *MockTTLCacheMockRecorder) GetTTL() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTTL", reflect.TypeOf((*MockTTLCache)(nil).GetTTL))
+}
+
 // Set mocks base method.
 func (m *MockTTLCache) Set(arg0 string, arg1 interface{}) {
 	m.ctrl.T.Helper()
@@ -152,7 +165,7 @@ func (mr *MockTTLCacheMockRecorder) Set(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // SetTTL mocks base method.
-func (m *MockTTLCache) SetTTL(arg0 time.Duration) {
+func (m *MockTTLCache) SetTTL(arg0 *async.TTL) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetTTL", arg0)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Currently, TTL cache MUST have a TTL value specified that is limited to the following range: `[-9223372036854775808, 9223372036854775807]`. This pull request allows for the TTL cache to have nil TTL set (i.e. practically equivalent to ∞ TTL).

Also, this pull request adds a `GetTTL` method for TTL cache. This method is currently mainly used in testing and compliments the `SetTTL` method that was added as part of https://github.com/aws/amazon-ecs-agent/pull/3953.

### Implementation details
<!-- How are the changes implemented? -->
- Define new struct type `TTL` and use in favor of current type `time.Duration` (which has underlying type `int64`)
- Add `GetTTL` method for TTL cache
- Clean up code comments (mainly make punctuation consistent/correct typos)
- Regenerate async package mocks

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit, integration, and functional tests.

New tests cover the changes: existing tests updated

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Minor refactor of TTL cache (allow nil TTL + get TTL)

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
