### PR TITLE
Add ECS client to ecs-agent module

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/httpclient/httpclient.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/httpclient/httpclient.go
@@ -29,9 +29,9 @@ import (
 // Below constants taken from the default http.Client behavior.
 // Ref: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/custom-http.html
 const (
-	defaultDialTimeout         = 30 * time.Second
-	defaultDialKeepalive       = 30 * time.Second
-	defaultTLSHandshakeTimeout = 10 * time.Second
+	DefaultDialTimeout         = 30 * time.Second
+	DefaultDialKeepalive       = 30 * time.Second
+	DefaultTLSHandshakeTimeout = 10 * time.Second
 )
 
 //go:generate mockgen -destination=mock/$GOFILE -copyright_file=../../scripts/copyright_file net/http RoundTripper
@@ -66,10 +66,10 @@ func New(timeout time.Duration, insecureSkipVerify bool, agentVersion string, os
 	transport := &http.Transport{
 		Proxy: httpproxy.Proxy,
 		DialContext: (&net.Dialer{
-			Timeout:   defaultDialTimeout,
-			KeepAlive: defaultDialKeepalive,
+			Timeout:   DefaultDialTimeout,
+			KeepAlive: DefaultDialKeepalive,
 		}).DialContext,
-		TLSHandshakeTimeout: defaultTLSHandshakeTimeout,
+		TLSHandshakeTimeout: DefaultTLSHandshakeTimeout,
 	}
 	transport.TLSClientConfig = &tls.Config{}
 	cipher.WithSupportedCipherSuites(transport.TLSClientConfig)

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
@@ -55,4 +55,10 @@ const (
 	MessageID               = "messageID"
 	RequestType             = "requestType"
 	CredentialsID           = "credentialsID"
+	ContainerInstanceARN    = "containerInstanceARN"
+	AttributeName           = "attributeName"
+	AttributeValue          = "attributeValue"
+	Endpoint                = "endpoint"
+	TelemetryEndpoint       = "telemetryEndpoint"
+	ServiceConnectEndpoint  = "serviceConnectEndpoint"
 )

--- a/ecs-agent/api/ecs/client/ecs_client.go
+++ b/ecs-agent/api/ecs/client/ecs_client.go
@@ -1,0 +1,801 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ecsclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"runtime"
+	"strings"
+	"time"
+
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs"
+	ecsmodel "github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/model/ecs"
+	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/async"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/config"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials/instancecreds"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/httpclient"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/docker/docker/pkg/meminfo"
+)
+
+const (
+	ecsMaxImageDigestLength     = 255
+	ecsMaxContainerReasonLength = 255
+	ecsMaxTaskReasonLength      = 1024
+	ecsMaxRuntimeIDLength       = 255
+	defaultPollEndpointCacheTTL = 12 * time.Hour
+	azAttrName                  = "ecs.availability-zone"
+	cpuArchAttrName             = "ecs.cpu-architecture"
+	osTypeAttrName              = "ecs.os-type"
+	osFamilyAttrName            = "ecs.os-family"
+	// RoundtripTimeout should only time out after dial and TLS handshake timeouts have elapsed.
+	// Add additional 2 seconds to the sum of these 2 timeouts to be extra sure of this.
+	RoundtripTimeout = httpclient.DefaultDialTimeout + httpclient.DefaultTLSHandshakeTimeout + 2*time.Second
+	// Below constants are used for SetInstanceIdentity retry with exponential backoff.
+	setInstanceIdRetryTimeOut         = 30 * time.Second
+	setInstanceIdRetryBackoffMin      = 100 * time.Millisecond
+	setInstanceIdRetryBackoffMax      = 5 * time.Second
+	setInstanceIdRetryBackoffJitter   = 0.2
+	setInstanceIdRetryBackoffMultiple = 2
+)
+
+// ecsClient implements ECSClient interface.
+type ecsClient struct {
+	credentialsProvider              *credentials.Credentials
+	configAccessor                   config.AgentConfigAccessor
+	standardClient                   ecs.ECSStandardSDK
+	submitStateChangeClient          ecs.ECSSubmitStateSDK
+	ec2metadata                      ec2.EC2MetadataClient
+	httpClient                       *http.Client
+	pollEndpointCache                async.TTLCache
+	isFIPSDetected                   bool
+	shouldExcludeIPv6PortBinding     bool
+	sascCustomRetryBackoff           func(func() error) error
+	stscAttachmentCustomRetryBackoff func(func() error) error
+}
+
+// NewECSClient creates a new ECSClient interface object.
+func NewECSClient(
+	credentialsProvider *credentials.Credentials,
+	configAccessor config.AgentConfigAccessor,
+	ec2MetadataClient ec2.EC2MetadataClient,
+	agentVer string,
+	options ...ECSClientOption) (ecs.ECSClient, error) {
+
+	client := &ecsClient{
+		credentialsProvider: credentialsProvider,
+		configAccessor:      configAccessor,
+		ec2metadata:         ec2MetadataClient,
+		httpClient:          httpclient.New(RoundtripTimeout, configAccessor.AcceptInsecureCert(), agentVer, configAccessor.OSType()),
+		pollEndpointCache:   async.NewTTLCache(&async.TTL{Duration: defaultPollEndpointCacheTTL}),
+	}
+
+	// Apply options to configure/override ECS client values.
+	for _, opt := range options {
+		opt(client)
+	}
+
+	ecsConfig := newECSConfig(credentialsProvider, configAccessor, client.httpClient, client.isFIPSDetected)
+	s, err := session.NewSession(&ecsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if client.standardClient == nil {
+		client.standardClient = ecsmodel.New(s)
+	}
+	if client.submitStateChangeClient == nil {
+		client.submitStateChangeClient = newSubmitStateChangeClient(&ecsConfig)
+	}
+
+	return client, nil
+}
+
+func newECSConfig(
+	credentialsProvider *credentials.Credentials,
+	configAccessor config.AgentConfigAccessor,
+	httpClient *http.Client,
+	isFIPSEnabled bool) aws.Config {
+	var ecsConfig aws.Config
+	ecsConfig.HTTPClient = httpClient
+	ecsConfig.Credentials = credentialsProvider
+	ecsConfig.Region = aws.String(configAccessor.AWSRegion())
+	// We should respect the endpoint given (if any) because it could be the Gamma or Zeta endpoint of ECS service which
+	// don't have the corresponding FIPS endpoints. Otherwise, when the host has FIPS enabled, we should tell SDK to
+	// pick the FIPS endpoint.
+	if configAccessor.APIEndpoint() != "" {
+		ecsConfig.Endpoint = aws.String(configAccessor.APIEndpoint())
+	} else if isFIPSEnabled {
+		ecsConfig.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+	}
+	return ecsConfig
+}
+
+// CreateCluster creates a cluster from a given name and returns its ARN.
+func (client *ecsClient) CreateCluster(clusterName string) (string, error) {
+	resp, err := client.standardClient.CreateCluster(&ecsmodel.CreateClusterInput{ClusterName: &clusterName})
+	if err != nil {
+		logger.Critical("Could not create cluster", logger.Fields{
+			field.Cluster: clusterName,
+			field.Error:   err,
+		})
+		return "", err
+	}
+	logger.Info("Successfully created a cluster", logger.Fields{
+		field.Cluster: clusterName,
+	})
+	return *resp.Cluster.ClusterName, nil
+}
+
+// RegisterContainerInstance calculates the appropriate resources, creates
+// the default cluster if necessary, and returns the registered
+// ContainerInstanceARN if successful. Supplying a non-empty container
+// instance ARN allows a container instance to update its registered
+// resources.
+func (client *ecsClient) RegisterContainerInstance(containerInstanceArn string, attributes []*ecsmodel.Attribute,
+	tags []*ecsmodel.Tag, registrationToken string, platformDevices []*ecsmodel.PlatformDevice,
+	outpostARN string) (string, string, error) {
+
+	clusterRef := client.configAccessor.Cluster()
+	// If our clusterRef is empty, we should try to create the default.
+	if clusterRef == "" {
+		clusterRef = client.configAccessor.DefaultClusterName()
+		defer client.configAccessor.UpdateCluster(clusterRef)
+		// Attempt to register without checking existence of the cluster so that we don't require
+		// excess permissions in the case where the cluster already exists and is active.
+		containerInstanceArn, availabilityzone, err := client.registerContainerInstance(clusterRef,
+			containerInstanceArn, attributes, tags, registrationToken, platformDevices, outpostARN)
+		if err == nil {
+			return containerInstanceArn, availabilityzone, nil
+		}
+
+		// If trying to register fails because the default cluster doesn't exist, try to create the cluster before
+		// calling register again.
+		if apierrors.IsClusterNotFoundError(err) {
+			clusterRef, err = client.CreateCluster(clusterRef)
+			if err != nil {
+				return "", "", err
+			}
+		}
+	}
+	return client.registerContainerInstance(clusterRef, containerInstanceArn, attributes, tags, registrationToken,
+		platformDevices, outpostARN)
+}
+
+func (client *ecsClient) registerContainerInstance(clusterRef string, containerInstanceArn string,
+	attributes []*ecsmodel.Attribute, tags []*ecsmodel.Tag, registrationToken string,
+	platformDevices []*ecsmodel.PlatformDevice, outpostARN string) (string, string, error) {
+
+	registerRequest := ecsmodel.RegisterContainerInstanceInput{Cluster: &clusterRef}
+	var registrationAttributes []*ecsmodel.Attribute
+	if containerInstanceArn != "" {
+		// We are re-connecting a previously registered instance, restored from snapshot.
+		registerRequest.ContainerInstanceArn = &containerInstanceArn
+	} else {
+		// This is a new instance, not previously registered.
+		// Custom attribute registration only happens on initial instance registration.
+		for _, attribute := range client.getCustomAttributes() {
+			logger.Debug("Added a new custom attribute", logger.Fields{
+				field.AttributeName:  aws.StringValue(attribute.Name),
+				field.AttributeValue: aws.StringValue(attribute.Value),
+			})
+			registrationAttributes = append(registrationAttributes, attribute)
+		}
+	}
+	// Standard attributes are included with all registrations.
+	registrationAttributes = append(registrationAttributes, attributes...)
+
+	// Add additional attributes, such as the OS type.
+	registrationAttributes = append(registrationAttributes, client.getAdditionalAttributes()...)
+	registrationAttributes = append(registrationAttributes, client.getOutpostAttribute(outpostARN)...)
+
+	registerRequest.Attributes = registrationAttributes
+	if len(tags) > 0 {
+		registerRequest.Tags = tags
+	}
+	registerRequest.PlatformDevices = platformDevices
+	registerRequest = client.setInstanceIdentity(registerRequest)
+
+	resources, err := client.getResources()
+	if err != nil {
+		return "", "", err
+	}
+
+	registerRequest.TotalResources = resources
+
+	registerRequest.ClientToken = &registrationToken
+	resp, err := client.standardClient.RegisterContainerInstance(&registerRequest)
+	if err != nil {
+		logger.Error("Unable to register as a container instance with ECS", logger.Fields{
+			field.Error: err,
+		})
+		return "", "", err
+	}
+
+	var availabilityzone = ""
+	if resp != nil {
+		for _, attr := range resp.ContainerInstance.Attributes {
+			if aws.StringValue(attr.Name) == azAttrName {
+				availabilityzone = aws.StringValue(attr.Value)
+				break
+			}
+		}
+	}
+
+	logger.Info("Registered container instance with cluster!")
+	err = validateRegisteredAttributes(registerRequest.Attributes, resp.ContainerInstance.Attributes)
+	return aws.StringValue(resp.ContainerInstance.ContainerInstanceArn), availabilityzone, err
+}
+
+func (client *ecsClient) setInstanceIdentity(
+	registerRequest ecsmodel.RegisterContainerInstanceInput) ecsmodel.RegisterContainerInstanceInput {
+	instanceIdentityDoc := ""
+	instanceIdentitySignature := ""
+
+	if client.configAccessor.NoInstanceIdentityDocument() {
+		logger.Info("Fetching Instance ID Document has been disabled")
+		registerRequest.InstanceIdentityDocument = &instanceIdentityDoc
+		registerRequest.InstanceIdentityDocumentSignature = &instanceIdentitySignature
+		return registerRequest
+	}
+
+	iidRetrieved := true
+	backoff := retry.NewExponentialBackoff(setInstanceIdRetryBackoffMin, setInstanceIdRetryBackoffMax,
+		setInstanceIdRetryBackoffJitter, setInstanceIdRetryBackoffMultiple)
+	ctx, cancel := context.WithTimeout(context.Background(), setInstanceIdRetryTimeOut)
+	defer cancel()
+	err := retry.RetryWithBackoffCtx(ctx, backoff, func() error {
+		var attemptErr error
+		logger.Debug("Attempting to get Instance Identity Document")
+		instanceIdentityDoc, attemptErr = client.ec2metadata.GetDynamicData(ec2.InstanceIdentityDocumentResource)
+		if attemptErr != nil {
+			logger.Debug("Unable to get instance identity document, retrying", logger.Fields{
+				field.Error: attemptErr,
+			})
+			// Force credentials to expire in case they are stale but not expired.
+			client.credentialsProvider.Expire()
+			client.credentialsProvider = instancecreds.GetCredentials(client.configAccessor.External())
+			return apierrors.NewRetriableError(apierrors.NewRetriable(true), attemptErr)
+		}
+		logger.Debug("Successfully retrieved Instance Identity Document")
+		return nil
+	})
+	if err != nil {
+		logger.Error("Unable to get instance identity document", logger.Fields{
+			field.Error: err,
+		})
+		iidRetrieved = false
+	}
+	registerRequest.InstanceIdentityDocument = &instanceIdentityDoc
+
+	if iidRetrieved {
+		instanceIdentitySignature, err = client.ec2metadata.
+			GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource)
+		if err != nil {
+			logger.Error("Unable to get instance identity signature", logger.Fields{
+				field.Error: err,
+			})
+		}
+	}
+
+	registerRequest.InstanceIdentityDocumentSignature = &instanceIdentitySignature
+	return registerRequest
+}
+
+func attributesToMap(attributes []*ecsmodel.Attribute) map[string]string {
+	attributeMap := make(map[string]string)
+	attribs := attributes
+	for _, attribute := range attribs {
+		attributeMap[aws.StringValue(attribute.Name)] = aws.StringValue(attribute.Value)
+	}
+	return attributeMap
+}
+
+func findMissingAttributes(expectedAttributes, actualAttributes map[string]string) ([]string, error) {
+	missingAttributes := make([]string, 0)
+	var err error
+	for key, val := range expectedAttributes {
+		if actualAttributes[key] != val {
+			missingAttributes = append(missingAttributes, key)
+		} else {
+			logger.Trace("Response contained expected value for attribute", logger.Fields{
+				"key": key,
+			})
+		}
+	}
+	if len(missingAttributes) > 0 {
+		err = apierrors.NewAttributeError("Attribute validation failed")
+	}
+	return missingAttributes, err
+}
+
+func (client *ecsClient) getResources() ([]*ecsmodel.Resource, error) {
+	// Below are micro-optimizations - the pointers to integerStr and stringSetStr are used multiple times below.
+	integerStr := "INTEGER"
+	stringSetStr := "STRINGSET"
+
+	cpu, mem := getCpuAndMemory()
+	remainingMem := mem - int64(client.configAccessor.ReservedMemory())
+	logger.Info("Remaining memory", logger.Fields{
+		"remainingMemory": remainingMem,
+	})
+	if remainingMem < 0 {
+		return nil, fmt.Errorf(
+			"api register-container-instance: reserved memory is higher than available memory on the host, "+
+				"total memory: %d, reserved: %d", mem, client.configAccessor.ReservedMemory())
+	}
+
+	cpuResource := ecsmodel.Resource{
+		Name:         aws.String("CPU"),
+		Type:         &integerStr,
+		IntegerValue: &cpu,
+	}
+	memResource := ecsmodel.Resource{
+		Name:         aws.String("MEMORY"),
+		Type:         &integerStr,
+		IntegerValue: &remainingMem,
+	}
+	portResource := ecsmodel.Resource{
+		Name:           aws.String("PORTS"),
+		Type:           &stringSetStr,
+		StringSetValue: utils.Uint16SliceToStringSlice(client.configAccessor.ReservedPorts()),
+	}
+	udpPortResource := ecsmodel.Resource{
+		Name:           aws.String("PORTS_UDP"),
+		Type:           &stringSetStr,
+		StringSetValue: utils.Uint16SliceToStringSlice(client.configAccessor.ReservedPortsUDP()),
+	}
+
+	return []*ecsmodel.Resource{&cpuResource, &memResource, &portResource, &udpPortResource}, nil
+}
+
+// GetHostResources calling getHostResources to get a list of CPU, MEMORY, PORTS and PORTS_UPD resources
+// and return a resourceMap that map the resource name to each resource
+func (client *ecsClient) GetHostResources() (map[string]*ecsmodel.Resource, error) {
+	resources, err := client.getResources()
+	if err != nil {
+		return nil, err
+	}
+	resourceMap := make(map[string]*ecsmodel.Resource)
+	for _, resource := range resources {
+		if *resource.Name == "PORTS" {
+			// Except for RCI, TCP Ports are named as PORTS_TCP in Agent for Host Resources purpose.
+			resource.Name = aws.String("PORTS_TCP")
+		}
+		resourceMap[*resource.Name] = resource
+	}
+	return resourceMap, nil
+}
+
+func getCpuAndMemory() (int64, int64) {
+	memInfo, err := meminfo.Read()
+	mem := int64(0)
+	if err == nil {
+		mem = memInfo.MemTotal / 1024 / 1024 // MiB
+	} else {
+		logger.Error("Unable to get memory info", logger.Fields{
+			field.Error: err,
+		})
+	}
+
+	cpu := runtime.NumCPU() * 1024
+
+	return int64(cpu), mem
+}
+
+func validateRegisteredAttributes(expectedAttributes, actualAttributes []*ecsmodel.Attribute) error {
+	var err error
+	expectedAttributesMap := attributesToMap(expectedAttributes)
+	actualAttributesMap := attributesToMap(actualAttributes)
+	missingAttributes, err := findMissingAttributes(expectedAttributesMap, actualAttributesMap)
+	if err != nil {
+		msg := strings.Join(missingAttributes, ",")
+		logger.Error("Error registering attributes", logger.Fields{
+			field.Error:         err,
+			"missingAttributes": msg,
+		})
+	}
+	return err
+}
+
+func (client *ecsClient) getAdditionalAttributes() []*ecsmodel.Attribute {
+	attrs := []*ecsmodel.Attribute{
+		{
+			Name:  aws.String(osTypeAttrName),
+			Value: aws.String(client.configAccessor.OSType()),
+		},
+		{
+			Name:  aws.String(osFamilyAttrName),
+			Value: aws.String(client.configAccessor.OSFamily()),
+		},
+	}
+	// Send CPU arch attribute directly when running on external capacity. When running on EC2 or Fargate launch type,
+	// this is not needed since the CPU arch is reported via instance identity document in those cases.
+	if client.configAccessor.External() {
+		attrs = append(attrs, &ecsmodel.Attribute{
+			Name:  aws.String(cpuArchAttrName),
+			Value: aws.String(getCPUArch()),
+		})
+	}
+	return attrs
+}
+
+func (client *ecsClient) getOutpostAttribute(outpostARN string) []*ecsmodel.Attribute {
+	if len(outpostARN) > 0 {
+		return []*ecsmodel.Attribute{
+			{
+				Name:  aws.String("ecs.outpost-arn"),
+				Value: aws.String(outpostARN),
+			},
+		}
+	}
+	return []*ecsmodel.Attribute{}
+}
+
+func (client *ecsClient) getCustomAttributes() []*ecsmodel.Attribute {
+	var attributes []*ecsmodel.Attribute
+	for attribute, value := range client.configAccessor.InstanceAttributes() {
+		attributes = append(attributes, &ecsmodel.Attribute{
+			Name:  aws.String(attribute),
+			Value: aws.String(value),
+		})
+	}
+	return attributes
+}
+
+func (client *ecsClient) SubmitTaskStateChange(change ecs.TaskStateChange) error {
+	if change.Attachment != nil && client.stscAttachmentCustomRetryBackoff != nil {
+		retryFunc := func() error {
+			err := client.submitTaskStateChange(change)
+			if err == nil {
+				return nil
+			}
+			return submitStateCustomRetriableError(err)
+		}
+		return client.stscAttachmentCustomRetryBackoff(retryFunc)
+	}
+	return client.submitTaskStateChange(change)
+}
+
+func (client *ecsClient) submitTaskStateChange(change ecs.TaskStateChange) error {
+	if change.Attachment != nil {
+		// Confirm attachment by submitting attachment state change via SubmitTaskStateChange API (specifically in
+		// the input's Attachments field).
+		var attachments []*ecsmodel.AttachmentStateChange
+		eniStatus := change.Attachment.Status.String()
+		attachments = []*ecsmodel.AttachmentStateChange{
+			{
+				AttachmentArn: aws.String(change.Attachment.AttachmentARN),
+				Status:        aws.String(eniStatus),
+			},
+		}
+
+		_, err := client.submitStateChangeClient.SubmitTaskStateChange(&ecsmodel.SubmitTaskStateChangeInput{
+			Cluster:     aws.String(client.configAccessor.Cluster()),
+			Task:        aws.String(change.TaskARN),
+			Attachments: attachments,
+		})
+		if err != nil {
+			logger.Warn("Could not submit task state change associated with confirming attachment",
+				logger.Fields{
+					field.Error:     err,
+					"attachmentARN": change.Attachment.AttachmentARN,
+					field.Status:    eniStatus,
+				})
+			return err
+		}
+
+		return nil
+	}
+
+	req := ecsmodel.SubmitTaskStateChangeInput{
+		Cluster:            aws.String(client.configAccessor.Cluster()),
+		Task:               aws.String(change.TaskARN),
+		Status:             aws.String(change.Status.BackendStatus()),
+		Reason:             aws.String(trimString(change.Reason, ecsMaxTaskReasonLength)),
+		PullStartedAt:      change.PullStartedAt,
+		PullStoppedAt:      change.PullStoppedAt,
+		ExecutionStoppedAt: change.ExecutionStoppedAt,
+		ManagedAgents:      change.ManagedAgents,
+		Containers:         formatContainers(change.Containers, client.shouldExcludeIPv6PortBinding, change.TaskARN),
+	}
+
+	_, err := client.submitStateChangeClient.SubmitTaskStateChange(&req)
+	if err != nil {
+		logger.Warn("Could not submit task state change", logger.Fields{
+			field.Error:       err,
+			"taskStateChange": change.String(),
+		})
+		return err
+	}
+
+	return nil
+}
+
+func (client *ecsClient) SubmitContainerStateChange(change ecs.ContainerStateChange) error {
+	input := ecsmodel.SubmitContainerStateChangeInput{
+		Cluster:       aws.String(client.configAccessor.Cluster()),
+		ContainerName: aws.String(change.ContainerName),
+		Task:          aws.String(change.TaskArn),
+	}
+
+	if change.RuntimeID != "" {
+		input.RuntimeId = aws.String(trimString(change.RuntimeID, ecsMaxRuntimeIDLength))
+	}
+
+	if change.Reason != "" {
+		input.Reason = aws.String(trimString(change.Reason, ecsMaxContainerReasonLength))
+	}
+
+	stat := change.Status.String()
+	if stat == "DEAD" {
+		stat = apicontainerstatus.ContainerStopped.String()
+	}
+	if stat != apicontainerstatus.ContainerStopped.String() && stat != apicontainerstatus.ContainerRunning.String() {
+		logger.Info("Not submitting unsupported upstream container state", logger.Fields{
+			field.ContainerName: change.ContainerName,
+			field.Status:        stat,
+			field.TaskARN:       change.TaskArn,
+		})
+		return nil
+	}
+	input.Status = aws.String(stat)
+
+	if change.ExitCode != nil {
+		exitCode := int64(aws.IntValue(change.ExitCode))
+		input.ExitCode = aws.Int64(exitCode)
+	}
+
+	networkBindings := change.NetworkBindings
+	if client.shouldExcludeIPv6PortBinding {
+		networkBindings = excludeIPv6PortBindingFromNetworkBindings(networkBindings, change.ContainerName,
+			change.TaskArn)
+	}
+	input.NetworkBindings = networkBindings
+
+	_, err := client.submitStateChangeClient.SubmitContainerStateChange(&input)
+	if err != nil {
+		logger.Warn("Could not submit container state change", logger.Fields{
+			field.Error:            err,
+			field.TaskARN:          change.TaskArn,
+			"containerStateChange": change.String(),
+		})
+		return err
+	}
+	return nil
+}
+
+func (client *ecsClient) SubmitAttachmentStateChange(change ecs.AttachmentStateChange) error {
+	if client.sascCustomRetryBackoff != nil {
+		retryFunc := func() error {
+			err := client.submitAttachmentStateChange(change)
+			if err == nil {
+				return nil
+			}
+			return submitStateCustomRetriableError(err)
+		}
+		return client.sascCustomRetryBackoff(retryFunc)
+	}
+	return client.submitAttachmentStateChange(change)
+}
+
+func (client *ecsClient) submitAttachmentStateChange(change ecs.AttachmentStateChange) error {
+	attachmentStatus := change.Attachment.GetAttachmentStatus()
+
+	req := ecsmodel.SubmitAttachmentStateChangesInput{
+		Cluster: aws.String(client.configAccessor.Cluster()),
+		Attachments: []*ecsmodel.AttachmentStateChange{
+			{
+				AttachmentArn: aws.String(change.Attachment.GetAttachmentARN()),
+				Status:        aws.String(attachmentStatus.String()),
+			},
+		},
+	}
+
+	_, err := client.submitStateChangeClient.SubmitAttachmentStateChanges(&req)
+	if err != nil {
+		logger.Warn("Could not submit attachment state change", logger.Fields{
+			field.Error:             err,
+			"attachmentStateChange": change.String(),
+		})
+		return err
+	}
+
+	return nil
+}
+
+func submitStateCustomRetriableError(err error) error {
+	retry := true
+	aerr, ok := err.(awserr.Error)
+	if ok {
+		switch aerr.Code() {
+		case ecsmodel.ErrCodeInvalidParameterException:
+			retry = false
+		case ecsmodel.ErrCodeAccessDeniedException:
+			retry = false
+		case ecsmodel.ErrCodeClientException:
+			retry = false
+		}
+	}
+	return apierrors.NewRetriableError(apierrors.NewRetriable(retry), err)
+}
+
+func (client *ecsClient) DiscoverPollEndpoint(containerInstanceArn string) (string, error) {
+	resp, err := client.discoverPollEndpoint(containerInstanceArn)
+	if err != nil {
+		return "", err
+	}
+	if resp.Endpoint == nil {
+		return "", errors.New("no endpoint returned; nil")
+	}
+
+	return aws.StringValue(resp.Endpoint), nil
+}
+
+func (client *ecsClient) DiscoverTelemetryEndpoint(containerInstanceArn string) (string, error) {
+	resp, err := client.discoverPollEndpoint(containerInstanceArn)
+	if err != nil {
+		return "", err
+	}
+	if resp.TelemetryEndpoint == nil {
+		return "", errors.New("no telemetry endpoint returned; nil")
+	}
+
+	return aws.StringValue(resp.TelemetryEndpoint), nil
+}
+
+func (client *ecsClient) DiscoverServiceConnectEndpoint(containerInstanceArn string) (string, error) {
+	resp, err := client.discoverPollEndpoint(containerInstanceArn)
+	if err != nil {
+		return "", err
+	}
+	if resp.ServiceConnectEndpoint == nil {
+		return "", errors.New("no ServiceConnect endpoint returned; nil")
+	}
+
+	return aws.StringValue(resp.ServiceConnectEndpoint), nil
+}
+
+func (client *ecsClient) discoverPollEndpoint(containerInstanceArn string) (*ecsmodel.DiscoverPollEndpointOutput,
+	error) {
+	// Try getting an entry from the cache.
+	cachedEndpoint, expired, found := client.pollEndpointCache.Get(containerInstanceArn)
+	if !expired && found {
+		// Cache hit and not expired. Return the output.
+		if output, ok := cachedEndpoint.(*ecsmodel.DiscoverPollEndpointOutput); ok {
+			logger.Info("Using cached DiscoverPollEndpoint", logger.Fields{
+				field.Endpoint:               aws.StringValue(output.Endpoint),
+				field.TelemetryEndpoint:      aws.StringValue(output.TelemetryEndpoint),
+				field.ServiceConnectEndpoint: aws.StringValue(output.ServiceConnectEndpoint),
+				field.ContainerInstanceARN:   containerInstanceArn,
+			})
+			return output, nil
+		}
+	}
+
+	// Cache miss or expired, invoke the ECS DiscoverPollEndpoint API.
+	logger.Debug("Invoking DiscoverPollEndpoint", logger.Fields{
+		field.ContainerInstanceARN: containerInstanceArn,
+	})
+	output, err := client.standardClient.DiscoverPollEndpoint(&ecsmodel.DiscoverPollEndpointInput{
+		ContainerInstance: &containerInstanceArn,
+		Cluster:           aws.String(client.configAccessor.Cluster()),
+	})
+	if err != nil {
+		// If we got an error calling the API, fallback to an expired cached endpoint if
+		// we have it.
+		if expired {
+			if output, ok := cachedEndpoint.(*ecsmodel.DiscoverPollEndpointOutput); ok {
+				logger.Info("Error calling DiscoverPollEndpoint. Using cached-but-expired endpoint as a fallback.",
+					logger.Fields{
+						field.Endpoint:               aws.StringValue(output.Endpoint),
+						field.TelemetryEndpoint:      aws.StringValue(output.TelemetryEndpoint),
+						field.ServiceConnectEndpoint: aws.StringValue(output.ServiceConnectEndpoint),
+						field.ContainerInstanceARN:   containerInstanceArn,
+					})
+				return output, nil
+			}
+		}
+		return nil, err
+	}
+
+	// Cache the response from ECS.
+	client.pollEndpointCache.Set(containerInstanceArn, output)
+	return output, nil
+}
+
+func (client *ecsClient) GetResourceTags(resourceArn string) ([]*ecsmodel.Tag, error) {
+	output, err := client.standardClient.ListTagsForResource(&ecsmodel.ListTagsForResourceInput{
+		ResourceArn: &resourceArn,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return output.Tags, nil
+}
+
+func (client *ecsClient) UpdateContainerInstancesState(instanceARN string, status string) error {
+	logger.Debug("Invoking UpdateContainerInstancesState", logger.Fields{
+		field.Status:               status,
+		field.ContainerInstanceARN: instanceARN,
+	})
+	_, err := client.standardClient.UpdateContainerInstancesState(&ecsmodel.UpdateContainerInstancesStateInput{
+		ContainerInstances: []*string{aws.String(instanceARN)},
+		Status:             aws.String(status),
+		Cluster:            aws.String(client.configAccessor.Cluster()),
+	})
+	return err
+}
+
+func formatContainers(containers []*ecsmodel.ContainerStateChange, shouldExcludeIPv6PortBinding bool,
+	taskARN string) []*ecsmodel.ContainerStateChange {
+	var result []*ecsmodel.ContainerStateChange
+	for _, c := range containers {
+		if c.RuntimeId != nil {
+			c.RuntimeId = aws.String(trimString(aws.StringValue(c.RuntimeId), ecsMaxRuntimeIDLength))
+		}
+		if c.Reason != nil {
+			c.Reason = aws.String(trimString(aws.StringValue(c.Reason), ecsMaxContainerReasonLength))
+		}
+		if c.ImageDigest != nil {
+			c.ImageDigest = aws.String(trimString(aws.StringValue(c.ImageDigest), ecsMaxImageDigestLength))
+		}
+		if shouldExcludeIPv6PortBinding {
+			c.NetworkBindings = excludeIPv6PortBindingFromNetworkBindings(c.NetworkBindings,
+				aws.StringValue(c.ContainerName), taskARN)
+		}
+		result = append(result, c)
+	}
+	return result
+}
+
+func excludeIPv6PortBindingFromNetworkBindings(networkBindings []*ecsmodel.NetworkBinding, containerName,
+	taskARN string) []*ecsmodel.NetworkBinding {
+	var result []*ecsmodel.NetworkBinding
+	for _, binding := range networkBindings {
+		if aws.StringValue(binding.BindIP) == "::" {
+			logger.Debug("Exclude IPv6 port binding", logger.Fields{
+				"portBinding":       binding,
+				field.ContainerName: containerName,
+				field.TaskARN:       taskARN,
+			})
+			continue
+		}
+		result = append(result, binding)
+	}
+	return result
+}
+
+func trimString(inputString string, maxLen int) string {
+	if len(inputString) > maxLen {
+		trimmed := inputString[0:maxLen]
+		return trimmed
+	} else {
+		return inputString
+	}
+}

--- a/ecs-agent/api/ecs/client/ecs_client_option.go
+++ b/ecs-agent/api/ecs/client/ecs_client_option.go
@@ -1,0 +1,89 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ecsclient
+
+import (
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/async"
+)
+
+// ECSClientOption allows for configuration of an ecsClient.
+type ECSClientOption func(*ecsClient)
+
+// WithFIPSDetected is an ECSClientOption that configures the
+// ecsClient.isFIPSDetected with the value passed as a parameter.
+func WithFIPSDetected(val bool) ECSClientOption {
+	return func(client *ecsClient) {
+		client.isFIPSDetected = val
+	}
+}
+
+// WithDiscoverPollEndpointCacheTTL is an ECSClientOption that configures the
+// ecsClient.pollEndpointCache.ttl with the value passed as a parameter.
+func WithDiscoverPollEndpointCacheTTL(t *async.TTL) ECSClientOption {
+	return func(client *ecsClient) {
+		client.pollEndpointCache.SetTTL(t)
+	}
+}
+
+// WithIPv6PortBindingExcluded is an ECSClientOption that configures the
+// ecsClient.shouldExcludeIPv6PortBinding with the value passed as a parameter.
+func WithIPv6PortBindingExcluded(val bool) ECSClientOption {
+	return func(client *ecsClient) {
+		client.shouldExcludeIPv6PortBinding = val
+	}
+}
+
+// WithSASCCustomRetryBackoff is an ECSClientOption that configures the
+// ecsClient.sascCustomRetryBackoff with the value passed as a parameter.
+func WithSASCCustomRetryBackoff(f func(func() error) error) ECSClientOption {
+	return func(client *ecsClient) {
+		client.sascCustomRetryBackoff = f
+	}
+}
+
+// WithSTSCAttachmentCustomRetryBackoff is an ECSClientOption that configures the
+// ecsClient.stscAttachmentCustomRetryBackoff with the value passed as a parameter.
+func WithSTSCAttachmentCustomRetryBackoff(f func(func() error) error) ECSClientOption {
+	return func(client *ecsClient) {
+		client.stscAttachmentCustomRetryBackoff = f
+	}
+}
+
+// WithDiscoverPollEndpointCache is an ECSClientOption that configures the
+// ecsClient.pollEndpointCache with the value passed as a parameter.
+// This is especially useful for injecting a test implementation.
+func WithDiscoverPollEndpointCache(c async.TTLCache) ECSClientOption {
+	return func(client *ecsClient) {
+		client.pollEndpointCache = c
+	}
+}
+
+// WithStandardClient is an ECSClientOption that configures the
+// ecsClient.standardClient with the value passed as a parameter.
+// This is especially useful for injecting a test implementation.
+func WithStandardClient(s ecs.ECSStandardSDK) ECSClientOption {
+	return func(client *ecsClient) {
+		client.standardClient = s
+	}
+}
+
+// WithSubmitStateChangeClient is an ECSClientOption that configures the
+// ecsClient.submitStateChangeClient with the value passed as a parameter.
+// This is especially useful for injecting a test implementation.
+func WithSubmitStateChangeClient(s ecs.ECSSubmitStateSDK) ECSClientOption {
+	return func(client *ecsClient) {
+		client.submitStateChangeClient = s
+	}
+}

--- a/ecs-agent/api/ecs/client/ecs_client_option_test.go
+++ b/ecs-agent/api/ecs/client/ecs_client_option_test.go
@@ -1,0 +1,104 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ecsclient
+
+import (
+	"testing"
+	"time"
+
+	mock_ecs "github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/mocks"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/async"
+	"github.com/stretchr/testify/assert"
+)
+
+const oneSecond = 1 * time.Second
+
+var callFnAndReturnNilFunc = func(fn func() error) error {
+	fn()
+	return nil
+}
+
+func TestWithFIPSDetected(t *testing.T) {
+	client := &ecsClient{
+		isFIPSDetected: true,
+	}
+	option := WithFIPSDetected(false)
+	option(client)
+	assert.False(t, client.isFIPSDetected)
+}
+
+func TestWithDiscoverPollEndpointCacheTTL(t *testing.T) {
+	client := &ecsClient{
+		pollEndpointCache: async.NewTTLCache(&async.TTL{Duration: defaultPollEndpointCacheTTL}),
+	}
+	option := WithDiscoverPollEndpointCacheTTL(&async.TTL{Duration: oneSecond})
+	option(client)
+	assert.Equal(t, oneSecond, client.pollEndpointCache.GetTTL().Duration)
+}
+
+func TestWithIPv6PortBindingExcluded(t *testing.T) {
+	client := &ecsClient{
+		shouldExcludeIPv6PortBinding: true,
+	}
+	option := WithIPv6PortBindingExcluded(false)
+	option(client)
+	assert.False(t, client.shouldExcludeIPv6PortBinding)
+}
+
+func TestWithSASCCustomRetryBackoff(t *testing.T) {
+	client := &ecsClient{} // client.sascCustomRetryBackoff is nil by default
+	option := WithSASCCustomRetryBackoff(callFnAndReturnNilFunc)
+	option(client)
+	assert.NotNil(t, client.sascCustomRetryBackoff)
+}
+
+func TestWithSTSCAttachmentCustomRetryBackoff(t *testing.T) {
+	client := &ecsClient{} // client.stscAttachmentCustomRetryBackoff is nil by default
+	option := WithSTSCAttachmentCustomRetryBackoff(callFnAndReturnNilFunc)
+	option(client)
+	assert.NotNil(t, client.stscAttachmentCustomRetryBackoff)
+}
+
+func TestWithDiscoverPollEndpointCache(t *testing.T) {
+	client := &ecsClient{
+		pollEndpointCache: async.NewTTLCache(&async.TTL{Duration: defaultPollEndpointCacheTTL}),
+	}
+	newPollEndpointCache := async.NewTTLCache(&async.TTL{Duration: oneSecond})
+	option := WithDiscoverPollEndpointCache(newPollEndpointCache)
+	option(client)
+	assert.Equal(t, newPollEndpointCache, client.pollEndpointCache)
+}
+
+func TestWithStandardClient(t *testing.T) {
+	client := &ecsClient{
+		standardClient: &mock_ecs.MockECSStandardSDK{},
+	}
+	newStandardClient := mock_ecs.NewMockECSStandardSDK(nil)
+	option := WithStandardClient(newStandardClient)
+	option(client)
+	assert.Equal(t, newStandardClient, client.standardClient)
+}
+
+func TestWithSubmitStateChangeClient(t *testing.T) {
+	client := &ecsClient{
+		submitStateChangeClient: &mock_ecs.MockECSSubmitStateSDK{},
+	}
+	newSubmitStateChangeClient := mock_ecs.NewMockECSSubmitStateSDK(nil)
+	option := WithSubmitStateChangeClient(newSubmitStateChangeClient)
+	option(client)
+	assert.Equal(t, newSubmitStateChangeClient, client.submitStateChangeClient)
+}

--- a/ecs-agent/api/ecs/client/ecs_client_test.go
+++ b/ecs-agent/api/ecs/client/ecs_client_test.go
@@ -1,0 +1,1370 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ecsclient
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs"
+	mock_ecs "github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/mocks"
+	ecsmodel "github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/model/ecs"
+	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/async"
+	mock_async "github.com/aws/amazon-ecs-agent/ecs-agent/async/mocks"
+	mock_config "github.com/aws/amazon-ecs-agent/ecs-agent/config/mocks"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
+	mock_ec2 "github.com/aws/amazon-ecs-agent/ecs-agent/ec2/mocks"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	configuredCluster    = "mycluster"
+	iid                  = "instanceIdentityDocument"
+	iidSignature         = "signature"
+	registrationToken    = "clientToken"
+	endpoint             = "https://some-endpoint.com"
+	region               = "us-east-1"
+	availabilityZone     = "us-west-2b"
+	defaultClusterName   = "default"
+	taskARN              = "taskArn"
+	containerName        = "cont"
+	runtimeID            = "runtime id"
+	outpostARN           = "test:arn:outpost"
+	containerInstanceARN = "registerArn"
+	attachmentARN        = "eniArn"
+	agentVer             = "0.0.0"
+	osType               = "linux"
+)
+
+var (
+	containerInstanceTags = []*ecsmodel.Tag{
+		{
+			Key:   aws.String("my_key1"),
+			Value: aws.String("my_val1"),
+		},
+		{
+			Key:   aws.String("my_key2"),
+			Value: aws.String("my_val2"),
+		},
+	}
+	containerInstanceTagsMap = map[string]string{
+		"my_key1": "my_val1",
+		"my_key2": "my_val2",
+	}
+	testManagedAgents = []*ecsmodel.ManagedAgentStateChange{
+		{
+			ManagedAgentName: aws.String("test_managed_agent"),
+			ContainerName:    aws.String(containerName),
+			Status:           aws.String("RUNNING"),
+			Reason:           aws.String("test_reason"),
+		},
+	}
+)
+
+// testHelper wraps all the objects required for a test.
+type testHelper struct {
+	ctrl                  *gomock.Controller
+	client                ecs.ECSClient
+	mockStandardClient    *mock_ecs.MockECSStandardSDK
+	mockSubmitStateClient *mock_ecs.MockECSSubmitStateSDK
+	mockCfgAccessor       *mock_config.MockAgentConfigAccessor
+}
+
+func setup(t *testing.T,
+	ctrl *gomock.Controller,
+	ec2MetadataClient ec2.EC2MetadataClient,
+	cfgAccessorOverrideFunc func(*mock_config.MockAgentConfigAccessor),
+	options ...ECSClientOption) *testHelper {
+	mockCfgAccessor := newMockConfigAccessor(ctrl, cfgAccessorOverrideFunc)
+	mockStandardClient := mock_ecs.NewMockECSStandardSDK(ctrl)
+	mockSubmitStateClient := mock_ecs.NewMockECSSubmitStateSDK(ctrl)
+	options = append(options, WithStandardClient(mockStandardClient),
+		WithSubmitStateChangeClient(mockSubmitStateClient))
+	client, err := NewECSClient(credentials.AnonymousCredentials, mockCfgAccessor, ec2MetadataClient, agentVer, options...)
+	assert.NoError(t, err)
+
+	return &testHelper{
+		ctrl:                  ctrl,
+		client:                client,
+		mockStandardClient:    mockStandardClient,
+		mockSubmitStateClient: mockSubmitStateClient,
+		mockCfgAccessor:       mockCfgAccessor,
+	}
+}
+
+func newMockConfigAccessor(ctrl *gomock.Controller,
+	cfgAccessorOverrideFunc func(*mock_config.MockAgentConfigAccessor)) *mock_config.MockAgentConfigAccessor {
+	cfgAccessor := mock_config.NewMockAgentConfigAccessor(ctrl)
+	if cfgAccessorOverrideFunc != nil {
+		cfgAccessorOverrideFunc(cfgAccessor)
+	}
+	applyMockCfgAccessorDefaults(cfgAccessor)
+	return cfgAccessor
+}
+
+func applyMockCfgAccessorDefaults(cfgAccessor *mock_config.MockAgentConfigAccessor) {
+	cfgAccessor.EXPECT().AcceptInsecureCert().Return(false).AnyTimes()
+	cfgAccessor.EXPECT().APIEndpoint().Return(endpoint).AnyTimes()
+	cfgAccessor.EXPECT().AWSRegion().Return(region).AnyTimes()
+	cfgAccessor.EXPECT().Cluster().Return(configuredCluster).AnyTimes()
+	cfgAccessor.EXPECT().DefaultClusterName().Return(defaultClusterName).AnyTimes()
+	cfgAccessor.EXPECT().External().Return(false).AnyTimes()
+	cfgAccessor.EXPECT().InstanceAttributes().Return(nil).AnyTimes()
+	cfgAccessor.EXPECT().NoInstanceIdentityDocument().Return(false).AnyTimes()
+	cfgAccessor.EXPECT().OSFamily().Return("LINUX").AnyTimes()
+	cfgAccessor.EXPECT().OSType().Return(osType).AnyTimes()
+	cfgAccessor.EXPECT().ReservedMemory().Return(uint16(20)).AnyTimes()
+	cfgAccessor.EXPECT().ReservedPorts().Return([]uint16{22, 2375, 2376, 51678}).AnyTimes()
+	cfgAccessor.EXPECT().ReservedPortsUDP().Return([]uint16{}).AnyTimes()
+}
+
+func TestSubmitContainerStateChange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+
+	tester.mockSubmitStateClient.EXPECT().SubmitContainerStateChange(&ecsmodel.SubmitContainerStateChangeInput{
+		Cluster:       aws.String(configuredCluster),
+		Task:          aws.String(taskARN),
+		ContainerName: aws.String(containerName),
+		RuntimeId:     aws.String(runtimeID),
+		Status:        aws.String("RUNNING"),
+		NetworkBindings: []*ecsmodel.NetworkBinding{
+			{
+				BindIP:        aws.String("1.2.3.4"),
+				ContainerPort: aws.Int64(1),
+				HostPort:      aws.Int64(2),
+				Protocol:      aws.String("tcp"),
+			},
+			{
+				BindIP:        aws.String("2.2.3.4"),
+				ContainerPort: aws.Int64(3),
+				HostPort:      aws.Int64(4),
+				Protocol:      aws.String("udp"),
+			},
+			{
+				BindIP:             aws.String("5.6.7.8"),
+				ContainerPortRange: aws.String("11-12"),
+				HostPortRange:      aws.String("11-12"),
+				Protocol:           aws.String("udp"),
+			},
+		},
+	})
+	err := tester.client.SubmitContainerStateChange(ecs.ContainerStateChange{
+		TaskArn:       taskARN,
+		ContainerName: containerName,
+		RuntimeID:     runtimeID,
+		Status:        apicontainerstatus.ContainerRunning,
+		NetworkBindings: []*ecsmodel.NetworkBinding{
+			{
+				BindIP:        aws.String("1.2.3.4"),
+				ContainerPort: aws.Int64(1),
+				HostPort:      aws.Int64(2),
+				Protocol:      aws.String("tcp"),
+			},
+			{
+				BindIP:        aws.String("2.2.3.4"),
+				ContainerPort: aws.Int64(3),
+				HostPort:      aws.Int64(4),
+				Protocol:      aws.String("udp"),
+			},
+			{
+				BindIP:             aws.String("5.6.7.8"),
+				ContainerPortRange: aws.String("11-12"),
+				HostPortRange:      aws.String("11-12"),
+				Protocol:           aws.String("udp"),
+			},
+		},
+	})
+
+	assert.NoError(t, err, "Unable to submit container state change")
+}
+
+func TestSubmitContainerStateChangeFull(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+
+	exitCode := 20
+	reason := "I exited"
+
+	tester.mockSubmitStateClient.EXPECT().SubmitContainerStateChange(&ecsmodel.SubmitContainerStateChangeInput{
+		Cluster:         aws.String(configuredCluster),
+		Task:            aws.String(taskARN),
+		ContainerName:   aws.String(containerName),
+		RuntimeId:       aws.String(runtimeID),
+		Status:          aws.String("STOPPED"),
+		ExitCode:        aws.Int64(int64(exitCode)),
+		Reason:          aws.String(reason),
+		NetworkBindings: []*ecsmodel.NetworkBinding{},
+	})
+	err := tester.client.SubmitContainerStateChange(ecs.ContainerStateChange{
+		TaskArn:         taskARN,
+		ContainerName:   containerName,
+		RuntimeID:       runtimeID,
+		Status:          apicontainerstatus.ContainerStopped,
+		ExitCode:        &exitCode,
+		Reason:          reason,
+		NetworkBindings: []*ecsmodel.NetworkBinding{},
+	})
+
+	assert.NoError(t, err, "Unable to submit container state change")
+}
+
+func TestSubmitContainerStateChangeReason(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+
+	exitCode := 20
+	reason := strings.Repeat("a", ecsMaxContainerReasonLength)
+
+	tester.mockSubmitStateClient.EXPECT().SubmitContainerStateChange(&ecsmodel.SubmitContainerStateChangeInput{
+		Cluster:         aws.String(configuredCluster),
+		Task:            aws.String(taskARN),
+		ContainerName:   aws.String(containerName),
+		Status:          aws.String("STOPPED"),
+		ExitCode:        aws.Int64(int64(exitCode)),
+		Reason:          aws.String(reason),
+		NetworkBindings: []*ecsmodel.NetworkBinding{},
+	})
+	err := tester.client.SubmitContainerStateChange(ecs.ContainerStateChange{
+		TaskArn:         taskARN,
+		ContainerName:   containerName,
+		Status:          apicontainerstatus.ContainerStopped,
+		ExitCode:        &exitCode,
+		Reason:          reason,
+		NetworkBindings: []*ecsmodel.NetworkBinding{},
+	})
+
+	assert.NoError(t, err)
+}
+
+func TestSubmitContainerStateChangeLongReason(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+
+	exitCode := 20
+	trimmedReason := strings.Repeat("a", ecsMaxContainerReasonLength)
+	reason := strings.Repeat("a", ecsMaxContainerReasonLength+1)
+
+	tester.mockSubmitStateClient.EXPECT().SubmitContainerStateChange(&ecsmodel.SubmitContainerStateChangeInput{
+		Cluster:         aws.String(configuredCluster),
+		Task:            aws.String(taskARN),
+		ContainerName:   aws.String(containerName),
+		Status:          aws.String("STOPPED"),
+		ExitCode:        aws.Int64(int64(exitCode)),
+		Reason:          aws.String(trimmedReason),
+		NetworkBindings: []*ecsmodel.NetworkBinding{},
+	})
+	err := tester.client.SubmitContainerStateChange(ecs.ContainerStateChange{
+		TaskArn:         taskARN,
+		ContainerName:   containerName,
+		Status:          apicontainerstatus.ContainerStopped,
+		ExitCode:        &exitCode,
+		Reason:          reason,
+		NetworkBindings: []*ecsmodel.NetworkBinding{},
+	})
+
+	assert.NoError(t, err, "Unable to submit container state change")
+}
+
+func buildAttributeList(capabilities []string, attributes map[string]string) []*ecsmodel.Attribute {
+	var rv []*ecsmodel.Attribute
+	for _, capability := range capabilities {
+		rv = append(rv, &ecsmodel.Attribute{Name: aws.String(capability)})
+	}
+	for key, value := range attributes {
+		rv = append(rv, &ecsmodel.Attribute{Name: aws.String(key), Value: aws.String(value)})
+	}
+	return rv
+}
+
+func TestRegisterContainerInstance(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		mockCfgAccessorOverride func(cfgAccessor *mock_config.MockAgentConfigAccessor)
+	}{
+		{
+			name:                    "basic case",
+			mockCfgAccessorOverride: nil,
+		},
+		{
+			name: "no instance identity doc",
+			mockCfgAccessorOverride: func(cfgAccessor *mock_config.MockAgentConfigAccessor) {
+				cfgAccessor.EXPECT().NoInstanceIdentityDocument().Return(true).AnyTimes()
+			},
+		},
+		{
+			name: "on prem",
+			mockCfgAccessorOverride: func(cfgAccessor *mock_config.MockAgentConfigAccessor) {
+				cfgAccessor.EXPECT().NoInstanceIdentityDocument().Return(true).AnyTimes()
+				cfgAccessor.EXPECT().External().Return(true).AnyTimes()
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockEC2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
+			additionalAttributes := map[string]string{"my_custom_attribute": "Custom_Value1",
+				"my_other_custom_attribute": "Custom_Value2",
+			}
+			cfgAccessorOverrideFunc := func(cfgAccessor *mock_config.MockAgentConfigAccessor) {
+				cfgAccessor.EXPECT().InstanceAttributes().Return(additionalAttributes).AnyTimes()
+				if tc.mockCfgAccessorOverride != nil {
+					tc.mockCfgAccessorOverride(cfgAccessor)
+				}
+			}
+			tester := setup(t, ctrl, mockEC2Metadata, cfgAccessorOverrideFunc)
+
+			fakeCapabilities := []string{"capability1", "capability2"}
+			expectedAttributes := map[string]string{
+				"ecs.os-type":               tester.mockCfgAccessor.OSType(),
+				"ecs.os-family":             tester.mockCfgAccessor.OSFamily(),
+				"my_custom_attribute":       "Custom_Value1",
+				"my_other_custom_attribute": "Custom_Value2",
+				"ecs.availability-zone":     availabilityZone,
+				"ecs.outpost-arn":           outpostARN,
+				cpuArchAttrName:             getCPUArch(),
+			}
+			capabilities := buildAttributeList(fakeCapabilities, nil)
+			platformDevices := []*ecsmodel.PlatformDevice{
+				{
+					Id:   aws.String("id1"),
+					Type: aws.String(ecsmodel.PlatformDeviceTypeGpu),
+				},
+				{
+					Id:   aws.String("id2"),
+					Type: aws.String(ecsmodel.PlatformDeviceTypeGpu),
+				},
+				{
+					Id:   aws.String("id3"),
+					Type: aws.String(ecsmodel.PlatformDeviceTypeGpu),
+				},
+			}
+
+			expectedIID := iid
+			expectedIIDSig := iidSignature
+			if tester.mockCfgAccessor.NoInstanceIdentityDocument() {
+				expectedIID = ""
+				expectedIIDSig = ""
+			} else if tc.name == "retry GetDynamicData" {
+				gomock.InOrder(
+					mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).
+						Return("", errors.New("fake unit test error")),
+					mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).
+						Return(expectedIID, nil),
+					mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).
+						Return(expectedIIDSig, nil),
+				)
+			} else {
+				// Basic case.
+				gomock.InOrder(
+					mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).
+						Return(expectedIID, nil),
+					mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).
+						Return(expectedIIDSig, nil),
+				)
+			}
+
+			var expectedNumOfAttributes int
+			if !tester.mockCfgAccessor.External() {
+				// 2 capability attributes: capability1, capability2
+				// and 5 other attributes:
+				// ecs.os-type, ecs.os-family, ecs.outpost-arn, my_custom_attribute, my_other_custom_attribute.
+				expectedNumOfAttributes = 7
+			} else {
+				// One more attribute for external case: ecs.cpu-architecture.
+				expectedNumOfAttributes = 8
+			}
+
+			gomock.InOrder(
+				tester.mockStandardClient.EXPECT().RegisterContainerInstance(gomock.Any()).
+					Do(func(req *ecsmodel.RegisterContainerInstanceInput) {
+						assert.Nil(t, req.ContainerInstanceArn)
+						assert.Equal(t, configuredCluster, *req.Cluster, "Wrong cluster")
+						assert.Equal(t, registrationToken, *req.ClientToken, "Wrong client token")
+						assert.Equal(t, expectedIID, *req.InstanceIdentityDocument, "Wrong IID")
+						assert.Equal(t, expectedIIDSig, *req.InstanceIdentityDocumentSignature, "Wrong IID sig")
+						assert.Equal(t, 4, len(req.TotalResources), "Wrong length of TotalResources")
+						resource, ok := findResource(req.TotalResources, "PORTS_UDP")
+						require.True(t, ok, `Could not find resource "PORTS_UDP"`)
+						assert.Equal(t, "STRINGSET", *resource.Type, `Wrong type for resource "PORTS_UDP"`)
+						assert.Equal(t, expectedNumOfAttributes, len(req.Attributes), "Wrong number of Attributes")
+						attrs := attributesToMap(req.Attributes)
+						for name, value := range attrs {
+							if strings.Contains(name, "capability") {
+								assert.Contains(t, fakeCapabilities, name)
+							} else {
+								assert.Equal(t, expectedAttributes[name], value)
+							}
+						}
+						assert.Equal(t, len(containerInstanceTags), len(req.Tags), "Wrong number of tags")
+						assert.Equal(t, len(platformDevices), len(req.PlatformDevices), "Wrong number of devices")
+						reqTags := extractTagsMapFromRegisterContainerInstanceInput(req)
+						for k, v := range reqTags {
+							assert.Contains(t, containerInstanceTagsMap, k)
+							assert.Equal(t, containerInstanceTagsMap[k], v)
+						}
+					}).Return(&ecsmodel.RegisterContainerInstanceOutput{
+					ContainerInstance: &ecsmodel.ContainerInstance{
+						ContainerInstanceArn: aws.String(containerInstanceARN),
+						Attributes:           buildAttributeList(fakeCapabilities, expectedAttributes)}},
+					nil),
+			)
+
+			arn, availabilityzone, err := tester.client.RegisterContainerInstance("", capabilities,
+				containerInstanceTags, registrationToken, platformDevices, outpostARN)
+			require.NoError(t, err)
+			assert.Equal(t, containerInstanceARN, arn)
+			assert.Equal(t, availabilityZone, availabilityzone)
+		})
+	}
+}
+
+func TestReRegisterContainerInstance(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockEC2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
+	additionalAttributes := map[string]string{"my_custom_attribute": "Custom_Value1",
+		"my_other_custom_attribute":    "Custom_Value2",
+		"attribute_name_with_no_value": "",
+	}
+	cfgAccessorOverrideFunc := func(cfgAccessor *mock_config.MockAgentConfigAccessor) {
+		cfgAccessor.EXPECT().InstanceAttributes().Return(additionalAttributes).AnyTimes()
+	}
+	tester := setup(t, ctrl, mockEC2Metadata, cfgAccessorOverrideFunc)
+
+	fakeCapabilities := []string{"capability1", "capability2"}
+	expectedAttributes := map[string]string{
+		"ecs.os-type":           tester.mockCfgAccessor.OSType(),
+		"ecs.os-family":         tester.mockCfgAccessor.OSFamily(),
+		"ecs.availability-zone": availabilityZone,
+		"ecs.outpost-arn":       outpostARN,
+	}
+	for i := range fakeCapabilities {
+		expectedAttributes[fakeCapabilities[i]] = ""
+	}
+	capabilities := buildAttributeList(fakeCapabilities, nil)
+
+	gomock.InOrder(
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).
+			Return("instanceIdentityDocument", nil),
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).
+			Return("signature", nil),
+		tester.mockStandardClient.EXPECT().RegisterContainerInstance(gomock.Any()).
+			Do(func(req *ecsmodel.RegisterContainerInstanceInput) {
+				assert.Equal(t, "arn:test", *req.ContainerInstanceArn, "Wrong container instance ARN")
+				assert.Equal(t, configuredCluster, *req.Cluster, "Wrong cluster")
+				assert.Equal(t, registrationToken, *req.ClientToken, "Wrong client token")
+				assert.Equal(t, iid, *req.InstanceIdentityDocument, "Wrong IID")
+				assert.Equal(t, iidSignature, *req.InstanceIdentityDocumentSignature, "Wrong IID sig")
+				assert.Equal(t, 4, len(req.TotalResources), "Wrong length of TotalResources")
+				resource, ok := findResource(req.TotalResources, "PORTS_UDP")
+				assert.True(t, ok, `Could not find resource "PORTS_UDP"`)
+				assert.Equal(t, "STRINGSET", *resource.Type, `Wrong type for resource "PORTS_UDP"`)
+				// "ecs.os-type", ecs.os-family, ecs.outpost-arn and the 2 that we specified as additionalAttributes.
+				assert.Equal(t, 5, len(req.Attributes), "Wrong number of Attributes")
+				reqAttributes := func() map[string]string {
+					rv := make(map[string]string, len(req.Attributes))
+					for i := range req.Attributes {
+						rv[aws.StringValue(req.Attributes[i].Name)] = aws.StringValue(req.Attributes[i].Value)
+					}
+					return rv
+				}()
+				for k, v := range reqAttributes {
+					assert.Contains(t, expectedAttributes, k)
+					assert.Equal(t, expectedAttributes[k], v)
+				}
+				assert.Equal(t, len(containerInstanceTags), len(req.Tags), "Wrong number of tags")
+				reqTags := extractTagsMapFromRegisterContainerInstanceInput(req)
+				for k, v := range reqTags {
+					assert.Contains(t, containerInstanceTagsMap, k)
+					assert.Equal(t, containerInstanceTagsMap[k], v)
+				}
+			}).Return(&ecsmodel.RegisterContainerInstanceOutput{
+			ContainerInstance: &ecsmodel.ContainerInstance{
+				ContainerInstanceArn: aws.String(containerInstanceARN),
+				Attributes:           buildAttributeList(fakeCapabilities, expectedAttributes),
+			}},
+			nil),
+	)
+
+	arn, availabilityzone, err := tester.client.RegisterContainerInstance("arn:test", capabilities,
+		containerInstanceTags, registrationToken, nil, outpostARN)
+
+	assert.NoError(t, err)
+	assert.Equal(t, containerInstanceARN, arn)
+	assert.Equal(t, availabilityZone, availabilityzone, "availabilityZone is incorrect")
+}
+
+// TestRegisterContainerInstanceWithNegativeResource tests the registration should fail with negative resource.
+func TestRegisterContainerInstanceWithNegativeResource(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, mem := getCpuAndMemory()
+	mockEC2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
+	cfgAccessorOverrideFunc := func(cfgAccessor *mock_config.MockAgentConfigAccessor) {
+		cfgAccessor.EXPECT().ReservedMemory().Return(uint16(mem) + 1).AnyTimes()
+	}
+	tester := setup(t, ctrl, mockEC2Metadata, cfgAccessorOverrideFunc)
+
+	gomock.InOrder(
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).
+			Return("instanceIdentityDocument", nil),
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).
+			Return("signature", nil),
+	)
+	_, _, err := tester.client.RegisterContainerInstance("", nil, nil,
+		"", nil, "")
+	assert.ErrorContains(t, err, "reserved memory is higher than available memory",
+		"Register resource with negative value should cause registration fail")
+}
+
+func TestRegisterContainerInstanceWithEmptyTags(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEC2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
+	tester := setup(t, ctrl, mockEC2Metadata, nil)
+
+	expectedAttributes := map[string]string{
+		"ecs.os-type":               tester.mockCfgAccessor.OSType(),
+		"ecs.os-family":             tester.mockCfgAccessor.OSFamily(),
+		"my_custom_attribute":       "Custom_Value1",
+		"my_other_custom_attribute": "Custom_Value2",
+	}
+	fakeCapabilities := []string{"capability1", "capability2"}
+
+	gomock.InOrder(
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).
+			Return("instanceIdentityDocument", nil),
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).
+			Return("signature", nil),
+		tester.mockStandardClient.EXPECT().RegisterContainerInstance(gomock.Any()).
+			Do(func(req *ecsmodel.RegisterContainerInstanceInput) {
+				assert.Nil(t, req.Tags)
+			}).Return(&ecsmodel.RegisterContainerInstanceOutput{
+			ContainerInstance: &ecsmodel.ContainerInstance{
+				ContainerInstanceArn: aws.String(containerInstanceARN),
+				Attributes:           buildAttributeList(fakeCapabilities, expectedAttributes)}},
+			nil),
+	)
+
+	_, _, err := tester.client.RegisterContainerInstance("", nil, make([]*ecsmodel.Tag, 0),
+		"", nil, "")
+	assert.NoError(t, err)
+}
+
+func TestValidateRegisteredAttributes(t *testing.T) {
+	origAttributes := []*ecsmodel.Attribute{
+		{Name: aws.String("foo"), Value: aws.String("bar")},
+		{Name: aws.String("baz"), Value: aws.String("quux")},
+		{Name: aws.String("no_value"), Value: aws.String("")},
+	}
+	actualAttributes := []*ecsmodel.Attribute{
+		{Name: aws.String("baz"), Value: aws.String("quux")},
+		{Name: aws.String("foo"), Value: aws.String("bar")},
+		{Name: aws.String("no_value"), Value: aws.String("")},
+		{Name: aws.String("ecs.internal-attribute"), Value: aws.String("some text")},
+	}
+	assert.NoError(t, validateRegisteredAttributes(origAttributes, actualAttributes))
+
+	origAttributes = append(origAttributes, &ecsmodel.Attribute{Name: aws.String("abc"), Value: aws.String("xyz")})
+	assert.ErrorContains(t, validateRegisteredAttributes(origAttributes, actualAttributes),
+		"Attribute validation failed")
+}
+
+func findResource(resources []*ecsmodel.Resource, name string) (*ecsmodel.Resource, bool) {
+	for _, resource := range resources {
+		if name == *resource.Name {
+			return resource, true
+		}
+	}
+	return nil, false
+}
+
+func TestRegisterBlankCluster(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEC2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
+	// Test the special 'empty cluster' behavior of creating 'default'.
+	cfgAccessorOverrideFunc := func(cfgAccessor *mock_config.MockAgentConfigAccessor) {
+		cfgAccessor.EXPECT().Cluster().Return("").AnyTimes()
+	}
+	tester := setup(t, ctrl, mockEC2Metadata, cfgAccessorOverrideFunc)
+
+	expectedAttributes := map[string]string{
+		"ecs.os-type":   tester.mockCfgAccessor.OSType(),
+		"ecs.os-family": tester.mockCfgAccessor.OSFamily(),
+	}
+	defaultCluster := tester.mockCfgAccessor.DefaultClusterName()
+	gomock.InOrder(
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).
+			Return("instanceIdentityDocument", nil),
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).
+			Return("signature", nil),
+		tester.mockStandardClient.EXPECT().RegisterContainerInstance(gomock.Any()).
+			Return(nil, awserr.New("ClientException", "Cluster not found.",
+				errors.New("Cluster not found."))),
+		tester.mockStandardClient.EXPECT().CreateCluster(&ecsmodel.CreateClusterInput{ClusterName: &defaultCluster}).
+			Return(&ecsmodel.CreateClusterOutput{Cluster: &ecsmodel.Cluster{ClusterName: &defaultCluster}}, nil),
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).
+			Return("instanceIdentityDocument", nil),
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).
+			Return("signature", nil),
+		tester.mockStandardClient.EXPECT().RegisterContainerInstance(gomock.Any()).
+			Do(func(req *ecsmodel.RegisterContainerInstanceInput) {
+				assert.Equal(t, defaultCluster, *req.Cluster, "Wrong cluster")
+				assert.Equal(t, iid, *req.InstanceIdentityDocument, "Wrong IID")
+				assert.Equal(t, iidSignature, *req.InstanceIdentityDocumentSignature, "Wrong IID sig")
+			}).Return(&ecsmodel.RegisterContainerInstanceOutput{
+			ContainerInstance: &ecsmodel.ContainerInstance{
+				ContainerInstanceArn: aws.String(containerInstanceARN),
+				Attributes:           buildAttributeList(nil, expectedAttributes)}},
+			nil),
+		tester.mockCfgAccessor.EXPECT().UpdateCluster(defaultCluster),
+	)
+
+	arn, availabilityzone, err := tester.client.RegisterContainerInstance("", nil, nil,
+		"", nil, "")
+	assert.NoError(t, err, "Should not be an error")
+	assert.Equal(t, containerInstanceARN, arn, "Wrong arn")
+	assert.Empty(t, availabilityzone, "wrong availability zone")
+}
+
+func TestRegisterBlankClusterNotCreatingClusterWhenErrorNotClusterNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEC2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
+	// Test the special 'empty cluster' behavior of creating 'default'.
+	cfgAccessorOverrideFunc := func(cfgAccessor *mock_config.MockAgentConfigAccessor) {
+		cfgAccessor.EXPECT().Cluster().Return("").AnyTimes()
+	}
+	tester := setup(t, ctrl, mockEC2Metadata, cfgAccessorOverrideFunc)
+
+	expectedAttributes := map[string]string{
+		"ecs.os-type":   tester.mockCfgAccessor.OSType(),
+		"ecs.os-family": tester.mockCfgAccessor.OSFamily(),
+	}
+
+	defaultCluster := tester.mockCfgAccessor.DefaultClusterName()
+	gomock.InOrder(
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).
+			Return("instanceIdentityDocument", nil),
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).
+			Return("signature", nil),
+		tester.mockStandardClient.EXPECT().RegisterContainerInstance(gomock.Any()).
+			Return(nil, awserr.New("ClientException", "Invalid request.",
+				errors.New("Invalid request."))),
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).
+			Return("instanceIdentityDocument", nil),
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).
+			Return("signature", nil),
+		tester.mockStandardClient.EXPECT().RegisterContainerInstance(gomock.Any()).
+			Do(func(req *ecsmodel.RegisterContainerInstanceInput) {
+				assert.Equal(t, defaultCluster, *req.Cluster, "Wrong cluster")
+				assert.Equal(t, iid, *req.InstanceIdentityDocument, "Wrong IID")
+				assert.Equal(t, iidSignature, *req.InstanceIdentityDocumentSignature, "Wrong IID sig")
+			}).Return(&ecsmodel.RegisterContainerInstanceOutput{
+			ContainerInstance: &ecsmodel.ContainerInstance{
+				ContainerInstanceArn: aws.String(containerInstanceARN),
+				Attributes:           buildAttributeList(nil, expectedAttributes)}},
+			nil),
+		tester.mockCfgAccessor.EXPECT().UpdateCluster(defaultCluster),
+	)
+
+	arn, _, err := tester.client.RegisterContainerInstance("", nil, nil, "",
+		nil, "")
+	assert.NoError(t, err, "Should not return error")
+	assert.Equal(t, containerInstanceARN, arn, "Wrong arn")
+}
+
+func TestDiscoverTelemetryEndpoint(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+	expectedEndpoint := "http://127.0.0.1"
+	tester.mockStandardClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).
+		Return(&ecsmodel.DiscoverPollEndpointOutput{TelemetryEndpoint: &expectedEndpoint}, nil)
+	endpoint, err := tester.client.DiscoverTelemetryEndpoint(containerInstanceARN)
+	assert.NoError(t, err, "Error getting telemetry endpoint")
+	assert.Equal(t, expectedEndpoint, endpoint, "Expected telemetry endpoint != endpoint")
+}
+
+func TestDiscoverTelemetryEndpointError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+
+	tester.mockStandardClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(nil,
+		fmt.Errorf("Error getting endpoint"))
+	_, err := tester.client.DiscoverTelemetryEndpoint(containerInstanceARN)
+	assert.ErrorContains(t, err, "Error getting endpoint",
+		"Expected error getting telemetry endpoint, didn't get any")
+}
+
+func TestDiscoverNilTelemetryEndpoint(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+	pollEndpoint := "http://127.0.0.1"
+	tester.mockStandardClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).
+		Return(&ecsmodel.DiscoverPollEndpointOutput{Endpoint: &pollEndpoint}, nil)
+	_, err := tester.client.DiscoverTelemetryEndpoint(containerInstanceARN)
+	assert.ErrorContains(t, err, "no telemetry endpoint returned",
+		"Expected error getting telemetry endpoint with old response")
+}
+
+func TestDiscoverServiceConnectEndpoint(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+	expectedEndpoint := "http://127.0.0.1"
+	tester.mockStandardClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).
+		Return(&ecsmodel.DiscoverPollEndpointOutput{ServiceConnectEndpoint: &expectedEndpoint}, nil)
+	endpoint, err := tester.client.DiscoverServiceConnectEndpoint(containerInstanceARN)
+	assert.NoError(t, err, "Error getting service connect endpoint")
+	assert.Equal(t, expectedEndpoint, endpoint, "Expected telemetry endpoint != endpoint")
+}
+
+func TestDiscoverServiceConnectEndpointError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+	tester.mockStandardClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(nil,
+		fmt.Errorf("Error getting endpoint"))
+	_, err := tester.client.DiscoverServiceConnectEndpoint(containerInstanceARN)
+	assert.ErrorContains(t, err, "Error getting endpoint",
+		"Expected error getting service connect endpoint, didn't get any")
+}
+
+func TestDiscoverNilServiceConnectEndpoint(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+	pollEndpoint := "http://127.0.0.1"
+	tester.mockStandardClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).
+		Return(&ecsmodel.DiscoverPollEndpointOutput{Endpoint: &pollEndpoint}, nil)
+	_, err := tester.client.DiscoverServiceConnectEndpoint(containerInstanceARN)
+	assert.ErrorContains(t, err, "no ServiceConnect endpoint returned",
+		"Expected error getting service connect endpoint with old response")
+}
+
+func TestUpdateContainerInstancesState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+	status := "DRAINING"
+	tester.mockStandardClient.EXPECT().UpdateContainerInstancesState(&ecsmodel.UpdateContainerInstancesStateInput{
+		ContainerInstances: []*string{aws.String(containerInstanceARN)},
+		Status:             aws.String(status),
+		Cluster:            aws.String(configuredCluster),
+	}).Return(&ecsmodel.UpdateContainerInstancesStateOutput{}, nil)
+
+	err := tester.client.UpdateContainerInstancesState(containerInstanceARN, status)
+	assert.NoError(t, err, fmt.Sprintf("Unexpected error calling UpdateContainerInstancesState: %s", err))
+}
+
+func TestUpdateContainerInstancesStateError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+
+	status := "DRAINING"
+	tester.mockStandardClient.EXPECT().UpdateContainerInstancesState(&ecsmodel.UpdateContainerInstancesStateInput{
+		ContainerInstances: []*string{aws.String(containerInstanceARN)},
+		Status:             aws.String(status),
+		Cluster:            aws.String(configuredCluster),
+	}).Return(nil, fmt.Errorf("ERROR"))
+
+	err := tester.client.UpdateContainerInstancesState(containerInstanceARN, status)
+	assert.ErrorContains(t, err, "ERROR",
+		"Expected an error calling UpdateContainerInstancesState but got nil")
+}
+
+func TestGetResourceTags(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+	tester.mockStandardClient.EXPECT().ListTagsForResource(&ecsmodel.ListTagsForResourceInput{
+		ResourceArn: aws.String(containerInstanceARN),
+	}).Return(&ecsmodel.ListTagsForResourceOutput{
+		Tags: containerInstanceTags,
+	}, nil)
+
+	_, err := tester.client.GetResourceTags(containerInstanceARN)
+	assert.NoError(t, err, fmt.Sprintf("Unexpected error calling GetResourceTags: %s", err))
+}
+
+func TestGetResourceTagsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+	tester.mockStandardClient.EXPECT().ListTagsForResource(&ecsmodel.ListTagsForResourceInput{
+		ResourceArn: aws.String(containerInstanceARN),
+	}).Return(nil, fmt.Errorf("ERROR"))
+
+	_, err := tester.client.GetResourceTags(containerInstanceARN)
+	assert.ErrorContains(t, err, "ERROR",
+		"Expected an error calling GetResourceTags but got nil")
+}
+
+func TestDiscoverPollEndpointCacheHit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pollEndpointCache := mock_async.NewMockTTLCache(ctrl)
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil,
+		WithDiscoverPollEndpointCache(pollEndpointCache))
+	pollEndpoint := "http://127.0.0.1"
+	pollEndpointCache.EXPECT().Get(containerInstanceARN).Return(
+		&ecsmodel.DiscoverPollEndpointOutput{
+			Endpoint: aws.String(pollEndpoint),
+		}, false, true)
+	output, err := tester.client.(*ecsClient).discoverPollEndpoint(containerInstanceARN)
+	assert.NoError(t, err, "Error in discoverPollEndpoint")
+	assert.Equal(t, pollEndpoint, aws.StringValue(output.Endpoint), "Mismatch in poll endpoint")
+}
+
+func TestDiscoverPollEndpointCacheMiss(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pollEndpointCache := mock_async.NewMockTTLCache(ctrl)
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil,
+		WithDiscoverPollEndpointCache(pollEndpointCache))
+	pollEndpoint := "http://127.0.0.1"
+	pollEndpointOutput := &ecsmodel.DiscoverPollEndpointOutput{
+		Endpoint: &pollEndpoint,
+	}
+
+	gomock.InOrder(
+		pollEndpointCache.EXPECT().Get(containerInstanceARN).Return(nil, false, false),
+		tester.mockStandardClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(pollEndpointOutput, nil),
+		pollEndpointCache.EXPECT().Set(containerInstanceARN, pollEndpointOutput),
+	)
+
+	output, err := tester.client.(*ecsClient).discoverPollEndpoint(containerInstanceARN)
+	assert.NoError(t, err, "Error in discoverPollEndpoint")
+	assert.Equal(t, pollEndpoint, aws.StringValue(output.Endpoint), "Mismatch in poll endpoint")
+}
+
+func TestDiscoverPollEndpointExpiredButDPEFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pollEndpointCache := mock_async.NewMockTTLCache(ctrl)
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil,
+		WithDiscoverPollEndpointCache(pollEndpointCache))
+	pollEndpoint := "http://127.0.0.1"
+	pollEndpointOutput := &ecsmodel.DiscoverPollEndpointOutput{
+		Endpoint: &pollEndpoint,
+	}
+
+	gomock.InOrder(
+		pollEndpointCache.EXPECT().Get(containerInstanceARN).Return(pollEndpointOutput, true, false),
+		tester.mockStandardClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(nil, fmt.Errorf("error!")),
+	)
+
+	output, err := tester.client.(*ecsClient).discoverPollEndpoint(containerInstanceARN)
+	assert.NoError(t, err, "Error in discoverPollEndpoint")
+	assert.Equal(t, pollEndpoint, aws.StringValue(output.Endpoint),
+		"Mismatch in poll endpoint")
+}
+
+func TestDiscoverTelemetryEndpointAfterPollEndpointCacheHit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pollEndpointCache := async.NewTTLCache(&async.TTL{Duration: 10 * time.Minute})
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil,
+		WithDiscoverPollEndpointCache(pollEndpointCache))
+	pollEndpoint := "http://127.0.0.1"
+	tester.mockStandardClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(
+		&ecsmodel.DiscoverPollEndpointOutput{
+			Endpoint:          &pollEndpoint,
+			TelemetryEndpoint: &pollEndpoint,
+		}, nil)
+	endpoint, err := tester.client.DiscoverPollEndpoint(containerInstanceARN)
+	assert.NoError(t, err, "Error in DiscoverPollEndpoint")
+	assert.Equal(t, pollEndpoint, endpoint, "Mismatch in poll endpoint")
+
+	telemetryEndpoint, err := tester.client.DiscoverTelemetryEndpoint(containerInstanceARN)
+	assert.NoError(t, err, "Error in discoverTelemetryEndpoint")
+	assert.Equal(t, pollEndpoint, telemetryEndpoint, "Mismatch in telemetry endpoint")
+}
+
+// TestSubmitTaskStateChangeWithAttachments tests the SubmitTaskStateChange API
+// also send the Attachment Status.
+func TestSubmitTaskStateChangeWithAttachments(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+	tester.mockSubmitStateClient.EXPECT().SubmitTaskStateChange(&ecsmodel.SubmitTaskStateChangeInput{
+		Cluster: aws.String(configuredCluster),
+		Task:    aws.String(taskARN),
+		Attachments: []*ecsmodel.AttachmentStateChange{
+			{
+				AttachmentArn: aws.String(attachmentARN),
+				Status:        aws.String("ATTACHED"),
+			},
+		},
+	})
+
+	err := tester.client.SubmitTaskStateChange(ecs.TaskStateChange{
+		TaskARN: taskARN,
+		Attachment: &ni.ENIAttachment{
+			AttachmentInfo: attachment.AttachmentInfo{
+				AttachmentARN: attachmentARN,
+				Status:        attachment.AttachmentAttached,
+			},
+		},
+	})
+	assert.NoError(t, err, "Unable to submit task state change with attachments")
+}
+
+func TestSubmitTaskStateChangeWithoutAttachments(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+	tester.mockSubmitStateClient.EXPECT().SubmitTaskStateChange(&ecsmodel.SubmitTaskStateChangeInput{
+		Cluster: aws.String(configuredCluster),
+		Task:    aws.String(taskARN),
+		Reason:  aws.String(""),
+		Status:  aws.String("RUNNING"),
+	})
+
+	err := tester.client.SubmitTaskStateChange(ecs.TaskStateChange{
+		TaskARN: taskARN,
+		Status:  apitaskstatus.TaskRunning,
+	})
+	assert.NoError(t, err, "Unable to submit task state change with no attachments")
+}
+
+func TestSubmitTaskStateChangeWithManagedAgents(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+	tester.mockSubmitStateClient.EXPECT().SubmitTaskStateChange(&ecsmodel.SubmitTaskStateChangeInput{
+		Cluster:       aws.String(configuredCluster),
+		Task:          aws.String(taskARN),
+		Reason:        aws.String(""),
+		Status:        aws.String("RUNNING"),
+		ManagedAgents: testManagedAgents,
+	})
+
+	err := tester.client.SubmitTaskStateChange(ecs.TaskStateChange{
+		TaskARN:       taskARN,
+		Status:        apitaskstatus.TaskRunning,
+		ManagedAgents: testManagedAgents,
+	})
+	assert.NoError(t, err, "Unable to submit task state change with managed agents")
+}
+
+// TestSubmitContainerStateChangeWhileTaskInPending tests the container state change was submitted
+// when the task is still in pending state.
+func TestSubmitContainerStateChangeWhileTaskInPending(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testCases := []struct {
+		taskStatus apitaskstatus.TaskStatus
+	}{
+		{
+			apitaskstatus.TaskStatusNone,
+		},
+		{
+			apitaskstatus.TaskPulled,
+		},
+		{
+			apitaskstatus.TaskCreated,
+		},
+	}
+
+	taskStateChangePending := ecs.TaskStateChange{
+		Status:  apitaskstatus.TaskCreated,
+		TaskARN: taskARN,
+		Containers: []*ecsmodel.ContainerStateChange{
+			{
+				ContainerName:   aws.String(containerName),
+				RuntimeId:       aws.String(runtimeID),
+				Status:          aws.String(apicontainerstatus.ContainerRunning.String()),
+				NetworkBindings: []*ecsmodel.NetworkBinding{},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("TaskStatus: %s", tc.taskStatus.String()), func(t *testing.T) {
+			taskStateChangePending.Status = tc.taskStatus
+			tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+			tester.mockSubmitStateClient.EXPECT().SubmitTaskStateChange(&ecsmodel.SubmitTaskStateChangeInput{
+				Cluster: aws.String(configuredCluster),
+				Task:    aws.String(taskARN),
+				Status:  aws.String("PENDING"),
+				Reason:  aws.String(""),
+				Containers: []*ecsmodel.ContainerStateChange{
+					{
+						ContainerName:   aws.String(containerName),
+						RuntimeId:       aws.String(runtimeID),
+						Status:          aws.String("RUNNING"),
+						NetworkBindings: []*ecsmodel.NetworkBinding{},
+					},
+				},
+			})
+			err := tester.client.SubmitTaskStateChange(taskStateChangePending)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestSubmitAttachmentStateChange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+
+	tester.mockSubmitStateClient.EXPECT().SubmitAttachmentStateChanges(&ecsmodel.SubmitAttachmentStateChangesInput{
+		Cluster: aws.String(configuredCluster),
+		Attachments: []*ecsmodel.AttachmentStateChange{
+			{
+				AttachmentArn: aws.String(attachmentARN),
+				Status:        aws.String("ATTACHED"),
+			},
+		},
+	})
+	err := tester.client.SubmitAttachmentStateChange(ecs.AttachmentStateChange{
+		Attachment: &ni.ENIAttachment{
+			AttachmentInfo: attachment.AttachmentInfo{
+				AttachmentARN: attachmentARN,
+				Status:        attachment.AttachmentAttached,
+			},
+		},
+	})
+
+	assert.NoError(t, err, "Unable to submit attachment state change")
+}
+
+func TestSubmitAttachmentStateChangeWithRetriableError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	sascCustomRetryBackoffCalled := false
+	sascCustomRetryBackoff := func(fn func() error) error {
+		sascCustomRetryBackoffCalled = true
+		return retry.RetryWithBackoff(retry.NewExponentialBackoff(
+			100*time.Millisecond, 100*time.Millisecond, 0, 1), fn)
+	}
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil,
+		WithSASCCustomRetryBackoff(sascCustomRetryBackoff))
+
+	input := &ecsmodel.SubmitAttachmentStateChangesInput{
+		Cluster: aws.String(configuredCluster),
+		Attachments: []*ecsmodel.AttachmentStateChange{
+			{
+				AttachmentArn: aws.String(attachmentARN),
+				Status:        aws.String("ATTACHED"),
+			},
+		},
+	}
+
+	// Ensure that we try to submit attachment state change twice (i.e., retried on retriable error).
+	retriableError := errors.New("retriable error")
+	tester.mockSubmitStateClient.EXPECT().SubmitAttachmentStateChanges(input).Return(
+		&ecsmodel.SubmitAttachmentStateChangesOutput{}, retriableError)
+	tester.mockSubmitStateClient.EXPECT().SubmitAttachmentStateChanges(input)
+
+	err := tester.client.SubmitAttachmentStateChange(ecs.AttachmentStateChange{
+		Attachment: &ni.ENIAttachment{
+			AttachmentInfo: attachment.AttachmentInfo{
+				AttachmentARN: attachmentARN,
+				Status:        attachment.AttachmentAttached,
+			},
+		},
+	})
+
+	assert.True(t, sascCustomRetryBackoffCalled)
+	assert.NoError(t, err, "Unable to submit attachment state change")
+}
+
+func TestSubmitAttachmentStateChangeWithNonRetriableError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	sascCustomRetryBackoffCalled := false
+	sascCustomRetryBackoff := func(fn func() error) error {
+		sascCustomRetryBackoffCalled = true
+		return retry.RetryWithBackoff(retry.NewExponentialBackoff(
+			100*time.Millisecond, 100*time.Millisecond, 0, 1), fn)
+	}
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil,
+		WithSASCCustomRetryBackoff(sascCustomRetryBackoff))
+
+	input := &ecsmodel.SubmitAttachmentStateChangesInput{
+		Cluster: aws.String(configuredCluster),
+		Attachments: []*ecsmodel.AttachmentStateChange{
+			{
+				AttachmentArn: aws.String(attachmentARN),
+				Status:        aws.String("ATTACHED"),
+			},
+		},
+	}
+
+	// Ensure that we try to submit attachment state change only once (i.e., not retried).
+	nonRetriableError := &ecsmodel.InvalidParameterException{}
+	tester.mockSubmitStateClient.EXPECT().SubmitAttachmentStateChanges(input).Return(
+		&ecsmodel.SubmitAttachmentStateChangesOutput{}, nonRetriableError)
+
+	err := tester.client.SubmitAttachmentStateChange(ecs.AttachmentStateChange{
+		Attachment: &ni.ENIAttachment{
+			AttachmentInfo: attachment.AttachmentInfo{
+				AttachmentARN: attachmentARN,
+				Status:        attachment.AttachmentAttached,
+			},
+		},
+	})
+
+	assert.True(t, sascCustomRetryBackoffCalled)
+	assert.Error(t, err,
+		"Received no error submitting attachment state change but expected to receive non-retriable error")
+}
+
+func TestFIPSEndpointStateWhenEndpointGiven(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Endpoint is given during the call to newMockConfigAccessor function.
+	cfgAccessor := newMockConfigAccessor(ctrl, nil)
+	assert.NotEmpty(t, cfgAccessor.APIEndpoint())
+
+	client, err := NewECSClient(credentials.AnonymousCredentials, cfgAccessor, ec2.NewBlackholeEC2MetadataClient(),
+		agentVer)
+	assert.NoError(t, err)
+	assert.Equal(t, endpoints.FIPSEndpointStateUnset,
+		client.(*ecsClient).standardClient.(*ecsmodel.ECS).Config.UseFIPSEndpoint)
+}
+
+func TestFIPSEndpointStateOnFIPSEnabledHosts(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfgAccessorOverrideFunc := func(cfgAccessor *mock_config.MockAgentConfigAccessor) {
+		cfgAccessor.EXPECT().APIEndpoint().Return("").AnyTimes()
+	}
+	cfgAccessor := newMockConfigAccessor(ctrl, cfgAccessorOverrideFunc)
+	assert.Empty(t, cfgAccessor.APIEndpoint())
+
+	client, err := NewECSClient(credentials.AnonymousCredentials, cfgAccessor, ec2.NewBlackholeEC2MetadataClient(), agentVer, WithFIPSDetected(true))
+	assert.NoError(t, err)
+	assert.Equal(t, endpoints.FIPSEndpointStateEnabled,
+		client.(*ecsClient).standardClient.(*ecsmodel.ECS).Config.UseFIPSEndpoint)
+}
+
+func TestFIPSEndpointStateOnFIPSDisabledHosts(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfgAccessorOverrideFunc := func(cfgAccessor *mock_config.MockAgentConfigAccessor) {
+		cfgAccessor.EXPECT().APIEndpoint().Return("").AnyTimes()
+	}
+	cfgAccessor := newMockConfigAccessor(ctrl, cfgAccessorOverrideFunc)
+	assert.Empty(t, cfgAccessor.APIEndpoint())
+
+	client, err := NewECSClient(credentials.AnonymousCredentials, cfgAccessor, ec2.NewBlackholeEC2MetadataClient(),
+		agentVer)
+	assert.NoError(t, err)
+	assert.Equal(t, endpoints.FIPSEndpointStateUnset,
+		client.(*ecsClient).standardClient.(*ecsmodel.ECS).Config.UseFIPSEndpoint)
+}
+
+func TestDiscoverPollEndpointCacheTTLSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ttlDuration := time.Minute
+	client, err := NewECSClient(credentials.AnonymousCredentials, newMockConfigAccessor(ctrl, nil), ec2.NewBlackholeEC2MetadataClient(), agentVer, WithDiscoverPollEndpointCacheTTL(&async.TTL{Duration: ttlDuration}))
+	assert.NoError(t, err)
+	assert.Equal(t, ttlDuration, client.(*ecsClient).pollEndpointCache.GetTTL().Duration)
+}
+
+func TestDiscoverPollEndpointCacheTTLSetAndExpired(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ttlDuration := time.Nanosecond
+	client, err := NewECSClient(credentials.AnonymousCredentials, newMockConfigAccessor(ctrl, nil), ec2.NewBlackholeEC2MetadataClient(), agentVer, WithDiscoverPollEndpointCacheTTL(&async.TTL{Duration: ttlDuration}))
+	assert.NoError(t, err)
+
+	client.(*ecsClient).pollEndpointCache.Set(containerInstanceARN, &ecsmodel.DiscoverPollEndpointOutput{
+		Endpoint: aws.String(endpoint),
+	})
+	time.Sleep(2 * ttlDuration)
+	cachedEndpoint, expired, found := client.(*ecsClient).pollEndpointCache.Get(containerInstanceARN)
+
+	assert.Equal(t, ttlDuration, client.(*ecsClient).pollEndpointCache.GetTTL().Duration)
+	assert.True(t, found)
+	assert.True(t, expired)
+	assert.Equal(t, endpoint, aws.StringValue(cachedEndpoint.(*ecsmodel.DiscoverPollEndpointOutput).Endpoint))
+}
+
+func TestDiscoverPollEndpointCacheTTLNotSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client, err := NewECSClient(credentials.AnonymousCredentials, newMockConfigAccessor(ctrl, nil), ec2.NewBlackholeEC2MetadataClient(), agentVer, WithDiscoverPollEndpointCacheTTL(nil))
+	assert.NoError(t, err)
+
+	client.(*ecsClient).pollEndpointCache.Set(containerInstanceARN, &ecsmodel.DiscoverPollEndpointOutput{
+		Endpoint: aws.String(endpoint),
+	})
+	cachedEndpoint, expired, found := client.(*ecsClient).pollEndpointCache.Get(containerInstanceARN)
+
+	assert.Nil(t, client.(*ecsClient).pollEndpointCache.GetTTL())
+	assert.True(t, found)
+	assert.False(t, expired)
+	assert.Equal(t, endpoint, aws.StringValue(cachedEndpoint.(*ecsmodel.DiscoverPollEndpointOutput).Endpoint))
+}
+
+func TestWithIPv6PortBindingExcludedSetTrue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil,
+		WithIPv6PortBindingExcluded(true))
+
+	ipv4PortBinding := &ecsmodel.NetworkBinding{
+		BindIP:        aws.String("0.0.0.0"),
+		ContainerPort: aws.Int64(1),
+		HostPort:      aws.Int64(2),
+		Protocol:      aws.String("tcp"),
+	}
+	ipv6PortBinding := &ecsmodel.NetworkBinding{
+		BindIP:        aws.String("::"),
+		ContainerPort: aws.Int64(3),
+		HostPort:      aws.Int64(4),
+		Protocol:      aws.String("tcp"),
+	}
+
+	// IPv6 port binding should be excluded from container state change submitted.
+	tester.mockSubmitStateClient.EXPECT().SubmitContainerStateChange(&ecsmodel.SubmitContainerStateChangeInput{
+		Cluster:       aws.String(configuredCluster),
+		Task:          aws.String(taskARN),
+		ContainerName: aws.String(containerName),
+		RuntimeId:     aws.String(runtimeID),
+		Status:        aws.String("RUNNING"),
+		NetworkBindings: []*ecsmodel.NetworkBinding{
+			ipv4PortBinding,
+		},
+	})
+	err := tester.client.SubmitContainerStateChange(ecs.ContainerStateChange{
+		TaskArn:       taskARN,
+		ContainerName: containerName,
+		RuntimeID:     runtimeID,
+		Status:        apicontainerstatus.ContainerRunning,
+		NetworkBindings: []*ecsmodel.NetworkBinding{
+			ipv4PortBinding,
+			ipv6PortBinding,
+		},
+	})
+
+	assert.NoError(t, err, "Unable to submit container state change")
+}
+
+func TestWithIPv6PortBindingExcludedSetFalse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+
+	ipv4PortBinding := &ecsmodel.NetworkBinding{
+		BindIP:        aws.String("0.0.0.0"),
+		ContainerPort: aws.Int64(1),
+		HostPort:      aws.Int64(2),
+		Protocol:      aws.String("tcp"),
+	}
+	ipv6PortBinding := &ecsmodel.NetworkBinding{
+		BindIP:        aws.String("::"),
+		ContainerPort: aws.Int64(3),
+		HostPort:      aws.Int64(4),
+		Protocol:      aws.String("tcp"),
+	}
+
+	// IPv6 port binding should NOT be excluded from container state change submitted.
+	tester.mockSubmitStateClient.EXPECT().SubmitContainerStateChange(&ecsmodel.SubmitContainerStateChangeInput{
+		Cluster:       aws.String(configuredCluster),
+		Task:          aws.String(taskARN),
+		ContainerName: aws.String(containerName),
+		RuntimeId:     aws.String(runtimeID),
+		Status:        aws.String("RUNNING"),
+		NetworkBindings: []*ecsmodel.NetworkBinding{
+			ipv4PortBinding,
+			ipv6PortBinding,
+		},
+	})
+	err := tester.client.SubmitContainerStateChange(ecs.ContainerStateChange{
+		TaskArn:       taskARN,
+		ContainerName: containerName,
+		RuntimeID:     runtimeID,
+		Status:        apicontainerstatus.ContainerRunning,
+		NetworkBindings: []*ecsmodel.NetworkBinding{
+			ipv4PortBinding,
+			ipv6PortBinding,
+		},
+	})
+
+	assert.NoError(t, err, "Unable to submit container state change")
+}
+
+func extractTagsMapFromRegisterContainerInstanceInput(req *ecsmodel.RegisterContainerInstanceInput) map[string]string {
+	tagsMap := make(map[string]string, len(req.Tags))
+	for i := range req.Tags {
+		tagsMap[aws.StringValue(req.Tags[i].Key)] = aws.StringValue(req.Tags[i].Value)
+	}
+	return tagsMap
+}

