### PR TITLE
Add logic for new TTL being nil for TTL cache

### DIFF
--- a/ecs-agent/async/ttl_cache_test.go
+++ b/ecs-agent/async/ttl_cache_test.go
@@ -114,3 +114,61 @@ func TestTTLCacheGetTTLAndSetTTL(t *testing.T) {
 	require.True(t, expired)
 	require.Equal(t, entryVal, actualVal)
 }
+
+func TestTTLSetNilTTLWhenCacheTTLNotNil(t *testing.T) {
+	entryKey := "foo"
+	entryVal := "bar"
+
+	// Initialize cache with a 1 second TTL (i.e., not nil TTL).
+	initialTTLDuration := 1 * time.Nanosecond
+	cache := NewTTLCache(&TTL{Duration: initialTTLDuration})
+	require.Equal(t, initialTTLDuration, cache.GetTTL().Duration)
+
+	// Add entry to the cache.
+	cache.Set(entryKey, entryVal)
+	time.Sleep(2 * initialTTLDuration)
+
+	// We should be able to retrieve the entry - it should be expired.
+	actualVal, expired, ok := cache.Get(entryKey)
+	require.True(t, ok)
+	require.True(t, expired)
+	require.Equal(t, entryVal, actualVal)
+
+	// Set TTL of cache to now be nil.
+	cache.SetTTL(nil)
+	require.Nil(t, cache.GetTTL())
+
+	// We should be able to retrieve the entry - it should not be expired.
+	actualVal, expired, ok = cache.Get(entryKey)
+	require.True(t, ok)
+	require.False(t, expired)
+	require.Equal(t, entryVal, actualVal)
+}
+
+func TestTTLSetNilTTLWhenCacheTTLNil(t *testing.T) {
+	entryKey := "foo"
+	entryVal := "bar"
+
+	// Initialize cache with a nil TTL.
+	cache := NewTTLCache(nil)
+	require.Nil(t, cache.GetTTL())
+
+	// Add entry to the cache.
+	cache.Set(entryKey, entryVal)
+
+	// We should be able to retrieve the entry - it should not be expired.
+	actualVal, expired, ok := cache.Get(entryKey)
+	require.True(t, ok)
+	require.False(t, expired)
+	require.Equal(t, entryVal, actualVal)
+
+	// Set TTL of cache to now be nil.
+	cache.SetTTL(nil)
+	require.Nil(t, cache.GetTTL())
+
+	// We should be able to retrieve the entry - it should still not be expired.
+	actualVal, expired, ok = cache.Get(entryKey)
+	require.True(t, ok)
+	require.False(t, expired)
+	require.Equal(t, entryVal, actualVal)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
There is a missing nil check right now for the case of setting the TTL of a TTL cache to be nil which is problematic. Add a nil check and corresponding logic to account for that case.

### Implementation details
<!-- How are the changes implemented? -->
Same as summary above.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit, integration, and functional tests.

New tests cover the changes: yes (new tests added would fail without these changes)<!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add logic for new TTL being nil for TTL cache

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.