### PR TITLE
Add network delete workflow for AWSVPC

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
@@ -51,6 +51,7 @@ const (
 	SaveNetworkNamespaceMetricName          = dbClientMetricNamespace + ".SaveNetworkNamespace"
 	GetNetworkNamespaceMetricName           = dbClientMetricNamespace + ".GetNetworkNamespace"
 
-	networkBuilderNamespace         = "NetworkBuilder"
-	BuildNetworkNamespaceMetricName = networkBuilderNamespace + ".BuildNetworkNamespace"
+	networkBuilderNamespace          = "NetworkBuilder"
+	BuildNetworkNamespaceMetricName  = networkBuilderNamespace + ".BuildNetworkNamespace"
+	DeleteNetworkNamespaceMetricName = networkBuilderNamespace + ".DeleteNetworkNamespace"
 )

--- a/ecs-agent/metrics/constants.go
+++ b/ecs-agent/metrics/constants.go
@@ -51,6 +51,7 @@ const (
 	SaveNetworkNamespaceMetricName          = dbClientMetricNamespace + ".SaveNetworkNamespace"
 	GetNetworkNamespaceMetricName           = dbClientMetricNamespace + ".GetNetworkNamespace"
 
-	networkBuilderNamespace         = "NetworkBuilder"
-	BuildNetworkNamespaceMetricName = networkBuilderNamespace + ".BuildNetworkNamespace"
+	networkBuilderNamespace          = "NetworkBuilder"
+	BuildNetworkNamespaceMetricName  = networkBuilderNamespace + ".BuildNetworkNamespace"
+	DeleteNetworkNamespaceMetricName = networkBuilderNamespace + ".DeleteNetworkNamespace"
 )

--- a/ecs-agent/netlib/network_builder.go
+++ b/ecs-agent/netlib/network_builder.go
@@ -106,13 +106,37 @@ func (nb *networkBuilder) Start(
 }
 
 func (nb *networkBuilder) Stop(ctx context.Context, mode string, taskID string, netNS *tasknetworkconfig.NetworkNamespace) error {
-	// TODO: To be implemented.
-	return nil
+	logFields := map[string]interface{}{
+		"NetworkMode":           mode,
+		"NetNSName":             netNS.Name,
+		"NetNSPath":             netNS.Path,
+		"AppMeshEnabled":        netNS.AppMeshConfig != nil,
+		"ServiceConnectEnabled": netNS.ServiceConnectConfig != nil,
+	}
+	metricEntry := nb.metricsFactory.New(metrics.DeleteNetworkNamespaceMetricName).WithFields(logFields)
+
+	netNS.Mutex.Lock()
+	defer netNS.Mutex.Unlock()
+
+	logger.Info("Deleting network namespace setup", logFields)
+
+	var err error
+	switch mode {
+	case ecs.NetworkModeAwsvpc:
+		err = nb.stopAWSVPC(ctx, netNS)
+	default:
+		err = errors.New("invalid network mode: " + mode)
+	}
+
+	metricEntry.Done(err)
+
+	return err
 }
 
 // startAWSVPC executes the required platform API methods in order to configure
 // the task's network namespace running in AWSVPC mode.
 func (nb *networkBuilder) startAWSVPC(ctx context.Context, taskID string, netNS *tasknetworkconfig.NetworkNamespace) error {
+	var err error
 	if netNS.DesiredState == status.NetworkDeleted {
 		return errors.New("invalid transition state encountered: " + netNS.DesiredState.String())
 	}
@@ -124,7 +148,7 @@ func (nb *networkBuilder) startAWSVPC(ctx context.Context, taskID string, netNS 
 
 		logger.Debug("Creating netns: " + netNS.Path)
 		// Create network namespace on the host.
-		err := nb.platformAPI.CreateNetNS(netNS.Path)
+		err = nb.platformAPI.CreateNetNS(netNS.Path)
 		if err != nil {
 			return err
 		}
@@ -138,27 +162,10 @@ func (nb *networkBuilder) startAWSVPC(ctx context.Context, taskID string, netNS 
 		}
 	}
 
-	// Execute CNI plugins to configure the interfaces in the namespace.
-	// Depending on the type of interfaces in the netns, there maybe operations
-	// to execute when the netns desired status is READY_PULL and READY.
-	for _, iface := range netNS.NetworkInterfaces {
-		logFields := logger.Fields{
-			"Interface": iface,
-			"NetNSName": netNS.Name,
-		}
-		if iface.KnownStatus == netNS.DesiredState {
-			logger.Debug("Interface already in desired state")
-			continue
-		}
-
-		logger.Debug("Configuring interface", logFields)
-		iface.DesiredStatus = netNS.DesiredState
-
-		err := nb.platformAPI.ConfigureInterface(ctx, netNS.Path, iface)
-		if err != nil {
-			return err
-		}
-		iface.KnownStatus = netNS.DesiredState
+	// Configure each interface inside the network namespace.
+	err = nb.configureNetNSInterfaces(ctx, netNS)
+	if err != nil {
+		return err
 	}
 
 	// Configure AppMesh and service connect rules in the netns.
@@ -169,7 +176,7 @@ func (nb *networkBuilder) startAWSVPC(ctx context.Context, taskID string, netNS 
 				"AppMeshConfig": netNS.AppMeshConfig,
 			})
 
-			err := nb.platformAPI.ConfigureAppMesh(ctx, netNS.Path, netNS.AppMeshConfig)
+			err = nb.platformAPI.ConfigureAppMesh(ctx, netNS.Path, netNS.AppMeshConfig)
 			if err != nil {
 				return errors.Wrapf(err, "failed to configure AppMesh in netns %s", netNS.Name)
 			}
@@ -180,7 +187,7 @@ func (nb *networkBuilder) startAWSVPC(ctx context.Context, taskID string, netNS 
 				"ServiceConnectConfig": netNS.ServiceConnectConfig,
 			})
 
