### PR TITLE
Enhance and standardize logger Config setters

### DIFF
--- a/agent/app/run.go
+++ b/agent/app/run.go
@@ -60,9 +60,11 @@ func Run(arguments []string) int {
 	}
 
 	if *parsedArgs.LogLevel != "" {
-		logger.SetLevel(*parsedArgs.LogLevel, *parsedArgs.LogLevel)
+		logger.SetDriverLogLevel(*parsedArgs.LogLevel)
+		logger.SetInstanceLogLevel(*parsedArgs.LogLevel)
 	} else {
-		logger.SetLevel(*parsedArgs.DriverLogLevel, *parsedArgs.InstanceLogLevel)
+		logger.SetDriverLogLevel(*parsedArgs.DriverLogLevel)
+		logger.SetInstanceLogLevel(*parsedArgs.InstanceLogLevel)
 	}
 
 	// Create an Agent object

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/log.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/log.go
@@ -44,18 +44,34 @@ const (
 	DEFAULT_TIMESTAMP_FORMAT                 = time.RFC3339
 	DEFAULT_MAX_FILE_SIZE            float64 = 10
 	DEFAULT_MAX_ROLL_COUNT           int     = 24
+	DEFAULT_LOGTO_STDOUT                     = true
 )
 
+// Because timestamp format will be called in the custom formatter
+// for each log message processed, it should not be handled
+// with an explicitly write protected configuration.
+var timestampFormat = DEFAULT_TIMESTAMP_FORMAT
+
+// logLevels is the mapping from ECS_LOGLEVEL to Seelog provided levels.
+var logLevels = map[string]string{
+	"debug": "debug",
+	"info":  "info",
+	"warn":  "warn",
+	"error": "error",
+	"crit":  "critical",
+	"none":  "off",
+}
+
 type logConfig struct {
-	RolloverType    string
-	MaxRollCount    int
-	MaxFileSizeMB   float64
-	logfile         string
-	driverLevel     string
-	instanceLevel   string
-	outputFormat    string
-	timestampFormat string
-	lock            sync.Mutex
+	RolloverType  string
+	MaxRollCount  int
+	MaxFileSizeMB float64
+	logfile       string
+	driverLevel   string
+	instanceLevel string
+	outputFormat  string
+	logToStdout   bool
+	lock          sync.Mutex
 }
 
 var Config *logConfig
