### PR TITLE
Implement task/container state change metadata getters in agent

### DIFF
--- a/agent/api/metadata_getter.go
+++ b/agent/api/metadata_getter.go
@@ -1,0 +1,90 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package api
+
+import (
+	"time"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+)
+
+// Implementation of the ContainerStateChange ContainerMetadataGetter Interface.
+type containerMetadataGetter struct {
+	container *apicontainer.Container
+}
+
+func NewContainerMetadataGetter(container *apicontainer.Container) *containerMetadataGetter {
+	return &containerMetadataGetter{
+		container: container,
+	}
+}
+
+// GetContainerIsNil returns the existence of the container.
+func (cmg *containerMetadataGetter) GetContainerIsNil() bool {
+	return cmg.container == nil
+}
+
+// GetContainerSentStatusString returns the last unsafe status sent to
+// the ECS SubmitContainerStateChange API.
+func (cmg *containerMetadataGetter) GetContainerSentStatusString() string {
+	return cmg.container.GetSentStatus().String()
+}
+
+// GetContainerRuntimeID returns the Docker ID of the container.
+func (cmg *containerMetadataGetter) GetContainerRuntimeID() string {
+	return cmg.container.GetRuntimeID()
+}
+
+// GetContainerIsEssential returns whether the container is essential
+// or not.
+func (cmg *containerMetadataGetter) GetContainerIsEssential() bool {
+	return cmg.container.IsEssential()
+}
+
+// Implementation of the TaskStateChange TaskMetadataGetter Interface.
+type taskMetadataGetter struct {
+	task *apitask.Task
+}
+
+func NewTaskMetadataGetter(task *apitask.Task) *taskMetadataGetter {
+	return &taskMetadataGetter{
+		task: task,
+	}
+}
+
+// GetTaskIsNil returns whether the task exists or not.
+func (tmg *taskMetadataGetter) GetTaskIsNil() bool {
+	return tmg.task == nil
+}
+
+// GetTaskSentStatusString returns the SentStatus of the task.
+func (tmg *taskMetadataGetter) GetTaskSentStatusString() string {
+	return tmg.task.GetSentStatus().String()
+}
+
+// GetTaskPullStartedAt returns the pull started at time of the task.
+func (tmg *taskMetadataGetter) GetTaskPullStartedAt() time.Time {
+	return tmg.task.GetPullStartedAt()
+}
+
+// GetTaskPullStartedAt returns the pull stopped at time of the task.
+func (tmg *taskMetadataGetter) GetTaskPullStoppedAt() time.Time {
+	return tmg.task.GetPullStoppedAt()
+}
+
+// GetTaskPullStartedAt returns the execution stopped at time of the task.
+func (tmg *taskMetadataGetter) GetTaskExecutionStoppedAt() time.Time {
+	return tmg.task.GetExecutionStoppedAt()
+}

--- a/agent/api/metadata_getter_test.go
+++ b/agent/api/metadata_getter_test.go
@@ -1,0 +1,81 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package api
+
+import (
+	"testing"
+	"time"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs"
+	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTaskStateChangeMetadataGetter validates the data stored in
+// TaskMetadataGetter to check its implementation. The Getter should
+// fetch this data from the task reference, not the state change itself.
+func TestTaskStateChangeMetadataGetter(t *testing.T) {
+	taskArn := "arn:123"
+	t1 := time.Now()
+	t2 := t1.Add(1)
+	t3 := t2.Add(1)
+	task := &apitask.Task{
+		Arn:                      taskArn,
+		SentStatusUnsafe:         apitaskstatus.TaskRunning,
+		PullStartedAtUnsafe:      t1,
+		PullStoppedAtUnsafe:      t2,
+		ExecutionStoppedAtUnsafe: t3,
+	}
+
+	metadataGetter := NewTaskMetadataGetter(task)
+
+	change := &ecs.TaskStateChange{
+		MetadataGetter: metadataGetter,
+	}
+
+	assert.NotNil(t, change.MetadataGetter)
+	assert.Equal(t, false, change.MetadataGetter.GetTaskIsNil())
+	assert.Equal(t, apitaskstatus.TaskRunningString, change.MetadataGetter.GetTaskSentStatusString())
+	assert.Equal(t, t1, change.MetadataGetter.GetTaskPullStartedAt())
+	assert.Equal(t, t2, change.MetadataGetter.GetTaskPullStoppedAt())
+	assert.Equal(t, t3, change.MetadataGetter.GetTaskExecutionStoppedAt())
+}
+
+// TestContainerStateChangeMetadataGetter validates the data stored in
+// ContainerMetadataGetter to check its implementation. The Getter should
+// fetch this data from the container reference, not the state change itself.
+func TestContainerStateChangeMetadataGetter(t *testing.T) {
+	dockerID := "dockerID"
+	container := &apicontainer.Container{
+		RuntimeID:        dockerID,
+		Essential:        true,
+		SentStatusUnsafe: apicontainerstatus.ContainerRunning,
+	}
+
+	metadataGetter := NewContainerMetadataGetter(container)
+
+	change := &ecs.ContainerStateChange{
+		MetadataGetter: metadataGetter,
+	}
+
+	assert.NotNil(t, change.MetadataGetter)
+	assert.Equal(t, false, change.MetadataGetter.GetContainerIsNil())
+	assert.Equal(t, apicontainerstatus.ContainerRunning.String(), change.MetadataGetter.GetContainerSentStatusString())
+	assert.Equal(t, dockerID, change.MetadataGetter.GetContainerRuntimeID())
+	assert.Equal(t, true, change.MetadataGetter.GetContainerIsEssential())
+}

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -26,9 +26,9 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
-	"github.com/pkg/errors"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/pkg/errors"
 )
 
 // ContainerStateChange represents a state change that needs to be sent to the


### PR DESCRIPTION
### Summary
This change implements two interfaces that were previously defined in this PR [#3943] and adds a unit test for each. These structs will be necessary for unified FE work later on, allowing the agent to pass this agnostic interface but access a proprietary container / task model.

### Implementation details
- `ContainerMetadataGetter` and `TaskMetadataGetter` interfaces are implemented as private structs in the `/agent/api` module. There is a public constructor and getter methods for each field of the struct.
- `TestTaskStateChangeMetadataGetter` and `TestContainerStateChangeMetadataGetter` create instances of these respective structs and validate that they return the correct values.

### Testing
In addition to two new passing tests, `make test` and `make run-integ-tests`

New tests cover the changes: yes

### Description for the changelog

 Implement task/container state change metadata getters in agent

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
