### PR TITLE
Fixing task volumes in task payload for EBS-backed tasks

### DIFF
--- a/agent/acs/session/payload_responder.go
+++ b/agent/acs/session/payload_responder.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	apiresource "github.com/aws/amazon-ecs-agent/ecs-agent/api/resource"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
@@ -106,6 +107,16 @@ func (pmHandler *payloadMessageHandler) addPayloadTasks(payload *ecsacs.PayloadM
 			allTasksOK = false
 			continue
 		}
+
+		// Note: If we receive an EBS-backed task, we'll also received an incomplete volume configuration in the list of Volumes
+		// To accomodate this, we'll first check if the task IS EBS-backed then we'll mark the corresponding Volume object to be
+		// of type "attachment". This volume object will be replaced by the newly created EBS volume configuration when we parse
+		// through the task attachments.
+		volName, ok := hasEBSAttachment(task)
+		if ok {
+			initializeAttachmentTypeVolume(task, volName)
+		}
+
 		apiTask, err := apitask.TaskFromACS(task, payload)
 		if err != nil {
 			pmHandler.handleInvalidTask(task, err, payload)
@@ -305,4 +316,27 @@ func isTaskStatusStopped(status apitaskstatus.TaskStatus) bool {
 // isTaskStatusNotStopped returns true if the task status != STOPPED.
 func isTaskStatusNotStopped(status apitaskstatus.TaskStatus) bool {
 	return status != apitaskstatus.TaskStopped
+}
+
+func hasEBSAttachment(acsTask *ecsacs.Task) (string, bool) {
+	// TODO: This will only work if there's one EBS volume per task. If we there is a case where we have multi-attach for a task, this needs to be modified
+	for _, attachment := range acsTask.Attachments {
+		if *attachment.AttachmentType == apiresource.EBSTaskAttach {
+			for _, property := range attachment.AttachmentProperties {
+				if *property.Name == apiresource.VolumeNameKey {
+					return *property.Value, true
+				}
+			}
+		}
+	}
+	return "", false
+}
+
+func initializeAttachmentTypeVolume(acsTask *ecsacs.Task, volName string) {
+	for _, volume := range acsTask.Volumes {
+		if *volume.Name == volName && volume.Type == nil {
+			newType := "attachment"
+			volume.Type = &newType
+		}
+	}
 }

--- a/agent/acs/session/payload_responder_test.go
+++ b/agent/acs/session/payload_responder_test.go
@@ -725,6 +725,12 @@ func TestHandlePayloadMessageAddedEBSToTask(t *testing.T) {
 					AttachmentType: aws.String(apiresource.EBSTaskAttach),
 				},
 			},
+			Volumes: []*ecsacs.Volume{
+				{
+					Name: aws.String(taskresourcevolume.TestVolumeName),
+					Type: aws.String(apitask.AttachmentType),
+				},
+			},
 		},
 	}
 

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -43,7 +43,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
-	apiresource "github.com/aws/amazon-ecs-agent/ecs-agent/api/resource"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ecs_client/model/ecs"
@@ -332,7 +331,6 @@ func TaskFromACS(acsTask *ecsacs.Task, envelope *ecsacs.PayloadMessage) (*Task, 
 	return task, nil
 }
 
