### PR TITLE
Bug: Windows numCPU returning incorrectly for values above 64

### DIFF
--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -17,7 +17,6 @@
 package task
 
 import (
-	"runtime"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/ecscni"
@@ -33,6 +32,7 @@ import (
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	eautils "github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/cihub/seelog"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/pkg/errors"
@@ -59,7 +59,7 @@ type PlatformFields struct {
 	MemoryUnbounded config.BooleanDefaultFalse `json:"memoryUnbounded"`
 }
 
-var cpuShareScaleFactor = runtime.NumCPU() * cpuSharesPerCore
+var cpuShareScaleFactor = eautils.GetNumCPU() * cpuSharesPerCore
 
 // adjustForPlatform makes Windows-specific changes to the task after unmarshal
 func (task *Task) adjustForPlatform(cfg *config.Config) {

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -19,7 +19,6 @@ package task
 import (
 	"encoding/json"
 	"fmt"
-	"runtime"
 	"testing"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
@@ -33,6 +32,7 @@ import (
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	eautils "github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/golang/mock/gomock"
 
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
@@ -222,7 +222,7 @@ func TestDockerHostConfigRawConfigMerging(t *testing.T) {
 }
 
 func TestCPUPercentBasedOnUnboundedEnabled(t *testing.T) {
-	cpuShareScaleFactor := runtime.NumCPU() * cpuSharesPerCore
+	cpuShareScaleFactor := eautils.GetNumCPU() * cpuSharesPerCore
 	testcases := []struct {
 		cpu          int64
 		cpuUnbounded config.BooleanDefaultFalse

--- a/agent/stats/utils.go
+++ b/agent/stats/utils.go
@@ -15,12 +15,12 @@ package stats
 
 import (
 	"math"
-	"runtime"
 
+	eautils "github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/docker/docker/api/types"
 )
 
-var numCores = uint64(runtime.NumCPU())
+var numCores = uint64(eautils.GetNumCPU())
 
 // nan32 returns a 32bit NaN.
 func nan32() float32 {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"runtime"
 	"strings"
 	"time"
 
@@ -417,7 +416,7 @@ func getCpuAndMemory() (int64, int64) {
 		})
 	}
 
-	cpu := runtime.NumCPU() * 1024
+	cpu := utils.GetNumCPU() * 1024
 
 	return int64(cpu), mem
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils_unix.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+// +build !windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import "runtime"
+
+func GetNumCPU() int {
+	return runtime.NumCPU()
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils_windows.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"runtime"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	win32APIGetAllActiveProcessorCount = windows.GetActiveProcessorCount
+	golangRuntimeNumCPU                = runtime.NumCPU
+)
+
+// GetNumCPU On Windows, runtime.NumCPU() does not return the correct value for vCPU > 64
+// To resolve this, we are using MSFT implementation of the function: https://github.com/microsoft/hcsshim/blob/dd45838a9bf9ff8f431847aaf3e4421763c15c49/internal/processorinfo/processor_count.go#L14
+// Background around issue: https://github.com/moby/moby/issues/38935, https://learn.microsoft.com/en-us/windows/win32/procthread/processor-groups
+// Explanation: As was mentioned above, many of the Windows processor affinity functions will only return the information for a single Processor Group.
+// Since a single group can only hold 64 logical processors, this means when there are more they will be divided into multiple groups.
+// Golang runtime.NumCPU will only return the value of one Processor Group (not the sum of all).
+func GetNumCPU() int {
+	if amount := win32APIGetAllActiveProcessorCount(windows.ALL_PROCESSOR_GROUPS); amount != 0 {
+		return int(amount)
+	}
+	// If the Win32 API does not return correctly, fall back to runtime.NumCPU()
+	return golangRuntimeNumCPU()
+}

--- a/ecs-agent/api/ecs/client/ecs_client.go
+++ b/ecs-agent/api/ecs/client/ecs_client.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"runtime"
 	"strings"
 	"time"
 
@@ -417,7 +416,7 @@ func getCpuAndMemory() (int64, int64) {
 		})
 	}
 
-	cpu := runtime.NumCPU() * 1024
+	cpu := utils.GetNumCPU() * 1024
 
 	return int64(cpu), mem
 }

--- a/ecs-agent/utils/utils_unix.go
+++ b/ecs-agent/utils/utils_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+// +build !windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import "runtime"
+
+func GetNumCPU() int {
+	return runtime.NumCPU()
+}

--- a/ecs-agent/utils/utils_windows.go
+++ b/ecs-agent/utils/utils_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"runtime"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	win32APIGetAllActiveProcessorCount = windows.GetActiveProcessorCount
+	golangRuntimeNumCPU                = runtime.NumCPU
+)
+
+// GetNumCPU On Windows, runtime.NumCPU() does not return the correct value for vCPU > 64
+// To resolve this, we are using MSFT implementation of the function: https://github.com/microsoft/hcsshim/blob/dd45838a9bf9ff8f431847aaf3e4421763c15c49/internal/processorinfo/processor_count.go#L14
+// Background around issue: https://github.com/moby/moby/issues/38935, https://learn.microsoft.com/en-us/windows/win32/procthread/processor-groups
+// Explanation: As was mentioned above, many of the Windows processor affinity functions will only return the information for a single Processor Group.
+// Since a single group can only hold 64 logical processors, this means when there are more they will be divided into multiple groups.
+// Golang runtime.NumCPU will only return the value of one Processor Group (not the sum of all).
+func GetNumCPU() int {
+	if amount := win32APIGetAllActiveProcessorCount(windows.ALL_PROCESSOR_GROUPS); amount != 0 {
+		return int(amount)
+	}
+	// If the Win32 API does not return correctly, fall back to runtime.NumCPU()
+	return golangRuntimeNumCPU()
+}

--- a/ecs-agent/utils/utils_windows_test.go
+++ b/ecs-agent/utils/utils_windows_test.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+)
+
+func TestGetNumCPU(t *testing.T) {
+	testCases := []struct {
+		win32APIReturn      uint32
+		runtimeNumCPUReturn int
+		expectedAnswer      int
+		name                string
+	}{
+		{128, 64, 128, "Both are valid"},
+		{0, 64, 64, "win32 API invalid"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				win32APIGetAllActiveProcessorCount = windows.GetActiveProcessorCount
+				golangRuntimeNumCPU = runtime.NumCPU
+			}()
+
+			win32APIGetAllActiveProcessorCount = func(groupNumber uint16) (ret uint32) {
+				return tc.win32APIReturn
+			}
+
+			golangRuntimeNumCPU = func() int {
+				return tc.runtimeNumCPUReturn
+			}
+
+			assert.Equal(t, tc.expectedAnswer, GetNumCPU(), tc.name)
+		})
+	}
+
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR fixes a customer issue wherein Windows contiainer instances with vCPU larger than 64 were reporting incorrect CPU values. 

### Implementation details
<!-- How are the changes implemented? -->
The changes are implemented by using MSFT win32 API to get the correct number of CPUs on the instance. 

### Testing
<!-- How was this tested? -->
This was tested by launching an EC2 instance with 128 vCPU and ensuring that the ECS console showed the right CPU count in the resources section. 

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
yes, there are unit tests added. 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug: Windows numCPU returning incorrectly for values above 64

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