@@ -89,7 +105,7 @@ func logfmtFormatter(params string) seelog.FormatterFunc {
 		buf.WriteString(level.String())
 		buf.WriteByte(' ')
 		buf.WriteString("time=")
-		buf.WriteString(context.CallTime().UTC().Format(Config.timestampFormat))
+		buf.WriteString(context.CallTime().UTC().Format(timestampFormat))
 		buf.WriteByte(' ')
 		// temporary measure to make this change backwards compatible as we update to structured logs
 		if strings.HasPrefix(message, structuredTxtFormatPrefix) {
@@ -114,7 +130,7 @@ func jsonFormatter(params string) seelog.FormatterFunc {
 		buf.WriteString(`{"level":"`)
 		buf.WriteString(level.String())
 		buf.WriteString(`","time":"`)
-		buf.WriteString(context.CallTime().UTC().Format(Config.timestampFormat))
+		buf.WriteString(context.CallTime().UTC().Format(timestampFormat))
 		buf.WriteString(`",`)
 		// temporary measure to make this change backwards compatible as we update to structured logs
 		if strings.HasPrefix(message, structuredJsonFormatPrefix) {
@@ -144,14 +160,26 @@ func reloadConfig() {
 }
 
 func seelogConfig() string {
+	driverLogChildren := []string{}
+	platformLogConfig := platformLogConfig()
+	if Config.logToStdout {
+		driverLogChildren = append(driverLogChildren, `	<console />`)
+	}
+	if platformLogConfig != "" {
+		driverLogChildren = append(driverLogChildren, platformLogConfig)
+	}
+
 	c := `
 <seelog type="asyncloop">
-	<outputs formatid="` + Config.outputFormat + `">
+	<outputs formatid="` + Config.outputFormat + `">`
+	if len(driverLogChildren) > 0 {
+		c += `
 		<filter levels="` + getLevelList(Config.driverLevel) + `">
-			<console />`
-	c += platformLogConfig()
-	c += `
+		`
+		c += strings.Join(driverLogChildren, "\n")
+		c += `
 		</filter>`
+	}
 	if Config.logfile != "" {
 		c += `
 		<filter levels="` + getLevelList(Config.instanceLevel) + `">`
@@ -159,6 +187,9 @@ func seelogConfig() string {
 			c += `
 			<rollingfile filename="` + Config.logfile + `" type="size"
 			 maxsize="` + strconv.Itoa(int(Config.MaxFileSizeMB*1000000)) + `" archivetype="none" maxrolls="` + strconv.Itoa(Config.MaxRollCount) + `" />`
+		} else if Config.RolloverType == "none" {
+			c += `
+			<file path="` + Config.logfile + `"/>`
 		} else {
 			c += `
 			<rollingfile filename="` + Config.logfile + `" type="date"
@@ -191,33 +222,6 @@ func getLevelList(fileLevel string) string {
 	return levelLists[fileLevel]
 }
 
-// SetLevel sets the log levels for logging
-func SetLevel(driverLogLevel, instanceLogLevel string) {
-	levels := map[string]string{
-		"debug": "debug",
-		"info":  "info",
-		"warn":  "warn",
-		"error": "error",
-		"crit":  "critical",
-		"none":  "off",
-	}
-
-	parsedDriverLevel, driverOk := levels[strings.ToLower(driverLogLevel)]
-	parsedInstanceLevel, instanceOk := levels[strings.ToLower(instanceLogLevel)]
-
-	if instanceOk || driverOk {
-		Config.lock.Lock()
-		defer Config.lock.Unlock()
-		if instanceOk {
-			Config.instanceLevel = parsedInstanceLevel
-		}
-		if driverOk {
-			Config.driverLevel = parsedDriverLevel
-		}
-		reloadConfig()
-	}
-}
-
 // GetLevel gets the log level
 func GetLevel() string {
 	Config.lock.Lock()
@@ -236,34 +240,82 @@ func setInstanceLevelDefault() string {
 	return DEFAULT_LOGLEVEL
 }
 
-// SetConfigLogFile sets the default output file of the logger.
-func SetConfigLogFile(logFile string) {
-	Config.lock.Lock()
-	defer Config.lock.Unlock()
-
-	Config.logfile = logFile
+// SetInstanceLogLevel explicitly sets the log level for instance logs.
+func SetInstanceLogLevel(instanceLogLevel string) {
+	parsedLevel, ok := logLevels[strings.ToLower(instanceLogLevel)]
+	if ok {
+		Config.lock.Lock()
+		defer Config.lock.Unlock()
+		Config.instanceLevel = parsedLevel
+		reloadConfig()
+	} else {
+		seelog.Error("Instance log level mapping not found")
+	}
 }
 
-// SetConfigLogFormat sets the output format of the logger.
+// SetDriverLogLevel explicitly sets the log level for a custom driver.
+func SetDriverLogLevel(driverLogLevel string) {
+	parsedLevel, ok := logLevels[strings.ToLower(driverLogLevel)]
+	if ok {
+		Config.lock.Lock()
+		defer Config.lock.Unlock()
+		Config.driverLevel = parsedLevel
+		reloadConfig()
+	} else {
+		seelog.Error("Driver log level mapping not found")
+	}
+}
+
+// SetConfigLogFile sets the default output file of the logger.
+func SetConfigLogFile(logFile string) {
+	if logFile != "" {
+		Config.lock.Lock()
+		defer Config.lock.Unlock()
+
+		Config.logfile = logFile
+		reloadConfig()
+	} else {
+		seelog.Error("Cannot use empty log file")
+	}
+}
+
+// SetConfigOutputFormat sets the output format of the logger.
 // e.g. json, xml, etc.
-func SetConfigLogFormat(logFormat string) {
+func SetConfigOutputFormat(outputFormat string) {
 	Config.lock.Lock()
 	defer Config.lock.Unlock()
 
-	os.Setenv(LOG_OUTPUT_FORMAT_ENV_VAR, logFormat)
-	Config.outputFormat = logFormat
+	Config.outputFormat = outputFormat
+	reloadConfig()
 }
 
 // SetConfigMaxFileSizeMB sets the max file size of a log file
 // in Megabytes before the logger rotates to a new file.
 func SetConfigMaxFileSizeMB(maxSizeInMB float64) {
-	Config.lock.Lock()
-	defer Config.lock.Unlock()
+	if maxSizeInMB > 0 {
+		Config.lock.Lock()
+		defer Config.lock.Unlock()
 
-	// Parse unit as string to set as environment variable.
-	strsize := strconv.FormatFloat(maxSizeInMB, 'f', -1, 64)
-	os.Setenv(LOG_MAX_FILE_SIZE_ENV_VAR, strsize)
-	Config.MaxFileSizeMB = maxSizeInMB
+		Config.MaxFileSizeMB = maxSizeInMB
+		reloadConfig()
+	} else {
+		seelog.Error("Invalid Max File Size Provided")
+	}
+}
+
+// SetRolloverType sets the logging rollover constraint.
+// This should be either size or date. Logger will roll
+// to a new log file based on this constraint.
+func SetRolloverType(rolloverType string) {
+	if rolloverType == "date" || rolloverType == "size" || rolloverType == "none" {
+		Config.lock.Lock()
+		defer Config.lock.Unlock()
+
+		Config.RolloverType = rolloverType
+		reloadConfig()
+	} else {
+		seelog.Error("Invalid log rollover type provided")
+	}
 }
 
 // SetTimestampFormat sets the time formatting
@@ -271,27 +323,38 @@ func SetConfigMaxFileSizeMB(maxSizeInMB float64) {
 // a valid time format such as time.RFC3339
 // or "2006-01-02T15:04:05.000".
 func SetTimestampFormat(format string) {
+	if format != "" {
+		timestampFormat = format
+	}
+}
+
+// SetLogToStdout decides whether the logger
+// should write to stdout using the <console/> tag
+// in addition to logfiles that are set up.
+func SetLogToStdout(duplicate bool) {
 	Config.lock.Lock()
 	defer Config.lock.Unlock()
 
-	if format != "" {
-		Config.timestampFormat = format
-	}
+	Config.logToStdout = duplicate
+	reloadConfig()
 }
 
 func init() {
 	Config = &logConfig{
-		logfile:         os.Getenv(LOGFILE_ENV_VAR),
-		driverLevel:     DEFAULT_LOGLEVEL,
-		instanceLevel:   setInstanceLevelDefault(),
-		RolloverType:    DEFAULT_ROLLOVER_TYPE,
-		outputFormat:    DEFAULT_OUTPUT_FORMAT,
-		MaxFileSizeMB:   DEFAULT_MAX_FILE_SIZE,
-		MaxRollCount:    DEFAULT_MAX_ROLL_COUNT,
-		timestampFormat: DEFAULT_TIMESTAMP_FORMAT,
+		logfile:       os.Getenv(LOGFILE_ENV_VAR),
+		driverLevel:   DEFAULT_LOGLEVEL,
+		instanceLevel: setInstanceLevelDefault(),
+		RolloverType:  DEFAULT_ROLLOVER_TYPE,
+		outputFormat:  DEFAULT_OUTPUT_FORMAT,
+		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
+		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 }
 
+// InitSeelog registers custom logging formats, updates the internal Config struct
+// and reloads the global logger. This should only be called once, as external
+// callers should use the Config struct over environment variables directly.
 func InitSeelog() {
 	if err := seelog.RegisterCustomFormatter("EcsAgentLogfmt", logfmtFormatter); err != nil {
 		seelog.Error(err)
@@ -303,8 +366,12 @@ func InitSeelog() {
 		seelog.Error(err)
 	}
 
-	SetLevel(os.Getenv(LOGLEVEL_ENV_VAR), os.Getenv(LOGLEVEL_ON_INSTANCE_ENV_VAR))
-
+	if DriverLogLevel := os.Getenv(LOGLEVEL_ENV_VAR); DriverLogLevel != "" {
+		SetDriverLogLevel(DriverLogLevel)
+	}
+	if InstanceLogLevel := os.Getenv(LOGLEVEL_ON_INSTANCE_ENV_VAR); InstanceLogLevel != "" {
+		SetInstanceLogLevel(InstanceLogLevel)
+	}
 	if RolloverType := os.Getenv(LOG_ROLLOVER_TYPE_ENV_VAR); RolloverType != "" {
 		Config.RolloverType = RolloverType
 	}

--- a/ecs-agent/logger/log.go
+++ b/ecs-agent/logger/log.go
@@ -44,18 +44,34 @@ const (
 	DEFAULT_TIMESTAMP_FORMAT                 = time.RFC3339
 	DEFAULT_MAX_FILE_SIZE            float64 = 10
 	DEFAULT_MAX_ROLL_COUNT           int     = 24
+	DEFAULT_LOGTO_STDOUT                     = true
 )
 
+// Because timestamp format will be called in the custom formatter
+// for each log message processed, it should not be handled
+// with an explicitly write protected configuration.
+var timestampFormat = DEFAULT_TIMESTAMP_FORMAT
+
+// logLevels is the mapping from ECS_LOGLEVEL to Seelog provided levels.
+var logLevels = map[string]string{
+	"debug": "debug",
+	"info":  "info",
+	"warn":  "warn",
+	"error": "error",
+	"crit":  "critical",
+	"none":  "off",
+}
+
 type logConfig struct {
-	RolloverType    string
-	MaxRollCount    int
-	MaxFileSizeMB   float64
-	logfile         string
-	driverLevel     string
-	instanceLevel   string
-	outputFormat    string
-	timestampFormat string
-	lock            sync.Mutex
+	RolloverType  string
+	MaxRollCount  int
+	MaxFileSizeMB float64
+	logfile       string
+	driverLevel   string
+	instanceLevel string
+	outputFormat  string
+	logToStdout   bool
+	lock          sync.Mutex
 }
 
 var Config *logConfig
@@ -89,7 +105,7 @@ func logfmtFormatter(params string) seelog.FormatterFunc {
 		buf.WriteString(level.String())
 		buf.WriteByte(' ')
 		buf.WriteString("time=")
-		buf.WriteString(context.CallTime().UTC().Format(Config.timestampFormat))
+		buf.WriteString(context.CallTime().UTC().Format(timestampFormat))
 		buf.WriteByte(' ')
 		// temporary measure to make this change backwards compatible as we update to structured logs
 		if strings.HasPrefix(message, structuredTxtFormatPrefix) {
@@ -114,7 +130,7 @@ func jsonFormatter(params string) seelog.FormatterFunc {
 		buf.WriteString(`{"level":"`)
 		buf.WriteString(level.String())
 		buf.WriteString(`","time":"`)
-		buf.WriteString(context.CallTime().UTC().Format(Config.timestampFormat))
+		buf.WriteString(context.CallTime().UTC().Format(timestampFormat))
 		buf.WriteString(`",`)
 		// temporary measure to make this change backwards compatible as we update to structured logs
 		if strings.HasPrefix(message, structuredJsonFormatPrefix) {
@@ -144,14 +160,26 @@ func reloadConfig() {
 }
 
 func seelogConfig() string {
+	driverLogChildren := []string{}
+	platformLogConfig := platformLogConfig()
+	if Config.logToStdout {
+		driverLogChildren = append(driverLogChildren, `	<console />`)
+	}
+	if platformLogConfig != "" {
+		driverLogChildren = append(driverLogChildren, platformLogConfig)
+	}
+
 	c := `
 <seelog type="asyncloop">
-	<outputs formatid="` + Config.outputFormat + `">
+	<outputs formatid="` + Config.outputFormat + `">`
+	if len(driverLogChildren) > 0 {
+		c += `
 		<filter levels="` + getLevelList(Config.driverLevel) + `">
-			<console />`
-	c += platformLogConfig()
-	c += `
+		`
+		c += strings.Join(driverLogChildren, "\n")
+		c += `
 		</filter>`
+	}
 	if Config.logfile != "" {
 		c += `
 		<filter levels="` + getLevelList(Config.instanceLevel) + `">`
@@ -159,6 +187,9 @@ func seelogConfig() string {
 			c += `
 			<rollingfile filename="` + Config.logfile + `" type="size"
 			 maxsize="` + strconv.Itoa(int(Config.MaxFileSizeMB*1000000)) + `" archivetype="none" maxrolls="` + strconv.Itoa(Config.MaxRollCount) + `" />`
+		} else if Config.RolloverType == "none" {
+			c += `
+			<file path="` + Config.logfile + `"/>`
 		} else {
 			c += `
 			<rollingfile filename="` + Config.logfile + `" type="date"
@@ -191,33 +222,6 @@ func getLevelList(fileLevel string) string {
 	return levelLists[fileLevel]
 }
 
-// SetLevel sets the log levels for logging
-func SetLevel(driverLogLevel, instanceLogLevel string) {
-	levels := map[string]string{
-		"debug": "debug",
-		"info":  "info",
-		"warn":  "warn",
-		"error": "error",
-		"crit":  "critical",
-		"none":  "off",
-	}
-
-	parsedDriverLevel, driverOk := levels[strings.ToLower(driverLogLevel)]
-	parsedInstanceLevel, instanceOk := levels[strings.ToLower(instanceLogLevel)]
-
-	if instanceOk || driverOk {
-		Config.lock.Lock()
-		defer Config.lock.Unlock()
-		if instanceOk {
-			Config.instanceLevel = parsedInstanceLevel
-		}
-		if driverOk {
-			Config.driverLevel = parsedDriverLevel
-		}
-		reloadConfig()
-	}
-}
-
 // GetLevel gets the log level
 func GetLevel() string {
 	Config.lock.Lock()
@@ -236,34 +240,82 @@ func setInstanceLevelDefault() string {
 	return DEFAULT_LOGLEVEL
 }
 
-// SetConfigLogFile sets the default output file of the logger.
-func SetConfigLogFile(logFile string) {
-	Config.lock.Lock()
-	defer Config.lock.Unlock()
-
-	Config.logfile = logFile
+// SetInstanceLogLevel explicitly sets the log level for instance logs.
+func SetInstanceLogLevel(instanceLogLevel string) {
+	parsedLevel, ok := logLevels[strings.ToLower(instanceLogLevel)]
+	if ok {
+		Config.lock.Lock()
+		defer Config.lock.Unlock()
+		Config.instanceLevel = parsedLevel
+		reloadConfig()
+	} else {
+		seelog.Error("Instance log level mapping not found")
+	}
 }
 
-// SetConfigLogFormat sets the output format of the logger.
+// SetDriverLogLevel explicitly sets the log level for a custom driver.
+func SetDriverLogLevel(driverLogLevel string) {
+	parsedLevel, ok := logLevels[strings.ToLower(driverLogLevel)]
+	if ok {
+		Config.lock.Lock()
+		defer Config.lock.Unlock()
+		Config.driverLevel = parsedLevel
+		reloadConfig()
+	} else {
+		seelog.Error("Driver log level mapping not found")
+	}
+}
+
+// SetConfigLogFile sets the default output file of the logger.
+func SetConfigLogFile(logFile string) {
+	if logFile != "" {
+		Config.lock.Lock()
+		defer Config.lock.Unlock()
+
+		Config.logfile = logFile
+		reloadConfig()
+	} else {
+		seelog.Error("Cannot use empty log file")
+	}
+}
+
+// SetConfigOutputFormat sets the output format of the logger.
 // e.g. json, xml, etc.
-func SetConfigLogFormat(logFormat string) {
+func SetConfigOutputFormat(outputFormat string) {
 	Config.lock.Lock()
 	defer Config.lock.Unlock()
 
-	os.Setenv(LOG_OUTPUT_FORMAT_ENV_VAR, logFormat)
-	Config.outputFormat = logFormat
+	Config.outputFormat = outputFormat
+	reloadConfig()
 }
 
 // SetConfigMaxFileSizeMB sets the max file size of a log file
 // in Megabytes before the logger rotates to a new file.
 func SetConfigMaxFileSizeMB(maxSizeInMB float64) {
-	Config.lock.Lock()
-	defer Config.lock.Unlock()
+	if maxSizeInMB > 0 {
+		Config.lock.Lock()
+		defer Config.lock.Unlock()
 
-	// Parse unit as string to set as environment variable.
-	strsize := strconv.FormatFloat(maxSizeInMB, 'f', -1, 64)
-	os.Setenv(LOG_MAX_FILE_SIZE_ENV_VAR, strsize)
-	Config.MaxFileSizeMB = maxSizeInMB
+		Config.MaxFileSizeMB = maxSizeInMB
+		reloadConfig()
+	} else {
+		seelog.Error("Invalid Max File Size Provided")
+	}
+}
+
+// SetRolloverType sets the logging rollover constraint.
+// This should be either size or date. Logger will roll
+// to a new log file based on this constraint.
+func SetRolloverType(rolloverType string) {
+	if rolloverType == "date" || rolloverType == "size" || rolloverType == "none" {
+		Config.lock.Lock()
+		defer Config.lock.Unlock()
+
+		Config.RolloverType = rolloverType
+		reloadConfig()
+	} else {
+		seelog.Error("Invalid log rollover type provided")
+	}
 }
 
 // SetTimestampFormat sets the time formatting
@@ -271,27 +323,38 @@ func SetConfigMaxFileSizeMB(maxSizeInMB float64) {
 // a valid time format such as time.RFC3339
 // or "2006-01-02T15:04:05.000".
 func SetTimestampFormat(format string) {
+	if format != "" {
+		timestampFormat = format
+	}
+}
+
+// SetLogToStdout decides whether the logger
+// should write to stdout using the <console/> tag
+// in addition to logfiles that are set up.
+func SetLogToStdout(duplicate bool) {
 	Config.lock.Lock()
 	defer Config.lock.Unlock()
 
-	if format != "" {
-		Config.timestampFormat = format
-	}
+	Config.logToStdout = duplicate
+	reloadConfig()
 }
 
 func init() {
 	Config = &logConfig{
-		logfile:         os.Getenv(LOGFILE_ENV_VAR),
-		driverLevel:     DEFAULT_LOGLEVEL,
-		instanceLevel:   setInstanceLevelDefault(),
-		RolloverType:    DEFAULT_ROLLOVER_TYPE,
-		outputFormat:    DEFAULT_OUTPUT_FORMAT,
-		MaxFileSizeMB:   DEFAULT_MAX_FILE_SIZE,
-		MaxRollCount:    DEFAULT_MAX_ROLL_COUNT,
-		timestampFormat: DEFAULT_TIMESTAMP_FORMAT,
+		logfile:       os.Getenv(LOGFILE_ENV_VAR),
+		driverLevel:   DEFAULT_LOGLEVEL,
+		instanceLevel: setInstanceLevelDefault(),
+		RolloverType:  DEFAULT_ROLLOVER_TYPE,
+		outputFormat:  DEFAULT_OUTPUT_FORMAT,
+		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
+		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 }
 
+// InitSeelog registers custom logging formats, updates the internal Config struct
+// and reloads the global logger. This should only be called once, as external
+// callers should use the Config struct over environment variables directly.
 func InitSeelog() {
 	if err := seelog.RegisterCustomFormatter("EcsAgentLogfmt", logfmtFormatter); err != nil {
 		seelog.Error(err)
@@ -303,8 +366,12 @@ func InitSeelog() {
 		seelog.Error(err)
 	}
 
-	SetLevel(os.Getenv(LOGLEVEL_ENV_VAR), os.Getenv(LOGLEVEL_ON_INSTANCE_ENV_VAR))
-
+	if DriverLogLevel := os.Getenv(LOGLEVEL_ENV_VAR); DriverLogLevel != "" {
+		SetDriverLogLevel(DriverLogLevel)
+	}
+	if InstanceLogLevel := os.Getenv(LOGLEVEL_ON_INSTANCE_ENV_VAR); InstanceLogLevel != "" {
+		SetInstanceLogLevel(InstanceLogLevel)
+	}
 	if RolloverType := os.Getenv(LOG_ROLLOVER_TYPE_ENV_VAR); RolloverType != "" {
 		Config.RolloverType = RolloverType
 	}

--- a/ecs-agent/logger/log_test.go
+++ b/ecs-agent/logger/log_test.go
@@ -142,7 +142,7 @@ func TestJSONFormat_Structured_Timestamp(t *testing.T) {
 	require.JSONEq(t, `{"level": "debug", "time": "2018-10-01T01:02:03.000", "msg": "This is my log message"}`, s)
 }
 
-func TestSetLevel(t *testing.T) {
+func TestSetLogLevels(t *testing.T) {
 	resetEnv := func() {
 		os.Unsetenv(LOGLEVEL_ENV_VAR)
 		os.Unsetenv(LOGLEVEL_ON_INSTANCE_ENV_VAR)
@@ -241,8 +241,11 @@ func TestSetLevel(t *testing.T) {
 				MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 				MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
 			}
-			SetLevel(os.Getenv(LOGLEVEL_ENV_VAR), os.Getenv(LOGLEVEL_ON_INSTANCE_ENV_VAR))
+
+			SetDriverLogLevel(test.loglevel)
 			require.Equal(t, test.expectedLoglevel, Config.driverLevel)
+
+			SetInstanceLogLevel(test.loglevelInstance)
 			require.Equal(t, test.expectedLoglevelInstance, Config.instanceLevel)
 		})
 	}

--- a/ecs-agent/logger/log_unix_test.go
+++ b/ecs-agent/logger/log_unix_test.go
@@ -23,16 +23,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSeelogConfig_Default(t *testing.T) {
+const DEFAULT_TEST_LOG_FILE = "foo.log"
+
+func SetDefaultConfig() {
 	Config = &logConfig{
-		logfile:       "foo.log",
+		logfile:       DEFAULT_TEST_LOG_FILE,
 		driverLevel:   DEFAULT_LOGLEVEL,
-		instanceLevel: DEFAULT_LOGLEVEL,
+		instanceLevel: setInstanceLevelDefault(),
 		RolloverType:  DEFAULT_ROLLOVER_TYPE,
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
+}
+
+func TestSeelogConfig_Default(t *testing.T) {
+	SetDefaultConfig()
 	c := seelogConfig()
 	require.Equal(t, `
 <seelog type="asyncloop">
@@ -61,6 +68,7 @@ func TestSeelogConfig_WithoutLogFile(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -78,16 +86,37 @@ func TestSeelogConfig_WithoutLogFile(t *testing.T) {
 </seelog>`, c)
 }
 
-func TestSeelogConfig_DebugLevel(t *testing.T) {
+func TestSeeLogConfig_WithoutStdout(t *testing.T) {
 	Config = &logConfig{
 		logfile:       "foo.log",
-		driverLevel:   "debug",
+		driverLevel:   DEFAULT_LOGLEVEL,
 		instanceLevel: DEFAULT_LOGLEVEL,
-		RolloverType:  DEFAULT_ROLLOVER_TYPE,
+		RolloverType:  "none",
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   false,
 	}
+	c := seelogConfig()
+	require.Equal(t, `
+<seelog type="asyncloop">
+	<outputs formatid="logfmt">
+		<filter levels="info,warn,error,critical">
+			<file path="foo.log"/>
+		</filter>
+	</outputs>
+	<formats>
+		<format id="logfmt" format="%EcsAgentLogfmt" />
+		<format id="json" format="%EcsAgentJson" />
+		<format id="windows" format="%EcsMsg" />
+	</formats>
+</seelog>`, c)
+}
+
+func TestSeelogConfig_DebugLevel(t *testing.T) {
+	SetDefaultConfig()
+	SetDriverLogLevel("debug")
+
 	c := seelogConfig()
 	require.Equal(t, `
 <seelog type="asyncloop">
@@ -117,6 +146,7 @@ func TestSeelogConfig_SizeRollover(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -147,6 +177,7 @@ func TestSeelogConfig_SizeRolloverFileSizeChange(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: 15,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -177,6 +208,7 @@ func TestSeelogConfig_SizeRolloverRollCountChange(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: 15,
 		MaxRollCount:  10,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -207,6 +239,7 @@ func TestSeelogConfig_JSONOutput(t *testing.T) {
 		outputFormat:  "json",
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  10,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -228,6 +261,64 @@ func TestSeelogConfig_JSONOutput(t *testing.T) {
 </seelog>`, c)
 }
 
+func TestSeelogConfig_JSONNoStdout(t *testing.T) {
+	Config = &logConfig{
+		logfile:       "foo.log",
+		driverLevel:   DEFAULT_LOGLEVEL,
+		instanceLevel: DEFAULT_LOGLEVEL,
+		RolloverType:  DEFAULT_ROLLOVER_TYPE,
+		outputFormat:  "json",
+		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
+		MaxRollCount:  10,
+		logToStdout:   false,
+	}
+	c := seelogConfig()
+	require.Equal(t, `
+<seelog type="asyncloop">
+	<outputs formatid="json">
+		<filter levels="info,warn,error,critical">
+			<rollingfile filename="foo.log" type="date"
+			 datepattern="2006-01-02-15" archivetype="none" maxrolls="10" />
+		</filter>
+	</outputs>
+	<formats>
+		<format id="logfmt" format="%EcsAgentLogfmt" />
+		<format id="json" format="%EcsAgentJson" />
+		<format id="windows" format="%EcsMsg" />
+	</formats>
+</seelog>`, c)
+}
+
+func TestSeelogConfig_JSONNoRollover(t *testing.T) {
+	Config = &logConfig{
+		logfile:       "foo.log",
+		driverLevel:   DEFAULT_LOGLEVEL,
+		instanceLevel: DEFAULT_LOGLEVEL,
+		RolloverType:  "none",
+		outputFormat:  "json",
+		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
+		MaxRollCount:  10,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
+	}
+	c := seelogConfig()
+	require.Equal(t, `
+<seelog type="asyncloop">
+	<outputs formatid="json">
+		<filter levels="info,warn,error,critical">
+			<console />
+		</filter>
+		<filter levels="info,warn,error,critical">
+			<file path="foo.log"/>
+		</filter>
+	</outputs>
+	<formats>
+		<format id="logfmt" format="%EcsAgentLogfmt" />
+		<format id="json" format="%EcsAgentJson" />
+		<format id="windows" format="%EcsMsg" />
+	</formats>
+</seelog>`, c)
+}
+
 func TestSeelogConfig_NoOnInstanceLog(t *testing.T) {
 	Config = &logConfig{
 		logfile:       "foo.log",
@@ -237,6 +328,7 @@ func TestSeelogConfig_NoOnInstanceLog(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -259,15 +351,13 @@ func TestSeelogConfig_NoOnInstanceLog(t *testing.T) {
 }
 
 func TestSeelogConfig_DifferentLevels(t *testing.T) {
-	Config = &logConfig{
-		logfile:       "foo.log",
-		driverLevel:   "warn",
-		instanceLevel: "critical",
-		RolloverType:  DEFAULT_ROLLOVER_TYPE,
-		outputFormat:  DEFAULT_OUTPUT_FORMAT,
-		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
-		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
-	}
+	SetDefaultConfig()
+
+	SetDriverLogLevel("warn")
+	SetInstanceLogLevel("critical")
+	defer SetDriverLogLevel(DEFAULT_LOGLEVEL)
+	defer SetInstanceLogLevel(setInstanceLevelDefault())
+
 	c := seelogConfig()
 	require.Equal(t, `
 <seelog type="asyncloop">
@@ -275,7 +365,7 @@ func TestSeelogConfig_DifferentLevels(t *testing.T) {
 		<filter levels="warn,error,critical">
 			<console />
 		</filter>
-		<filter levels="critical">
+		<filter levels="info,warn,error,critical">
 			<rollingfile filename="foo.log" type="date"
 			 datepattern="2006-01-02-15" archivetype="none" maxrolls="24" />
 		</filter>
@@ -300,6 +390,7 @@ func TestSeelogConfig_FileLevelDefault(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -309,6 +400,129 @@ func TestSeelogConfig_FileLevelDefault(t *testing.T) {
 			<console />
 		</filter>
 		<filter levels="off">
+			<rollingfile filename="foo.log" type="date"
+			 datepattern="2006-01-02-15" archivetype="none" maxrolls="24" />
+		</filter>
+	</outputs>
+	<formats>
+		<format id="logfmt" format="%EcsAgentLogfmt" />
+		<format id="json" format="%EcsAgentJson" />
+		<format id="windows" format="%EcsMsg" />
+	</formats>
+</seelog>`, c)
+}
+
+func TestSetLogFile(t *testing.T) {
+	SetDefaultConfig()
+	SetRolloverType("none")
+	SetConfigLogFile("bar.log")
+	defer SetConfigLogFile("foo.log")
+
+	c := seelogConfig()
+	require.Equal(t, `
+<seelog type="asyncloop">
+	<outputs formatid="logfmt">
+		<filter levels="info,warn,error,critical">
+			<console />
+		</filter>
+		<filter levels="info,warn,error,critical">
+			<file path="bar.log"/>
+		</filter>
+	</outputs>
+	<formats>
+		<format id="logfmt" format="%EcsAgentLogfmt" />
+		<format id="json" format="%EcsAgentJson" />
+		<format id="windows" format="%EcsMsg" />
+	</formats>
+</seelog>`, c)
+}
+
+func TestSetOutputFormat(t *testing.T) {
+	SetDefaultConfig()
+	SetConfigOutputFormat("json")
+	defer SetConfigOutputFormat(DEFAULT_OUTPUT_FORMAT)
+
+	c := seelogConfig()
+	require.Equal(t, `
+<seelog type="asyncloop">
+	<outputs formatid="json">
+		<filter levels="info,warn,error,critical">
+			<console />
+		</filter>
+		<filter levels="info,warn,error,critical">
+			<rollingfile filename="foo.log" type="date"
+			 datepattern="2006-01-02-15" archivetype="none" maxrolls="24" />
+		</filter>
+	</outputs>
+	<formats>
+		<format id="logfmt" format="%EcsAgentLogfmt" />
+		<format id="json" format="%EcsAgentJson" />
+		<format id="windows" format="%EcsMsg" />
+	</formats>
+</seelog>`, c)
+}
+
+func TestSetMaxFileSizeMB(t *testing.T) {
+	SetDefaultConfig()
+	SetRolloverType("size")
+	SetConfigMaxFileSizeMB(5)
+	defer SetRolloverType(DEFAULT_ROLLOVER_TYPE)
+	defer SetConfigMaxFileSizeMB(DEFAULT_MAX_FILE_SIZE)
+
+	c := seelogConfig()
+	require.Equal(t, `
+<seelog type="asyncloop">
+	<outputs formatid="logfmt">
+		<filter levels="info,warn,error,critical">
+			<console />
+		</filter>
+		<filter levels="info,warn,error,critical">
+			<rollingfile filename="foo.log" type="size"
+			 maxsize="5000000" archivetype="none" maxrolls="24" />
+		</filter>
+	</outputs>
+	<formats>
+		<format id="logfmt" format="%EcsAgentLogfmt" />
+		<format id="json" format="%EcsAgentJson" />
+		<format id="windows" format="%EcsMsg" />
+	</formats>
+</seelog>`, c)
+}
+
+func TestSetRolloverType(t *testing.T) {
+	SetDefaultConfig()
+	SetRolloverType("none")
+	defer SetRolloverType(DEFAULT_ROLLOVER_TYPE)
+
+	c := seelogConfig()
+	require.Equal(t, `
+<seelog type="asyncloop">
+	<outputs formatid="logfmt">
+		<filter levels="info,warn,error,critical">
+			<console />
+		</filter>
+		<filter levels="info,warn,error,critical">
+			<file path="foo.log"/>
+		</filter>
+	</outputs>
+	<formats>
+		<format id="logfmt" format="%EcsAgentLogfmt" />
+		<format id="json" format="%EcsAgentJson" />
+		<format id="windows" format="%EcsMsg" />
+	</formats>
+</seelog>`, c)
+}
+
+func TestSetLogToStdout(t *testing.T) {
+	SetDefaultConfig()
+	SetLogToStdout(false)
+	defer SetLogToStdout(DEFAULT_LOGTO_STDOUT)
+
+	c := seelogConfig()
+	require.Equal(t, `
+<seelog type="asyncloop">
+	<outputs formatid="logfmt">
+		<filter levels="info,warn,error,critical">
 			<rollingfile filename="foo.log" type="date"
 			 datepattern="2006-01-02-15" archivetype="none" maxrolls="24" />
 		</filter>

--- a/ecs-agent/logger/log_windows_test.go
+++ b/ecs-agent/logger/log_windows_test.go
@@ -32,6 +32,7 @@ func TestSeelogConfigWindows_Default(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -39,6 +40,7 @@ func TestSeelogConfigWindows_Default(t *testing.T) {
 	<outputs formatid="logfmt">
 		<filter levels="info,warn,error,critical">
 			<console />
+
 			<custom name="wineventlog" formatid="windows" />
 		</filter>
 		<filter levels="info,warn,error,critical">
@@ -62,6 +64,7 @@ func TestSeelogConfigWindows_WithoutLogFile(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -69,6 +72,7 @@ func TestSeelogConfigWindows_WithoutLogFile(t *testing.T) {
 	<outputs formatid="logfmt">
 		<filter levels="info,warn,error,critical">
 			<console />
+
 			<custom name="wineventlog" formatid="windows" />
 		</filter>
 	</outputs>
@@ -89,6 +93,7 @@ func TestSeelogConfigWindows_DebugLevel(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -96,6 +101,7 @@ func TestSeelogConfigWindows_DebugLevel(t *testing.T) {
 	<outputs formatid="logfmt">
 		<filter levels="debug,info,warn,error,critical">
 			<console />
+
 			<custom name="wineventlog" formatid="windows" />
 		</filter>
 		<filter levels="info,warn,error,critical">
@@ -120,6 +126,7 @@ func TestSeelogConfigWindows_SizeRollover(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -127,6 +134,7 @@ func TestSeelogConfigWindows_SizeRollover(t *testing.T) {
 	<outputs formatid="logfmt">
 		<filter levels="info,warn,error,critical">
 			<console />
+
 			<custom name="wineventlog" formatid="windows" />
 		</filter>
 		<filter levels="info,warn,error,critical">
@@ -151,6 +159,7 @@ func TestSeelogConfigWindows_SizeRolloverFileSizeChange(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: 15,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -158,6 +167,7 @@ func TestSeelogConfigWindows_SizeRolloverFileSizeChange(t *testing.T) {
 	<outputs formatid="logfmt">
 		<filter levels="info,warn,error,critical">
 			<console />
+
 			<custom name="wineventlog" formatid="windows" />
 		</filter>
 		<filter levels="info,warn,error,critical">
@@ -182,6 +192,7 @@ func TestSeelogConfigWindows_SizeRolloverRollCountChange(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: 15,
 		MaxRollCount:  10,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -189,6 +200,7 @@ func TestSeelogConfigWindows_SizeRolloverRollCountChange(t *testing.T) {
 	<outputs formatid="logfmt">
 		<filter levels="info,warn,error,critical">
 			<console />
+
 			<custom name="wineventlog" formatid="windows" />
 		</filter>
 		<filter levels="info,warn,error,critical">
@@ -213,6 +225,7 @@ func TestSeelogConfigWindows_JSONOutput(t *testing.T) {
 		outputFormat:  "json",
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  10,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -220,6 +233,7 @@ func TestSeelogConfigWindows_JSONOutput(t *testing.T) {
 	<outputs formatid="json">
 		<filter levels="info,warn,error,critical">
 			<console />
+
 			<custom name="wineventlog" formatid="windows" />
 		</filter>
 		<filter levels="info,warn,error,critical">
@@ -244,6 +258,7 @@ func TestSeelogConfigWindows_NoOnInstanceLog(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -251,6 +266,7 @@ func TestSeelogConfigWindows_NoOnInstanceLog(t *testing.T) {
 	<outputs formatid="logfmt">
 		<filter levels="info,warn,error,critical">
 			<console />
+
 			<custom name="wineventlog" formatid="windows" />
 		</filter>
 		<filter levels="off">
@@ -275,6 +291,7 @@ func TestSeelogConfigWindows_DifferentLevels(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -282,6 +299,7 @@ func TestSeelogConfigWindows_DifferentLevels(t *testing.T) {
 	<outputs formatid="logfmt">
 		<filter levels="warn,error,critical">
 			<console />
+
 			<custom name="wineventlog" formatid="windows" />
 		</filter>
 		<filter levels="critical">
@@ -309,6 +327,7 @@ func TestSeelogConfigWindows_FileLevelDefault(t *testing.T) {
 		outputFormat:  DEFAULT_OUTPUT_FORMAT,
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+		logToStdout:   DEFAULT_LOGTO_STDOUT,
 	}
 	c := seelogConfig()
 	require.Equal(t, `
@@ -316,6 +335,7 @@ func TestSeelogConfigWindows_FileLevelDefault(t *testing.T) {
 	<outputs formatid="logfmt">
 		<filter levels="info,warn,error,critical">
 			<console />
+
 			<custom name="wineventlog" formatid="windows" />
 		</filter>
 		<filter levels="off">


### PR DESCRIPTION
### Summary
This change enhances the access pattern for the Seelog configuration. Environment variables are currently used in `InitSeelog` when the agent is started to pass in logging values. After that, all changes to the logger should be managed by the Config struct.

This is a follow up to #4048.

### Implementation details
- Enhances existing setters by adding basic checks and mutex locks
- Splits the `SetLevel` setter into driver and instance level functions
- Calls `reloadConfig` in each setter
- Abstracts `logLevels` mapping from ECS_LOGLEVEL to Seelog level options to a file wide variable
- Adds a new variable to the Config, `logToStdout` that will decide whether we should duplicate output to stdout or not. Currently, we are outputting to a rolling log file as well as stdout. The latter should be optional.
- Changes the `seelogConfig` method with this `logToStdout` option. 
    - The stdout seelog config setting, and windows platform settings are wrapped in a <filter> tag. On Linux, we do not set the platform tag. If we do not output to stdout then the filter tag will be empty. This will cause logging to fail to apply to outputs. So, we should conditionally omit the filter tag if both of these tags are empty.
- Adds `SetRolloverType` setter to modify the rollover type of the logs, if any. The default behavior has been kept as size in the agent module, and this also falls back to date based rolling. Passing in 'none' allows for no rollover policy.
- Removes `timestampFormat` from the Config object. This var is special in that it is actively used in runtime when a custom log formatter is used. There is a potential data race with the mutex locked `Config` struct, so we can let this variable's setter directly access it without locks - knowing this will likely be used at startup and not runtime.
- Adds and refactors tests as described below

### Testing
Existing tests pass.

New unit tests `TestSeeLogConfig_WithoutStdout`, `TestSeelogConfig_JSONNoStdout`, and `TestSeelogConfig_JSONNoRollover` have been added to validate new logic.

New tests cover the changes: no

### Description for the changelog
Update logger Config setter access pattern

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
no model breaking changes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