-// TODO: Add unit test
 func (task *Task) RemoveVolume(index int) {
 	task.lock.Lock()
 	defer task.lock.Unlock()
@@ -343,7 +341,6 @@ func (task *Task) removeVolumeUnsafe(index int) {
 	if index < 0 || index >= len(task.Volumes) {
 		return
 	}
-	// temp := task.Volumes[:1]
 	out := make([]TaskVolume, 0)
 	out = append(out, task.Volumes[:index]...)
 	out = append(out, task.Volumes[index+1:]...)
@@ -352,17 +349,6 @@ func (task *Task) removeVolumeUnsafe(index int) {
 
 func (task *Task) initializeVolumes(cfg *config.Config, dockerClient dockerapi.DockerClient, ctx context.Context) error {
 	// TODO: Have EBS volumes use the DockerVolumeConfig to create the mountpoint
-	if task.IsEBSTaskAttachEnabled() {
-		ebsVolumes := task.GetEBSVolumeNames()
-		for index, tv := range task.Volumes {
-			volumeName := tv.Name
-			volumeType := tv.Type
-			if ebsVolumes[volumeName] && volumeType != apiresource.EBSTaskAttach {
-				task.RemoveVolume(index)
-			}
-		}
-	}
-
 	err := task.initializeDockerLocalVolumes(dockerClient, ctx)
 	if err != nil {
 		return apierrors.NewResourceInitError(task.Arn, err)
@@ -3483,28 +3469,6 @@ func (task *Task) isEBSTaskAttachEnabledUnsafe() bool {
 		}
 	}
 	return false
-}
-
-// TODO: Add unit tests
-func (task *Task) GetEBSVolumeNames() map[string]bool {
-	task.lock.RLock()
-	defer task.lock.RUnlock()
-	return task.getEBSVolumeNamesUnsafe()
-}
-
-func (task *Task) getEBSVolumeNamesUnsafe() map[string]bool {
-	volNames := map[string]bool{}
-	for _, tv := range task.Volumes {
-		switch tv.Volume.(type) {
-		case *taskresourcevolume.EBSTaskVolumeConfig:
-			logger.Debug("found ebs volume config")
-			ebsCfg := tv.Volume.(*taskresourcevolume.EBSTaskVolumeConfig)
-			volNames[ebsCfg.VolumeName] = true
-		default:
-			continue
-		}
-	}
-	return volNames
 }
 
 func (task *Task) IsServiceConnectBridgeModeApplicationContainer(container *apicontainer.Container) bool {

--- a/agent/api/task/task_attachment_handler_test.go
+++ b/agent/api/task/task_attachment_handler_test.go
@@ -274,6 +274,12 @@ func TestHandleTaskAttachmentWithEBSVolumeAttachment(t *testing.T) {
 						AttachmentType: stringToPointer(apiresource.EBSTaskAttach),
 					},
 				},
+				Volumes: []*ecsacs.Volume{
+					{
+						Name: strptr("test-volume"),
+						Type: strptr(AttachmentType),
+					},
+				},
 			}
 			testTask := &Task{}
 			err := handleTaskAttachments(testAcsTask, testTask)

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -4691,6 +4691,15 @@ func TestTaskWithEBSVolumeAttachment(t *testing.T) {
 				AttachmentType: strptr(apiresource.EBSTaskAttach),
 			},
 		},
+		Volumes: []*ecsacs.Volume{
+			{
+				Name: strptr("test-volume"),
+				Type: strptr(AttachmentType),
+				Host: &ecsacs.HostVolumeProperties{
+					SourcePath: strptr("/host/path"),
+				},
+			},
+		},
 	}
 
 	testExpectedEBSCfg := &taskresourcevolume.EBSTaskVolumeConfig{
@@ -5233,4 +5242,39 @@ func TestToHostResources(t *testing.T) {
 		}
 		assert.Equal(t, len(tc.expectedResources["PORTS_UDP"].StringSetValue), len(calcResources["PORTS_UDP"].StringSetValue), "Error converting task UDP port resources")
 	}
+}
+
+func TestRemoveVolumes(t *testing.T) {
+	task := &Task{
+		Volumes: []TaskVolume{
+			{
+				Name: "volName",
+				Type: "host",
+				Volume: &taskresourcevolume.FSHostVolume{
+					FSSourcePath: "/host/path",
+				},
+			},
+		},
+	}
+	task.RemoveVolume(0)
+	assert.Equal(t, len(task.Volumes), 0)
+}
+
+func TestRemoveVolumeIndexOutOfBounds(t *testing.T) {
+	task := &Task{
+		Volumes: []TaskVolume{
+			{
+				Name: "volName",
+				Type: "host",
+				Volume: &taskresourcevolume.FSHostVolume{
+					FSSourcePath: "/host/path",
+				},
+			},
+		},
+	}
+	task.RemoveVolume(1)
+	assert.Equal(t, len(task.Volumes), 1)
+
+	task.RemoveVolume(-1)
+	assert.Equal(t, len(task.Volumes), 1)
 }

--- a/agent/api/task/taskvolume.go
+++ b/agent/api/task/taskvolume.go
@@ -32,6 +32,7 @@ const (
 	DockerVolumeType               = "docker"
 	EFSVolumeType                  = "efs"
 	FSxWindowsFileServerVolumeType = "fsxWindowsFileServer"
+	AttachmentType                 = "attachment"
 )
 
 // TaskVolume is a definition of all the volumes available for containers to
