### PR TITLE
Addressing TODOs for NodeGetVolumeMetrics and NodeUnstageVolume

### DIFF
--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -44,11 +44,14 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
+	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
+	apiresource "github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment/resource"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	mock_credentials "github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks"
+	mock_csiclient "github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/mocks"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	mock_ttime "github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime/mocks"
@@ -2226,4 +2229,64 @@ func TestTaskWaitForHostResources(t *testing.T) {
 	// Verify arn2 got dequeued
 	topTask, err = taskEngine.topTask()
 	assert.Error(t, err)
+}
+
+func TestUnstageVolumes(t *testing.T) {
+	tcs := []struct {
+		name      string
+		err       error
+		numErrors int
+	}{
+		{
+			name:      "Success",
+			err:       nil,
+			numErrors: 0,
+		},
+		{
+			name:      "Failure",
+			err:       errors.New("unable to unstage volume"),
+			numErrors: 1,
+		},
+		{
+			name:      "TimeoutFailure",
+			err:       errors.New("rpc error: code = DeadlineExceeded desc = context deadline exceeded"),
+			numErrors: 1,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
+			mtask := &managedTask{
+				Task: &apitask.Task{
+					ResourcesMapUnsafe:  make(map[string][]taskresource.TaskResource),
+					DesiredStatusUnsafe: apitaskstatus.TaskRunning,
+					Volumes: []apitask.TaskVolume{
+						{
+							Name: taskresourcevolume.TestVolumeName,
+							Type: apiresource.EBSTaskAttach,
+							Volume: &taskresourcevolume.EBSTaskVolumeConfig{
+								VolumeId:             taskresourcevolume.TestVolumeId,
+								VolumeName:           taskresourcevolume.TestVolumeId,
+								VolumeSizeGib:        taskresourcevolume.TestVolumeSizeGib,
+								SourceVolumeHostPath: taskresourcevolume.TestSourceVolumeHostPath,
+								DeviceName:           taskresourcevolume.TestDeviceName,
+								FileSystem:           taskresourcevolume.TestFileSystem,
+							},
+						},
+					},
+				},
+				ctx:                      ctx,
+				resourceStateChangeEvent: make(chan resourceStateChange),
+			}
+			mockCsiClient := mock_csiclient.NewMockCSIClient(mockCtrl)
+			mockCsiClient.EXPECT().NodeUnstageVolume(gomock.Any(), "vol-12345", "/mnt/ecs/ebs/taskarn_vol-12345").Return(tc.err).Times(1)
+
+			errors := mtask.UnstageVolumes(mockCsiClient)
+			assert.Len(t, errors, tc.numErrors)
+		})
+	}
 }

--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_unsupported.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_unsupported.go
@@ -140,6 +140,20 @@ func (cfg *FSxWindowsFileServerVolumeConfig) Source() string {
 	return "undefined"
 }
 