--- a/ecs-agent/api/ecs/client/retry_handler.go
+++ b/ecs-agent/api/ecs/client/retry_handler.go
@@ -1,0 +1,85 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ecsclient
+
+import (
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/model/ecs"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+const (
+	// submitStateChangeInitialRetries is the initial set of retries where delay
+	// between retries grows exponentially at 2^n * 45+-15ms.  This should be roughly
+	// 5 minutes of delay at the last growing retry.
+	// 5 min = 2^n * (30 + 15) ms
+	// n ~= 12.7
+	// We round up to 13 (which really gives us ~6 minutes) for no
+	// particular reason.
+	// Because of jitter, this caps at ~8 minutes
+	submitStateChangeInitialRetries = 13
+
+	// submitStateChangeExtraRetries is the set of retries (at the max delay per
+	// retry of exactly 5 minutes) which should reach roughly 24 hours of elapsed
+	// time.
+	// baseTryTime = \sum_{i=0}^13{2^i * 45 ms} ~= 12 minutes
+	// 24 hours ~= 12 minutes + (n * 5 minutes)
+	// n ~= 285
+	submitStateChangeExtraRetries = 285
+)
+
+// newSubmitStateChangeClient returns a client intended to be used for
+// Submit*StateChange APIs which has the behavior of retrying the call on
+// retriable errors for an extended period of time (roughly 24 hours).
+func newSubmitStateChangeClient(awsConfig *aws.Config) *ecs.ECS {
+	sscConfig := awsConfig.Copy()
+	sscConfig.Retryer = &oneDayRetrier{}
+	client := ecs.New(session.New(sscConfig))
+	return client
+}
+
+// oneDayRetrier is a retrier for the AWS SDK that retries up to one day.
+// Each retry will have an exponential backoff from 30ms to 5 minutes. Once the
+// backoff has reached 5 minutes, it will not increase further.
+// Conforms to the request.Retryer interface https://github.com/aws/aws-sdk-go/blob/v1.0.0/aws/request/retryer.go#L13
+type oneDayRetrier struct {
+	client.DefaultRetryer
+}
+
+// MaxRetries returns the number of retries needed to retry for roughly a day
+// for this Retrier
+func (retrier *oneDayRetrier) MaxRetries() int {
+	return submitStateChangeExtraRetries + submitStateChangeInitialRetries
+}
+
+// RetryRules returns the correct time to delay between retries for this
+// instance of a retry. For the first 14 requests, it follows an exponential
+// backoff between 30ms and 1 minute.
+// See the const comments for math on how this gets us to around 24 hours
+// total.
+func (retrier *oneDayRetrier) RetryRules(r *request.Request) time.Duration {
+	// This logic is the same as the default retrier, but duplicated here such
+	// that upstream changes do not invalidate the math done above.
+	if r.RetryCount <= submitStateChangeInitialRetries {
+		delay := int(math.Pow(2, float64(r.RetryCount))) * (rand.Intn(30) + 30)
+		return time.Duration(delay) * time.Millisecond
+	}
+	return 5 * time.Minute
+}

