### PR TITLE
Decouple ENI in ecs-agent/ AttachmentStateChange

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/statechange.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/statechange.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/model/ecs"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
@@ -96,8 +97,8 @@ type TaskStateChange struct {
 // AttachmentStateChange represents a state change that needs to be sent to the
 // SubmitAttachmentStateChanges API.
 type AttachmentStateChange struct {
-	// Attachment is the ENI attachment object to send.
-	Attachment *ni.ENIAttachment
+	// Attachment is the attachment object to send.
+	Attachment attachment.Attachment
 }
 
 // String returns a human readable string representation of a ContainerStateChange.
@@ -146,8 +147,8 @@ func (change *TaskStateChange) String() string {
 // String returns a human readable string representation of an AttachmentStateChange.
 func (change *AttachmentStateChange) String() string {
 	if change.Attachment != nil {
-		return fmt.Sprintf("%s -> %s, %s", change.Attachment.AttachmentARN, change.Attachment.Status.String(),
-			change.Attachment.String())
+		return fmt.Sprintf("%s -> %v, %s", change.Attachment.GetAttachmentARN(),
+			change.Attachment.GetAttachmentStatus(), change.Attachment.String())
 	}
 
 	return ""

--- a/ecs-agent/api/ecs/statechange.go
+++ b/ecs-agent/api/ecs/statechange.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/model/ecs"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
@@ -96,8 +97,8 @@ type TaskStateChange struct {
 // AttachmentStateChange represents a state change that needs to be sent to the
 // SubmitAttachmentStateChanges API.
 type AttachmentStateChange struct {
-	// Attachment is the ENI attachment object to send.
-	Attachment *ni.ENIAttachment
+	// Attachment is the attachment object to send.
+	Attachment attachment.Attachment
 }
 
 // String returns a human readable string representation of a ContainerStateChange.
@@ -146,8 +147,8 @@ func (change *TaskStateChange) String() string {
 // String returns a human readable string representation of an AttachmentStateChange.
 func (change *AttachmentStateChange) String() string {
 	if change.Attachment != nil {
-		return fmt.Sprintf("%s -> %s, %s", change.Attachment.AttachmentARN, change.Attachment.Status.String(),
-			change.Attachment.String())
+		return fmt.Sprintf("%s -> %v, %s", change.Attachment.GetAttachmentARN(),
+			change.Attachment.GetAttachmentStatus(), change.Attachment.String())
 	}
 
 	return ""

--- a/ecs-agent/api/ecs/statechange_test.go
+++ b/ecs-agent/api/ecs/statechange_test.go
@@ -157,8 +157,8 @@ func TestAttachmentStateChangeString(t *testing.T) {
 		},
 	}
 
-	expectedStr := fmt.Sprintf("%s -> %s, %s", change.Attachment.AttachmentARN,
-		change.Attachment.Status.String(), change.Attachment.String())
+	expectedStr := fmt.Sprintf("%s -> %v, %s", change.Attachment.GetAttachmentARN(),
+		change.Attachment.GetAttachmentStatus(), change.Attachment.String())
 
 	assert.Equal(t, expectedStr, change.String())
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update AttachmentStateChange in ecs-agent module to take into account the ENI decoupling from https://github.com/aws/amazon-ecs-agent/pull/3969 (since that pull request did not update the AttachmentStateChange type that was added to ecs-agent module as part of https://github.com/aws/amazon-ecs-agent/pull/3943).

### Implementation details
<!-- How are the changes implemented? -->
Same as summary.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit, integration, and functional tests.

New tests cover the changes: no, but existing test modified

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Decouple ENI in ecs-agent/ AttachmentStateChange

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
