### PR TITLE
Generalize seelog config and add setters

### DIFF
--- a/ecs-agent/logger/log_test.go
+++ b/ecs-agent/logger/log_test.go
@@ -102,6 +102,18 @@ func TestLogfmtFormat_Structured_debug(t *testing.T) {
 `, s)
 }
 
+func TestLogfmtFormat_Structured_Timestamp(t *testing.T) {
+	SetTimestampFormat("2006-01-02T15:04:05.000")
+	defer SetTimestampFormat(DEFAULT_TIMESTAMP_FORMAT)
+	logfmt := logfmtFormatter("")
+	fm := defaultStructuredTextFormatter.Format("This is my log message")
+	out := logfmt(fm, seelog.DebugLvl, &LogContextMock{})
+	s, ok := out.(string)
+	require.True(t, ok)
+	require.Equal(t, `level=debug time=2018-10-01T01:02:03.000 msg="This is my log message"
+`, s)
+}
+
 func TestJSONFormat_debug(t *testing.T) {
 	jsonF := jsonFormatter("")
 	out := jsonF("This is my log message", seelog.DebugLvl, &LogContextMock{})
@@ -117,6 +129,17 @@ func TestJSONFormat_Structured_debug(t *testing.T) {
 	s, ok := out.(string)
 	require.True(t, ok)
 	require.JSONEq(t, `{"level": "debug", "time": "2018-10-01T01:02:03Z", "msg": "This is my log message"}`, s)
+}
+
+func TestJSONFormat_Structured_Timestamp(t *testing.T) {
+	SetTimestampFormat("2006-01-02T15:04:05.000")
+	defer SetTimestampFormat(DEFAULT_TIMESTAMP_FORMAT)
+	jsonF := jsonFormatter("")
+	fm := defaultStructuredJsonFormatter.Format("This is my log message")
+	out := jsonF(fm, seelog.DebugLvl, &LogContextMock{})
+	s, ok := out.(string)
+	require.True(t, ok)
+	require.JSONEq(t, `{"level": "debug", "time": "2018-10-01T01:02:03.000", "msg": "This is my log message"}`, s)
 }
 
 func TestSetLevel(t *testing.T) {


### PR DESCRIPTION
### Summary
This change generalizes the Seelog/global logger configuration. Currently, the timestamp format is hardcoded in, and it is unwieldy to change values such as the default output file, log format, etc. by hand as they are controlled by environment variables, and a logger `Config` struct. 

### Implementation details
- Adds a new `timestampFormat` field into the private logger Config struct. This will specify the timestamp format used by structured loggers (i.e. RFC 3339). A new default has been added to the value used in `agent` module, so there is no functional change introduced. Custom formatters now consume this Config attribute rather than the direct time format.
- New setter functions have been added to modify the Config struct for consumer facing logger config
 - `SetTimestampFormat`: Set the logger timestamp format. time.Format() will accept a time format struct, or something custom such as `SetConfigLogFile`.
 - `SetConfigMaxFileSizeMB`: Set the max file size of the logger before log rotation
 - `SetConfigLogFormat`: Set the format for logging(logfmt or json)
- `SetConfigLogFile`: Set the output file for logging.

### Testing
New tests cover the changes: yes

`TestLogfmtFormat_Structured_Timestamp` and `TestJSONFormat_Structured_Timestamp` have been introduced to test the ability to pass a custom time format. They will validate the correctness of a custom time format passed in. Existing tests verify that timestamp format remains consistent when untouched.

### Description for the changelog
Generalize seelog config and add setters

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No. Most of this PR adds setters, and what was abstracted has been replaced with a default used by the `agent` module.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
