### PR TITLE
advertise new capability to support single region accounts

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -81,6 +81,7 @@ const (
 	capabilityServiceConnect                               = "service-connect-v1"
 	capabilityGpuDriverVersion                             = "gpu-driver-version"
 	capabilityEBSTaskAttach                                = "storage.ebs-task-volume-attach"
+	capabilitySingleRegionAccounts                         = "single-region-accounts"
 
 	// network capabilities, going forward, please append "network." prefix to any new networking capability we introduce
 	networkCapabilityPrefix      = "network."
@@ -110,6 +111,8 @@ var (
 		capabilityEnvFilesS3,
 		// support container port range in container definition - port mapping field
 		capabilityContainerPortRange,
+		// support single region accounts in agent
+		capabilitySingleRegionAccounts,
 	}
 	// use empty struct as value type to simulate set
 	capabilityExecInvalidSsmVersions = map[string]struct{}{}
@@ -194,6 +197,8 @@ var (
 //	ecs.capability.external
 //	ecs.capability.service-connect-v1
 //	ecs.capability.network.container-port-range
+//	ecs.capability.single-region-accounts
+
 func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	var capabilities []*ecs.Attribute
 

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -147,6 +147,7 @@ func TestCapabilities(t *testing.T) {
 		attributePrefix + capabilityExec,
 		attributePrefix + capabilityServiceConnect,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilitySingleRegionAccounts,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -1347,6 +1348,7 @@ func TestCapabilitiesNoServiceConnect(t *testing.T) {
 		attributePrefix + taskENIBlockInstanceMetadataAttributeSuffix,
 		attributePrefix + capabilityExec,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilitySingleRegionAccounts,
 	}
 
 	var expectedCapabilities []*ecs.Attribute

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -549,6 +549,7 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesUnix(t *testing.T) {
 		attributePrefix + capabilityEnvFilesS3,
 		attributePrefix + capabiltyPIDAndIPCNamespaceSharing,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilitySingleRegionAccounts,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -706,6 +707,7 @@ func TestAppMeshCapabilitiesUnix(t *testing.T) {
 		attributePrefix + capabiltyPIDAndIPCNamespaceSharing,
 		attributePrefix + appMeshAttributeSuffix,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilitySingleRegionAccounts,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -913,6 +915,7 @@ func TestCapabilitiesUnix(t *testing.T) {
 		attributePrefix + capabilityFirelensLoggingDriver + capabilityFireLensLoggingDriverConfigBufferLimitSuffix,
 		attributePrefix + capabilityEnvFilesS3,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilitySingleRegionAccounts,
 	}
 
 	var expectedCapabilities []*ecs.Attribute

--- a/agent/app/agent_capability_windows_test.go
+++ b/agent/app/agent_capability_windows_test.go
@@ -190,6 +190,7 @@ func TestSupportedCapabilitiesWindows(t *testing.T) {
 		attributePrefix + capabilityEnvFilesS3,
 		attributePrefix + taskENIBlockInstanceMetadataAttributeSuffix,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilitySingleRegionAccounts,
 	}
 
 	var expectedCapabilities []*ecs.Attribute


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR advertise new capability `ecs.capability.single-region-accounts` so that task will only be placed on instances with Agent that supports SRA.
### Implementation details
<!-- How are the changes implemented? -->
- Added and advertise new capability `single-region-accounts`  to agent
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
add SingleRegionAccounts capability


<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