--- a/ecs-agent/api/ecs/client/retry_handler_test.go
+++ b/ecs-agent/api/ecs/client/retry_handler_test.go
@@ -1,0 +1,58 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ecsclient
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/model/ecs"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/defaults"
+)
+
+func TestOneDayRetrier(t *testing.T) {
+	stateChangeClient := newSubmitStateChangeClient(defaults.Config())
+
+	request, _ := stateChangeClient.SubmitContainerStateChangeRequest(&ecs.SubmitContainerStateChangeInput{})
+
+	retrier := stateChangeClient.Retryer
+
+	var totalDelay time.Duration
+	for retries := 0; retries < retrier.MaxRetries(); retries++ {
+		request.Error = errors.New("")
+		request.Retryable = aws.Bool(true)
+		request.HTTPResponse = &http.Response{StatusCode: 500}
+		if request.WillRetry() && request.IsErrorRetryable() {
+			totalDelay += retrier.RetryRules(request)
+			request.RetryCount++
+		}
+	}
+
+	request.Error = errors.New("")
+	request.Retryable = aws.Bool(true)
+	request.HTTPResponse = &http.Response{StatusCode: 500}
+	if request.WillRetry() {
+		t.Errorf("Expected request to not be retried after %v retries", retrier.MaxRetries())
+	}
+
+	if totalDelay > 25*time.Hour || totalDelay < 23*time.Hour {
+		t.Errorf("Expected accumulated retry delay to be roughly 24 hours; was %v", totalDelay)
+	}
+}

