### PR TITLE
Incorporate ebs-csi-driver tests; add nodeStage and nodeUnstage unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,10 @@ ifneq (${BUILD_PLATFORM},aarch64)
 	GOTEST += -race
 endif
 
-test:
+test-ebs-csi:
+	make -C ./ecs-agent/daemonimages/csidriver test
+
+test: test-ebs-csi
 	cd agent && GO111MODULE=on ${GOTEST} ${VERBOSE} -tags unit -mod vendor -coverprofile ../cover.out -timeout=120s ./... && cd ..
 	go tool cover -func cover.out > coverprofile.out
 	cd ecs-agent && GO111MODULE=on ${GOTEST} ${VERBOSE} -tags unit -mod vendor -coverprofile ../cover.out -timeout=120s ./... && cd ..
@@ -155,7 +158,7 @@ test-init:
 	go test -count=1 -short -v -coverprofile cover.out ./ecs-init/...
 	go tool cover -func cover.out > coverprofile-init.out
 
-test-silent:
+test-silent: test-ebs-csi
 	cd agent && GO111MODULE=on ${GOTEST} -tags unit -mod vendor -coverprofile ../cover.out -timeout=120s ./... && cd ..
 	go tool cover -func cover.out > coverprofile.out
 	cd ecs-agent && GO111MODULE=on ${GOTEST} -tags unit -mod vendor -coverprofile ../cover.out -timeout=120s ./... && cd ..

--- a/ecs-agent/daemonimages/csidriver/Makefile
+++ b/ecs-agent/daemonimages/csidriver/Makefile
@@ -12,10 +12,17 @@
 # permissions and limitations under the License.
 .PHONY: all image mockgen clean
 
+# 'go' may not be on the $PATH for sudo tests
+GO_EXECUTABLE=$(shell command -v go 2> /dev/null)
 CSI_DRIVER_VERSION="v$(shell cat CSI_DRIVER_VERSION)"
 BUILD_DATE=$(shell date -u -Iseconds)
 GO_VERSION=$(shell cat ../../../GO_VERSION)
 IMAGE_REF?="ebs-csi-driver:latest"
+# -count=1 runs the test without using the build cache.  The build cache can
+# provide false positives when running integ tests, so we err on the side of
+# caution. See `go help test`
+# unit tests include the coverage profile
+GOTEST=${GO_EXECUTABLE} test -count=1
 
 all: tarfiles/ebs-csi-driver.tar
 
@@ -27,6 +34,9 @@ bin/ebs-csi-driver:
 
 image:
 	docker build --build-arg GO_VERSION=$(GO_VERSION) -t $(IMAGE_REF) .
+
+test:
+	GO111MODULE=on ${GOTEST} -v -race ./driver/... -tags unit -mod vendor -timeout=120s
 
 tarfiles/ebs-csi-driver.tar: image
 	mkdir -p tarfiles

--- a/ecs-agent/daemonimages/csidriver/driver/constants.go
+++ b/ecs-agent/daemonimages/csidriver/driver/constants.go
@@ -45,14 +45,20 @@ const (
 	// BlockSizeKey configures the block size when formatting a volume
 	BlockSizeKey = "blocksize"
 
-	// INodeSizeKey configures the inode size when formatting a volume
-	INodeSizeKey = "inodesize"
+	// InodeSizeKey configures the inode size when formatting a volume
+	InodeSizeKey = "inodesize"
 
-	// BytesPerINodeKey configures the `bytes-per-inode` when formatting a volume
-	BytesPerINodeKey = "bytesperinode"
+	// BytesPerInodeKey configures the `bytes-per-inode` when formatting a volume
+	BytesPerInodeKey = "bytesperinode"
 
-	// NumberOfINodesKey configures the `number-of-inodes` when formatting a volume
-	NumberOfINodesKey = "numberofinodes"
+	// NumberOfInodesKey configures the `number-of-inodes` when formatting a volume
+	NumberOfInodesKey = "numberofinodes"
+
+	// Ext4ClusterSizeKey enables the bigalloc option when formatting an ext4 volume
+	Ext4BigAllocKey = "ext4bigalloc"
+
+	// Ext4ClusterSizeKey configures the cluster size when formatting an ext4 volume with the bigalloc option enabled
+	Ext4ClusterSizeKey = "ext4clustersize"
 )
 
 type fileSystemConfig struct {
@@ -79,16 +85,16 @@ var (
 		},
 		FSTypeXfs: {
 			NotSupportedParams: map[string]struct{}{
-				BytesPerINodeKey:  {},
-				NumberOfINodesKey: {},
+				BytesPerInodeKey:  {},
+				NumberOfInodesKey: {},
 			},
 		},
 		FSTypeNtfs: {
 			NotSupportedParams: map[string]struct{}{
 				BlockSizeKey:      {},
-				INodeSizeKey:      {},
-				BytesPerINodeKey:  {},
-				NumberOfINodesKey: {},
+				InodeSizeKey:      {},
+				BytesPerInodeKey:  {},
+				NumberOfInodesKey: {},
 			},
 		},
 	}

