### PR TITLE
Fix loading CSI driver container from state if it exists

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -1508,3 +1508,16 @@ func (c *Container) GetContainerPortRangeMap() map[string]string {
 	defer c.lock.RUnlock()
 	return c.ContainerPortRangeMap
 }
+
+func (c *Container) IsManagedDaemonContainer() bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.Type == ContainerManagedDaemon
+}
+
+func (c *Container) GetImageName() string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	containerImage := strings.Split(c.Image, ":")[0]
+	return containerImage
+}

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -130,9 +130,49 @@ func TestIsInternal(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("IsInternal shoukd return %t for %s", tc.internal, tc.container.String()),
+		t.Run(fmt.Sprintf("IsInternal should return %t for %s", tc.internal, tc.container.String()),
 			func(t *testing.T) {
 				assert.Equal(t, tc.internal, tc.container.IsInternal())
+			})
+	}
+}
+
+func TestIsManagedDaemonContainer(t *testing.T) {
+	testCases := []struct {
+		container       *Container
+		internal        bool
+		isManagedDaemon bool
+	}{
+		{&Container{}, false, false},
+		{&Container{Type: ContainerNormal, Image: "someImage:latest"}, false, false},
+		{&Container{Type: ContainerManagedDaemon, Image: "someImage:latest"}, true, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("IsManagedDaemonContainer should return %t for %s", tc.isManagedDaemon, tc.container.String()),
+			func(t *testing.T) {
+				assert.Equal(t, tc.internal, tc.container.IsInternal())
+				ok := tc.container.IsManagedDaemonContainer()
+				assert.Equal(t, tc.isManagedDaemon, ok)
+			})
+	}
+}
+
+func TestGetImageName(t *testing.T) {
+	testCases := []struct {
+		container *Container
+		imageName string
+	}{
+		{&Container{}, ""},
+		{&Container{Image: "someImage:latest"}, "someImage"},
+		{&Container{Image: "someImage"}, "someImage"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("GetImageName should return %s for %s", tc.imageName, tc.container.String()),
+			func(t *testing.T) {
+				imageName := tc.container.GetImageName()
+				assert.Equal(t, tc.imageName, imageName)
 			})
 	}
 }

--- a/agent/api/container/containertype.go
+++ b/agent/api/container/containertype.go
@@ -53,6 +53,7 @@ var stringToContainerType = map[string]ContainerType{
 	"EMPTY_HOST_VOLUME": ContainerEmptyHostVolume,
 	"CNI_PAUSE":         ContainerCNIPause,
 	"NAMESPACE_PAUSE":   ContainerNamespacePause,
+	"MANAGED_DAEMON":    ContainerManagedDaemon,
 }
 
 // String converts the container type enum to a string

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -5278,3 +5278,105 @@ func TestRemoveVolumeIndexOutOfBounds(t *testing.T) {
 	task.RemoveVolume(-1)
 	assert.Equal(t, len(task.Volumes), 1)
 }
+
+func TestIsManagedDaemonTask(t *testing.T) {
+
+	testTask1 := &Task{
+		Containers: []*apicontainer.Container{
+			{
+				Type:  apicontainer.ContainerManagedDaemon,
+				Image: "someImage:latest",
+			},
+		},
+		IsInternal:        true,
+		KnownStatusUnsafe: apitaskstatus.TaskRunning,
+	}
+
+	testTask2 := &Task{
+		Containers: []*apicontainer.Container{
+			{
+				Type:  apicontainer.ContainerNormal,
+				Image: "someImage",
+			},
+			{
+				Type:  apicontainer.ContainerNormal,
+				Image: "someImage:latest",
+			},
+		},
+		IsInternal:        false,
+		KnownStatusUnsafe: apitaskstatus.TaskRunning,
+	}
+
+	testTask3 := &Task{
+		Containers: []*apicontainer.Container{
+			{
+				Type:  apicontainer.ContainerManagedDaemon,
+				Image: "someImage:latest",
+			},
+		},
+		IsInternal:        true,
+		KnownStatusUnsafe: apitaskstatus.TaskStopped,
+	}
+
+	testTask4 := &Task{
+		Containers: []*apicontainer.Container{
+			{
+				Type:  apicontainer.ContainerManagedDaemon,
+				Image: "someImage:latest",
+			},
+		},
+		IsInternal:        true,
+		KnownStatusUnsafe: apitaskstatus.TaskCreated,
+	}
+
+	testTask5 := &Task{
+		Containers: []*apicontainer.Container{
+			{
+				Type:  apicontainer.ContainerNormal,
+				Image: "someImage",
+			},
+		},
+		IsInternal:        true,
+		KnownStatusUnsafe: apitaskstatus.TaskStopped,
+	}
+
+	testCases := []struct {
+		task            *Task
+		internal        bool
+		isManagedDaemon bool
+	}{
+		{
+			task:            testTask1,
+			internal:        true,
+			isManagedDaemon: true,
+		},
+		{
+			task:            testTask2,
+			internal:        false,
+			isManagedDaemon: false,
+		},
+		{
+			task:            testTask3,
+			internal:        true,
+			isManagedDaemon: false,
+		},
+		{
+			task:            testTask4,
+			internal:        true,
+			isManagedDaemon: true,
+		},
+		{
+			task:            testTask5,
+			internal:        true,
+			isManagedDaemon: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("IsManagedDaemonTask should return %t for %s", tc.isManagedDaemon, tc.task.String()),
+			func(t *testing.T) {
+				_, ok := tc.task.IsManagedDaemonTask()
+				assert.Equal(t, tc.isManagedDaemon, ok)
+			})
+	}
+}