--- a/ecs-agent/api/ecs/client/utils.go
+++ b/ecs-agent/api/ecs/client/utils.go
@@ -1,0 +1,30 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ecsclient
+
+import (
+	"runtime"
+)
+
+func getCPUArch() string {
+	arch := runtime.GOARCH
+	// For amd64 and 386, change to x86_64 and i386 to match the value in instance identity doc
+	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html.
+	if arch == "amd64" {
+		arch = "x86_64"
+	} else if arch == "386" {
+		arch = "i386"
+	}
+	return arch
+}

--- a/ecs-agent/api/ecs/client/utils_amd64_test.go
+++ b/ecs-agent/api/ecs/client/utils_amd64_test.go
@@ -1,0 +1,27 @@
+//go:build amd64 && unit
+// +build amd64,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ecsclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCPUArch(t *testing.T) {
+	assert.Equal(t, "x86_64", getCPUArch())
+}

--- a/ecs-agent/api/ecs/client/utils_arm64_test.go
+++ b/ecs-agent/api/ecs/client/utils_arm64_test.go
@@ -1,0 +1,27 @@
+//go:build arm64 && unit
+// +build arm64,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ecsclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCPUArch(t *testing.T) {
+	assert.Equal(t, "arm64", getCPUArch())
+}

--- a/ecs-agent/httpclient/httpclient.go
+++ b/ecs-agent/httpclient/httpclient.go
@@ -29,9 +29,9 @@ import (
 // Below constants taken from the default http.Client behavior.
 // Ref: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/custom-http.html
 const (
-	defaultDialTimeout         = 30 * time.Second
-	defaultDialKeepalive       = 30 * time.Second
-	defaultTLSHandshakeTimeout = 10 * time.Second
+	DefaultDialTimeout         = 30 * time.Second
+	DefaultDialKeepalive       = 30 * time.Second
+	DefaultTLSHandshakeTimeout = 10 * time.Second
 )
 
 //go:generate mockgen -destination=mock/$GOFILE -copyright_file=../../scripts/copyright_file net/http RoundTripper
@@ -66,10 +66,10 @@ func New(timeout time.Duration, insecureSkipVerify bool, agentVersion string, os
 	transport := &http.Transport{
 		Proxy: httpproxy.Proxy,
 		DialContext: (&net.Dialer{
-			Timeout:   defaultDialTimeout,
-			KeepAlive: defaultDialKeepalive,
+			Timeout:   DefaultDialTimeout,
+			KeepAlive: DefaultDialKeepalive,
 		}).DialContext,
-		TLSHandshakeTimeout: defaultTLSHandshakeTimeout,
+		TLSHandshakeTimeout: DefaultTLSHandshakeTimeout,
 	}
 	transport.TLSClientConfig = &tls.Config{}
 	cipher.WithSupportedCipherSuites(transport.TLSClientConfig)

--- a/ecs-agent/logger/field/constants.go
+++ b/ecs-agent/logger/field/constants.go
@@ -55,4 +55,10 @@ const (
 	MessageID               = "messageID"
 	RequestType             = "requestType"
 	CredentialsID           = "credentialsID"
+	ContainerInstanceARN    = "containerInstanceARN"
+	AttributeName           = "attributeName"
+	AttributeValue          = "attributeValue"
+	Endpoint                = "endpoint"
+	TelemetryEndpoint       = "telemetryEndpoint"
+	ServiceConnectEndpoint  = "serviceConnectEndpoint"
 )

--- a/ecs-agent/vendor/github.com/docker/docker/pkg/meminfo/meminfo.go
+++ b/ecs-agent/vendor/github.com/docker/docker/pkg/meminfo/meminfo.go
@@ -1,0 +1,26 @@
+// Package meminfo provides utilites to retrieve memory statistics of
+// the host system.
+package meminfo
+
+// Read retrieves memory statistics of the host system and returns a
+// Memory type. It is only supported on Linux and Windows, and returns an
+// error on other platforms.
+func Read() (*Memory, error) {
+	return readMemInfo()
+}
+
+// Memory contains memory statistics of the host system.
+type Memory struct {
+	// Total usable RAM (i.e. physical RAM minus a few reserved bits and the
+	// kernel binary code).
+	MemTotal int64
+
+	// Amount of free memory.
+	MemFree int64
+
+	// Total amount of swap space available.
+	SwapTotal int64
+
+	// Amount of swap space that is currently unused.
+	SwapFree int64
+}

--- a/ecs-agent/vendor/github.com/docker/docker/pkg/meminfo/meminfo_linux.go
+++ b/ecs-agent/vendor/github.com/docker/docker/pkg/meminfo/meminfo_linux.go
@@ -1,0 +1,69 @@
+package meminfo
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// readMemInfo retrieves memory statistics of the host system and returns a
+// Memory type.
+func readMemInfo() (*Memory, error) {
+	file, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return parseMemInfo(file)
+}
+
+// parseMemInfo parses the /proc/meminfo file into
+// a Memory object given an io.Reader to the file.
+// Throws error if there are problems reading from the file
+func parseMemInfo(reader io.Reader) (*Memory, error) {
+	meminfo := &Memory{}
+	scanner := bufio.NewScanner(reader)
+	memAvailable := int64(-1)
+	for scanner.Scan() {
+		// Expected format: ["MemTotal:", "1234", "kB"]
+		parts := strings.Fields(scanner.Text())
+
+		// Sanity checks: Skip malformed entries.
+		if len(parts) < 3 || parts[2] != "kB" {
+			continue
+		}
+
+		// Convert to bytes.
+		size, err := strconv.Atoi(parts[1])
+		if err != nil {
+			continue
+		}
+		// Convert to KiB
+		bytes := int64(size) * 1024
+
+		switch parts[0] {
+		case "MemTotal:":
+			meminfo.MemTotal = bytes
+		case "MemFree:":
+			meminfo.MemFree = bytes
+		case "MemAvailable:":
+			memAvailable = bytes
+		case "SwapTotal:":
+			meminfo.SwapTotal = bytes
+		case "SwapFree:":
+			meminfo.SwapFree = bytes
+		}
+	}
+	if memAvailable != -1 {
+		meminfo.MemFree = memAvailable
+	}
+
+	// Handle errors that may have occurred during the reading of the file.
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return meminfo, nil
+}

--- a/ecs-agent/vendor/github.com/docker/docker/pkg/meminfo/meminfo_unsupported.go
+++ b/ecs-agent/vendor/github.com/docker/docker/pkg/meminfo/meminfo_unsupported.go
@@ -1,0 +1,11 @@
+//go:build !linux && !windows
+// +build !linux,!windows
+
+package meminfo
+
+import "errors"
+
+// readMemInfo is not supported on platforms other than linux and windows.
+func readMemInfo() (*Memory, error) {
+	return nil, errors.New("platform and architecture is not supported")
+}

--- a/ecs-agent/vendor/github.com/docker/docker/pkg/meminfo/meminfo_windows.go
+++ b/ecs-agent/vendor/github.com/docker/docker/pkg/meminfo/meminfo_windows.go
@@ -1,0 +1,45 @@
+package meminfo
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
+
+	procGlobalMemoryStatusEx = modkernel32.NewProc("GlobalMemoryStatusEx")
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa366589(v=vs.85).aspx
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa366770(v=vs.85).aspx
+type memorystatusex struct {
+	dwLength                uint32
+	dwMemoryLoad            uint32
+	ullTotalPhys            uint64
+	ullAvailPhys            uint64
+	ullTotalPageFile        uint64
+	ullAvailPageFile        uint64
+	ullTotalVirtual         uint64
+	ullAvailVirtual         uint64
+	ullAvailExtendedVirtual uint64
+}
+
+// readMemInfo retrieves memory statistics of the host system and returns a
+// Memory type.
+func readMemInfo() (*Memory, error) {
+	msi := &memorystatusex{
+		dwLength: 64,
+	}
+	r1, _, _ := procGlobalMemoryStatusEx.Call(uintptr(unsafe.Pointer(msi)))
+	if r1 == 0 {
+		return &Memory{}, nil
+	}
+	return &Memory{
+		MemTotal:  int64(msi.ullTotalPhys),
+		MemFree:   int64(msi.ullAvailPhys),
+		SwapTotal: int64(msi.ullTotalPageFile),
+		SwapFree:  int64(msi.ullAvailPageFile),
+	}, nil
+}

--- a/ecs-agent/vendor/modules.txt
+++ b/ecs-agent/vendor/modules.txt
@@ -125,6 +125,7 @@ github.com/docker/docker/api/types/swarm
 github.com/docker/docker/api/types/swarm/runtime
 github.com/docker/docker/api/types/versions
 github.com/docker/docker/api/types/volume
+github.com/docker/docker/pkg/meminfo
 # github.com/docker/go-connections v0.4.0
 ## explicit
 github.com/docker/go-connections/nat


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add ECS client to the ecs-agent module, as well as some related functionality.

For clarity, this pull request just includes changes to the ecs-agent module and does NOT change the agent module in any way to use these files (except for a few existing vendored files which are not directly a part of the ECS client). In a future pull request, we will raise changes in the agent module to consume the ECS client from the ecs-agent module and then remove the resulting unused ECS client related files from the agent module.

### Implementation details
<!-- How are the changes implemented? -->
- Add ECS client (i.e., `ecsClient` struct) to `ecs-agent/api/ecs/client/ecs_client.go` and test it in `ecs-agent/api/ecs/client/ecs_client_test.go`. This struct implements the `ECSClient` interface defined in `ecs-agent/api/ecs/interface.go`
- Use functional options design pattern to provide callers flexible ways to configure the ECS client. Implement and test pertinent options in the following files:
   - `ecs-agent/api/ecs/client/ecs_client_option.go`
   - `ecs-agent/api/ecs/client/ecs_client_option_test.go`
- Make default dial timeout, default dial keep alive, and default TLS handshake timeout constants in `ecs-agent/httpclient/httpclient.go` public so that they can be used in `ecs-agent/api/ecs/client/ecs_client.go`
- Create logger field constants for credentials ID, container instance ARN, attribute name, attribute value, endpoint, telemetry endpoint, and service connect endpoint in `ecs-agent/logger/field/constants.go` for use in `ecs-agent/api/ecs/client/ecs_client.go`
- Copy over the following files:
   - `ecs-agent/api/ecs/client/retry_handler.go` from `agent/api/ecsclient/retry_handler.go`
   - `ecs-agent/api/ecs/client/retry_handler_test.go` from `agent/api/ecsclient/retry_handler_test.go`
   - `ecs-agent/api/ecs/client/utils.go` from `agent/api/ecsclient/utils.go`
   - `ecs-agent/api/ecs/client/utils_amd64_test.go` from `agent/api/ecsclient/utils_amd64_test.go`
   - `ecs-agent/api/ecs/client/utils_arm64_test.go` from `agent/api/ecsclient/utils_arm64_test.go`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit, integration, and functional tests.

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add ECS client to ecs-agent module

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.