@@ -78,6 +79,9 @@ func (tv *TaskVolume) UnmarshalJSON(b []byte) error {
 		return tv.unmarshalFSxWindowsFileServerVolume(intermediate["fsxWindowsFileServerVolumeConfiguration"])
 	case apiresource.EBSTaskAttach:
 		return tv.unmarshalEBSVolume(intermediate["ebsVolumeConfiguration"])
+	case AttachmentType:
+		seelog.Warn("Obtaining the volume configuration from task attachments.")
+		return nil
 	default:
 		return errors.Errorf("unrecognized volume type: %q", tv.Type)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will address the current issue where if we launch an EBS-backed task, the list of volumes we get from the payload to be invalid in the eyes of agent. An example:
```
"Volumes": [{
            "DockerVolumeConfiguration": null,
            "EbsVolumeConfiguration": null,
            "EfsVolumeConfiguration": null,
            "FsxWindowsFileServerVolumeConfiguration": null,
            "Host": null,
            "Name": "someName",
            "Type": null
 }]
```
By default if the volume type is empty or nil, agent will fall back on volume type `host` and then look to try to parse whatever is in the `Host` field of the volume object for a host volume configuration. However, since everything except the volume name is empty, it will fail with the following error:
```
taskStatus="STOPPED" taskReason="UnrecogniedTaskError: Error loading task - invalid volume: empty volume configuration" taskKnownSentStatus="NONE" taskPullStartedAt="0001-01-01T00:00:00Z" taskPullStoppedAt="0001-01-01T00:00:00Z"
```
which isn't desired for EBS-backed tasks since the EBS volume is in the task attachments.

To accommodate this, we'll mark the corresponding volume object with the same volume name as the EBS volume attachment object to be of type `attachment`. This volume object will ultimately be replaced when we're parsing the EBS volume from the list of task attachments.

### Implementation details
Implemented new functionality in:
* `agent/acs/session/payload_responder.go`: 
  * New functionality called `hasEBSAttachment` to check if the task payload that we've received has EBS attachments within the list task attachments. If there are then we'll return the volume name. 
  * New functionlality called `initializeAttachmentTypeVolume` to find a volume object within the list of task volumes by volume name and then initialize/change the type to `attachment`. This task volume object will ultimately be replaced by the volume defined in the list of task attachments. This is currently only applicable to EBS volumes.
*  `agent/api/task/task.go` -> `agent/api/task/task_attachment_handler.go`: Moved functionality to clean up and remove all non-EBS volume configuration with the same volume name as EBS volume configuration within the list of task volumes.
* `agent/api/task/taskvolume.go`: Added a new task volume type called `attachment` for EBS volumes found in the list of task attachments within the payload.

### Testing
Unit tests

Manual testing:
Ran an EBS-backed task and it was able to successfully start one up.

Before changing the task volume type
```
"Volumes": [{
            "DockerVolumeConfiguration": null,
            "EbsVolumeConfiguration": null,
            "EfsVolumeConfiguration": null,
            "FsxWindowsFileServerVolumeConfiguration": null,
            "Host": null,
            "Name": "ebs1",
            "Type": null
        }],
```

After changing the task volume type
```
"volumes": [{
        "name": "ebs1",
        "type": "attachment"
    }]
```

EBS-backed task was started up
```
CONTAINER ID   IMAGE                            COMMAND                  CREATED              STATUS                    PORTS     NAMES
3e9e05f65c17   mreferre/yelb-db:0.5             "docker-entrypoint.s…"   About a minute ago   Up About a minute                   ecs-evm-db-6-db-9aa3bedbfcb8f1ec9201
4df58e21e339   amazon/amazon-ecs-agent:latest   "/agent"                 25 minutes ago       Up 25 minutes (healthy)             ecs-agent
e137050d8a00   ebs-csi-driver:latest            "/bin/ebs-csi-driver…"   5 hours ago          Up 5 hours                          ecs---ecs-managed-ebs-csi-driver-d2d7c8ddd1f08c91bc01
```

Mountpoint for the task
```
"Mounts": [
            {
                "Type": "bind",
                "Source": "/mnt/ecs/ebs/7bcd9e3ff65a489b9e1c43bfd6592384_vol-0501243308b3d16bc",
                "Destination": "/var/stuff",
                "Mode": "",
                "RW": true,
                "Propagation": "rprivate"
            }
```


New tests cover the changes: <!-- yes|no -->

### Description for the changelog
Fix invalid task volumes field for EBS-backed task payload

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
