### PR TITLE
Volume plugin changes to fix EFS unmount

### DIFF
--- a/ecs-init/volumes/driver/driver.go
+++ b/ecs-init/volumes/driver/driver.go
@@ -28,6 +28,9 @@ type VolumeDriver interface {
 
 	// Remove unmounts the volume from the host.
 	Remove(removeRequest *RemoveRequest) error
+
+	// Method to check if a volume is currently mounted.
+	IsMounted(volumeName string) bool
 }
 
 // CreateRequest holds fields necessary for creating a volume

--- a/ecs-init/volumes/driver/mock/driver_mocks.go
+++ b/ecs-init/volumes/driver/mock/driver_mocks.go
@@ -62,6 +62,20 @@ func (mr *MockVolumeDriverMockRecorder) Create(createRequest interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockVolumeDriver)(nil).Create), createRequest)
 }
 
+// IsMounted mocks base method.
+func (m *MockVolumeDriver) IsMounted(volumeName string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsMounted", volumeName)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsMounted indicates an expected call of IsMounted.
+func (mr *MockVolumeDriverMockRecorder) IsMounted(volumeName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMounted", reflect.TypeOf((*MockVolumeDriver)(nil).IsMounted), volumeName)
+}
+
 // Remove mocks base method.
 func (m *MockVolumeDriver) Remove(removeRequest *driver.RemoveRequest) error {
 	m.ctrl.T.Helper()

--- a/ecs-init/volumes/ecs_volume_driver.go
+++ b/ecs-init/volumes/ecs_volume_driver.go
@@ -127,6 +127,8 @@ func (e *ECSVolumeDriver) Remove(req *driver.RemoveRequest) error {
 
 // Method to check if a volume is currently mounted.
 func (e *ECSVolumeDriver) IsMounted(volumeName string) bool {
+	e.lock.RLock()
+	defer e.lock.RUnlock()
 	_, exists := e.volumeMounts[volumeName]
 	return exists
 }

--- a/ecs-init/volumes/ecs_volume_driver.go
+++ b/ecs-init/volumes/ecs_volume_driver.go
@@ -66,10 +66,6 @@ func (e *ECSVolumeDriver) Create(r *driver.CreateRequest) error {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
-	if _, ok := e.volumeMounts[r.Name]; ok {
-		return fmt.Errorf("volume already exists")
-	}
-
 	mnt := setOptions(r.Options)
 	mnt.Target = r.Path
 

--- a/ecs-init/volumes/ecs_volume_driver.go
+++ b/ecs-init/volumes/ecs_volume_driver.go
@@ -115,3 +115,9 @@ func (e *ECSVolumeDriver) Remove(req *driver.RemoveRequest) error {
 	seelog.Infof("Unmounted volume %s successfully.", req.Name)
 	return err
 }
+
+// Method to check if a volume is currently mounted.
+func (e *ECSVolumeDriver) IsMounted(volumeName string) bool {
+	_, exists := e.volumeMounts[volumeName]
+	return exists
+}

--- a/ecs-init/volumes/ecs_volume_driver.go
+++ b/ecs-init/volumes/ecs_volume_driver.go
@@ -23,8 +23,16 @@ import (
 	"github.com/cihub/seelog"
 )
 
-// TODO: might be a good idea to check the mount point with a tool like mountpoint instead of matching error message.
-const notMountedErrMsg = "not mounted"
+const (
+	// TODO: might be a good idea to check the mount point with a tool like mountpoint instead of matching error message.
+	notMountedErrMsg = "not mounted"
+
+	// This error is returned when volume is already unmounted
+	// Example -
+	// $ sudo umount -l abc
+	// umount: abc: no mount point specified.
+	noMountPointSpecifiedErrMsg = "no mount point specified"
+)
 
 // ECSVolumeDriver holds mount helper and methods for different Volume Mounts
 type ECSVolumeDriver struct {
@@ -104,7 +112,8 @@ func (e *ECSVolumeDriver) Remove(req *driver.RemoveRequest) error {
 	}
 	err := mnt.Unmount()
 	if err != nil {
-		if strings.Contains(err.Error(), notMountedErrMsg) {
+		if strings.Contains(err.Error(), notMountedErrMsg) ||
+			strings.Contains(err.Error(), noMountPointSpecifiedErrMsg) {
 			seelog.Infof("Unmounting volume %s failed because it's not mounted.", req.Name)
 			delete(e.volumeMounts, req.Name)
 			return nil

--- a/ecs-init/volumes/ecs_volume_driver_test.go
+++ b/ecs-init/volumes/ecs_volume_driver_test.go
@@ -114,23 +114,41 @@ func TestRemoveVolumeHappyPath(t *testing.T) {
 }
 
 func TestRemoveVolumeUnmounted(t *testing.T) {
-	e := NewECSVolumeDriver()
-	e.volumeMounts["vol"] = &MountHelper{}
-	req := driver.RemoveRequest{
-		Name: "vol",
+	tcs := []struct {
+		name     string
+		errorMsg string
+	}{
+		{
+			name:     "not mounted",
+			errorMsg: "not mounted",
+		},
+		{
+			name:     "no mount point specified",
+			errorMsg: "umount: abc: no mount point specified.",
+		},
 	}
-	lookPath = func(string) (string, error) {
-		return "path", nil
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			e := NewECSVolumeDriver()
+			e.volumeMounts["vol"] = &MountHelper{}
+			req := driver.RemoveRequest{
+				Name: "vol",
+			}
+			lookPath = func(string) (string, error) {
+				return "path", nil
+			}
+			runUnmount = func(string, string) error {
+				return errors.New(tc.errorMsg)
+			}
+			defer func() {
+				lookPath = getPath
+				runUnmount = runUnmountCommand
+			}()
+			assert.NoError(t, e.Remove(&req), "expected no error when unmount failed because of not mounted")
+			assert.Len(t, e.volumeMounts, 0)
+		})
 	}
-	runUnmount = func(string, string) error {
-		return errors.New("not mounted")
-	}
-	defer func() {
-		lookPath = getPath
-		runUnmount = runUnmountCommand
-	}()
-	assert.NoError(t, e.Remove(&req), "expected no error when unmount failed because of not mounted")
-	assert.Len(t, e.volumeMounts, 0)
 }
 
 func TestRemoveUnmountFailure(t *testing.T) {

--- a/ecs-init/volumes/ecs_volume_driver_test.go
+++ b/ecs-init/volumes/ecs_volume_driver_test.go
@@ -196,3 +196,15 @@ func TestRemoveVolumeNotPresent(t *testing.T) {
 	assert.Error(t, e.Remove(&req), "expected error when volume to remove is not found")
 	assert.Len(t, e.volumeMounts, 1)
 }
+
+func TestIsMounted(t *testing.T) {
+	t.Run("not unmounted", func(t *testing.T) {
+		e := NewECSVolumeDriver()
+		assert.False(t, e.IsMounted("nope"))
+	})
+	t.Run("mounted", func(t *testing.T) {
+		e := NewECSVolumeDriver()
+		e.volumeMounts["vol"] = &MountHelper{}
+		assert.True(t, e.IsMounted("vol"))
+	})
+}

--- a/ecs-init/volumes/ecs_volume_plugin.go
+++ b/ecs-init/volumes/ecs_volume_plugin.go
@@ -190,6 +190,11 @@ func deleteMountPath(path string) error {
 func (a *AmazonECSVolumePlugin) Mount(r *volume.MountRequest) (*volume.MountResponse, error) {
 	seelog.Infof("Received mount request %+v", r)
 
+	// Validate the request
+	if len(r.ID) == 0 {
+		return nil, fmt.Errorf("no mount ID in the request")
+	}
+
 	// Acquire write lock
 	a.lock.Lock()
 	defer a.lock.Unlock()
@@ -247,6 +252,11 @@ func (a *AmazonECSVolumePlugin) Mount(r *volume.MountRequest) (*volume.MountResp
 // Unmount implements Docker volume plugin's Unmount Method
 func (a *AmazonECSVolumePlugin) Unmount(r *volume.UnmountRequest) error {
 	seelog.Infof("Received unmount request %+v", r)
+
+	// Validate the request
+	if len(r.ID) == 0 {
+		return fmt.Errorf("no mount ID in the request")
+	}
 
 	// Acquire write lock
 	a.lock.Lock()

--- a/ecs-init/volumes/ecs_volume_plugin.go
+++ b/ecs-init/volumes/ecs_volume_plugin.go
@@ -297,7 +297,6 @@ func (a *AmazonECSVolumePlugin) Unmount(r *volume.UnmountRequest) error {
 	if len(vol.Mounts) == 0 {
 		seelog.Infof("No active mounts left on volume %s, unmounting it", r.Name)
 		if err := volDriver.Remove(&driver.RemoveRequest{Name: r.Name}); err != nil {
-			vol.AddMount(r.ID)
 			seelog.Errorf("Failed to unmount volume %v: %v", r.Name, err)
 			return fmt.Errorf("failed to unmount volume %v: %w", r.Name, err)
 		}

--- a/ecs-init/volumes/ecs_volume_plugin.go
+++ b/ecs-init/volumes/ecs_volume_plugin.go
@@ -268,7 +268,7 @@ func (a *AmazonECSVolumePlugin) Unmount(r *volume.UnmountRequest) error {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
-	// Find  the volume
+	// Find the volume
 	vol, ok := a.volumes[r.Name]
 	if !ok {
 		seelog.Errorf("Volume %s to unmount is not found", r.Name)

--- a/ecs-init/volumes/ecs_volume_plugin.go
+++ b/ecs-init/volumes/ecs_volume_plugin.go
@@ -336,6 +336,7 @@ func (a *AmazonECSVolumePlugin) Remove(r *volume.RemoveRequest) error {
 	// mounted. This is mainly to unmount volumes created by an older version of the
 	// plugin in which unmounts were not handled by Unmount method.
 	if volDriver.IsMounted(r.Name) {
+		seelog.Infof("Volume %s is currently mounted, unmouting it", r.Name)
 		if err := volDriver.Remove(&driver.RemoveRequest{Name: r.Name}); err != nil {
 			seelog.Errorf("Volume %s removal failure: %v", r.Name, err)
 			return err

--- a/ecs-init/volumes/ecs_volume_plugin.go
+++ b/ecs-init/volumes/ecs_volume_plugin.go
@@ -191,6 +191,9 @@ func (a *AmazonECSVolumePlugin) Mount(r *volume.MountRequest) (*volume.MountResp
 	seelog.Infof("Received mount request %+v", r)
 
 	// Validate the request
+	if len(r.Name) == 0 {
+		return nil, fmt.Errorf("no volume in the request")
+	}
 	if len(r.ID) == 0 {
 		return nil, fmt.Errorf("no mount ID in the request")
 	}
@@ -254,6 +257,9 @@ func (a *AmazonECSVolumePlugin) Unmount(r *volume.UnmountRequest) error {
 	seelog.Infof("Received unmount request %+v", r)
 
 	// Validate the request
+	if len(r.Name) == 0 {
+		return fmt.Errorf("no volume in the request")
+	}
 	if len(r.ID) == 0 {
 		return fmt.Errorf("no mount ID in the request")
 	}

--- a/ecs-init/volumes/ecs_volume_plugin.go
+++ b/ecs-init/volumes/ecs_volume_plugin.go
@@ -306,17 +306,7 @@ func (a *AmazonECSVolumePlugin) Unmount(r *volume.UnmountRequest) error {
 	// Save state
 	if err := a.state.recordVolume(r.Name, vol); err != nil {
 		// State save failed, so roll back the changes made so far to make state consistent
-		seelog.Errorf("Error saving state of volume %s, rolling back changes: %v", r.Name, err)
-		if len(vol.Mounts) == 0 {
-			seelog.Warnf("Rolling back unmounting of volume %s", r.Name)
-			req := &driver.CreateRequest{Name: r.Name, Path: vol.Path, Options: vol.Options}
-			if err := volDriver.Create(req); err != nil {
-				seelog.Errorf("Failed to mount volume %s during rollback: %v", r.Name, err)
-			}
-		}
-		vol.AddMount(r.ID)
-		a.state.recordVolume(r.Name, vol)
-		return fmt.Errorf("unmount failed due to an error while saving state: %w", err)
+		seelog.Errorf("Error saving state of volume %s", r.Name, err)
 	}
 
 	// All good

--- a/ecs-init/volumes/ecs_volume_plugin.go
+++ b/ecs-init/volumes/ecs_volume_plugin.go
@@ -81,6 +81,7 @@ func (a *AmazonECSVolumePlugin) LoadState() error {
 			Path:      vol.Path,
 			Options:   vol.Options,
 			CreatedAt: vol.CreatedAt,
+			Mounts:    vol.Mounts,
 		}
 		a.volumes[volName] = volume
 		voldriver.Setup(volName, volume)
@@ -140,26 +141,12 @@ func (a *AmazonECSVolumePlugin) Create(r *volume.CreateRequest) error {
 		}
 	}
 
-	req := &driver.CreateRequest{
-		Name:    r.Name,
-		Path:    target,
-		Options: r.Options,
-	}
-	err = volDriver.Create(req)
-	if err != nil {
-		seelog.Errorf("Volume %s creation failure: %v", r.Name, err)
-		cErr := a.CleanupMountPath(target)
-		if cErr != nil {
-			seelog.Warnf("Failed to cleanup mount path for volume %s: %v", r.Name, cErr)
-		}
-		return err
-	}
-	seelog.Infof("Volume %s created successfully", r.Name)
 	vol := &types.Volume{
 		Type:      driverType,
 		Path:      target,
 		Options:   r.Options,
 		CreatedAt: time.Now().Format(time.RFC3339Nano),
+		Mounts:    map[string]*string{},
 	}
 	// record the volume information
 	a.volumes[r.Name] = vol
@@ -201,25 +188,119 @@ func deleteMountPath(path string) error {
 
 // Mount implements Docker volume plugin's Mount Method
 func (a *AmazonECSVolumePlugin) Mount(r *volume.MountRequest) (*volume.MountResponse, error) {
-	a.lock.RLock()
-	defer a.lock.RUnlock()
+	seelog.Infof("Received mount request %+v", r)
+
+	// Acquire write lock
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	// Find the volume
 	vol, ok := a.volumes[r.Name]
 	if !ok {
 		seelog.Errorf("Volume %s to mount is not found", r.Name)
 		return nil, fmt.Errorf("volume %s not found", r.Name)
 	}
+
+	// Find the volume driver
+	volDriver, err := a.getVolumeDriver(vol.Type)
+	if err != nil {
+		seelog.Errorf("Volume %s's driver type %s not supported: %v", r.Name, vol.Type, err)
+		return nil, fmt.Errorf("Volume %s's driver type %s not supported: %w", r.Name, vol.Type, err)
+	}
+	if volDriver == nil {
+		// This case shouldn't happen normally
+		return nil, fmt.Errorf("no volume driver found for type %s", vol.Type)
+	}
+
+	// Mount the volume on the host if there are no active mounts for the volume.
+	if len(vol.Mounts) == 0 {
+		seelog.Infof("Mounting volume %s as there are no existing mounts for it", r.Name)
+		createReq := &driver.CreateRequest{Name: r.Name, Path: vol.Path, Options: vol.Options}
+		if err := volDriver.Create(createReq); err != nil {
+			seelog.Errorf("Volume %s creation failure: %v", r.Name, err)
+			return nil, fmt.Errorf("failed to mount volume %s: %w", r.Name, err)
+		}
+		seelog.Infof("Volume %s mounted successfully", r.Name)
+	}
+
+	// Update state
+	seelog.Infof("Adding mount %s to volume %s", r.ID, r.Name)
+	vol.AddMount(r.ID)
+	if err := a.state.recordVolume(r.Name, vol); err != nil {
+		// State update failed, so roll back the changes made so far to make state consistent
+		seelog.Errorf("Failed to save volume %s, rolling back changes: %v", r.Name, err)
+		vol.RemoveMount(r.ID)
+		if len(vol.Mounts) == 0 {
+			seelog.Warnf("Rolling back mounting of volume %s", r.Name)
+			if err := volDriver.Remove(&driver.RemoveRequest{Name: r.Name}); err != nil {
+				seelog.Errorf("Volume %s removal failure: %v", r.Name, err)
+			}
+		}
+		a.state.recordVolume(r.Name, vol)
+		return nil, fmt.Errorf("mount failed due to an error while saving state: %w", err)
+	}
+
+	// All good
 	return &volume.MountResponse{Mountpoint: vol.Path}, nil
 }
 
 // Unmount implements Docker volume plugin's Unmount Method
 func (a *AmazonECSVolumePlugin) Unmount(r *volume.UnmountRequest) error {
-	a.lock.RLock()
-	defer a.lock.RUnlock()
-	_, ok := a.volumes[r.Name]
+	seelog.Infof("Received unmount request %+v", r)
+
+	// Acquire write lock
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	// Find  the volume
+	vol, ok := a.volumes[r.Name]
 	if !ok {
 		seelog.Errorf("Volume %s to unmount is not found", r.Name)
 		return fmt.Errorf("volume %s not found", r.Name)
 	}
+
+	// Get the corresponding volume driver
+	volDriver, err := a.getVolumeDriver(vol.Type)
+	if err != nil {
+		seelog.Errorf("Volume %s removal failure: %v", r.Name, err)
+		return fmt.Errorf("volume %v of type %s is unsupported: %w", r.Name, vol.Type, err)
+	}
+	if volDriver == nil {
+		// this case should not happen normally
+		return fmt.Errorf("no corresponding volume driver found for type %s", vol.Type)
+	}
+
+	// Remove the mount from the volume
+	seelog.Infof("Removing mount %s from volume %s", r.ID, r.Name)
+	vol.RemoveMount(r.ID)
+
+	// If there are no more mounts left on the volume then unmount the volume from the host
+	if len(vol.Mounts) == 0 {
+		seelog.Infof("No active mounts left on volume %s, unmounting it", r.Name)
+		if err := volDriver.Remove(&driver.RemoveRequest{Name: r.Name}); err != nil {
+			vol.AddMount(r.ID)
+			seelog.Errorf("Failed to unmount volume %v: %v", r.Name, err)
+			return fmt.Errorf("failed to unmount volume %v: %w", r.Name, err)
+		}
+	}
+
+	// Save state
+	if err := a.state.recordVolume(r.Name, vol); err != nil {
+		// State save failed, so roll back the changes made so far to make state consistent
+		seelog.Errorf("Error saving state of volume %s, rolling back changes: %v", r.Name, err)
+		if len(vol.Mounts) == 0 {
+			seelog.Warnf("Rolling back unmounting of volume %s", r.Name)
+			req := &driver.CreateRequest{Name: r.Name, Path: vol.Path, Options: vol.Options}
+			if err := volDriver.Create(req); err != nil {
+				seelog.Errorf("Failed to mount volume %s during rollback: %v", r.Name, err)
+			}
+		}
+		vol.AddMount(r.ID)
+		a.state.recordVolume(r.Name, vol)
+		return fmt.Errorf("unmount failed due to an error while saving state: %w", err)
+	}
+
+	// All good
 	return nil
 }
 
@@ -234,37 +315,15 @@ func (a *AmazonECSVolumePlugin) Remove(r *volume.RemoveRequest) error {
 		return fmt.Errorf("volume %s not found", r.Name)
 	}
 
-	// get corresponding volume driver to unmount
-	volDriver, err := a.getVolumeDriver(vol.Type)
-	if err != nil {
-		seelog.Errorf("Volume %s removal failure: %s", r.Name, err)
-		return err
-	}
-	if volDriver == nil {
-		// this case should not happen normally
-		return fmt.Errorf("no corresponding volume driver found for type %s", vol.Type)
-	}
-
-	req := &driver.RemoveRequest{
-		Name: r.Name,
-	}
-	err = volDriver.Remove(req)
-	if err != nil {
-		seelog.Errorf("Volume %s removal failure: %v", r.Name, err)
-		return err
-	}
-
 	// remove the volume information
 	delete(a.volumes, r.Name)
 	// cleanup the volume's host mount path
-	err = a.CleanupMountPath(vol.Path)
-	if err != nil {
+	if err := a.CleanupMountPath(vol.Path); err != nil {
 		seelog.Errorf("Cleaning mount path failed for volume %s: %v", r.Name, err)
 	}
 	seelog.Infof("Saving state after removing volume %s", r.Name)
 	// remove the state of deleted volume
-	err = a.state.removeVolume(r.Name)
-	if err != nil {
+	if err := a.state.removeVolume(r.Name); err != nil {
 		seelog.Errorf("Error saving state after removing volume %s: %v", r.Name, err)
 	}
 	return nil

--- a/ecs-init/volumes/ecs_volume_plugin_test.go
+++ b/ecs-init/volumes/ecs_volume_plugin_test.go
@@ -744,7 +744,7 @@ func TestPluginMount(t *testing.T) {
 	}{
 		{
 			name:          "volume not found",
-			req:           &volume.MountRequest{Name: "unknown"},
+			req:           &volume.MountRequest{Name: "unknown", ID: reqMountID},
 			expectedError: "volume unknown not found",
 		},
 		{
@@ -800,6 +800,11 @@ func TestPluginMount(t *testing.T) {
 			pluginVolumes: map[string]*types.Volume{volName: {Path: volPath, Type: "unknown"}},
 			req:           &volume.MountRequest{Name: volName, ID: reqMountID},
 			expectedError: "Volume volume's driver type unknown not supported: volume unknown type not supported",
+		},
+		{
+			name:          "no ID in the request",
+			req:           &volume.MountRequest{Name: volName},
+			expectedError: "no mount ID in the request",
 		},
 		{
 			name: "driver fails to mount",
@@ -944,7 +949,7 @@ func TestPluginUnmount(t *testing.T) {
 	}{
 		{
 			name:          "volume not found",
-			req:           &volume.UnmountRequest{Name: "unknown"},
+			req:           &volume.UnmountRequest{Name: "unknown", ID: reqMountID},
 			expectedError: "volume unknown not found",
 		},
 		{
@@ -994,6 +999,11 @@ func TestPluginUnmount(t *testing.T) {
 			pluginVolumes: map[string]*types.Volume{volName: {Path: volPath, Type: "unknown"}},
 			req:           &volume.UnmountRequest{Name: volName, ID: reqMountID},
 			expectedError: "volume volume of type unknown is unsupported: volume unknown type not supported",
+		},
+		{
+			name:          "no ID in the request",
+			req:           &volume.UnmountRequest{Name: volName},
+			expectedError: "no mount ID in the request",
 		},
 		{
 			name: "driver fails to unmount",

--- a/ecs-init/volumes/ecs_volume_plugin_test.go
+++ b/ecs-init/volumes/ecs_volume_plugin_test.go
@@ -822,6 +822,33 @@ func TestPluginMount(t *testing.T) {
 			},
 		},
 		{
+			name: "duplicate mount is a no-op",
+			pluginVolumes: map[string]*types.Volume{
+				volName: {
+					Path:    volPath,
+					Mounts:  map[string]*string{reqMountID: nil},
+					Options: volOpts,
+				},
+			},
+			req:              &volume.MountRequest{Name: volName, ID: reqMountID},
+			expectedResponse: &volume.MountResponse{Mountpoint: volPath},
+			assertPluginState: func(t *testing.T, plugin *AmazonECSVolumePlugin) {
+				mounts := map[string]*string{reqMountID: nil}
+				assert.Equal(t,
+					map[string]*types.Volume{
+						volName: {Path: volPath, Options: volOpts, Mounts: mounts},
+					},
+					plugin.volumes)
+				assert.Equal(t,
+					&VolumeState{
+						Volumes: map[string]*VolumeInfo{
+							volName: {Path: volPath, Options: volOpts, Mounts: mounts},
+						},
+					},
+					plugin.state.VolState)
+			},
+		},
+		{
 			name: "roll back changes if saving state fails",
 			setDriverExpectations: func(d *mock_driver.MockVolumeDriver) {
 				d.EXPECT().Create(&driver.CreateRequest{Name: volName, Path: volPath}).Return(nil)

--- a/ecs-init/volumes/ecs_volume_plugin_test.go
+++ b/ecs-init/volumes/ecs_volume_plugin_test.go
@@ -1041,39 +1041,6 @@ func TestPluginUnmount(t *testing.T) {
 			},
 		},
 		{
-			name: "roll back unmount if saving state fails",
-			setDriverExpectations: func(d *mock_driver.MockVolumeDriver) {
-				d.EXPECT().Remove(&driver.RemoveRequest{Name: volName}).Return(nil)
-				d.EXPECT().
-					Create(&driver.CreateRequest{Name: volName, Path: volPath, Options: volOpts}).
-					Return(nil)
-			},
-			pluginVolumes: map[string]*types.Volume{
-				volName: {
-					Path: volPath, Options: volOpts, Mounts: map[string]*string{reqMountID: nil},
-				},
-			},
-			mockSaveStateFn: func(b []byte) error { return errors.New("some error") },
-			req:             &volume.UnmountRequest{Name: volName, ID: reqMountID},
-			expectedError:   "unmount failed due to an error while saving state: some error",
-			assertPluginState: func(t *testing.T, plugin *AmazonECSVolumePlugin) {
-				// Mount should still exist in state
-				mounts := map[string]*string{reqMountID: nil}
-				assert.Equal(t,
-					map[string]*types.Volume{
-						volName: {Path: volPath, Mounts: mounts, Options: volOpts},
-					},
-					plugin.volumes)
-				assert.Equal(t,
-					&VolumeState{
-						Volumes: map[string]*VolumeInfo{
-							volName: {Path: volPath, Mounts: mounts, Options: volOpts},
-						},
-					},
-					plugin.state.VolState)
-			},
-		},
-		{
 			name:          "no-op when mount not found on the volume",
 			pluginVolumes: map[string]*types.Volume{volName: {Path: volPath, Options: volOpts}},
 			req:           &volume.UnmountRequest{Name: volName, ID: reqMountID},

--- a/ecs-init/volumes/ecs_volume_plugin_test.go
+++ b/ecs-init/volumes/ecs_volume_plugin_test.go
@@ -807,6 +807,11 @@ func TestPluginMount(t *testing.T) {
 			expectedError: "no mount ID in the request",
 		},
 		{
+			name:          "no volume in the request",
+			req:           &volume.MountRequest{},
+			expectedError: "no volume in the request",
+		},
+		{
 			name: "driver fails to mount",
 			setDriverExpectations: func(d *mock_driver.MockVolumeDriver) {
 				d.EXPECT().
@@ -1004,6 +1009,11 @@ func TestPluginUnmount(t *testing.T) {
 			name:          "no ID in the request",
 			req:           &volume.UnmountRequest{Name: volName},
 			expectedError: "no mount ID in the request",
+		},
+		{
+			name:          "no volume in the request",
+			req:           &volume.UnmountRequest{},
+			expectedError: "no volume in the request",
 		},
 		{
 			name: "driver fails to unmount",

--- a/ecs-init/volumes/ecs_volume_plugin_test.go
+++ b/ecs-init/volumes/ecs_volume_plugin_test.go
@@ -1028,16 +1028,11 @@ func TestPluginUnmount(t *testing.T) {
 			req:           &volume.UnmountRequest{Name: volName, ID: reqMountID},
 			expectedError: "failed to unmount volume volume: some error",
 			assertPluginState: func(t *testing.T, plugin *AmazonECSVolumePlugin) {
-				// Mount should still exist in the plugin state
-				mounts := map[string]*string{reqMountID: nil}
+				// Mount should not exist in the plugin state
+				mounts := map[string]*string{}
 				assert.Equal(t,
 					map[string]*types.Volume{volName: {Path: volPath, Mounts: mounts}},
 					plugin.volumes)
-				assert.Equal(t,
-					&VolumeState{
-						Volumes: map[string]*VolumeInfo{volName: {Path: volPath, Mounts: mounts}},
-					},
-					plugin.state.VolState)
 			},
 		},
 		{

--- a/ecs-init/volumes/state_manager.go
+++ b/ecs-init/volumes/state_manager.go
@@ -47,10 +47,11 @@ type VolumeState struct {
 
 // VolumeInfo contains the information of managed volumes
 type VolumeInfo struct {
-	Type      string            `json:"type,omitempty"`
-	Path      string            `json:"path,omitempty"`
-	Options   map[string]string `json:"options,omitempty"`
-	CreatedAt string            `json:"createdAt,omitempty"`
+	Type      string             `json:"type,omitempty"`
+	Path      string             `json:"path,omitempty"`
+	Options   map[string]string  `json:"options,omitempty"`
+	CreatedAt string             `json:"createdAt,omitempty"`
+	Mounts    map[string]*string `json:"mounts,omitempty"`
 }
 
 // NewStateManager initializes the state manager of volume plugin
@@ -63,11 +64,18 @@ func NewStateManager() *StateManager {
 }
 
 func (s *StateManager) recordVolume(volName string, vol *types.Volume) error {
+	// Copy the mounts so that the map is not shared
+	mountsCopy := map[string]*string{}
+	for k, v := range vol.Mounts {
+		mountsCopy[k] = v
+	}
+
 	s.VolState.Volumes[volName] = &VolumeInfo{
 		Type:      vol.Type,
 		Path:      vol.Path,
 		Options:   vol.Options,
 		CreatedAt: vol.CreatedAt,
+		Mounts:    mountsCopy,
 	}
 	return s.save()
 }

--- a/ecs-init/volumes/types/types.go
+++ b/ecs-init/volumes/types/types.go
@@ -33,6 +33,9 @@ func (v *Volume) AddMount(mountID string) {
 
 // Removes a mount from the volume.
 // This method is not thread-safe, caller is responsible for holding any locks on the volume.
-func (v *Volume) RemoveMount(mountID string) {
+// Returns a bool indicating whether the mountID was found in mounts or not.
+func (v *Volume) RemoveMount(mountID string) bool {
+	_, exists := v.Mounts[mountID]
 	delete(v.Mounts, mountID)
+	return exists
 }

--- a/ecs-init/volumes/types/types.go
+++ b/ecs-init/volumes/types/types.go
@@ -19,4 +19,20 @@ type Volume struct {
 	Path      string
 	Options   map[string]string
 	CreatedAt string
+	Mounts    map[string]*string
+}
+
+// Adds a new mount to the volume.
+// This method is not thread-safe, caller is responsible for holding any locks on the volume.
+func (v *Volume) AddMount(mountID string) {
+	if v.Mounts == nil {
+		v.Mounts = map[string]*string{}
+	}
+	v.Mounts[mountID] = nil
+}
+
+// Removes a mount from the volume.
+// This method is not thread-safe, caller is responsible for holding any locks on the volume.
+func (v *Volume) RemoveMount(mountID string) {
+	delete(v.Mounts, mountID)
 }

--- a/ecs-init/volumes/types/types_test.go
+++ b/ecs-init/volumes/types/types_test.go
@@ -1,0 +1,53 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddMount(t *testing.T) {
+	t.Run("new map is created when Mounts is nil", func(t *testing.T) {
+		v := &Volume{}
+		v.AddMount("id")
+		assert.Equal(t, map[string]*string{"id": nil}, v.Mounts)
+	})
+	t.Run("second mount", func(t *testing.T) {
+		v := &Volume{}
+		v.AddMount("id")
+		v.AddMount("id2")
+		assert.Equal(t, map[string]*string{"id": nil, "id2": nil}, v.Mounts)
+	})
+	t.Run("mount already exists", func(t *testing.T) {
+		v := &Volume{}
+		v.AddMount("id")
+		assert.Equal(t, map[string]*string{"id": nil}, v.Mounts)
+	})
+}
+
+func TestRemoveMount(t *testing.T) {
+	t.Run("no-op when mount not found", func(t *testing.T) {
+		v := &Volume{}
+		v.RemoveMount("id")
+		assert.Empty(t, v.Mounts)
+	})
+	t.Run("mount should be removed if it exists", func(t *testing.T) {
+		v := &Volume{}
+		v.AddMount("id")
+		v.RemoveMount("id")
+		assert.Empty(t, v.Mounts)
+	})
+}

--- a/ecs-init/volumes/types/types_test.go
+++ b/ecs-init/volumes/types/types_test.go
@@ -41,13 +41,13 @@ func TestAddMount(t *testing.T) {
 func TestRemoveMount(t *testing.T) {
 	t.Run("no-op when mount not found", func(t *testing.T) {
 		v := &Volume{}
-		v.RemoveMount("id")
+		assert.False(t, v.RemoveMount("id"))
 		assert.Empty(t, v.Mounts)
 	})
 	t.Run("mount should be removed if it exists", func(t *testing.T) {
 		v := &Volume{}
 		v.AddMount("id")
-		v.RemoveMount("id")
+		assert.True(t, v.RemoveMount("id"))
 		assert.Empty(t, v.Mounts)
 	})
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR updates Amazon ECS Volume Plugin, that is used for provisioning and deprovisioning EFS volumes on ECS container instances, so that it mounts and unmounts volumes when `Mount` and `Unmount` requests are made to it instead of `Create` and `Remove` requests, respectively. 

For EFS tasks in awsvpc network mode the task network namespace is torn down at task stop which causes EFS volume unmounting to hang when a `Remove` request is made to the plugin for the task's volumes at task cleanup time later. With this change, EFS volumes will be unmounted from the host when the task is being stopped and while task network namespace is still in place and configured. 

After this change, `Create`, `Mount`, `Unmount`, and `Remove` requests will be handled by the plugin as described below. 
* Create - Create mount path on the host and store information about the volume in plugin state but don't mount the volume yet. 
* Mount - If there are no active mounts for the volume then mount it on the host. Add the mount to the volume's set of active mounts in plugin state. 
* Unmount - Remove the mount from the volume's set of active mounts in plugin state. If the volume's active mount count has decreased to zero then unmount the volume from the host. 
* Remove - If the volume is still mounted on the host then unmount it (this is to handle unmounting of volumes created by older versions of the plugin that are still in state). Remove the mount path from the host and remove the volume from plugin's state.

### Implementation details
<!-- How are the changes implemented? -->
* Moved code for mounting an EFS volume from `Create` method to `Mount` method of `AmazonECSVolumePlugin`. Added relevant tests in `TestPluginMount` function. Also added roll-back steps to `Mount` method to make sure its effects are atomic.
* Added code for unmounting an EFS volume to `Unmount` method of `AmazonECSVolumePlugin`. Added relevant tests in `TestPluginUnmount` function. Also added roll-back steps to `Unmount` method to make sure its effects are atomic.
* Updated `Remove` method to make it unmount the volume only if it's currently mounted. Added a new `IsMounted` method to `VolumeDriver` interface. Implemented `IsMounted` method for `ECSVolumeDriver` that checks if the volume is present in driver's state. 
* Updated `Remove` method of `ECSVolumeDriver` to swallow unmount errors caused due to the volume not being mounted on the host. The method already had that logic as it swallows errors with "not mounted" in them but during my testing I found out that error "no mount point specified" is also returned by `umount` when the volume is not mounted. This is to make `Remove` method not fail for already unmounted volumes.
* Updated `Create` method of `ECSVolumeDriver` to not check its internal state for volume's mount state before mounting the requested volume. This is because `ECSVolumeDriver` does not track active mounts on the volume and an unmounted but not yet removed volume will reappear in its state if plugin restarts and with the check in place the driver will not allow the `Mount` request handler to perform volume mounts. The check does not server any purpose currently as the driver's internal state is completely controlled by `AmazonECSVolumePlugin` that has its own checks to prevent duplicate mount attempts. In future we should make `ECSVolumeDriver` completely stateless and have all state handling in `AmazonECSVolumePlugin` only but that's out of scope of this PR.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Did extensive manual testing with the new plugin. Tested that - 
* awsvpc tasks clean up without issues ✅
* Host mode tasks work fine ✅
* Bridge mode tasks work fine ✅
* New version of the plugin is be able to unmount and remove volumes created by an older version of the plugin ✅
* Volume plugin restart between Unmount and Remove requests for a volume doesn't cause an error during Remove request ✅
* New plugin version is able to handle restarts without any issues  ✅
* Old version of the plugin is compatible with the state file created by the new version. ✅
* Tasks with multiple containers with EFS volumes work as expected ✅
* Task with multiple EFS volumes work as expected ✅
* A task with EFS volumes can be run multiple times on the same container instance without any issues ✅
* Tested that rollback works as expected for Mount request. For this test I deleted the parent directory of the state file directory of the plugin to make state save operations fail. ✅ 

A new functional test has been added that runs an AWSVPC EFS task twice in succession on an instance with a cleanup duration of 1 second. The test fails on instances with current version of the volume plugin but passes on instances with the version of the volume plugin in this PR.

Ran Agent functional tests on instances with a new version of volume plugin installed. All tests passed. 

Added many unit tests. 

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bugfix: Fix EFS unmount hanging issue for awsvpc tasks

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
