### PR TITLE
Support docker engine 25.x

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -1097,26 +1097,24 @@ func (agent *ecsAgent) startACSSession(
 	return exitcodes.ExitSuccess
 }
 
-// validateRequiredVersion validates docker version.
+// verifyRequiredDockerVersion validates docker version.
 // Minimum docker version supported is 1.9.0, maps to api version 1.21
 // see https://docs.docker.com/develop/sdk/#api-version-matrix
 func (agent *ecsAgent) verifyRequiredDockerVersion() (int, bool) {
-	supportedVersions := agent.dockerClient.SupportedVersions()
+	supportedVersions := dockerclient.SupportedVersionsExtended(agent.dockerClient.SupportedVersions)
 	if len(supportedVersions) == 0 {
 		seelog.Critical("Could not get supported docker versions.")
 		return exitcodes.ExitError, false
 	}
 
-	// if api version 1.21 is supported, it means docker version is at least 1.9.0
 	for _, version := range supportedVersions {
-		if version == dockerclient.Version_1_21 {
+		if version == dockerclient.MinDockerAPIVersion {
 			return -1, true
 		}
 	}
 
-	// api 1.21 is not supported, docker version is older than 1.9.0
-	seelog.Criticalf("Required minimum docker API verion %s is not supported",
-		dockerclient.Version_1_21)
+	seelog.Criticalf("Required minimum docker API version %s is not supported",
+		dockerclient.MinDockerAPIVersion)
 	return exitcodes.ExitTerminal, false
 }
 

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -206,14 +206,14 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	}
 
 	supportedVersions := make(map[dockerclient.DockerVersion]bool)
-	// Determine API versions to report as supported. Supported versions are also used for capability-enablement, except
-	// logging drivers.
-	for _, version := range agent.dockerClient.SupportedVersions() {
+	// Determine API versions to report as supported via com.amazonaws.ecs.capability.docker-remote-api.X.XX capabilities
+	// and for determining which features we support that depend on specific docker API versions
+	for _, version := range dockerclient.SupportedVersionsExtended(agent.dockerClient.SupportedVersions) {
 		capabilities = appendNameOnlyAttribute(capabilities, capabilityPrefix+"docker-remote-api."+string(version))
 		supportedVersions[version] = true
 	}
 
-	capabilities = agent.appendLoggingDriverCapabilities(capabilities)
+	capabilities = agent.appendLoggingDriverCapabilities(capabilities, supportedVersions)
 
 	if agent.cfg.SELinuxCapable.Enabled() {
 		capabilities = appendNameOnlyAttribute(capabilities, capabilityPrefix+"selinux")
@@ -315,7 +315,6 @@ func (agent *ecsAgent) appendDockerDependentCapabilities(capabilities []*ecs.Att
 		capabilities = appendNameOnlyAttribute(capabilities, capabilityPrefix+"ecr-auth")
 		capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+"execution-role-ecr-pull")
 	}
-
 	if _, ok := supportedVersions[dockerclient.Version_1_24]; ok && !agent.cfg.DisableDockerHealthCheck.Enabled() {
 		// Docker health check was added in API 1.24
 		capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+"container-health-check")
@@ -339,17 +338,10 @@ func (agent *ecsAgent) appendGMSADomainlessCapabilities(capabilities []*ecs.Attr
 	return capabilities
 }
 
-func (agent *ecsAgent) appendLoggingDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	knownVersions := make(map[dockerclient.DockerVersion]struct{})
-	// Determine known API versions. Known versions are used exclusively for logging-driver enablement, since none of
-	// the structural API elements change.
-	for _, version := range agent.dockerClient.KnownVersions() {
-		knownVersions[version] = struct{}{}
-	}
-
+func (agent *ecsAgent) appendLoggingDriverCapabilities(capabilities []*ecs.Attribute, supportedVersions map[dockerclient.DockerVersion]bool) []*ecs.Attribute {
 	for _, loggingDriver := range agent.cfg.AvailableLoggingDrivers {
 		requiredVersion := dockerclient.LoggingDriverMinimumVersion[loggingDriver]
-		if _, ok := knownVersions[requiredVersion]; ok {
+		if _, ok := supportedVersions[requiredVersion]; ok {
 			capabilities = appendNameOnlyAttribute(capabilities, capabilityPrefix+"logging-driver."+string(loggingDriver))
 		}
 	}

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -108,10 +108,6 @@ func TestCapabilities(t *testing.T) {
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 			dockerclient.Version_1_18,
-		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-			dockerclient.Version_1_18,
 			dockerclient.Version_1_19,
 		}),
 		// CNI plugins are platform dependent.
@@ -255,11 +251,6 @@ func getCapabilitiesWithConfig(cfg *config.Config, t *testing.T) []*ecs.Attribut
 			dockerclient.Version_1_17,
 			dockerclient.Version_1_18,
 		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-			dockerclient.Version_1_18,
-			dockerclient.Version_1_19,
-		}),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -295,7 +286,6 @@ func TestCapabilitiesECR(t *testing.T) {
 	client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 		dockerclient.Version_1_19,
 	})
-	client.EXPECT().KnownVersions().Return(nil)
 	mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil)
 	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any()).AnyTimes().Return([]string{}, nil)
@@ -352,7 +342,6 @@ func TestCapabilitiesTaskIAMRoleForSupportedDockerVersion(t *testing.T) {
 	client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 		dockerclient.Version_1_19,
 	})
-	client.EXPECT().KnownVersions().Return(nil)
 	mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil)
 	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any()).AnyTimes().Return([]string{}, nil)
@@ -407,7 +396,6 @@ func TestCapabilitiesTaskIAMRoleForUnSupportedDockerVersion(t *testing.T) {
 	client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 		dockerclient.Version_1_18,
 	})
-	client.EXPECT().KnownVersions().Return(nil)
 	mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil)
 	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any()).AnyTimes().Return([]string{}, nil)
@@ -462,7 +450,6 @@ func TestCapabilitiesTaskIAMRoleNetworkHostForSupportedDockerVersion(t *testing.
 	client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 		dockerclient.Version_1_19,
 	})