+func (cfg *FSxWindowsFileServerVolumeConfig) GetType() string {
+	return "undefined"
+}
+
+// Currently not meant for use
+func (cfg *FSxWindowsFileServerVolumeConfig) GetVolumeId() string {
+	return ""
+}
+
+// Currently not meant for use
+func (cfg *FSxWindowsFileServerVolumeConfig) GetVolumeName() string {
+	return ""
+}
+
 // GetName safely returns the name of the resource
 func (fv *FSxWindowsFileServerResource) GetName() string {
 	return "undefined"

--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows.go
@@ -47,6 +47,7 @@ import (
 const (
 	psCredentialCommandFormat = "$(New-Object System.Management.Automation.PSCredential('%s', $(ConvertTo-SecureString '%s' -AsPlainText -Force)))"
 	resourceProvisioningError = "VolumeError: Agent could not create task's volume resources"
+	fsxVolumeType             = "fsx"
 )
 
 // FSxWindowsFileServerResource represents a fsxwindowsfileserver resource
@@ -291,6 +292,20 @@ func (fv *FSxWindowsFileServerResource) SetCreatedAt(createdAt time.Time) {
 // Source returns the host path of the fsxwindowsfileserver resource which is used as the source of the volume mount
 func (cfg *FSxWindowsFileServerVolumeConfig) Source() string {
 	return utils.GetCanonicalPath(cfg.HostPath)
+}
+
+func (cfg *FSxWindowsFileServerVolumeConfig) GetType() string {
+	return fsxVolumeType
+}
+
+func (cfg *FSxWindowsFileServerVolumeConfig) GetVolumeId() string {
+	return cfg.FileSystemID
+}
+
+// Note: The name is within the FSxWindowsFileServerResource struct. In order to use this in the future, this needs to be modified.
+// Currently not meant for use
+func (cfg *FSxWindowsFileServerVolumeConfig) GetVolumeName() string {
+	return ""
 }
 
 // GetName safely returns the name of the fsxwindowsfileserver resource

--- a/agent/taskresource/volume/dockervolume.go
+++ b/agent/taskresource/volume/dockervolume.go
@@ -40,6 +40,9 @@ const (
 	DockerLocalVolumeDriver   = "local"
 	resourceProvisioningError = "VolumeError: Agent could not create task's volume resources"
 	EFSVolumeType             = "efs"
+	EBSVolumeType             = "ebs"
+	DockerVolumeType          = "docker"
+	FSHostVolumeType          = "fshost"
 	netNSFormat               = "/proc/%s/ns/net"
 	EBSSourcePrefix           = "/mnt/ecs/ebs/"
 )
@@ -152,14 +155,50 @@ func (cfg *EFSVolumeConfig) Source() string {
 	return cfg.DockerVolumeName
 }
 
+func (cfg *EFSVolumeConfig) GetType() string {
+	return EFSVolumeType
+}
+
+func (cfg *EFSVolumeConfig) GetVolumeId() string {
+	return cfg.FileSystemID
+}
+
+func (cfg *EFSVolumeConfig) GetVolumeName() string {
+	return cfg.DockerVolumeName
+}
+
 // Source returns the name of the volume resource which is used as the source of the volume mount
 func (cfg *DockerVolumeConfig) Source() string {
+	return cfg.DockerVolumeName
+}
+
+func (cfg *DockerVolumeConfig) GetType() string {
+	return DockerVolumeType
+}
+
+func (cfg *DockerVolumeConfig) GetVolumeId() string {
+	return cfg.DockerVolumeName
+}
+
+func (cfg *DockerVolumeConfig) GetVolumeName() string {
 	return cfg.DockerVolumeName
 }
 
 // Source returns the source volume host mount point for an EBS volume
 func (cfg *EBSTaskVolumeConfig) Source() string {
 	return EBSSourcePrefix + cfg.SourceVolumeHostPath
+}
+
+func (cfg *EBSTaskVolumeConfig) GetType() string {
+	return EBSVolumeType
+}
+
+func (cfg *EBSTaskVolumeConfig) GetVolumeId() string {
+	return cfg.VolumeId
+}
+
+func (cfg *EBSTaskVolumeConfig) GetVolumeName() string {
+	return cfg.VolumeName
 }
 
 // GetName returns the name of the volume resource

--- a/agent/taskresource/volume/volumetypes.go
+++ b/agent/taskresource/volume/volumetypes.go
@@ -17,6 +17,9 @@ package volume
 // docker volume mount
 type Volume interface {
 	Source() string
+	GetType() string
+	GetVolumeId() string
+	GetVolumeName() string
 }
 
 // FSHostVolume is a simple type of HostVolume which references an arbitrary
@@ -30,6 +33,21 @@ func (fs *FSHostVolume) Source() string {
 	return fs.FSSourcePath
 }
 
+// Currently not meant for use
+func (fs *FSHostVolume) GetType() string {
+	return FSHostVolumeType
+}
+
+// Currently not meant for use
+func (fs *FSHostVolume) GetVolumeId() string {
+	return ""
+}
+
+// Currently not meant for use
+func (fs *FSHostVolume) GetVolumeName() string {
+	return ""
+}
+
 // LocalDockerVolume represents a volume without a specified host path
 // This is essentially DockerVolume with only the name specified; however,
 // for backward compatibility we can't directly map to DockerVolume.
@@ -40,4 +58,19 @@ type LocalDockerVolume struct {
 // SourcePath returns the generated host path for the volume
 func (e *LocalDockerVolume) Source() string {
 	return e.HostPath
+}
+
+// Currently not meant for use
+func (e *LocalDockerVolume) GetType() string {
+	return DockerLocalVolumeDriver
+}
+
+// Currently not meant for use
+func (e *LocalDockerVolume) GetVolumeId() string {
+	return ""
+}
+
+// Currently not meant for use
+func (e *LocalDockerVolume) GetVolumeName() string {
+	return ""
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will address all of the leftover TODOs for `NodeGetVolumeMetrics` and `NodeUnstageVolume` functionality for EBS-backed tasks.

### Implementation details
* `agent/engine/task_manager.go`: Changed `UnstageVolumes` to return a list of any errors that were encountered when trying to unstage a volume via the CSI driver. We'll then log all encountered errors. This will be helpful for having unit tests since otherwise we wouldn't know whether or not there were any issues.
* `agent/taskresource`: Added new getters within the `Volume` interface. This is to avoid typecasting the volume within the `NodeGetVolumeMetrics` as mentioned in [#3929](https://github.com/aws/amazon-ecs-agent/pull/3929).
* `agent/stats/engine_unix.go`: No longer type casting the task volume within `fetchEBSVolumeMetrics` in order to obtain the EBS volume and will instead use the getters implemented in `agent/taskresource`

Related PR: https://github.com/aws/amazon-ecs-agent/pull/3929

### Testing
New unit tests:
* TestFetchEBSVolumeMetricsHappy
* TestFetchEBSVolumeMetricsUnhappy
* TestFetchEBSVolumeMetricsNoTimeoutError
* TestFetchEBSVolumeMetricsTimeoutError
* TestUnstageVolumesHappy
* TestUnstageVolumesUnhappy
* TestUnstageVolumesNoTimeoutError
* TestUnstageVolumesTimeoutError

New tests cover the changes: Yes

### Description for the changelog
Added more unit testing for NodeUnstageVolume and NodeGetVolumeMetrics as well as address other leftover TODOs  for EBS-backed task

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
