### PR TITLE
Add an integration test for EBS CSI Client's GetVolumeMetrics method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ analyze-cover-profile-init: coverprofile-init.out
 	./scripts/analyze-cover-profile coverprofile-init.out
 
 run-integ-tests: test-registry gremlin start-ebs-csi-driver container-health-check-image run-sudo-tests
-	ECS_LOGLEVEL=debug ${GOTEST} -tags integration -timeout=30m -v ./agent/... ./ecs-agent/...
+	ECS_LOGLEVEL=debug ${GOTEST} -tags integration -timeout=30m ./agent/... ./ecs-agent/...
 	$(MAKE) stop-ebs-csi-driver
 
 run-sudo-tests:

--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,9 @@ analyze-cover-profile: coverprofile.out coverprofile-ecs-agent.out
 analyze-cover-profile-init: coverprofile-init.out
 	./scripts/analyze-cover-profile coverprofile-init.out
 
-run-integ-tests: test-registry gremlin container-health-check-image run-sudo-tests
-	ECS_LOGLEVEL=debug ${GOTEST} -tags integration -timeout=30m ./agent/... ./ecs-agent/...
+run-integ-tests: test-registry gremlin start-ebs-csi-driver container-health-check-image run-sudo-tests
+	ECS_LOGLEVEL=debug ${GOTEST} -tags integration -timeout=30m -v ./agent/... ./ecs-agent/...
+	$(MAKE) stop-ebs-csi-driver
 
 run-sudo-tests:
 	sudo -E ${GOTEST} -tags sudo -timeout=10m ./agent/...
@@ -289,13 +290,27 @@ exec-command-agent-test:
 
 	@./scripts/setup-test-registry
 
-.PHONY: fluentd gremlin image-cleanup-test-images
+.PHONY: fluentd gremlin ebs-csi-driver start-ebs-csi-driver stop-ebs-csi-driver image-cleanup-test-images
 
 gremlin:
 	$(MAKE) -C misc/gremlin $(MFLAGS)
 
 fluentd:
 	$(MAKE) -C misc/fluentd $(MFLAGS)
+
+EBS_CSI_DRIVER_DIR=./ecs-agent/daemonimages/csidriver
+
+ebs-csi-driver:
+	$(MAKE) -C $(EBS_CSI_DRIVER_DIR) $(MFLAGS) bin/ebs-csi-driver
+
+# Starts EBS CSI Driver as a background process.
+# The driver uses /tmp/ebs-csi-driver.sock as the socket file.
+start-ebs-csi-driver: ebs-csi-driver
+	$(EBS_CSI_DRIVER_DIR)/bin/ebs-csi-driver --endpoint unix:///tmp/ebs-csi-driver.sock &
+
+# Stops EBS CSI Driver process started by start-ebs-csi-driver target.
+stop-ebs-csi-driver:
+	ps aux | grep $(EBS_CSI_DRIVER_DIR)/bin/ebs-csi-driver | grep -v grep | awk '{print $$2}' | xargs -L1 kill
 
 image-cleanup-test-images:
 	$(MAKE) -C misc/image-cleanup-test-images $(MFLAGS)
@@ -468,6 +483,7 @@ clean:
 	-rm -f .amazon-linux-rpm-integrated-done
 	-rm -f .generic-rpm-integrated-done
 	-rm -f amazon-ecs-volume-plugin
+	-rm -rf $(EBS_CSI_DRIVER_DIR)/bin
 
 clean-all: clean
 	# for our dockerfree builds, we likely don't have docker

--- a/ecs-agent/csiclient/csi_client_linux_integ_test.go
+++ b/ecs-agent/csiclient/csi_client_linux_integ_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const timeoutDuration = 5 * time.Second
+const timeoutDuration = 1 * time.Second
 
 // Tests that CSIClient can fetch EBS volume metrics from EBS CSI Driver.
 //

--- a/ecs-agent/csiclient/csi_client_linux_integ_test.go
+++ b/ecs-agent/csiclient/csi_client_linux_integ_test.go
@@ -48,8 +48,14 @@ func TestNodeVolumeStats(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, len(lsblkOut.BlockDevices) > 0)
 
-	// Get metrics for the root volume from EBS CSI Driver.
+	// There is no serial reported for EBS volumes on Xen devices.
+	// Skip the test for such instances.
 	volumeID := lsblkOut.BlockDevices[0].Serial
+	if volumeID == "" {
+		t.Skip("Test not supported on xen instances")
+	}
+
+	// Get metrics for the root volume from EBS CSI Driver.
 	csiClient := NewCSIClient("/tmp/ebs-csi-driver.sock")
 	getVolumeCtx, getVolumeCtxCancel := context.WithTimeout(context.Background(), timeoutDuration)
 	defer getVolumeCtxCancel()

--- a/ecs-agent/csiclient/csi_client_linux_integ_test.go
+++ b/ecs-agent/csiclient/csi_client_linux_integ_test.go
@@ -38,6 +38,12 @@ import (
 func TestNodeVolumeStats(t *testing.T) {
 	const timeoutDuration = 5 * time.Second
 
+	// Skip if lsblk command does not exist on the host
+	_, err := exec.LookPath("lsblk")
+	if err != nil {
+		t.Skip("lsblk command not found", err)
+	}
+
 	// Find the root volume using lsblk
 	lsblkCtx, lsblkCtxCancel := context.WithTimeout(context.Background(), timeoutDuration)
 	defer lsblkCtxCancel()

--- a/ecs-agent/csiclient/csi_client_linux_integ_test.go
+++ b/ecs-agent/csiclient/csi_client_linux_integ_test.go
@@ -52,11 +52,10 @@ func TestNodeVolumeStats(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, len(lsblkOut.BlockDevices) > 0)
 
-	// There is no serial reported for EBS volumes on Xen devices.
-	// Skip the test for such instances.
 	volumeID := lsblkOut.BlockDevices[0].Serial
 	if volumeID == "" {
-		t.Skip("Test not supported on xen instances")
+		// Driver doesn't actually care about the volume ID as long as it's not empty
+		volumeID = "unknown"
 	}
 
 	// Get metrics for the root volume from EBS CSI Driver.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add an integration test for `CSIClient`'s `GetVolumeMetrics` method. This method calls a CSI Driver (EBS in this case) to fetch volume metrics for a volume. The test expects a CSI Driver to be up and running. New make targets are added to start and stop EBS CSI Driver for testing. The test assumes that the host has a single EBS volume attached that is mounted at '/' path. 

### Implementation details
<!-- How are the changes implemented? -->
* Added `TestNodeVolumeStats` integration test that finds the volume ID of a single EBS volume on the host and then gets metrics for the volume using a `CSIClient`. It asserts that non-zero metrics are returned successfully. The test is skipped if `lsblk` version is older than 2.27 as those versions don't support JSON output format.
* Added some new make targets. 
   * `ebs-csi-driver`: builds EBS CSI Driver executable. 
   * `start-ebs-csi-driver`: starts an EBS CSI Driver process.
   * `stop-ecs-csi-driver`: stops running EBS CSI Driver processes.
* Updated the existing `run-integ-tests` target to make it start an EBS CSI Driver process before running the integration tests and stopping the driver process after the tests have finished. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Ran `make run-integ-tests` on an EC2 instance. EBS CSI Driver was successfully started and stopped by the make target. `TestNodeVolumeStats` passed. 

CI checks will also run the new test.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add integration test for `CSIClient`'s `GetvolumeMetrics` method.

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