-	client.EXPECT().KnownVersions().Return(nil)
 	mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil)
 	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any()).AnyTimes().Return([]string{}, nil)
@@ -517,7 +504,6 @@ func TestCapabilitiesTaskIAMRoleNetworkHostForUnSupportedDockerVersion(t *testin
 	client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 		dockerclient.Version_1_18,
 	})
-	client.EXPECT().KnownVersions().Return(nil)
 	mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil)
 	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any()).AnyTimes().Return([]string{}, nil)
@@ -591,11 +577,6 @@ func TestAWSVPCBlockInstanceMetadataWhenTaskENIIsDisabled(t *testing.T) {
 			dockerclient.Version_1_17,
 			dockerclient.Version_1_18,
 		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-			dockerclient.Version_1_18,
-			dockerclient.Version_1_19,
-		}),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -660,7 +641,6 @@ func TestCapabilitiesExecutionRoleAWSLogs(t *testing.T) {
 	client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 		dockerclient.Version_1_17,
 	})
-	client.EXPECT().KnownVersions().Return(nil)
 	// CNI plugins are platform dependent.
 	// Therefore, for any version query for any plugin return an error
 	cniClient.EXPECT().Version(gomock.Any()).Return("v1", errors.New("some error happened"))
@@ -727,7 +707,6 @@ func TestCapabilitiesTaskResourceLimit(t *testing.T) {
 
 	gomock.InOrder(
 		client.EXPECT().SupportedVersions().Return(versionList),
-		client.EXPECT().KnownVersions().Return(versionList),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -781,7 +760,6 @@ func TestCapabilitesTaskResourceLimitDisabledByMissingDockerVersion(t *testing.T
 
 	gomock.InOrder(
 		client.EXPECT().SupportedVersions().Return(versionList),
-		client.EXPECT().KnownVersions().Return(versionList),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -834,7 +812,6 @@ func TestCapabilitesTaskResourceLimitErrorCase(t *testing.T) {
 
 	gomock.InOrder(
 		client.EXPECT().SupportedVersions().Return(versionList),
-		client.EXPECT().KnownVersions().Return(versionList),
 	)
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -904,7 +881,6 @@ func TestCapabilitiesIncreasedTaskCPULimit(t *testing.T) {
 
 			gomock.InOrder(
 				client.EXPECT().SupportedVersions().Return(versionList),
-				client.EXPECT().KnownVersions().Return(versionList),
 				mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 				client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -947,7 +923,6 @@ func TestCapabilitiesContainerHealth(t *testing.T) {
 	client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 		dockerclient.Version_1_24,
 	})
-	client.EXPECT().KnownVersions().Return(nil)
 	mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil)
 	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any()).AnyTimes().Return([]string{}, nil)
@@ -998,7 +973,6 @@ func TestCapabilitiesContainerHealthDisabled(t *testing.T) {
 	client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 		dockerclient.Version_1_24,
 	})
-	client.EXPECT().KnownVersions().Return(nil)
 	mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil)
 	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any()).AnyTimes().Return([]string{}, nil)
@@ -1058,7 +1032,6 @@ func TestCapabilitesListPluginsErrorCase(t *testing.T) {
 
 	gomock.InOrder(
 		client.EXPECT().SupportedVersions().Return(versionList),
-		client.EXPECT().KnownVersions().Return(versionList),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return(nil, errors.New("listPlugins error happened")),
@@ -1106,7 +1079,6 @@ func TestCapabilitesScanPluginsErrorCase(t *testing.T) {
 
 	gomock.InOrder(
 		client.EXPECT().SupportedVersions().Return(versionList),
-		client.EXPECT().KnownVersions().Return(versionList),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return(nil, errors.New("Scan plugins error happened")),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -1224,7 +1196,6 @@ func TestCapabilitiesExecuteCommand(t *testing.T) {
 
 			gomock.InOrder(
 				client.EXPECT().SupportedVersions().Return(versionList),
-				client.EXPECT().KnownVersions().Return(versionList),
 				mockMobyPlugins.EXPECT().Scan().AnyTimes().Return(nil, errors.New("Scan plugins error happened")),
 				client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -1308,10 +1279,6 @@ func TestCapabilitiesNoServiceConnect(t *testing.T) {
 	// AnyTimes() because they are not called in windows.
 	gomock.InOrder(
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-			dockerclient.Version_1_18,
-		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 			dockerclient.Version_1_18,
 			dockerclient.Version_1_19,

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -88,10 +88,6 @@ func TestVolumeDriverCapabilitiesUnix(t *testing.T) {
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 			dockerclient.Version_1_18,
-		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-			dockerclient.Version_1_18,
 			dockerclient.Version_1_19,
 		}),
 		cniClient.EXPECT().Version(ecscni.VPCENIPluginName).Return("v1", nil),
@@ -183,9 +179,6 @@ func TestNvidiaDriverCapabilitiesUnix(t *testing.T) {
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-		}),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -269,9 +262,6 @@ func TestEmptyNvidiaDriverCapabilitiesUnix(t *testing.T) {
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-		}),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -347,9 +337,6 @@ func TestENITrunkingCapabilitiesUnix(t *testing.T) {
 
 	gomock.InOrder(
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 		}),
 		cniClient.EXPECT().Version(ecscni.VPCENIPluginName).Return("v1", nil),
@@ -444,9 +431,6 @@ func TestNoENITrunkingCapabilitiesUnix(t *testing.T) {
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-		}),
 		cniClient.EXPECT().Version(ecscni.VPCENIPluginName).Return("v1", nil),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
@@ -527,9 +511,6 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesUnix(t *testing.T) {
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-		}),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -606,9 +587,6 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesNoPauseContainer(t *testing.T) {
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-		}),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -681,9 +659,6 @@ func TestAppMeshCapabilitiesUnix(t *testing.T) {
 
 	gomock.InOrder(
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 		}),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
@@ -769,9 +744,6 @@ func TestTaskEIACapabilitiesNoOptimizedCPU(t *testing.T) {
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-		}),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -828,9 +800,6 @@ func TestTaskEIACapabilitiesWithOptimizedCPU(t *testing.T) {
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-		}),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -882,9 +851,6 @@ func TestCapabilitiesUnix(t *testing.T) {
 
 	gomock.InOrder(
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 		}),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
@@ -967,9 +933,6 @@ func TestFirelensConfigCapabilitiesUnix(t *testing.T) {
 
 	gomock.InOrder(
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 		}),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),

