### PR TITLE
Trim managed agent reason + add retries for getting instance identity signature

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
@@ -294,8 +294,22 @@ func (client *ecsClient) setInstanceIdentity(
 	registerRequest.InstanceIdentityDocument = &instanceIdentityDoc
 
 	if iidRetrieved {
-		instanceIdentitySignature, err = client.ec2metadata.
-			GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource)
+		ctx, cancel = context.WithTimeout(context.Background(), setInstanceIdRetryTimeOut)
+		defer cancel()
+		err = retry.RetryWithBackoffCtx(ctx, backoff, func() error {
+			var attemptErr error
+			logger.Debug("Attempting to get Instance Identity Signature")
+			instanceIdentitySignature, attemptErr = client.ec2metadata.
+				GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource)
+			if attemptErr != nil {
+				logger.Debug("Unable to get instance identity signature, retrying", logger.Fields{
+					field.Error: attemptErr,
+				})
+				return apierrors.NewRetriableError(apierrors.NewRetriable(true), attemptErr)
+			}
+			logger.Debug("Successfully retrieved Instance Identity Signature")
+			return nil
+		})
 		if err != nil {
 			logger.Error("Unable to get instance identity signature", logger.Fields{
 				field.Error: err,
@@ -521,7 +535,7 @@ func (client *ecsClient) submitTaskStateChange(change ecs.TaskStateChange) error
 		PullStartedAt:      change.PullStartedAt,
 		PullStoppedAt:      change.PullStoppedAt,
 		ExecutionStoppedAt: change.ExecutionStoppedAt,
-		ManagedAgents:      change.ManagedAgents,
+		ManagedAgents:      formatManagedAgents(change.ManagedAgents),
 		Containers:         formatContainers(change.Containers, client.shouldExcludeIPv6PortBinding, change.TaskARN),
 	}
 
@@ -752,18 +766,29 @@ func (client *ecsClient) UpdateContainerInstancesState(instanceARN string, statu
 	return err
 }
 
+func formatManagedAgents(managedAgents []*ecsmodel.ManagedAgentStateChange) []*ecsmodel.ManagedAgentStateChange {
+	var result []*ecsmodel.ManagedAgentStateChange
+	for _, m := range managedAgents {
+		if m.Reason != nil {
+			m.Reason = trimStringPtr(m.Reason, ecsMaxContainerReasonLength)
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
 func formatContainers(containers []*ecsmodel.ContainerStateChange, shouldExcludeIPv6PortBinding bool,
 	taskARN string) []*ecsmodel.ContainerStateChange {
 	var result []*ecsmodel.ContainerStateChange
 	for _, c := range containers {
 		if c.RuntimeId != nil {
-			c.RuntimeId = aws.String(trimString(aws.StringValue(c.RuntimeId), ecsMaxRuntimeIDLength))
+			c.RuntimeId = trimStringPtr(c.RuntimeId, ecsMaxRuntimeIDLength)
 		}
 		if c.Reason != nil {
-			c.Reason = aws.String(trimString(aws.StringValue(c.Reason), ecsMaxContainerReasonLength))
+			c.Reason = trimStringPtr(c.Reason, ecsMaxContainerReasonLength)
 		}
 		if c.ImageDigest != nil {
-			c.ImageDigest = aws.String(trimString(aws.StringValue(c.ImageDigest), ecsMaxImageDigestLength))
+			c.ImageDigest = trimStringPtr(c.ImageDigest, ecsMaxImageDigestLength)
 		}
 		if shouldExcludeIPv6PortBinding {
 			c.NetworkBindings = excludeIPv6PortBindingFromNetworkBindings(c.NetworkBindings,
@@ -789,6 +814,13 @@ func excludeIPv6PortBindingFromNetworkBindings(networkBindings []*ecsmodel.Netwo
 		result = append(result, binding)
 	}
 	return result
+}
+
+func trimStringPtr(inputStringPtr *string, maxLen int) *string {
+	if inputStringPtr == nil {
+		return nil
+	}
+	return aws.String(trimString(aws.StringValue(inputStringPtr), maxLen))
 }
 
 func trimString(inputString string, maxLen int) string {

--- a/ecs-agent/api/ecs/client/ecs_client.go
+++ b/ecs-agent/api/ecs/client/ecs_client.go
@@ -294,8 +294,22 @@ func (client *ecsClient) setInstanceIdentity(
 	registerRequest.InstanceIdentityDocument = &instanceIdentityDoc
 
 	if iidRetrieved {
-		instanceIdentitySignature, err = client.ec2metadata.
-			GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource)
+		ctx, cancel = context.WithTimeout(context.Background(), setInstanceIdRetryTimeOut)
+		defer cancel()
+		err = retry.RetryWithBackoffCtx(ctx, backoff, func() error {
+			var attemptErr error
+			logger.Debug("Attempting to get Instance Identity Signature")
+			instanceIdentitySignature, attemptErr = client.ec2metadata.
+				GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource)
+			if attemptErr != nil {
+				logger.Debug("Unable to get instance identity signature, retrying", logger.Fields{
+					field.Error: attemptErr,
+				})
+				return apierrors.NewRetriableError(apierrors.NewRetriable(true), attemptErr)
+			}
+			logger.Debug("Successfully retrieved Instance Identity Signature")
+			return nil
+		})
 		if err != nil {
 			logger.Error("Unable to get instance identity signature", logger.Fields{
 				field.Error: err,
@@ -521,7 +535,7 @@ func (client *ecsClient) submitTaskStateChange(change ecs.TaskStateChange) error
 		PullStartedAt:      change.PullStartedAt,
 		PullStoppedAt:      change.PullStoppedAt,
 		ExecutionStoppedAt: change.ExecutionStoppedAt,
-		ManagedAgents:      change.ManagedAgents,
+		ManagedAgents:      formatManagedAgents(change.ManagedAgents),
 		Containers:         formatContainers(change.Containers, client.shouldExcludeIPv6PortBinding, change.TaskARN),
 	}
 
@@ -752,18 +766,29 @@ func (client *ecsClient) UpdateContainerInstancesState(instanceARN string, statu
 	return err
 }
 
+func formatManagedAgents(managedAgents []*ecsmodel.ManagedAgentStateChange) []*ecsmodel.ManagedAgentStateChange {
+	var result []*ecsmodel.ManagedAgentStateChange
+	for _, m := range managedAgents {
+		if m.Reason != nil {
+			m.Reason = trimStringPtr(m.Reason, ecsMaxContainerReasonLength)
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
 func formatContainers(containers []*ecsmodel.ContainerStateChange, shouldExcludeIPv6PortBinding bool,
 	taskARN string) []*ecsmodel.ContainerStateChange {
 	var result []*ecsmodel.ContainerStateChange
 	for _, c := range containers {
 		if c.RuntimeId != nil {
-			c.RuntimeId = aws.String(trimString(aws.StringValue(c.RuntimeId), ecsMaxRuntimeIDLength))
+			c.RuntimeId = trimStringPtr(c.RuntimeId, ecsMaxRuntimeIDLength)
 		}
 		if c.Reason != nil {
-			c.Reason = aws.String(trimString(aws.StringValue(c.Reason), ecsMaxContainerReasonLength))
+			c.Reason = trimStringPtr(c.Reason, ecsMaxContainerReasonLength)
 		}
 		if c.ImageDigest != nil {
-			c.ImageDigest = aws.String(trimString(aws.StringValue(c.ImageDigest), ecsMaxImageDigestLength))
+			c.ImageDigest = trimStringPtr(c.ImageDigest, ecsMaxImageDigestLength)
 		}
 		if shouldExcludeIPv6PortBinding {
 			c.NetworkBindings = excludeIPv6PortBindingFromNetworkBindings(c.NetworkBindings,
@@ -789,6 +814,13 @@ func excludeIPv6PortBindingFromNetworkBindings(networkBindings []*ecsmodel.Netwo
 		result = append(result, binding)
 	}
 	return result
+}
+
+func trimStringPtr(inputStringPtr *string, maxLen int) *string {
+	if inputStringPtr == nil {
+		return nil
+	}
+	return aws.String(trimString(aws.StringValue(inputStringPtr), maxLen))
 }
 
 func trimString(inputString string, maxLen int) string {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add two enhancements to ECS client:
1. Trim managed agent reason to a max of 255 characters
   - This is not strictly required (since currently in practice Agent will not send a reason that exceeds this max), but is more of a safeguard in case Agent sends larger managed agent reasons in the future. For reference, we already have similar trimming logic in place for other "reason" fields such as container reason - we will reuse this logic by defining a reusable function
2. Add retries with exponential backoff for retrieving instance identity signature
   - This is a proactive measure in case we run into any intermittent upstream issues when retrieving instance identity signature. For reference, we already have similar retry with exponential backoff logic for retrieving instance identity document

### Implementation details
<!-- How are the changes implemented? -->
Same as above.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes (existing test also modified and addresses testing bug)

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Trim managed agent reason + add retries for getting instance identity signature

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
