### PR TITLE
update daemon log path host root in container

### DIFF
--- a/agent/engine/daemonmanager/daemon_manager_linux.go
+++ b/agent/engine/daemonmanager/daemon_manager_linux.go
@@ -49,7 +49,7 @@ const (
 	ecsAgentLogFileENV                          = "ECS_LOGFILE"
 	defaultECSAgentLogPathContainer             = "/log"
 	socketPathHostRoot                          = "/var/run/ecs"
-	logPathHostRoot                             = "/log/ecs/daemons"
+	logPathHostRoot                             = "/log/daemons"
 )
 
 var mkdirAllAndChown = utils.MkdirAllAndChown


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This fixes a bug in the log mount file creation.  The original didn't account for the actual ecs-agent container source directory which includes `ecs` in its path.  

```
{
  "Type": "bind",
  "Source": "/var/log/ecs",
  "Destination": "/log",
...
},
```
That means that the host path being created had a duplicate /ecs:
```
$ pwd
/var/log/ecs/ecs/daemons/ebs-csi-driver
```

### Implementation details
update logPathHostRoot to account for the `ecs` in the host mount of the ecs-agent container.

### Testing
Tested by removing all logging directories which were not created by ecs-init, starting ecs service, then launching an EBS-Backed task.  As the daemon is created, these host paths are also created.  Validated that the correct path was created.

New tests cover the changes: no

### Description for the changelog
Bugfix: update ecs-agent in-container path for managed daemon logging.

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