--- a/agent/app/agent_capability_windows_test.go
+++ b/agent/app/agent_capability_windows_test.go
@@ -69,10 +69,6 @@ func TestVolumeDriverCapabilitiesWindows(t *testing.T) {
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 			dockerclient.Version_1_18,
-		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-			dockerclient.Version_1_18,
 			dockerclient.Version_1_19,
 		}),
 		cniClient.EXPECT().Version(ecscni.ECSVPCENIPluginExecutable).Return("v1", nil),
@@ -82,6 +78,7 @@ func TestVolumeDriverCapabilitiesWindows(t *testing.T) {
 		capabilityPrefix + "privileged-container",
 		capabilityPrefix + "docker-remote-api.1.17",
 		capabilityPrefix + "docker-remote-api.1.18",
+		capabilityPrefix + "docker-remote-api.1.19",
 		capabilityPrefix + "logging-driver.json-file",
 		capabilityPrefix + "logging-driver.syslog",
 		capabilityPrefix + "logging-driver.journald",
@@ -159,10 +156,6 @@ func TestSupportedCapabilitiesWindows(t *testing.T) {
 		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
 			dockerclient.Version_1_17,
 			dockerclient.Version_1_18,
-		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-			dockerclient.Version_1_18,
 			dockerclient.Version_1_19,
 		}),
 		cniClient.EXPECT().Version(ecscni.ECSVPCENIPluginExecutable).Return("v1", nil),
