### PR TITLE
Add containerId, networkNameSpace, containerCGroup to ManagedDaemon

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon/managed_daemon.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon/managed_daemon.go
@@ -62,6 +62,11 @@ type ManagedDaemon struct {
 
 	linuxParameters *ecsacs.LinuxParameters
 	privileged      bool
+
+	containerId string
+
+	containerCGroup  string
+	networkNameSpace string
 }
 
 // A valid managed daemon will require
@@ -184,6 +189,11 @@ func (md *ManagedDaemon) GetCommand() []string {
 	return md.command
 }
 
+func (md *ManagedDaemon) SetCommand(command []string) {
+	md.command = make([]string, len(command))
+	copy(md.command, command)
+}
+
 // returns list of mountpoints without the
 // agentCommunicationMount and applicationLogMount
 func (md *ManagedDaemon) GetFilteredMountPoints() []*MountPoint {
@@ -209,6 +219,26 @@ func (md *ManagedDaemon) GetEnvironment() map[string]string {
 
 func (md *ManagedDaemon) GetLoadedDaemonImageRef() string {
 	return md.loadedDaemonImageRef
+}
+
+func (md *ManagedDaemon) SetLoadedDaemonImageRef(loadedImageRef string) {
+	md.loadedDaemonImageRef = loadedImageRef
+}
+
+func (md *ManagedDaemon) GetHealthCheckTest() []string {
+	return md.healthCheckTest
+}
+
+func (md *ManagedDaemon) GetHealthCheckInterval() time.Duration {
+	return md.healthCheckInterval
+}
+
+func (md *ManagedDaemon) GetHealthCheckTimeout() time.Duration {
+	return md.healthCheckTimeout
+}
+
+func (md *ManagedDaemon) GetHealthCheckRetries() int {
+	return md.healthCheckRetries
 }
 
 func (md *ManagedDaemon) SetHealthCheck(
@@ -277,12 +307,32 @@ func (md *ManagedDaemon) SetEnvironment(environment map[string]string) {
 	}
 }
 
-func (md *ManagedDaemon) SetLoadedDaemonImageRef(loadedImageRef string) {
-	md.loadedDaemonImageRef = loadedImageRef
-}
-
 func (md *ManagedDaemon) SetPrivileged(isPrivileged bool) {
 	md.privileged = isPrivileged
+}
+
+func (md *ManagedDaemon) GetContainerId() string {
+	return md.containerId
+}
+
+func (md *ManagedDaemon) SetContainerId(containerId string) {
+	md.containerId = containerId
+}
+
+func (md *ManagedDaemon) GetContainerCGroup() string {
+	return md.containerCGroup
+}
+
+func (md *ManagedDaemon) SetContainerCGroup(containerCGroup string) {
+	md.containerCGroup = containerCGroup
+}
+
+func (md *ManagedDaemon) GetNetworkNameSpace() string {
+	return md.networkNameSpace
+}
+
+func (md *ManagedDaemon) SetNetworkNameSpace(networkNameSpace string) {
+	md.networkNameSpace = networkNameSpace
 }
 
 // AddMountPoint will add by MountPoint.SourceVolume

--- a/ecs-agent/manageddaemon/managed_daemon.go
+++ b/ecs-agent/manageddaemon/managed_daemon.go
@@ -62,6 +62,11 @@ type ManagedDaemon struct {
 
 	linuxParameters *ecsacs.LinuxParameters
 	privileged      bool
+
+	containerId string
+
+	containerCGroup  string
+	networkNameSpace string
 }
 
 // A valid managed daemon will require
@@ -184,6 +189,11 @@ func (md *ManagedDaemon) GetCommand() []string {
 	return md.command
 }
 
+func (md *ManagedDaemon) SetCommand(command []string) {
+	md.command = make([]string, len(command))
+	copy(md.command, command)
+}
+
 // returns list of mountpoints without the
 // agentCommunicationMount and applicationLogMount
 func (md *ManagedDaemon) GetFilteredMountPoints() []*MountPoint {
@@ -209,6 +219,26 @@ func (md *ManagedDaemon) GetEnvironment() map[string]string {
 
 func (md *ManagedDaemon) GetLoadedDaemonImageRef() string {
 	return md.loadedDaemonImageRef
+}
+
+func (md *ManagedDaemon) SetLoadedDaemonImageRef(loadedImageRef string) {
+	md.loadedDaemonImageRef = loadedImageRef
+}
+
+func (md *ManagedDaemon) GetHealthCheckTest() []string {
+	return md.healthCheckTest
+}
+
+func (md *ManagedDaemon) GetHealthCheckInterval() time.Duration {
+	return md.healthCheckInterval
+}
+
+func (md *ManagedDaemon) GetHealthCheckTimeout() time.Duration {
+	return md.healthCheckTimeout
+}
+
+func (md *ManagedDaemon) GetHealthCheckRetries() int {
+	return md.healthCheckRetries
 }
 
 func (md *ManagedDaemon) SetHealthCheck(
@@ -277,12 +307,32 @@ func (md *ManagedDaemon) SetEnvironment(environment map[string]string) {
 	}
 }
 
-func (md *ManagedDaemon) SetLoadedDaemonImageRef(loadedImageRef string) {
-	md.loadedDaemonImageRef = loadedImageRef
-}
-
 func (md *ManagedDaemon) SetPrivileged(isPrivileged bool) {
 	md.privileged = isPrivileged
+}
+
+func (md *ManagedDaemon) GetContainerId() string {
+	return md.containerId
+}
+
+func (md *ManagedDaemon) SetContainerId(containerId string) {
+	md.containerId = containerId
+}
+
+func (md *ManagedDaemon) GetContainerCGroup() string {
+	return md.containerCGroup
+}
+
+func (md *ManagedDaemon) SetContainerCGroup(containerCGroup string) {
+	md.containerCGroup = containerCGroup
+}
+
+func (md *ManagedDaemon) GetNetworkNameSpace() string {
+	return md.networkNameSpace
+}
+
+func (md *ManagedDaemon) SetNetworkNameSpace(networkNameSpace string) {
+	md.networkNameSpace = networkNameSpace
 }
 
 // AddMountPoint will add by MountPoint.SourceVolume

--- a/ecs-agent/manageddaemon/managed_daemon_test.go
+++ b/ecs-agent/manageddaemon/managed_daemon_test.go
@@ -333,3 +333,31 @@ func TestIsValidManagedDaemon(t *testing.T) {
 		})
 	}
 }
+
+func TestSetContainerId(t *testing.T) {
+	testContainerId := "testContainerId"
+	tmd := NewManagedDaemon(TestImageName, TestImageTag)
+	tmd.SetContainerId(testContainerId)
+	assert.Equal(t, testContainerId, tmd.GetContainerId(), "Wrong value for set ContainerId")
+}
+
+func TestSetContainerCGroup(t *testing.T) {
+	testContainerCGroup := "testContainerCGroup"
+	tmd := NewManagedDaemon(TestImageName, TestImageTag)
+	tmd.SetContainerCGroup(testContainerCGroup)
+	assert.Equal(t, testContainerCGroup, tmd.GetContainerCGroup(), "Wrong value for set ContainerCGroup")
+}
+
+func TestSetNetworkNameSpace(t *testing.T) {
+	testNetworkNameSpace := "testNetworkNameSpace"
+	tmd := NewManagedDaemon(TestImageName, TestImageTag)
+	tmd.SetNetworkNameSpace(testNetworkNameSpace)
+	assert.Equal(t, testNetworkNameSpace, tmd.GetNetworkNameSpace(), "Wrong value for set NetworkNameSpace")
+}
+
+func TestSetCommand(t *testing.T) {
+	testCommand := []string{"testCommand1", "testCommand2"}
+	tmd := NewManagedDaemon(TestImageName, TestImageTag)
+	tmd.SetCommand(testCommand)
+	assert.Equal(t, testCommand, tmd.GetCommand(), "Wrong value for set Command")
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
- This PR adds new attributes to `ManagedDaemon`
 - `containerId`
 - `containerCGroup`
 - `networkNameSpace`
- Adds Getter and Setter for attributes needed to create credentials-fetcher managed daemon

### Implementation details
- Adds Getter and Setter for `containerId`, `containerCGroup`, `networkNameSpace`, `healthChecks` and `command` to `ManagedDaemon`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
* Added unit tests in `managed_daemon_test.go`

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
- Feature - Added `containerId`, `containerCGroup`, `networkNameSpace` to ManagedDaemon

**Does this PR include breaking model changes? If so, Have you added transformation functions?** - no  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
