### PR TITLE
EBS CSI Log to file

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon/managed_daemon.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon/managed_daemon.go
@@ -134,7 +134,9 @@ func defaultImportAll() ([]*ManagedDaemon, error) {
 	}
 	var thisCommand []string
 	thisCommand = append(thisCommand, "--endpoint=unix://csi-driver/csi-driver.sock")
-	thisCommand = append(thisCommand, "--log_dir=/var/log")
+	thisCommand = append(thisCommand, "--log_file=/var/log/csi.log")
+	thisCommand = append(thisCommand, "--log_file_max_size=20")
+	thisCommand = append(thisCommand, "--logtostderr=false")
 	sysAdmin := "SYS_ADMIN"
 	addCapabilities := []*string{&sysAdmin}
 	kernelCapabilities := ecsacs.KernelCapabilities{Add: addCapabilities}

--- a/ecs-agent/manageddaemon/managed_daemon.go
+++ b/ecs-agent/manageddaemon/managed_daemon.go
@@ -134,7 +134,9 @@ func defaultImportAll() ([]*ManagedDaemon, error) {
 	}
 	var thisCommand []string
 	thisCommand = append(thisCommand, "--endpoint=unix://csi-driver/csi-driver.sock")
-	thisCommand = append(thisCommand, "--log_dir=/var/log")
+	thisCommand = append(thisCommand, "--log_file=/var/log/csi.log")
+	thisCommand = append(thisCommand, "--log_file_max_size=20")
+	thisCommand = append(thisCommand, "--logtostderr=false")
 	sysAdmin := "SYS_ADMIN"
 	addCapabilities := []*string{&sysAdmin}
 	kernelCapabilities := ecsacs.KernelCapabilities{Add: addCapabilities}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
The EBS CSI logs weren't showing up in the host.  This is due to a misconfiguration in the logging cli arguments passed to the container.

### Implementation details
The configuration required `--log_file=/var/log/csi.log` and `--logtostderr=false` as the [klog documentation recommends](
https://github.com/kubernetes/klog/blob/main/examples/log_file/usage_log_file.go#L12)

### Testing
Ran with latest CSI Driver image; built a new agent with this change.
I now see the CSI Driver container logs showing up in their expected host directory.
```
[ec2-user ebs-csi-driver]$ pwd
/var/log/ecs/daemons/ebs-csi-driver
[ec2-user ebs-csi-driver]$ ls
csi.log
[ec2-user ebs-csi-driver]$ cat csi.log
Log file created at: 2023/11/01 18:09:31
Running on machine: 
Binary: Built with gc go1.20.10 for linux/amd64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
I1101 18:09:31.455041       1 driver.go:45] "Driver Information" Driver="csi-driver" Version="v1.0.0"
I1101 18:09:31.639455       1 node_linux.go:55] "Device Path:" Driver="/dev/nvme2n1" VolumeID="vol-0a9c635c74e3da29d" Partition=""
I1101 18:09:31.639471       1 node_linux.go:69] "Device Path:" Driver="/dev/nvme2n1" VolumeID="vol-0a9c635c74e3da29d" Partition=""
I1101 18:09:31.639503       1 node.go:161] "NodeStageVolume: path exists:" exists=false
I1101 18:09:31.639511       1 node.go:172] "NodeStageVolume: creating target dir" target="/mnt/ecs/ebs/ca4e2f08a78e43f698bef10faa5be302_vol-0a9c635c74e3da29d"
...
```

New tests cover the changes: no

### Description for the changelog
Bugfix to log EBS CSI to a file.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