@@ -172,6 +165,7 @@ func TestSupportedCapabilitiesWindows(t *testing.T) {
 		capabilityPrefix + "privileged-container",
 		capabilityPrefix + "docker-remote-api.1.17",
 		capabilityPrefix + "docker-remote-api.1.18",
+		capabilityPrefix + "docker-remote-api.1.19",
 		capabilityPrefix + "logging-driver.json-file",
 		capabilityPrefix + "logging-driver.syslog",
 		capabilityPrefix + "logging-driver.journald",
@@ -221,7 +215,6 @@ func TestSupportedCapabilitiesWindows(t *testing.T) {
 	capabilities, err := agent.capabilities()
 	assert.NoError(t, err)
 
-	assert.Equal(t, len(expectedCapabilities), len(capabilities))
 	for _, expected := range expectedCapabilities {
 		assert.Contains(t, capabilities, &ecs.Attribute{
 			Name:  expected.Name,

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"sync"
 	"testing"
 	"time"
 
@@ -80,9 +79,8 @@ var notFoundErr = awserr.NewRequestFailure(awserr.Error(awserr.New("NotFound", "
 var badReqErr = awserr.NewRequestFailure(awserr.Error(awserr.New("BadRequest", "", errors.New(""))), 400, "")
 var serverErr = awserr.NewRequestFailure(awserr.Error(awserr.New("InternalServerError", "", errors.New(""))), 500, "")
 var apiVersions = []dockerclient.DockerVersion{
-	dockerclient.Version_1_21,
-	dockerclient.Version_1_22,
-	dockerclient.Version_1_23}
+	dockerclient.MinDockerAPIVersion,
+}
 var capabilities []*ecs.Attribute
 var testHostCPU = int64(1024)
 var testHostMEMORY = int64(1024)
@@ -249,13 +247,11 @@ func TestDoStartRegisterContainerInstanceErrorTerminal(t *testing.T) {
 	mockDaemonManagers := map[string]dm.DaemonManager{md.EbsCsiDriver: mockDaemonManager}
 	mockDaemonManager.EXPECT().IsLoaded(gomock.Any()).Return(true, nil).AnyTimes()
 	mockDaemonManager.EXPECT().LoadImage(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions).AnyTimes()
 
 	gomock.InOrder(
-		dockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		client.EXPECT().GetHostResources().Return(testHostResource, nil),
 		mockCredentialsProvider.EXPECT().Retrieve().Return(aws_credentials.Value{}, nil),
-		dockerClient.EXPECT().SupportedVersions().Return(nil),
-		dockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{""}, nil),
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -313,13 +309,11 @@ func TestDoStartRegisterContainerInstanceErrorNonTerminal(t *testing.T) {
 	mockDaemonManagers := map[string]dm.DaemonManager{md.EbsCsiDriver: mockDaemonManager}
 	mockDaemonManager.EXPECT().IsLoaded(gomock.Any()).Return(true, nil).AnyTimes()
 	mockDaemonManager.EXPECT().LoadImage(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions).AnyTimes()
 
 	gomock.InOrder(
-		dockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		client.EXPECT().GetHostResources().Return(testHostResource, nil),
 		mockCredentialsProvider.EXPECT().Retrieve().Return(aws_credentials.Value{}, nil),
-		dockerClient.EXPECT().SupportedVersions().Return(nil),
-		dockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{""}, nil),
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -444,10 +438,7 @@ func testDoStartHappyPathWithConditions(t *testing.T, blackholed bool, warmPools
 		ec2MetadataClient.EXPECT().InstanceID().Return(instanceID, nil)
 	}
 
-	var discoverEndpointsInvoked sync.WaitGroup
-	discoverEndpointsInvoked.Add(2)
 	mockMobyPlugins := mock_mobypkgwrapper.NewMockPlugins(ctrl)
-	dockerClient.EXPECT().Version(gomock.Any(), gomock.Any()).AnyTimes()
 	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
 	containermetadata := mock_containermetadata.NewMockManager(ctrl)
 	mockPauseLoader := mock_loader.NewMockLoader(ctrl)
@@ -468,28 +459,28 @@ func testDoStartHappyPathWithConditions(t *testing.T, blackholed bool, warmPools
 		return []*md.ManagedDaemon{}, nil
 	}
 
+	waitC := make(chan bool, 3)
 	imageManager.EXPECT().AddImageToCleanUpExclusionList(gomock.Eq("service_connect_agent:v1")).Times(1)
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
 	dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		dockerapi.ListContainersResponse{}).AnyTimes()
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions).AnyTimes()
+	dockerClient.EXPECT().Version(gomock.Any(), gomock.Any()).Return("20.10.15", nil).AnyTimes()
 	client.EXPECT().DiscoverPollEndpoint(gomock.Any()).Do(func(x interface{}) {
-		// Ensures that the test waits until acs session has bee started
-		discoverEndpointsInvoked.Done()
+		// Ensures that the test waits until acs session has been started
+		waitC <- true
 	}).Return("poll-endpoint", nil)
 	client.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return("acs-endpoint", nil).AnyTimes()
 	client.EXPECT().DiscoverTelemetryEndpoint(gomock.Any()).Do(func(x interface{}) {
-		// Ensures that the test waits until telemetry session has bee started
-		discoverEndpointsInvoked.Done()
+		// Ensures that the test waits until telemetry session has been started
+		waitC <- true
 	}).Return("telemetry-endpoint", nil)
 	client.EXPECT().DiscoverTelemetryEndpoint(gomock.Any()).Return(
 		"tele-endpoint", nil).AnyTimes()
 
 	gomock.InOrder(
-		dockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		client.EXPECT().GetHostResources().Return(testHostResource, nil),
 		mockCredentialsProvider.EXPECT().Retrieve().Return(aws_credentials.Value{}, nil),
-		dockerClient.EXPECT().SupportedVersions().Return(nil),
-		dockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{""}, nil),
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -535,17 +526,30 @@ func testDoStartHappyPathWithConditions(t *testing.T, blackholed bool, warmPools
 		serviceconnectManager: mockServiceConnectManager,
 	}
 
-	var agentW sync.WaitGroup
-	agentW.Add(1)
 	go func() {
 		agent.doStart(eventstream.NewEventStream("events", ctx),
 			credentialsManager, dockerstate.NewTaskEngineState(), imageManager, client, execCmdMgr)
-		agentW.Done()
+		waitC <- true
 	}()
 
-	discoverEndpointsInvoked.Wait()
+	timeoutC := time.After(time.Second * 30)
+	for i := 0; i < 2; i++ {
+		select {
+		case <-waitC:
+			// expect to receive 2 times from this channel
+		case <-timeoutC:
+			ctrl.Finish()
+			// cancel the loop
+			i = 4
+		}
+	}
 	cancel()
-	agentW.Wait()
+	// wait for agent to exit
+	select {
+	case <-waitC:
+	case <-time.After(time.Second * 10):
+		t.Logf("Timed out waiting for agent to exit")
+	}
 
 	assertMetadata(t, data.AgentVersionKey, version.Version, dataClient)
 	assertMetadata(t, data.AvailabilityZoneKey, availabilityZone, dataClient)
@@ -991,8 +995,7 @@ func TestReregisterContainerInstanceHappyPath(t *testing.T) {
 
 	gomock.InOrder(
 		mockCredentialsProvider.EXPECT().Retrieve().Return(aws_credentials.Value{}, nil),
-		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
-		mockDockerClient.EXPECT().KnownVersions().Return(nil),
+		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{""}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -1051,8 +1054,7 @@ func TestReregisterContainerInstanceInstanceTypeChanged(t *testing.T) {
 
 	gomock.InOrder(
 		mockCredentialsProvider.EXPECT().Retrieve().Return(aws_credentials.Value{}, nil),
-		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
-		mockDockerClient.EXPECT().KnownVersions().Return(nil),
+		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{""}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -1113,8 +1115,7 @@ func TestReregisterContainerInstanceAttributeError(t *testing.T) {
 
 	gomock.InOrder(
 		mockCredentialsProvider.EXPECT().Retrieve().Return(aws_credentials.Value{}, nil),
-		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
-		mockDockerClient.EXPECT().KnownVersions().Return(nil),
+		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -1173,8 +1174,7 @@ func TestReregisterContainerInstanceNonTerminalError(t *testing.T) {
 
 	gomock.InOrder(
 		mockCredentialsProvider.EXPECT().Retrieve().Return(aws_credentials.Value{}, nil),
-		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
-		mockDockerClient.EXPECT().KnownVersions().Return(nil),
+		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -1234,8 +1234,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetHappyPath(t *t
 
 	gomock.InOrder(
 		mockCredentialsProvider.EXPECT().Retrieve().Return(aws_credentials.Value{}, nil),
-		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
-		mockDockerClient.EXPECT().KnownVersions().Return(nil),
+		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -1293,8 +1292,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetCanRetryError(
 	retriableError := apierrors.NewRetriableError(apierrors.NewRetriable(true), errors.New("error"))
 	gomock.InOrder(
 		mockCredentialsProvider.EXPECT().Retrieve().Return(aws_credentials.Value{}, nil),
-		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
-		mockDockerClient.EXPECT().KnownVersions().Return(nil),
+		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -1352,8 +1350,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetCannotRetryErr
 	cannotRetryError := apierrors.NewRetriableError(apierrors.NewRetriable(false), errors.New("error"))
 	gomock.InOrder(
 		mockCredentialsProvider.EXPECT().Retrieve().Return(aws_credentials.Value{}, nil),
-		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
-		mockDockerClient.EXPECT().KnownVersions().Return(nil),
+		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -1410,8 +1407,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetAttributeError
 
 	gomock.InOrder(
 		mockCredentialsProvider.EXPECT().Retrieve().Return(aws_credentials.Value{}, nil),
-		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
-		mockDockerClient.EXPECT().KnownVersions().Return(nil),
+		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -1468,12 +1464,11 @@ func TestRegisterContainerInstanceInvalidParameterTerminalError(t *testing.T) {
 	mockDaemonManager.EXPECT().IsLoaded(gomock.Any()).Return(true, nil).AnyTimes()
 	mockDaemonManager.EXPECT().LoadImage(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions).AnyTimes()
+
 	gomock.InOrder(
-		dockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		client.EXPECT().GetHostResources().Return(testHostResource, nil),
 		mockCredentialsProvider.EXPECT().Retrieve().Return(aws_credentials.Value{}, nil),
-		dockerClient.EXPECT().SupportedVersions().Return(nil),
-		dockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -90,7 +90,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 	// invoked via go routines, which will lead to occasional test failues
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 	dockerClient.EXPECT().Version(gomock.Any(), gomock.Any()).AnyTimes()
-	dockerClient.EXPECT().SupportedVersions().Return(apiVersions)
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions).AnyTimes()
 	dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		dockerapi.ListContainersResponse{}).AnyTimes()
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
@@ -136,8 +136,6 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 		cniClient.EXPECT().Capabilities(ecscni.ECSAppMeshPluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSBranchENIPluginName).Return(cniCapabilities, nil),
 		mockCredentialsProvider.EXPECT().Retrieve().Return(credentials.Value{}, nil),
-		dockerClient.EXPECT().SupportedVersions().Return(nil),
-		dockerClient.EXPECT().KnownVersions().Return(nil),
 		cniClient.EXPECT().Version(ecscni.VPCENIPluginName).Return("v1", nil),
 		cniClient.EXPECT().Version(ecscni.ECSBranchENIPluginName).Return("v2", nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
@@ -453,7 +451,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 
 	ec2MetadataClient := mock_ec2.NewMockEC2MetadataClient(ctrl)
 	dockerClient.EXPECT().Version(gomock.Any(), gomock.Any()).AnyTimes()
-	dockerClient.EXPECT().SupportedVersions().Return(apiVersions)
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions).AnyTimes()
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 	ec2MetadataClient.EXPECT().PrimaryENIMAC().Return("mac", nil)
@@ -482,8 +480,6 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 	gomock.InOrder(
 		mockControl.EXPECT().Init().Return(nil),
 		mockCredentialsProvider.EXPECT().Retrieve().Return(credentials.Value{}, nil),
-		dockerClient.EXPECT().SupportedVersions().Return(nil),
-		dockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).Return([]string{}, nil),
@@ -558,7 +554,7 @@ func TestDoStartCgroupInitErrorPath(t *testing.T) {
 	discoverEndpointsInvoked.Add(2)
 
 	dockerClient.EXPECT().Version(gomock.Any(), gomock.Any()).AnyTimes()
-	dockerClient.EXPECT().SupportedVersions().Return(apiVersions)
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions).AnyTimes()
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 	mockPauseLoader.EXPECT().LoadImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
@@ -632,7 +628,7 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 	containerChangeEvents := make(chan dockerapi.DockerContainerChangeEvent)
 
 	dockerClient.EXPECT().Version(gomock.Any(), gomock.Any()).AnyTimes()
-	dockerClient.EXPECT().SupportedVersions().Return(apiVersions)
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions).AnyTimes()
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 	ec2MetadataClient.EXPECT().PrimaryENIMAC().Return("mac", nil)
@@ -662,8 +658,6 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 	gomock.InOrder(
 		mockGPUManager.EXPECT().Initialize().Return(nil),
 		mockCredentialsProvider.EXPECT().Retrieve().Return(credentials.Value{}, nil),
-		dockerClient.EXPECT().SupportedVersions().Return(nil),
-		dockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).Return([]string{}, nil),
@@ -741,7 +735,7 @@ func TestDoStartGPUManagerInitError(t *testing.T) {
 	discoverEndpointsInvoked.Add(2)
 
 	dockerClient.EXPECT().Version(gomock.Any(), gomock.Any()).AnyTimes()
-	dockerClient.EXPECT().SupportedVersions().Return(apiVersions)
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions).AnyTimes()
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 	mockGPUManager.EXPECT().Initialize().Return(errors.New("init error"))
@@ -797,7 +791,7 @@ func TestDoStartTaskENIPauseError(t *testing.T) {
 	// invoked via go routines, which will lead to occasional test failures
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 	dockerClient.EXPECT().Version(gomock.Any(), gomock.Any()).AnyTimes()
-	dockerClient.EXPECT().SupportedVersions().Return(apiVersions)
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions).AnyTimes()
 	dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		dockerapi.ListContainersResponse{}).AnyTimes()
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)

--- a/agent/dockerclient/dockerapi_compare_versions_test.go
+++ b/agent/dockerclient/dockerapi_compare_versions_test.go
@@ -117,6 +117,16 @@ func TestDockerVersionMatches(t *testing.T) {
 			selector:       ">=1.9,<=1.9",
 			expectedOutput: true,
 		},
+		{
+			version:        "1.24",
+			selector:       ">=1.24",
+			expectedOutput: true,
+		},
+		{
+			version:        "1.25",
+			selector:       ">=1.24",
+			expectedOutput: true,
+		},
 	}
 
 	for i, testCase := range testCases {

--- a/agent/dockerclient/sdkclientfactory/sdkclientfactory_test.go
+++ b/agent/dockerclient/sdkclientfactory/sdkclientfactory_test.go
@@ -138,31 +138,6 @@ func TestFindSupportedAPIVersionsFromMinAPIVersions(t *testing.T) {
 	}
 }
 
-func TestCompareDockerVersionsWithMinAPIVersion(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	minAPIVersion := "1.12"
-	apiVersion := "1.32"
-	versions := []string{"1.11", "1.33"}
-	rightVersion := "1.25"
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-
-	for _, version := range versions {
-		_, err := getDockerClientForVersion("endpoint", version, minAPIVersion, apiVersion, ctx)
-		assert.EqualError(t, err, "version detection using MinAPIVersion: unsupported version: "+version)
-	}
-
-	mockClients := make(map[string]*mock_sdkclient.MockClient)
-	newVersionedClient = func(endpoint, version string) (sdkclient.Client, error) {
-		mockClients[version] = mock_sdkclient.NewMockClient(ctrl)
-		mockClients[version].EXPECT().Ping(gomock.Any())
-		return mockClients[version], nil
-	}
-	client, _ := getDockerClientForVersion("endpoint", rightVersion, minAPIVersion, apiVersion, ctx)
-	assert.Equal(t, mockClients[rightVersion], client)
-}
-
 func TestGetClientCached(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/agent/dockerclient/sdkclientfactory/sdkclientfactory_windows_test.go
+++ b/agent/dockerclient/sdkclientfactory/sdkclientfactory_windows_test.go
@@ -36,7 +36,7 @@ func TestGetClientMinimumVersion(t *testing.T) {
 
 	newVersionedClient = func(endpoint, version string) (sdkclient.Client, error) {
 		mockClient := mock_sdkclient.NewMockClient(ctrl)
-		if version == string(minDockerAPIVersion) {
+		if version == string(dockerclient.MinDockerAPIVersion) {
 			mockClient = expectedClient
 		}
 		mockClient.EXPECT().ServerVersion(gomock.Any()).Return(docker.Version{}, nil).AnyTimes()
@@ -44,8 +44,8 @@ func TestGetClientMinimumVersion(t *testing.T) {
 		return mockClient, nil
 	}
 
-	// Ensure a call to GetClient with a version below the minDockerAPIVersion
-	// is replaced by the minDockerAPIVersion
+	// Ensure a call to GetClient with a version below the dockerclient.MinDockerAPIVersion
+	// is replaced by the dockerclient.MinDockerAPIVersion
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	factory := NewFactory(ctx, expectedEndpoint)
@@ -64,7 +64,7 @@ func TestFindClientAPIVersion(t *testing.T) {
 
 	for _, version := range getAgentSupportedDockerVersions() {
 		if isWindowsReplaceableVersion(version) {
-			version = minDockerAPIVersion
+			version = dockerclient.MinDockerAPIVersion
 		}
 		mockClient.EXPECT().ClientVersion().Return(string(version))
 		assert.Equal(t, version, factory.FindClientAPIVersion(mockClient))

--- a/agent/dockerclient/sdkclientfactory/versionsupport_unix.go
+++ b/agent/dockerclient/sdkclientfactory/versionsupport_unix.go
@@ -21,11 +21,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclient"
 )
 
-const (
-	// minDockerAPIVersion is the min Docker API version supported by agent
-	minDockerAPIVersion = dockerclient.Version_1_17
-)
-
 // GetClient on linux will simply return the cached client from the map
 func (f *factory) GetClient(version dockerclient.DockerVersion) (sdkclient.Client, error) {
 	return f.getClient(version)
@@ -33,27 +28,10 @@ func (f *factory) GetClient(version dockerclient.DockerVersion) (sdkclient.Clien
 
 // getAgentSupportedDockerVersions returns a list of agent-supported Docker versions for linux
 func getAgentSupportedDockerVersions() []dockerclient.DockerVersion {
-	return []dockerclient.DockerVersion{
-		dockerclient.Version_1_17,
-		dockerclient.Version_1_18,
-		dockerclient.Version_1_19,
-		dockerclient.Version_1_20,
-		dockerclient.Version_1_21,
-		dockerclient.Version_1_22,
-		dockerclient.Version_1_23,
-		dockerclient.Version_1_24,
-		dockerclient.Version_1_25,
-		dockerclient.Version_1_26,
-		dockerclient.Version_1_27,
-		dockerclient.Version_1_28,
-		dockerclient.Version_1_29,
-		dockerclient.Version_1_30,
-		dockerclient.Version_1_31,
-		dockerclient.Version_1_32,
-	}
+	return dockerclient.GetKnownAPIVersions()
 }
 
 // getDefaultVersion will return the default Docker API version for linux
 func GetDefaultVersion() dockerclient.DockerVersion {
-	return dockerclient.Version_1_21
+	return dockerclient.MinDockerAPIVersion
 }

--- a/agent/dockerclient/versions_test.go
+++ b/agent/dockerclient/versions_test.go
@@ -1,0 +1,100 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package dockerclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSupportedDockerAPIVersion(t *testing.T) {
+	oldVersionResult := GetSupportedDockerAPIVersion(Version_1_17)
+	assert.Equal(t, MinDockerAPIVersion, oldVersionResult)
+	newVersionResult := GetSupportedDockerAPIVersion(Version_1_32)
+	assert.Equal(t, Version_1_32, newVersionResult)
+	invalidVersionResult := GetSupportedDockerAPIVersion(DockerVersion("Foo.Bar"))
+	assert.Equal(t, MinDockerAPIVersion, invalidVersionResult)
+}
+
+func TestCompare(t *testing.T) {
+	testCases := []struct {
+		lhs            DockerVersion
+		rhs            DockerVersion
+		expectedResult int
+	}{
+		{
+			lhs:            Version_1_17,
+			rhs:            Version_1_17,
+			expectedResult: 0,
+		},
+		{
+			lhs:            Version_1_44,
+			rhs:            Version_1_44,
+			expectedResult: 0,
+		},
+		{
+			lhs:            Version_1_17,
+			rhs:            Version_1_33,
+			expectedResult: -1,
+		},
+		{
+			lhs:            Version_1_33,
+			rhs:            Version_1_43,
+			expectedResult: -1,
+		},
+		{
+			lhs:            Version_1_34,
+			rhs:            Version_1_35,
+			expectedResult: -1,
+		},
+		{
+			lhs:            Version_1_30,
+			rhs:            Version_1_17,
+			expectedResult: 1,
+		},
+		{
+			lhs:            Version_1_18,
+			rhs:            Version_1_17,
+			expectedResult: 1,
+		},
+		{
+			lhs:            Version_1_44,
+			rhs:            Version_1_35,
+			expectedResult: 1,
+		},
+		{
+			lhs:            DockerVersion("Foo.Bar"),
+			rhs:            Version_1_35,
+			expectedResult: 0,
+		},
+		{
+			lhs:            Version_1_35,
+			rhs:            DockerVersion("foobar"),
+			expectedResult: 0,
+		},
+		{
+			lhs:            DockerVersion("Foo.Bar"),
+			rhs:            DockerVersion("Foo.Bar"),
+			expectedResult: 0,
+		},
+	}
+	for _, tc := range testCases {
+		actual := tc.lhs.Compare(tc.rhs)
+		assert.Equal(t, tc.expectedResult, actual)
+	}
+}

--- a/agent/dockerclient/versions_unix.go
+++ b/agent/dockerclient/versions_unix.go
@@ -1,0 +1,49 @@
+//go:build !windows
+// +build !windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package dockerclient
+
+import "github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+
+// SupportedVersionsExtended takes in a function that returns supported docker API versions.
+// It returns a list of "extended" API versions that may not be directly supported
+// but their functionality is supported.
+// For example, in Docker Engine 25.x API versions 1.17-1.23 were deprecated to be used
+// directly, although their functionality is still supported.
+func SupportedVersionsExtended(supportedVersionsFn func() []DockerVersion) []DockerVersion {
+	supportedAPIVersions := supportedVersionsFn()
+	// Check if MinDockerAPIVersion is greater than or equal to 1.24
+	// This version is used because this is the earliest API version supported when docker
+	// deprecated early API versions. See https://docs.docker.com/engine/deprecated/
+	cmp := MinDockerAPIVersion.Compare(Version_1_24)
+
+	if cmp == 1 || cmp == 0 {
+		// extend list of supported versions to include earlier known versions of docker api
+		extendedAPIVersions := []DockerVersion{}
+		knownAPIVersions := GetKnownAPIVersions()
+		for _, knownAPIVersion := range knownAPIVersions {
+			if knownAPIVersion.Compare(MinDockerAPIVersion) < 0 {
+				extendedAPIVersions = append(extendedAPIVersions, knownAPIVersion)
+			}
+		}
+		supportedAPIVersions = append(extendedAPIVersions, supportedAPIVersions...)
+	}
+
+	logger.Debug("Extended supported docker API versions", logger.Fields{
+		"supportedAPIVersions": supportedAPIVersions,
+	})
+	return supportedAPIVersions
+}

--- a/agent/dockerclient/versions_unix_test.go
+++ b/agent/dockerclient/versions_unix_test.go
@@ -1,0 +1,119 @@
+//go:build !windows && unit
+// +build !windows,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package dockerclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func setTestMinDockerAPIVersion(minVersion DockerVersion) func() {
+	origMin := MinDockerAPIVersion
+	SetMinDockerAPIVersion(minVersion)
+	return func() {
+		SetMinDockerAPIVersion(origMin)
+	}
+}
+
+func TestSupportedVersionsExtended(t *testing.T) {
+	defer setTestMinDockerAPIVersion(Version_1_19)()
+	supportedVersionsTestFunc := func() []DockerVersion {
+		return []DockerVersion{
+			Version_1_19,
+			Version_1_20,
+			Version_1_21,
+			Version_1_22,
+			Version_1_23,
+			Version_1_24,
+		}
+	}
+	actualSupportedVersions := SupportedVersionsExtended(supportedVersionsTestFunc)
+	expectedSupportedVersions := []DockerVersion{
+		Version_1_19,
+		Version_1_20,
+		Version_1_21,
+		Version_1_22,
+		Version_1_23,
+		Version_1_24,
+	}
+
+	assert.Equal(t,
+		expectedSupportedVersions,
+		actualSupportedVersions,
+	)
+}
+
+func TestSupportedVersionsExtended_1_24(t *testing.T) {
+	// Min version 1.24 triggers the 'extended' docker versions to be added
+	defer setTestMinDockerAPIVersion(Version_1_24)()
+	supportedVersionsTestFunc := func() []DockerVersion {
+		return []DockerVersion{
+			Version_1_24,
+			Version_1_25,
+			Version_1_26,
+		}
+	}
+	actualSupportedVersions := SupportedVersionsExtended(supportedVersionsTestFunc)
+	expectedSupportedVersions := []DockerVersion{
+		Version_1_17,
+		Version_1_18,
+		Version_1_19,
+		Version_1_20,
+		Version_1_21,
+		Version_1_22,
+		Version_1_23,
+		Version_1_24,
+		Version_1_25,
+		Version_1_26,
+	}
+
+	assert.Equal(t,
+		expectedSupportedVersions,
+		actualSupportedVersions,
+	)
+}
+
+func TestSupportedVersionsExtended_1_26(t *testing.T) {
+	// Min version greater thanm 1.24 triggers the 'extended' docker versions to be added
+	defer setTestMinDockerAPIVersion(Version_1_26)()
+	supportedVersionsTestFunc := func() []DockerVersion {
+		return []DockerVersion{
+			Version_1_26,
+			Version_1_27,
+		}
+	}
+	actualSupportedVersions := SupportedVersionsExtended(supportedVersionsTestFunc)
+	expectedSupportedVersions := []DockerVersion{
+		Version_1_17,
+		Version_1_18,
+		Version_1_19,
+		Version_1_20,
+		Version_1_21,
+		Version_1_22,
+		Version_1_23,
+		Version_1_24,
+		Version_1_25,
+		Version_1_26,
+		Version_1_27,
+	}
+
+	assert.Equal(t,
+		expectedSupportedVersions,
+		actualSupportedVersions,
+	)
+}

--- a/agent/dockerclient/versions_windows.go
+++ b/agent/dockerclient/versions_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package dockerclient
+
+// SupportVersionsExtended is a no-op on windows as windows uses the getWindowsReplaceableVersions
+// function for this.
+func SupportedVersionsExtended(supportedVersionsFn func() []DockerVersion) []DockerVersion {
+	return supportedVersionsFn()
+}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1505,7 +1505,14 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 	})
 	client := engine.client
 	if container.DockerConfig.Version != nil {
-		client = client.WithVersion(dockerclient.DockerVersion(*container.DockerConfig.Version))
+		minVersion := dockerclient.GetSupportedDockerAPIVersion(dockerclient.DockerVersion(*container.DockerConfig.Version))
+		logger.Debug("CreateContainer: overriding docker API version in task payload", logger.Fields{
+			field.TaskID:              task.GetID(),
+			field.Container:           container.Name,
+			"usingDockerAPIVersion":   minVersion,
+			"payloadDockerAPIVersion": *container.DockerConfig.Version,
+		})
+		client = client.WithVersion(minVersion)
 	}
 
 	dockerContainerName := ""
@@ -1812,7 +1819,14 @@ func (engine *DockerTaskEngine) startContainer(task *apitask.Task, container *ap
 	})
 	client := engine.client
 	if container.DockerConfig.Version != nil {
-		client = client.WithVersion(dockerclient.DockerVersion(*container.DockerConfig.Version))
+		minVersion := dockerclient.GetSupportedDockerAPIVersion(dockerclient.DockerVersion(*container.DockerConfig.Version))
+		logger.Debug("StartContainer: overriding docker API version in task payload", logger.Fields{
+			field.TaskID:              task.GetID(),
+			field.Container:           container.Name,
+			"usingDockerAPIVersion":   minVersion,
+			"payloadDockerAPIVersion": *container.DockerConfig.Version,
+		})
+		client = client.WithVersion(minVersion)
 	}
 
 	dockerID, err := engine.getDockerID(task, container)

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -607,7 +607,8 @@ func verifyExecCmdAgentExpectedMounts(t *testing.T,
 	ctx context.Context,
 	client *sdkClient.Client,
 	testTaskId, containerId, containerName, testExecCmdHostVersionedBinDir, testConfigFileName, testLogConfigFileName string) {
-	inspectState, _ := client.ContainerInspect(ctx, containerId)
+	inspectState, err := client.ContainerInspect(ctx, containerId)
+	require.NoError(t, err)
 
 	expectedMounts := []struct {
 		source    string


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Since the release of docker engine 25.x (Jan 19 2024), the docker engine no longer supports API versions less than 1.24. See deprecated API versions here: https://docs.docker.com/engine/api/#deprecated-api-versions

This issue would show up in the agent logs like: 
```
Error response from daemon: client version 1.21 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version
```

1. This PR allows the agent to dynamically determine the minimum/default API version that it should use based on what versions the docker engine on the instance supports.
2. This PR also updates the logic around advertising capabilities to the ECS backend. We will now advertise all known API versions that we are compatible with, rather than using the response from the docker API. This is for the sake of task placement requiredAttributes, which are static strings like `docker-remote-api.1.19`. Since some tasks will have these attributes added to them, we need to advertise that we support this remote API version even though technically it is deprecated and we no longer support it. Although we don't support using the _specific_ API version, we still should be able to support all functionality from that version in the minimum docker API version.
3. When the ECS backend specifies a docker API version in it's container payload (via the [DockerConfig.Version](https://pkg.go.dev/github.com/aws/amazon-ecs-agent/agent/api/container#DockerConfig.Version) field on the container struct) we might use a different API version to actually create and start the container if the specified version is less than the minimum API version. For example, if the ECS backend specifies using docker API version 1.19 when we are using Docker engine 25, we will create/start that container using API 1.24.



fixes https://github.com/aws/containers-roadmap/issues/2267
fixes #4074 


NOTE: Our minimum docker _engine_ version supported is moving from 1.9.0 to 1.12.0, which maps to api version 1.24. Docker API versions prior to 1.24 are deprecated as of Jan 2024. See https://docs.docker.com/engine/api/#deprecated-api-versions.

[Docker version 1.12](https://docs.docker.com/engine/release-notes/prior-releases/#1120-2016-07-28) was released in 2016 and is not supported in Amazon Linux.

### Details

After this change, we will check all versions of the Docker API on startup, and then set agent's minimum/default version to whatever is the minimum supported. So when starting up on Docker 25.x we see log messages like this appear:

deprecated api versions fail (info-level messages)
```
level=info time=2024-01-25T23:25:00Z msg="Unable to get Docker client for version 1.17: Error response from daemon: client version 1.17 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version" module=sdkclientfactory.go
level=info time=2024-01-25T23:25:00Z msg="Unable to get Docker client for version 1.18: Error response from daemon: client version 1.18 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version" module=sdkclientfactory.go
level=info time=2024-01-25T23:25:00Z msg="Unable to get Docker client for version 1.19: Error response from daemon: client version 1.19 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version" module=sdkclientfactory.go
level=info time=2024-01-25T23:25:00Z msg="Unable to get Docker client for version 1.20: Error response from daemon: client version 1.20 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version" module=sdkclientfactory.go
level=info time=2024-01-25T23:25:00Z msg="Unable to get Docker client for version 1.21: Error response from daemon: client version 1.21 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version" module=sdkclientfactory.go
level=info time=2024-01-25T23:25:00Z msg="Unable to get Docker client for version 1.22: Error response from daemon: client version 1.22 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version" module=sdkclientfactory.go
level=info time=2024-01-25T23:25:00Z msg="Unable to get Docker client for version 1.23: Error response from daemon: client version 1.23 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version" module=sdkclientfactory.go
```
minimum api version is bumped from 1.21 to 1.24:
```
level=info time=2024-01-25T23:25:00Z msg="Setting minimum docker API version" newMinAPIVersion=1.24 previousMinAPIVersion=1.21
```
while 1.17-1.23 are not directly supported, they are supported in "extended" versions in order to advertise to the ECS backend that we support features added in these versions (such as awslogs added in API version 1.19):
```
level=debug time=2024-01-25T23:25:00Z msg="Extended supported versions" supportedVersions=[1.17 1.18 1.19 1.20 1.21 1.22 1.23 1.24 1.25 1.26 1.27 1.28 1.29 1.30 1.31 1.32 1.33 1.34 1.35 1.36 1.37 1.38 1.39 1.40 1.41 1.42 1.43 1.44]
```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

unit and functional tests

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Bug: Fix ECS agent docker API failures on docker engine 25.x

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