-			err := nb.platformAPI.ConfigureServiceConnect(
+			err = nb.platformAPI.ConfigureServiceConnect(
 				ctx, netNS.Path, netNS.GetPrimaryInterface(), netNS.ServiceConnectConfig)
 			if err != nil {
 				return errors.Wrapf(err, "failed to configure ServiceConnect in netns %s", netNS.Name)
@@ -188,5 +195,44 @@ func (nb *networkBuilder) startAWSVPC(ctx context.Context, taskID string, netNS 
 		}
 	}
 
+	return err
+}
+
+// configureNetNSInterfaces executes the platform API to configure every interface inside a network namespace.
+func (nb *networkBuilder) configureNetNSInterfaces(ctx context.Context, netNS *tasknetworkconfig.NetworkNamespace) error {
+	for _, iface := range netNS.NetworkInterfaces {
+		logFields := logger.Fields{
+			"Interface": iface,
+			"NetNSName": netNS.Name,
+		}
+		if iface.KnownStatus == netNS.DesiredState {
+			logger.Debug("Interface already in desired state", logFields)
+			continue
+		}
+
+		// The interface desired status is driven by the network namespace's desired state.
+		logger.Debug("Configuring interface", logFields)
+		iface.DesiredStatus = netNS.DesiredState
+
+		err := nb.platformAPI.ConfigureInterface(ctx, netNS.Path, iface)
+		if err != nil {
+			return err
+		}
+		iface.KnownStatus = netNS.DesiredState
+	}
+
 	return nil
+}
+
+func (nb *networkBuilder) stopAWSVPC(ctx context.Context, netNS *tasknetworkconfig.NetworkNamespace) error {
+	if netNS.DesiredState != status.NetworkDeleted {
+		return errors.New("invalid transition state encountered: " + netNS.DesiredState.String())
+	}
+
+	err := nb.configureNetNSInterfaces(ctx, netNS)
+	if err != nil {
+		return err
+	}
+
+	return nb.platformAPI.DeleteNetNS(netNS.Path)
 }

--- a/ecs-agent/netlib/platform/api.go
+++ b/ecs-agent/netlib/platform/api.go
@@ -35,7 +35,7 @@ type API interface {
 	CreateNetNS(netNSPath string) error
 
 	// DeleteNetNS deletes the specified network namespace.
-	DeleteNetNS(netNSName string) error
+	DeleteNetNS(netNSPath string) error
 
 	// CreateDNSConfig creates the following DNS config files depending on the
 	// network namespace configuration:

--- a/ecs-agent/netlib/platform/common_linux.go
+++ b/ecs-agent/netlib/platform/common_linux.go
@@ -284,6 +284,24 @@ func (c *common) CreateNetNS(netNSPath string) error {
 	return err
 }
 
+func (c *common) DeleteNetNS(netNSPath string) error {
+	nsExists, err := c.nsUtil.NSExists(netNSPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check netns %s", netNSPath)
+	}
+
+	if !nsExists {
+		return nil
+	}
+
+	err = c.nsUtil.DelNetNS(netNSPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete netns %s", netNSPath)
+	}
+
+	return nil
+}
+
 // setUpLoFunc returns a method that sets the loop back interface inside a
 // particular network namespace to the state "UP". This function is used to
 // set up the loop back interface inside a task network namespace soon after

--- a/ecs-agent/netlib/platform/containerd_linux.go
+++ b/ecs-agent/netlib/platform/containerd_linux.go
@@ -35,10 +35,6 @@ func (c *containerd) BuildTaskNetworkConfiguration(
 	return c.common.buildTaskNetworkConfiguration(taskID, taskPayload)
 }
 
-func (c *containerd) DeleteNetNS(netnsName string) error {
-	return nil
-}
-
 func (c *containerd) CreateDNSConfig(taskID string, netNS *tasknetworkconfig.NetworkNamespace) error {
 	return c.common.createDNSConfig(taskID, false, netNS)
 }

--- a/ecs-agent/netlib/platform/containerd_windows.go
+++ b/ecs-agent/netlib/platform/containerd_windows.go
@@ -50,7 +50,7 @@ func (c *common) CreateNetNS(netNSPath string) error {
 	return nil
 }
 
-func (c *common) DeleteNetNS(netNSName string) error {
+func (c *common) DeleteNetNS(netNSPath string) error {
 	return nil
 }
 


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
Implements Stop method in NetworkBuilder to delete network resources for AWSVPC mode.

### Implementation details
<!-- How are the changes implemented? -->
Implemented NetworkBuilder's Stop method and Platform API's DeleteNetNS method.

### Testing
`go test -tags unit ./ecs-agent/...`

New tests cover the changes: <!-- yes|no --> Yes

### Description for the changelog
Add network delete workflow for AWSVPC

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