--- a/agent/engine/data.go
+++ b/agent/engine/data.go
@@ -56,6 +56,12 @@ func (engine *DockerTaskEngine) loadTasks() error {
 	for _, task := range tasks {
 		engine.state.AddTask(task)
 
+		// TODO: Will need to clean up all of the STOPPED managed daemon tasks
+		md, ok := task.IsManagedDaemonTask()
+		if ok {
+			engine.SetDaemonTask(md, task)
+		}
+
 		// Populate ip <-> task mapping if task has a local ip. This mapping is needed for serving v2 task metadata.
 		if ip := task.GetLocalIPAddress(); ip != "" {
 			engine.state.AddTaskIPAddress(ip, task.Arn)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will address the issue where agent won't be able to recognize an existing running CSI driver daemon task after an agent restart. Because of this, when we get a new EBS attachment payload, agent will start up a new CSI driver daemon task even if there's already an existing running CSI driver task. While all of the managed tasks are properly populated back into the task engine during the setup of agent start, the list of managed daemon task aren't. To fix this, we'll check if there's an existing non-stopped CSI driver daemon task right after we load all of the managed tasks from BoltDB on agent restart.

### Implementation details
Implemented the following:
* `agent/api/task/task.go`: New functionality called `IsManagedDaemonTask` where it checks if the task is a managed daemon if it satisfy the following: 
  * Was internally made by agent
  * Not stopped (i.e. not terminal)
  * Has container of type `ContainerManagedDaemon`
  * If all of the above satisfy, then the task will be added to the map of daemon tasks within `loadTask`
* `agent/api/container/container.go`: 
  * New functionality called `IsManagedDaemonContainer` where it checks if a container is of type `ContainerManagedDaemon`.  This will be called in `IsManagedDaemonTask` as part of the managed daemon task check. 
  * New functionality called `GetImageName` where it gets the image name without the tags of a container
* `agent/api/container/containertype.go`: Added `ContainerManagedDaemon` to the map of container types that's used for encoding and decoding `ContainerType` objects
* `agent/engine/data.go`: Modified `loadTask` to check if any of the tasks are considered a managed daemon task. If a task is then we add it to the map of managed daemon tasks in our task engine.
* `agent/ebs/watcher.go`: Added an extra condition that we should also be creating a new CSI driver daemon task if the existing CSI driver daemon task has stopped (i.e. terminal).

(Note: There should only be at most one of each managed daemon task running on one instance at a time; i.e. multiple managed daemon tasks can be running on one instance as long as they're not the same one)

### Testing
Added new unit tests.

Manual testing:
Ran an EBS-backed task which then created the CSI driver daemon task. After a bit, I restarted agent with the CSI driver task still running and was able to confirm that agent was able to properly load back the existing CSI driver daemon task.
```
level=debug time=2023-10-18T17:11:51Z msg="Task is not internally made"
level=debug time=2023-10-18T17:11:51Z msg="Task is not a managed daemon task: arn:aws:ecs:us-west-2::task/evm-test-gamma/9bb5422fecda42088bcc3451a8d37dbb" module=data.go
level=debug time=2023-10-18T17:11:51Z msg="Container is running and is internal"
level=debug time=2023-10-18T17:11:51Z msg="Successfully set managed daemon task for: ebs-csi-driver" module=data.go
level=info time=2023-10-18T17:11:51Z msg="Cluster was successfully restored" cluster="evm-test-gamma"
level=debug time=2023-10-18T17:11:51Z msg="Loading pause container tarball:" image="/images/amazon-ecs-pause.tar"
level=debug time=2023-10-18T17:11:51Z msg="Inspecting container image: " image="amazon/amazon-ecs-pause:0.1.0"
```
Ran another EBS-backed task and agent didn't create a new CSI driver daemon task as well as reused the existing task.
```
[ec2-user@ip-172-31-35-197 amazon-ecs-agent]$ docker ps
CONTAINER ID   IMAGE                            COMMAND                  CREATED         STATUS                   PORTS     NAMES
953d6d9ddf96   mreferre/yelb-db:0.5             "docker-entrypoint.s…"   2 minutes ago   Up 2 minutes                       ecs-evm-db-6-db-fee385a6f78fe3a1af01
f09b5e9f3526   amazon/amazon-ecs-agent:latest   "/agent"                 3 minutes ago   Up 3 minutes (healthy)             ecs-agent
b3ede243b73a   ebs-csi-driver:latest            "/bin/ebs-csi-driver…"   6 minutes ago   Up 6 minutes                       ecs---ecs-managed-ebs-csi-driver-a48dcaeed3cfdfdafb01
```

New tests cover the changes:Yes

### Description for the changelog
Fix local agent state for CSI driver daemon task

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
