### PR TITLE
Add support for finding EBS devices on Xen instances

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery.go
@@ -35,13 +35,31 @@ var (
 )
 
 type EBSDiscoveryClient struct {
-	ctx context.Context
+	ctx           context.Context
+	hasXenSupport bool
 }
 
-func NewDiscoveryClient(ctx context.Context) *EBSDiscoveryClient {
-	return &EBSDiscoveryClient{
+type EBSDiscoveryClientOption func(*EBSDiscoveryClient)
+
+// Enable Xen instances support for EBS Discovery Client
+func WithXenSupport() EBSDiscoveryClientOption {
+	return func(ec *EBSDiscoveryClient) {
+		ec.hasXenSupport = true
+	}
+}
+
+func NewDiscoveryClient(ctx context.Context, opts ...EBSDiscoveryClientOption) *EBSDiscoveryClient {
+	client := &EBSDiscoveryClient{
 		ctx: ctx,
 	}
+	for _, opt := range opts {
+		opt(client)
+	}
+	return client
+}
+
+func (client *EBSDiscoveryClient) HasXenSupport() bool {
+	return client.hasXenSupport
 }
 
 // ScanEBSVolumes will iterate through the entire list of provided EBS volume attachments within the agent state and checks if it's attached on the host.

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_linux.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_linux.go
@@ -115,8 +115,7 @@ func matchXenBlockDevice(block BlockDevice, deviceName string) (string, bool) {
 		if trimXenPrefix(block.Name) == trimXenPrefix(deviceName) {
 			return block.Name, true
 		}
-	}
-	if block.Name == deviceName {
+	} else if block.Name == deviceName {
 		return block.Name, true
 	}
 	return "", false

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_linux.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_linux.go
@@ -85,7 +85,8 @@ func (api *EBSDiscoveryClient) ConfirmEBSVolumeIsAttached(deviceName, volumeID s
 //	 }
 //
 // If hasXenSupport is true then, in addition to matching a device by its serial, this function
-// matches a device by its name disregarding "sd" or "xvd" prefix (whichever is present).
+// matches devices by their names disregarding "sd" or "xvd" prefix if it exists in
+// device name in parseLsblkOutput and deviceName both.
 // This is because on Xen instances the device name received from upstream with "sd" or "xvd"
 // prefix might appear on the instance with the prefix interchanged, that is "xvd" instead of "sd"
 // and vice-versa.
@@ -109,7 +110,8 @@ func parseLsblkOutput(
 }
 
 // Matches a block device against a device name by matching the block device's name and
-// the device name after stripping "sd" or "xvd" prefixes (whichever is present) from both names.
+// the device name after stripping "sd" or "xvd" prefixes (whichever is present) from both names
+// if it is present in both names.
 func matchXenBlockDevice(block BlockDevice, deviceName string) (string, bool) {
 	if hasXenPrefix(block.Name) && hasXenPrefix(deviceName) {
 		if trimXenPrefix(block.Name) == trimXenPrefix(deviceName) {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_linux.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_linux.go
@@ -25,6 +25,11 @@ import (
 	"strings"
 )
 
+const (
+	sdPrefix  = "sd"
+	xvdPrefix = "xvd"
+)
+
 // LsblkOutput is used to manage and track the output of `lsblk`
 type LsblkOutput struct {
 	BlockDevices []BlockDevice `json:"blockdevices"`
@@ -106,24 +111,28 @@ func parseLsblkOutput(
 // Matches a block device against a device name by matching the block device's name and
 // the device name after stripping "sd" or "xvd" prefixes (whichever is present) from both names.
 func matchXenBlockDevice(block BlockDevice, deviceName string) (string, bool) {
-	if trimXenPrefix(block.Name) == trimXenPrefix(deviceName) {
+	if hasXenPrefix(block.Name) && hasXenPrefix(deviceName) {
+		if trimXenPrefix(block.Name) == trimXenPrefix(deviceName) {
+			return block.Name, true
+		}
+	}
+	if block.Name == deviceName {
 		return block.Name, true
 	}
 	return "", false
 }
 
+// Checks if the device name has sd or xvd prefix.
+func hasXenPrefix(name string) bool {
+	return strings.HasPrefix(name, sdPrefix) || strings.HasPrefix(name, xvdPrefix)
+}
+
 // Trims "sd" or "xvd" prefix (whichever is present) from the given name.
 func trimXenPrefix(name string) string {
-	const (
-		sdPrefix  = "sd"
-		xvdPrefix = "xvd"
-	)
-
 	if strings.HasPrefix(name, sdPrefix) {
 		return strings.TrimPrefix(name, sdPrefix)
 	} else if strings.HasPrefix(name, xvdPrefix) {
 		return strings.TrimPrefix(name, xvdPrefix)
 	}
-
 	return name
 }

--- a/ecs-agent/api/resource/ebs_discovery.go
+++ b/ecs-agent/api/resource/ebs_discovery.go
@@ -35,13 +35,31 @@ var (
 )
 
 type EBSDiscoveryClient struct {
-	ctx context.Context
+	ctx           context.Context
+	hasXenSupport bool
 }
 
-func NewDiscoveryClient(ctx context.Context) *EBSDiscoveryClient {
-	return &EBSDiscoveryClient{
+type EBSDiscoveryClientOption func(*EBSDiscoveryClient)
+
+// Enable Xen instances support for EBS Discovery Client
+func WithXenSupport() EBSDiscoveryClientOption {
+	return func(ec *EBSDiscoveryClient) {
+		ec.hasXenSupport = true
+	}
+}
+
+func NewDiscoveryClient(ctx context.Context, opts ...EBSDiscoveryClientOption) *EBSDiscoveryClient {
+	client := &EBSDiscoveryClient{
 		ctx: ctx,
 	}
+	for _, opt := range opts {
+		opt(client)
+	}
+	return client
+}
+
+func (client *EBSDiscoveryClient) HasXenSupport() bool {
+	return client.hasXenSupport
 }
 
 // ScanEBSVolumes will iterate through the entire list of provided EBS volume attachments within the agent state and checks if it's attached on the host.

--- a/ecs-agent/api/resource/ebs_discovery_linux.go
+++ b/ecs-agent/api/resource/ebs_discovery_linux.go
@@ -115,8 +115,7 @@ func matchXenBlockDevice(block BlockDevice, deviceName string) (string, bool) {
 		if trimXenPrefix(block.Name) == trimXenPrefix(deviceName) {
 			return block.Name, true
 		}
-	}
-	if block.Name == deviceName {
+	} else if block.Name == deviceName {
 		return block.Name, true
 	}
 	return "", false

--- a/ecs-agent/api/resource/ebs_discovery_linux.go
+++ b/ecs-agent/api/resource/ebs_discovery_linux.go
@@ -85,7 +85,8 @@ func (api *EBSDiscoveryClient) ConfirmEBSVolumeIsAttached(deviceName, volumeID s
 //	 }
 //
 // If hasXenSupport is true then, in addition to matching a device by its serial, this function
-// matches a device by its name disregarding "sd" or "xvd" prefix (whichever is present).
+// matches devices by their names disregarding "sd" or "xvd" prefix if it exists in
+// device name in parseLsblkOutput and deviceName both.
 // This is because on Xen instances the device name received from upstream with "sd" or "xvd"
 // prefix might appear on the instance with the prefix interchanged, that is "xvd" instead of "sd"
 // and vice-versa.
@@ -109,7 +110,8 @@ func parseLsblkOutput(
 }
 
 // Matches a block device against a device name by matching the block device's name and
-// the device name after stripping "sd" or "xvd" prefixes (whichever is present) from both names.
+// the device name after stripping "sd" or "xvd" prefixes (whichever is present) from both names
+// if it is present in both names.
 func matchXenBlockDevice(block BlockDevice, deviceName string) (string, bool) {
 	if hasXenPrefix(block.Name) && hasXenPrefix(deviceName) {
 		if trimXenPrefix(block.Name) == trimXenPrefix(deviceName) {

--- a/ecs-agent/api/resource/ebs_discovery_linux.go
+++ b/ecs-agent/api/resource/ebs_discovery_linux.go
@@ -25,6 +25,11 @@ import (
 	"strings"
 )
 
+const (
+	sdPrefix  = "sd"
+	xvdPrefix = "xvd"
+)
+
 // LsblkOutput is used to manage and track the output of `lsblk`
 type LsblkOutput struct {
 	BlockDevices []BlockDevice `json:"blockdevices"`
@@ -106,24 +111,28 @@ func parseLsblkOutput(
 // Matches a block device against a device name by matching the block device's name and
 // the device name after stripping "sd" or "xvd" prefixes (whichever is present) from both names.
 func matchXenBlockDevice(block BlockDevice, deviceName string) (string, bool) {
-	if trimXenPrefix(block.Name) == trimXenPrefix(deviceName) {
+	if hasXenPrefix(block.Name) && hasXenPrefix(deviceName) {
+		if trimXenPrefix(block.Name) == trimXenPrefix(deviceName) {
+			return block.Name, true
+		}
+	}
+	if block.Name == deviceName {
 		return block.Name, true
 	}
 	return "", false
 }
 
+// Checks if the device name has sd or xvd prefix.
+func hasXenPrefix(name string) bool {
+	return strings.HasPrefix(name, sdPrefix) || strings.HasPrefix(name, xvdPrefix)
+}
+
 // Trims "sd" or "xvd" prefix (whichever is present) from the given name.
 func trimXenPrefix(name string) string {
-	const (
-		sdPrefix  = "sd"
-		xvdPrefix = "xvd"
-	)
-
 	if strings.HasPrefix(name, sdPrefix) {
 		return strings.TrimPrefix(name, sdPrefix)
 	} else if strings.HasPrefix(name, xvdPrefix) {
 		return strings.TrimPrefix(name, xvdPrefix)
 	}
-
 	return name
 }

--- a/ecs-agent/api/resource/ebs_discovery_linux_test.go
+++ b/ecs-agent/api/resource/ebs_discovery_linux_test.go
@@ -17,48 +17,116 @@
 package resource
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-)
-
-const (
-	testVolumeID   = "vol-1234"
-	testDeviceName = "nvme0n1"
 )
 
 func TestParseLsblkOutput(t *testing.T) {
-	blockDevice := BlockDevice{
-		Name:     testDeviceName,
-		Serial:   testVolumeID,
-		Children: make([]*BlockDevice, 0),
+	mkError := func(deviceName string, volumeId string) string {
+		return fmt.Sprintf("cannot find EBS volume with device name: %v and volume ID: %v",
+			deviceName, volumeId)
 	}
 
-	lsblkOutput := &LsblkOutput{
-		BlockDevices: []BlockDevice{
-			blockDevice,
+	tcs := []struct {
+		name                     string
+		lsblkOutput              LsblkOutput
+		deviceName               string
+		volumeId                 string
+		hasXenSupport            bool
+		expectedActualDeviceName string
+		expectedError            string
+	}{
+		{
+			name: "nitro device found with the same name",
+			lsblkOutput: LsblkOutput{[]BlockDevice{
+				{Name: "mydevice", Serial: "myvolumeid"},
+			}},
+			deviceName:               "/dev/mydevice",
+			volumeId:                 "myvolumeid",
+			expectedActualDeviceName: "mydevice",
+		},
+		{
+			name: "nitro device found with another name",
+			lsblkOutput: LsblkOutput{[]BlockDevice{
+				{Name: "mydevice", Serial: "myvolumeid"},
+			}},
+			deviceName:               "/dev/otherdevice",
+			volumeId:                 "myvolumeid",
+			expectedActualDeviceName: "mydevice",
+		},
+		{
+			name: "nitro device not found",
+			lsblkOutput: LsblkOutput{[]BlockDevice{
+				{Name: "mydevice", Serial: "myvolumeid"},
+			}},
+			deviceName:    "/dev/mydevice",
+			volumeId:      "othervolumeid",
+			expectedError: mkError("mydevice", "othervolumeid"),
+		},
+		{
+			name:                     "xen received sd found sd",
+			lsblkOutput:              LsblkOutput{[]BlockDevice{{Name: "sddevice"}}},
+			deviceName:               "/dev/sddevice",
+			volumeId:                 "volumeid",
+			hasXenSupport:            true,
+			expectedActualDeviceName: "sddevice",
+		},
+		{
+			name:                     "xen received xvd found xvd",
+			lsblkOutput:              LsblkOutput{[]BlockDevice{{Name: "xvddevice"}}},
+			deviceName:               "/dev/xvddevice",
+			volumeId:                 "volumeid",
+			hasXenSupport:            true,
+			expectedActualDeviceName: "xvddevice",
+		},
+		{
+			name:                     "xen received sd found xvd",
+			lsblkOutput:              LsblkOutput{[]BlockDevice{{Name: "xvddevice"}}},
+			deviceName:               "/dev/sddevice",
+			volumeId:                 "volumeid",
+			hasXenSupport:            true,
+			expectedActualDeviceName: "xvddevice",
+		},
+		{
+			name:                     "xen received xvd found sd",
+			lsblkOutput:              LsblkOutput{[]BlockDevice{{Name: "sddevice"}}},
+			deviceName:               "/dev/xvddevice",
+			volumeId:                 "volumeid",
+			hasXenSupport:            true,
+			expectedActualDeviceName: "sddevice",
+		},
+		{
+			name:          "xen device not found",
+			lsblkOutput:   LsblkOutput{[]BlockDevice{{Name: "sda"}}},
+			deviceName:    "/dev/xvdb",
+			volumeId:      "volumeid",
+			hasXenSupport: true,
+			expectedError: mkError("xvdb", "volumeid"),
 		},
 	}
 
-	actualDeviceName, err := parseLsblkOutput(lsblkOutput, "/dev/"+testDeviceName, testVolumeID)
-	require.NoError(t, err)
-	assert.Equal(t, testDeviceName, actualDeviceName)
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			actualDeviceName, err := parseLsblkOutput(
+				&tc.lsblkOutput, tc.deviceName, tc.volumeId, tc.hasXenSupport)
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedActualDeviceName, actualDeviceName)
+			} else {
+				assert.EqualError(t, err, tc.expectedError)
+			}
+		})
+	}
 }
 
-func TestParseLsblkOutputError(t *testing.T) {
-	blockDevice := BlockDevice{
-		Name:     testDeviceName,
-		Serial:   "vol-456",
-		Children: make([]*BlockDevice, 0),
-	}
-
-	lsblkOutput := &LsblkOutput{
-		BlockDevices: []BlockDevice{
-			blockDevice,
-		},
-	}
-	actualDeviceName, err := parseLsblkOutput(lsblkOutput, testDeviceName, testVolumeID)
-	require.Error(t, err, "cannot find the device name: %v", "/dev/"+testDeviceName)
-	assert.Equal(t, "", actualDeviceName)
+func TestWithXenSupport(t *testing.T) {
+	t.Run("no xen support by default", func(t *testing.T) {
+		assert.False(t, NewDiscoveryClient(context.Background()).HasXenSupport())
+	})
+	t.Run("with xen support", func(t *testing.T) {
+		assert.True(t, NewDiscoveryClient(context.Background(), WithXenSupport()).HasXenSupport())
+	})
 }

--- a/ecs-agent/api/resource/ebs_discovery_linux_test.go
+++ b/ecs-agent/api/resource/ebs_discovery_linux_test.go
@@ -58,6 +58,16 @@ func TestParseLsblkOutput(t *testing.T) {
 			expectedActualDeviceName: "mydevice",
 		},
 		{
+			name: "nitro device found with another name multiple devices",
+			lsblkOutput: LsblkOutput{[]BlockDevice{
+				{Name: "mydevice2", Serial: "myvolumeid2"},
+				{Name: "mydevice", Serial: "myvolumeid"},
+			}},
+			deviceName:               "/dev/otherdevice",
+			volumeId:                 "myvolumeid",
+			expectedActualDeviceName: "mydevice",
+		},
+		{
 			name: "nitro device not found",
 			lsblkOutput: LsblkOutput{[]BlockDevice{
 				{Name: "mydevice", Serial: "myvolumeid"},
@@ -105,6 +115,65 @@ func TestParseLsblkOutput(t *testing.T) {
 			volumeId:      "volumeid",
 			hasXenSupport: true,
 			expectedError: mkError("xvdb", "volumeid"),
+		},
+		{
+			name:          "xen received sda shouldn't match with found a",
+			lsblkOutput:   LsblkOutput{[]BlockDevice{{Name: "a"}}},
+			deviceName:    "/dev/sda",
+			volumeId:      "volumeid",
+			hasXenSupport: true,
+			expectedError: mkError("sda", "volumeid"),
+		},
+		{
+			name:          "xen received xvda shouldn't match with found a",
+			lsblkOutput:   LsblkOutput{[]BlockDevice{{Name: "a"}}},
+			deviceName:    "/dev/xvda",
+			volumeId:      "volumeid",
+			hasXenSupport: true,
+			expectedError: mkError("xvda", "volumeid"),
+		},
+		{
+			name:          "xen received a shouldn't match with found sda",
+			lsblkOutput:   LsblkOutput{[]BlockDevice{{Name: "sda"}}},
+			deviceName:    "/dev/a",
+			volumeId:      "volumeid",
+			hasXenSupport: true,
+			expectedError: mkError("a", "volumeid"),
+		},
+		{
+			name:          "xen received a shouldn't match with found xvda",
+			lsblkOutput:   LsblkOutput{[]BlockDevice{{Name: "xvda"}}},
+			deviceName:    "/dev/a",
+			volumeId:      "volumeid",
+			hasXenSupport: true,
+			expectedError: mkError("a", "volumeid"),
+		},
+		{
+			name:                     "xen received abc should match with found abc",
+			lsblkOutput:              LsblkOutput{[]BlockDevice{{Name: "abc"}}},
+			deviceName:               "/dev/abc",
+			volumeId:                 "volumeid",
+			hasXenSupport:            true,
+			expectedActualDeviceName: "abc",
+		},
+		{
+			name:          "xen received abc shouldn't match with found xyz",
+			lsblkOutput:   LsblkOutput{[]BlockDevice{{Name: "xyz"}}},
+			deviceName:    "/dev/abc",
+			volumeId:      "volumeid",
+			hasXenSupport: true,
+			expectedError: mkError("abc", "volumeid"),
+		},
+		{
+			name: "xen received xvd found sd multiple devices",
+			lsblkOutput: LsblkOutput{[]BlockDevice{
+				{Name: "some_other_device"},
+				{Name: "sddevice"},
+			}},
+			deviceName:               "/dev/xvddevice",
+			volumeId:                 "volumeid",
+			hasXenSupport:            true,
+			expectedActualDeviceName: "sddevice",
 		},
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add support to `EBSDiscoveryClient` for discovering EBS devices on Xen instances. An EBS device can appear on a Xen instance with `sd` or `xvd` prefix of its name interchanged as compared to its name on the AWS backend. This PR updates the device discovery logic of `EBSDiscoveryClient` accordingly. 

### Implementation details
<!-- How are the changes implemented? -->
* A new function `matchXenBlockDevice` is added that checks if a block device matches a device name on Xen instances as per the matching logic explained in the summary. 
* `parseLsblkOutput` function is updated with a new `hasXenSupport bool` parameter. When this parameter is `true` the function will call `matchXenBlockDevice` function to match block devices in addition to the regular matching logic. 
* `EBSDiscoveryClient` is updated with a new `hasXenSupport bool` field and its constructor function is updated to take any number of options of type `EBSDiscoveryClientOption`. A new `WithXenSupport` function is added that returns a `EBSDiscoveryClientOption` that enables Xen support on an `EBSDiscoveryClient`.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add support for finding EBS devices on Xen instances

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