--- a/ecs-agent/daemonimages/csidriver/driver/node.go
+++ b/ecs-agent/daemonimages/csidriver/driver/node.go
@@ -115,15 +115,15 @@ func (d *nodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if err != nil {
 		return nil, err
 	}
-	inodeSize, err := recheckParameter(context, INodeSizeKey, FileSystemConfigs, fsType)
+	inodeSize, err := recheckParameter(context, InodeSizeKey, FileSystemConfigs, fsType)
 	if err != nil {
 		return nil, err
 	}
-	bytesPerINode, err := recheckParameter(context, BytesPerINodeKey, FileSystemConfigs, fsType)
+	bytesPerInode, err := recheckParameter(context, BytesPerInodeKey, FileSystemConfigs, fsType)
 	if err != nil {
 		return nil, err
 	}
-	numINodes, err := recheckParameter(context, NumberOfINodesKey, FileSystemConfigs, fsType)
+	numInodes, err := recheckParameter(context, NumberOfInodesKey, FileSystemConfigs, fsType)
 	if err != nil {
 		return nil, err
 	}
@@ -209,11 +209,11 @@ func (d *nodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		}
 		formatOptions = append(formatOptions, option, inodeSize)
 	}
-	if len(bytesPerINode) > 0 {
-		formatOptions = append(formatOptions, "-i", bytesPerINode)
+	if len(bytesPerInode) > 0 {
+		formatOptions = append(formatOptions, "-i", bytesPerInode)
 	}
-	if len(numINodes) > 0 {
-		formatOptions = append(formatOptions, "-N", numINodes)
+	if len(numInodes) > 0 {
+		formatOptions = append(formatOptions, "-N", numInodes)
 	}
 	err = d.mounter.FormatAndMountSensitiveWithFormatOptions(source, target, fsType, mountOptions, nil, formatOptions)
 	if err != nil {

--- a/ecs-agent/daemonimages/csidriver/driver/node_linux_test.go
+++ b/ecs-agent/daemonimages/csidriver/driver/node_linux_test.go
@@ -20,20 +20,522 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/aws/amazon-ecs-agent/ecs-agent/daemonimages/csidriver/driver/internal"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 var (
-	volumeID = "voltest"
-	nvmeName = "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_voltest"
+	volumeID        = "voltest"
+	nvmeName        = "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_voltest"
+	symlinkFileInfo = fs.FileInfo(&fakeFileInfo{nvmeName, os.ModeSymlink})
 )
+
+func TestNodeStageVolume(t *testing.T) {
+	var (
+		targetPath     = "/test/path"
+		devicePath     = "/dev/fake"
+		nvmeDevicePath = "/dev/nvmefake1n1"
+		deviceFileInfo = fs.FileInfo(&fakeFileInfo{devicePath, os.ModeDevice})
+		stdVolCap      = &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{
+					FsType: FSTypeXfs,
+				},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		}
+		// With few exceptions, all "success" non-block cases have roughly the same
+		// expected calls and only care about testing the FormatAndMountSensitiveWithFormatOptions call. The
+		// exceptions should not call this, instead they should define expectMock
+		// from scratch.
+		successExpectMock = func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
+			mockMounter.EXPECT().PathExists(gomock.Eq(targetPath)).Return(false, nil)
+			mockMounter.EXPECT().MakeDir(targetPath).Return(nil)
+			mockMounter.EXPECT().GetDeviceNameFromMount(targetPath).Return("", 1, nil)
+			mockMounter.EXPECT().PathExists(gomock.Eq(devicePath)).Return(true, nil)
+			mockDeviceIdentifier.EXPECT().Lstat(gomock.Eq(devicePath)).Return(deviceFileInfo, nil)
+			mockMounter.EXPECT().NeedResize(gomock.Eq(devicePath), gomock.Eq(targetPath)).Return(false, nil)
+		}
+	)
+	testCases := []struct {
+		name         string
+		request      *csi.NodeStageVolumeRequest
+		inFlightFunc func(*internal.InFlight) *internal.InFlight
+		expectMock   func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier)
+		expectedCode codes.Code
+	}{
+		{
+			name: "success normal",
+			request: &csi.NodeStageVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: devicePath},
+				StagingTargetPath: targetPath,
+				VolumeCapability:  stdVolCap,
+				VolumeId:          volumeID,
+			},
+			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
+				successExpectMock(mockMounter, mockDeviceIdentifier)
+				mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq(devicePath), gomock.Eq(targetPath), gomock.Eq(defaultFsType), gomock.Any(), gomock.Nil(), gomock.Len(0))
+			},
+		},
+		{
+			name: "success normal [raw block]",
+			request: &csi.NodeStageVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: devicePath},
+				StagingTargetPath: targetPath,
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Block{
+						Block: &csi.VolumeCapability_BlockVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+				VolumeId: volumeID,
+			},
+			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
+				mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Nil(), gomock.Len(0)).Times(0)
+			},
+		},
+		{
+			name: "success fsType ext4",
+			request: &csi.NodeStageVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: devicePath},
+				StagingTargetPath: targetPath,
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{
+							FsType: FSTypeExt4,
+						},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+				VolumeId: volumeID,
+			},
+			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
+				successExpectMock(mockMounter, mockDeviceIdentifier)
+				mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq(devicePath), gomock.Eq(targetPath), gomock.Eq(FSTypeExt4), gomock.Any(), gomock.Nil(), gomock.Len(0))
+			},
+		},
+
+		{
+			name: "success fsType ext3",
+			request: &csi.NodeStageVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: devicePath},
+				StagingTargetPath: targetPath,
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{
+							FsType: FSTypeExt3,
+						},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+				VolumeId: volumeID,
+			},
+			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
+				successExpectMock(mockMounter, mockDeviceIdentifier)
+				mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq(devicePath), gomock.Eq(targetPath), gomock.Eq(FSTypeExt3), gomock.Any(), gomock.Nil(), gomock.Len(0))
+			},
+		},
+		{
+			name: "success mount with default fsType xfs",
+			request: &csi.NodeStageVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: devicePath},
+				StagingTargetPath: targetPath,
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{
+							FsType: "",
+						},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+				VolumeId: volumeID,
+			},
+			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
+				successExpectMock(mockMounter, mockDeviceIdentifier)
+				mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq(devicePath), gomock.Eq(targetPath), gomock.Eq(FSTypeXfs), gomock.Any(), gomock.Nil(), gomock.Len(0))
+			},
+		},
+		{
+			name: "success device already mounted at target",
+			request: &csi.NodeStageVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: devicePath},
+				StagingTargetPath: targetPath,
+				VolumeCapability:  stdVolCap,
+				VolumeId:          volumeID,
+			},
+			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
+				mockMounter.EXPECT().PathExists(gomock.Eq(targetPath)).Return(true, nil)
+				mockMounter.EXPECT().GetDeviceNameFromMount(targetPath).Return(devicePath, 1, nil)
+				mockMounter.EXPECT().PathExists(gomock.Eq(devicePath)).Return(true, nil)
+				mockDeviceIdentifier.EXPECT().Lstat(gomock.Eq(devicePath)).Return(deviceFileInfo, nil)
+
+				mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Nil(), gomock.Len(0)).Times(0)
+			},
+		},
+		{
+			name: "success nvme device already mounted at target",
+			request: &csi.NodeStageVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: devicePath},
+				StagingTargetPath: targetPath,
+				VolumeCapability:  stdVolCap,
+				VolumeId:          volumeID,
+			},
+			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
+				mockMounter.EXPECT().PathExists(gomock.Eq(targetPath)).Return(true, nil)
+
+				// If the device is nvme GetDeviceNameFromMount should return the
+				// canonical device path
+				mockMounter.EXPECT().GetDeviceNameFromMount(targetPath).Return(nvmeDevicePath, 1, nil)
+
+				// The publish context device path may not exist but the driver should
+				// find the canonical device path (see TestFindDevicePath), compare it
+				// to the one returned by GetDeviceNameFromMount, and then skip
+				// FormatAndMountSensitiveWithFormatOptions
+				mockMounter.EXPECT().PathExists(gomock.Eq(devicePath)).Return(false, nil)
+				mockDeviceIdentifier.EXPECT().Lstat(gomock.Eq(nvmeName)).Return(symlinkFileInfo, nil)
+				mockDeviceIdentifier.EXPECT().EvalSymlinks(gomock.Eq(symlinkFileInfo.Name())).Return(nvmeDevicePath, nil)
+
+				mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Nil(), gomock.Len(0)).Times(0)
+			},
+		},
+		{
+			name: "fail no VolumeId",
+			request: &csi.NodeStageVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: devicePath},
+				StagingTargetPath: targetPath,
+				VolumeCapability:  stdVolCap,
+			},
+			expectedCode: codes.InvalidArgument,
+		},
+		{
+			name: "fail no mount",
+			request: &csi.NodeStageVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: devicePath},
+				StagingTargetPath: targetPath,
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+			},
+			expectedCode: codes.InvalidArgument,
+		},
+		{
+			name: "fail no StagingTargetPath",
+			request: &csi.NodeStageVolumeRequest{
+				PublishContext:   map[string]string{DevicePathKey: devicePath},
+				VolumeCapability: stdVolCap,
+				VolumeId:         volumeID,
+			},
+			expectedCode: codes.InvalidArgument,
+		},
+		{
+			name: "fail no VolumeCapability",
+			request: &csi.NodeStageVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: devicePath},
+				StagingTargetPath: targetPath,
+				VolumeId:          volumeID,
+			},
+			expectedCode: codes.InvalidArgument,
+		},
+		{
+			name: "fail invalid VolumeCapability",
+			request: &csi.NodeStageVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: devicePath},
+				StagingTargetPath: targetPath,
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_UNKNOWN,
+					},
+				},
+				VolumeId: volumeID,
+			},
+			expectedCode: codes.InvalidArgument,
+		},
+		{
+			name: "fail no devicePath",
+			request: &csi.NodeStageVolumeRequest{
+				VolumeCapability: stdVolCap,
+				VolumeId:         volumeID,
+			},
+			expectedCode: codes.InvalidArgument,
+		},
+		{
+			name: "fail invalid volumeContext",
+			request: &csi.NodeStageVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: devicePath},
+				StagingTargetPath: targetPath,
+				VolumeCapability:  stdVolCap,
+				VolumeContext:     map[string]string{VolumeAttributePartition: "partition1"},
+				VolumeId:          volumeID,
+			},
+			expectedCode: codes.InvalidArgument,
+		},
+		{
+			name: "fail with in-flight request",
+			request: &csi.NodeStageVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: devicePath},
+				StagingTargetPath: targetPath,
+				VolumeCapability:  stdVolCap,
+				VolumeId:          volumeID,
+			},
+			inFlightFunc: func(inFlight *internal.InFlight) *internal.InFlight {
+				inFlight.Insert(volumeID)
+				return inFlight
+			},
+			expectedCode: codes.Aborted,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtl := gomock.NewController(t)
+			defer mockCtl.Finish()
+
+			mockMounter := NewMockMounter(mockCtl)
+			mockDeviceIdentifier := NewMockDeviceIdentifier(mockCtl)
+
+			inFlight := internal.NewInFlight()
+			if tc.inFlightFunc != nil {
+				tc.inFlightFunc(inFlight)
+			}
+
+			awsDriver := &nodeService{
+				mounter:          mockMounter,
+				deviceIdentifier: mockDeviceIdentifier,
+				inFlight:         inFlight,
+			}
+
+			if tc.expectMock != nil {
+				tc.expectMock(*mockMounter, *mockDeviceIdentifier)
+			}
+
+			_, err := awsDriver.NodeStageVolume(context.TODO(), tc.request)
+			if tc.expectedCode != codes.OK {
+				expectErr(t, err, tc.expectedCode)
+			} else if err != nil {
+				t.Fatalf("Expect no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestNodeUnstageVolume(t *testing.T) {
+	targetPath := "/test/path"
+	devicePath := "/dev/fake"
+
+	testCases := []struct {
+		name     string
+		testFunc func(t *testing.T)
+	}{
+		{
+			name: "success normal",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMounter := NewMockMounter(mockCtl)
+				mockDeviceIdentifier := NewMockDeviceIdentifier(mockCtl)
+
+				awsDriver := &nodeService{
+					mounter:          mockMounter,
+					deviceIdentifier: mockDeviceIdentifier,
+					inFlight:         internal.NewInFlight(),
+				}
+
+				mockMounter.EXPECT().GetDeviceNameFromMount(gomock.Eq(targetPath)).Return(devicePath, 1, nil)
+				mockMounter.EXPECT().Unstage(gomock.Eq(targetPath)).Return(nil)
+
+				req := &csi.NodeUnstageVolumeRequest{
+					StagingTargetPath: targetPath,
+					VolumeId:          volumeID,
+				}
+
+				_, err := awsDriver.NodeUnstageVolume(context.TODO(), req)
+				if err != nil {
+					t.Fatalf("Expect no error but got: %v", err)
+				}
+			},
+		},
+		{
+			name: "success no device mounted at target",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMounter := NewMockMounter(mockCtl)
+				mockDeviceIdentifier := NewMockDeviceIdentifier(mockCtl)
+
+				awsDriver := &nodeService{
+					mounter:          mockMounter,
+					deviceIdentifier: mockDeviceIdentifier,
+					inFlight:         internal.NewInFlight(),
+				}
+
+				mockMounter.EXPECT().GetDeviceNameFromMount(gomock.Eq(targetPath)).Return(devicePath, 0, nil)
+
+				req := &csi.NodeUnstageVolumeRequest{
+					StagingTargetPath: targetPath,
+					VolumeId:          volumeID,
+				}
+				_, err := awsDriver.NodeUnstageVolume(context.TODO(), req)
+				if err != nil {
+					t.Fatalf("Expect no error but got: %v", err)
+				}
+			},
+		},
+		{
+			name: "success device mounted at multiple targets",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMounter := NewMockMounter(mockCtl)
+				mockDeviceIdentifier := NewMockDeviceIdentifier(mockCtl)
+
+				awsDriver := &nodeService{
+					mounter:          mockMounter,
+					deviceIdentifier: mockDeviceIdentifier,
+					inFlight:         internal.NewInFlight(),
+				}
+
+				mockMounter.EXPECT().GetDeviceNameFromMount(gomock.Eq(targetPath)).Return(devicePath, 2, nil)
+				mockMounter.EXPECT().Unstage(gomock.Eq(targetPath)).Return(nil)
+
+				req := &csi.NodeUnstageVolumeRequest{
+					StagingTargetPath: targetPath,
+					VolumeId:          volumeID,
+				}
+
+				_, err := awsDriver.NodeUnstageVolume(context.TODO(), req)
+				if err != nil {
+					t.Fatalf("Expect no error but got: %v", err)
+				}
+			},
+		},
+		{
+			name: "fail no VolumeId",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMounter := NewMockMounter(mockCtl)
+				mockDeviceIdentifier := NewMockDeviceIdentifier(mockCtl)
+
+				awsDriver := &nodeService{
+					mounter:          mockMounter,
+					deviceIdentifier: mockDeviceIdentifier,
+					inFlight:         internal.NewInFlight(),
+				}
+
+				req := &csi.NodeUnstageVolumeRequest{
+					StagingTargetPath: targetPath,
+				}
+
+				_, err := awsDriver.NodeUnstageVolume(context.TODO(), req)
+				expectErr(t, err, codes.InvalidArgument)
+			},
+		},
+		{
+			name: "fail no StagingTargetPath",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMounter := NewMockMounter(mockCtl)
+				mockDeviceIdentifier := NewMockDeviceIdentifier(mockCtl)
+
+				awsDriver := &nodeService{
+					mounter:          mockMounter,
+					deviceIdentifier: mockDeviceIdentifier,
+					inFlight:         internal.NewInFlight(),
+				}
+
+				req := &csi.NodeUnstageVolumeRequest{
+					VolumeId: volumeID,
+				}
+				_, err := awsDriver.NodeUnstageVolume(context.TODO(), req)
+				expectErr(t, err, codes.InvalidArgument)
+			},
+		},
+		{
+			name: "fail GetDeviceName returns error",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMounter := NewMockMounter(mockCtl)
+				mockDeviceIdentifier := NewMockDeviceIdentifier(mockCtl)
+
+				awsDriver := &nodeService{
+					mounter:          mockMounter,
+					deviceIdentifier: mockDeviceIdentifier,
+					inFlight:         internal.NewInFlight(),
+				}
+
+				mockMounter.EXPECT().GetDeviceNameFromMount(gomock.Eq(targetPath)).Return("", 0, errors.New("GetDeviceName faield"))
+
+				req := &csi.NodeUnstageVolumeRequest{
+					StagingTargetPath: targetPath,
+					VolumeId:          volumeID,
+				}
+
+				_, err := awsDriver.NodeUnstageVolume(context.TODO(), req)
+				expectErr(t, err, codes.Internal)
+			},
+		},
+		{
+			name: "fail another operation in-flight on given volumeId",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMounter := NewMockMounter(mockCtl)
+				mockDeviceIdentifier := NewMockDeviceIdentifier(mockCtl)
+
+				awsDriver := &nodeService{
+					mounter:          mockMounter,
+					deviceIdentifier: mockDeviceIdentifier,
+					inFlight:         internal.NewInFlight(),
+				}
+
+				req := &csi.NodeUnstageVolumeRequest{
+					StagingTargetPath: targetPath,
+					VolumeId:          volumeID,
+				}
+
+				awsDriver.inFlight.Insert(volumeID)
+				_, err := awsDriver.NodeUnstageVolume(context.TODO(), req)
+				expectErr(t, err, codes.Aborted)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.testFunc)
+	}
+}
 
 func TestNodeGetVolumeStats(t *testing.T) {
 	testCases := []struct {
@@ -170,4 +672,166 @@ func expectErrorMessage(t *testing.T, actualErr error, expectedPartialMsg string
 		expectedPartialMsg,
 		fmt.Sprintf("Expected partial error message %s", expectedPartialMsg),
 	)
+}
+
+func TestFindDevicePath(t *testing.T) {
+	devicePath := "/dev/xvdaa"
+	nvmeDevicePath := "/dev/nvme1n1"
+	volumeID := "vol-test"
+	nvmeName := "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_voltest"
+	deviceFileInfo := fs.FileInfo(&fakeFileInfo{devicePath, os.ModeDevice})
+	symlinkFileInfo := fs.FileInfo(&fakeFileInfo{nvmeName, os.ModeSymlink})
+	nvmeDevicePathSymlinkFileInfo := fs.FileInfo(&fakeFileInfo{nvmeDevicePath, os.ModeSymlink})
+	type testCase struct {
+		name             string
+		devicePath       string
+		volumeID         string
+		partition        string
+		expectMock       func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier)
+		expectDevicePath string
+		expectError      string
+	}
+	testCases := []testCase{
+		{
+			name:       "11: device path exists and nvme device path exists",
+			devicePath: devicePath,
+			volumeID:   volumeID,
+			partition:  "",
+			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
+				gomock.InOrder(
+					mockMounter.EXPECT().PathExists(gomock.Eq(devicePath)).Return(true, nil),
+					mockDeviceIdentifier.EXPECT().Lstat(gomock.Eq(devicePath)).Return(nvmeDevicePathSymlinkFileInfo, nil),
+					mockDeviceIdentifier.EXPECT().EvalSymlinks(gomock.Eq(devicePath)).Return(nvmeDevicePath, nil),
+				)
+			},
+			expectDevicePath: nvmeDevicePath,
+		},
+		{
+			name:       "10: device path exists and nvme device path doesn't exist",
+			devicePath: devicePath,
+			volumeID:   volumeID,
+			partition:  "",
+			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
+				gomock.InOrder(
+					mockMounter.EXPECT().PathExists(gomock.Eq(devicePath)).Return(true, nil),
+					mockDeviceIdentifier.EXPECT().Lstat(gomock.Eq(devicePath)).Return(deviceFileInfo, nil),
+				)
+			},
+			expectDevicePath: devicePath,
+		},
+		{
+			name:       "01: device path doesn't exist and nvme device path exists",
+			devicePath: devicePath,
+			volumeID:   volumeID,
+			partition:  "",
+			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
+				gomock.InOrder(
+					mockMounter.EXPECT().PathExists(gomock.Eq(devicePath)).Return(false, nil),
+
+					mockDeviceIdentifier.EXPECT().Lstat(gomock.Eq(nvmeName)).Return(symlinkFileInfo, nil),
+					mockDeviceIdentifier.EXPECT().EvalSymlinks(gomock.Eq(symlinkFileInfo.Name())).Return(nvmeDevicePath, nil),
+				)
+			},
+			expectDevicePath: nvmeDevicePath,
+		},
+		{
+			name:       "00: device path doesn't exist and nvme device path doesn't exist",
+			devicePath: devicePath,
+			volumeID:   volumeID,
+			partition:  "",
+			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
+				gomock.InOrder(
+					mockMounter.EXPECT().PathExists(gomock.Eq(devicePath)).Return(false, nil),
+
+					mockDeviceIdentifier.EXPECT().Lstat(gomock.Eq(nvmeName)).Return(nil, os.ErrNotExist),
+				)
+			},
+			expectError: errNoDevicePathFound(devicePath, volumeID).Error(),
+		},
+	}
+	// The partition variant of each case should be the same except the partition
+	// is expected to be appended to devicePath
+	generatedTestCases := []testCase{}
+	for _, tc := range testCases {
+		tc.name += " (with partition)"
+		tc.partition = "1"
+		if tc.expectDevicePath == devicePath {
+			tc.expectDevicePath += tc.partition
+		} else if tc.expectDevicePath == nvmeDevicePath {
+			tc.expectDevicePath += "p" + tc.partition
+		}
+		generatedTestCases = append(generatedTestCases, tc)
+	}
+	testCases = append(testCases, generatedTestCases...)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtl := gomock.NewController(t)
+			defer mockCtl.Finish()
+
+			mockMounter := NewMockMounter(mockCtl)
+			mockDeviceIdentifier := NewMockDeviceIdentifier(mockCtl)
+
+			nodeDriver := nodeService{
+				mounter:          mockMounter,
+				deviceIdentifier: mockDeviceIdentifier,
+				inFlight:         internal.NewInFlight(),
+			}
+
+			if tc.expectMock != nil {
+				tc.expectMock(*mockMounter, *mockDeviceIdentifier)
+			}
+
+			devicePath, err := nodeDriver.findDevicePath(tc.devicePath, tc.volumeID, tc.partition)
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.Equal(t, tc.expectDevicePath, devicePath)
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+type fakeFileInfo struct {
+	name string
+	mode os.FileMode
+}
+
+func (fi *fakeFileInfo) Name() string {
+	return fi.name
+}
+
+func (fi *fakeFileInfo) Size() int64 {
+	return 0
+}
+
+func (fi *fakeFileInfo) Mode() os.FileMode {
+	return fi.mode
+}
+
+func (fi *fakeFileInfo) ModTime() time.Time {
+	return time.Now()
+}
+
+func (fi *fakeFileInfo) IsDir() bool {
+	return false
+}
+
+func (fi *fakeFileInfo) Sys() interface{} {
+	return nil
+}
+
+func expectErr(t *testing.T, actualErr error, expectedCode codes.Code) {
+	if actualErr == nil {
+		t.Fatalf("Expect error but got no error")
+	}
+
+	status, ok := status.FromError(actualErr)
+	if !ok {
+		t.Fatalf("Failed to get error status code from error: %v", actualErr)
+	}
+
+	if status.Code() != expectedCode {
+		t.Fatalf("Expected error code %d, got %d message %s", codes.InvalidArgument, status.Code(), status.Message())
+	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This change adds NodeStage and NodeUnstage unit tests for the EBS CSI Driver and also incorporates CSI Driver tests into the agent `test` and `test-silent` make targets.

### Implementation details
The tests are modified from the [ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/02f1d73eda27571e4e8155d451308a9916de7f1a/pkg/driver/node_test.go) and reflect our current capabilities.  The cloud metadata was removed, as was testing for partitions and certain volume parameters including Inode configuration which are not supported for initial launch.

### Testing
Tested locally on an instance of the latest linux (AL2-based) ECS Optimized AMI.

New tests cover the changes: yes

### Description for the changelog
Add CSI Driver tests for NodeStage and NodeUnstage.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
