### PR TITLE
Add check in ecs clint library to ensure only non empty values are added to API request.

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
@@ -438,15 +438,25 @@ func validateRegisteredAttributes(expectedAttributes, actualAttributes []*ecsmod
 }
 
 func (client *ecsClient) getAdditionalAttributes() []*ecsmodel.Attribute {
-	attrs := []*ecsmodel.Attribute{
-		{
+	var attrs []*ecsmodel.Attribute
+
+	// Add a check to ensure only non-empty values are added
+	// to API call.
+	if client.configAccessor.OSType() != "" {
+		attrs = append(attrs, &ecsmodel.Attribute{
 			Name:  aws.String(osTypeAttrName),
 			Value: aws.String(client.configAccessor.OSType()),
-		},
-		{
+		})
+	}
+
+	// OSFamily should be treated as an optional field as it is not applicable for all agents
+	// using ecs client shared library. Add a check to ensure only non-empty values are added
+	// to API call.
+	if client.configAccessor.OSFamily() != "" {
+		attrs = append(attrs, &ecsmodel.Attribute{
 			Name:  aws.String(osFamilyAttrName),
 			Value: aws.String(client.configAccessor.OSFamily()),
-		},
+		})
 	}
 	// Send CPU arch attribute directly when running on external capacity. When running on EC2 or Fargate launch type,
 	// this is not needed since the CPU arch is reported via instance identity document in those cases.

--- a/ecs-agent/api/ecs/client/ecs_client.go
+++ b/ecs-agent/api/ecs/client/ecs_client.go
@@ -438,15 +438,25 @@ func validateRegisteredAttributes(expectedAttributes, actualAttributes []*ecsmod
 }
 
 func (client *ecsClient) getAdditionalAttributes() []*ecsmodel.Attribute {
-	attrs := []*ecsmodel.Attribute{
-		{
+	var attrs []*ecsmodel.Attribute
+
+	// Add a check to ensure only non-empty values are added
+	// to API call.
+	if client.configAccessor.OSType() != "" {
+		attrs = append(attrs, &ecsmodel.Attribute{
 			Name:  aws.String(osTypeAttrName),
 			Value: aws.String(client.configAccessor.OSType()),
-		},
-		{
+		})
+	}
+
+	// OSFamily should be treated as an optional field as it is not applicable for all agents
+	// using ecs client shared library. Add a check to ensure only non-empty values are added
+	// to API call.
+	if client.configAccessor.OSFamily() != "" {
+		attrs = append(attrs, &ecsmodel.Attribute{
 			Name:  aws.String(osFamilyAttrName),
 			Value: aws.String(client.configAccessor.OSFamily()),
-		},
+		})
 	}
 	// Send CPU arch attribute directly when running on external capacity. When running on EC2 or Fargate launch type,
 	// this is not needed since the CPU arch is reported via instance identity document in those cases.


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
This PR adds the check in ecs clint library to ensure only non empty values are added to API request.

### Implementation details
<!-- How are the changes implemented? -->
1. Added empty string check for client.configAccessor.OSFamily() as this is an optional field for one of the users of the ecs client shared library.
2. Added empty string check for client.configAccessor.OSType() as a safety to ensure any future users who have this field as optional would not hit the issue of passing empty value.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit tested
New tests cover the changes: <!-- yes|no --> NA

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add check in ecs clint library to ensure only non empty values are added to API request.

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
