### PR TITLE
Minor patches in netlib

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
@@ -50,6 +50,7 @@ const (
 	GetNetworkConfigurationByTaskMetricName = dbClientMetricNamespace + ".GetNetworkConfigurationByTask"
 	SaveNetworkNamespaceMetricName          = dbClientMetricNamespace + ".SaveNetworkNamespace"
 	GetNetworkNamespaceMetricName           = dbClientMetricNamespace + ".GetNetworkNamespace"
+	DelNetworkNamespaceMetricName           = dbClientMetricNamespace + ".DeleteNetworkNamespace"
 	AssignGeneveDstPortMetricName           = dbClientMetricNamespace + ".AssignGeneveDstPort"
 
 	networkBuilderNamespace               = "NetworkBuilder"

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface.go
@@ -55,12 +55,12 @@ type NetworkInterface struct {
 	// InterfaceAssociationProtocol is the type of NetworkInterface, valid value: "default", "vlan"
 	InterfaceAssociationProtocol string `json:",omitempty"`
 
-	Index         int64                `json:"Index,omitempty"`
-	UserID        uint32               `json:"UserID,omitempty"`
-	Name          string               `json:"Name,omitempty"`
-	DeviceName    string               `json:"DeviceName,omitempty"`
-	KnownStatus   status.NetworkStatus `json:"KnownStatus,omitempty"`
-	DesiredStatus status.NetworkStatus `json:"DesiredStatus,omitempty"`
+	Index         int64                `json:"Index"`
+	UserID        uint32               `json:"UserID"`
+	Name          string               `json:"Name"`
+	DeviceName    string               `json:"DeviceName"`
+	KnownStatus   status.NetworkStatus `json:"KnownStatus"`
+	DesiredStatus status.NetworkStatus `json:"DesiredStatus"`
 
 	// GuestNetNSName represents the interface's network namespace inside a guest OS if applicable.
 	// A sample use case is while running tasks inside Firecracker microVMs.

--- a/ecs-agent/metrics/constants.go
+++ b/ecs-agent/metrics/constants.go
@@ -50,6 +50,7 @@ const (
 	GetNetworkConfigurationByTaskMetricName = dbClientMetricNamespace + ".GetNetworkConfigurationByTask"
 	SaveNetworkNamespaceMetricName          = dbClientMetricNamespace + ".SaveNetworkNamespace"
 	GetNetworkNamespaceMetricName           = dbClientMetricNamespace + ".GetNetworkNamespace"
+	DelNetworkNamespaceMetricName           = dbClientMetricNamespace + ".DeleteNetworkNamespace"
 	AssignGeneveDstPortMetricName           = dbClientMetricNamespace + ".AssignGeneveDstPort"
 
 	networkBuilderNamespace               = "NetworkBuilder"

--- a/ecs-agent/netlib/model/networkinterface/networkinterface.go
+++ b/ecs-agent/netlib/model/networkinterface/networkinterface.go
@@ -55,12 +55,12 @@ type NetworkInterface struct {
 	// InterfaceAssociationProtocol is the type of NetworkInterface, valid value: "default", "vlan"
 	InterfaceAssociationProtocol string `json:",omitempty"`
 
-	Index         int64                `json:"Index,omitempty"`
-	UserID        uint32               `json:"UserID,omitempty"`
-	Name          string               `json:"Name,omitempty"`
-	DeviceName    string               `json:"DeviceName,omitempty"`
-	KnownStatus   status.NetworkStatus `json:"KnownStatus,omitempty"`
-	DesiredStatus status.NetworkStatus `json:"DesiredStatus,omitempty"`
+	Index         int64                `json:"Index"`
+	UserID        uint32               `json:"UserID"`
+	Name          string               `json:"Name"`
+	DeviceName    string               `json:"DeviceName"`
+	KnownStatus   status.NetworkStatus `json:"KnownStatus"`
+	DesiredStatus status.NetworkStatus `json:"DesiredStatus"`
 
 	// GuestNetNSName represents the interface's network namespace inside a guest OS if applicable.
 	// A sample use case is while running tasks inside Firecracker microVMs.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Added a new metric name and modified json attributes for network interface fields.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
```
go test -tags unit ./agent/...
go test -tags unit ./ecs-agent/...
```

New tests cover the changes: <!-- yes|no -->
n/a
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Added a new metric name and modified json attributes for network interface fields.

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
