### PR TITLE
Fix netns model creation issue

### DIFF
--- a/ecs-agent/netlib/common_test.go
+++ b/ecs-agent/netlib/common_test.go
@@ -62,6 +62,7 @@ func getSingleNetNSAWSVPCTestData(testTaskID string) (*ecsacs.Task, tasknetworkc
 	taskPayload := &ecsacs.Task{
 		NetworkMode:              aws.String(ecs.NetworkModeAwsvpc),
 		ElasticNetworkInterfaces: []*ecsacs.ElasticNetworkInterface{enis[0]},
+		Containers:               []*ecsacs.Container{{}},
 	}
 
 	netNSName := fmt.Sprintf(netNSNamePattern, testTaskID, eniName)
@@ -81,6 +82,23 @@ func getSingleNetNSAWSVPCTestData(testTaskID string) (*ecsacs.Task, tasknetworkc
 			},
 		},
 	}
+
+	return taskPayload, taskNetConfig
+}
+
+// getSingleNetNSMultiIfaceWithNameTestData returns the test data for EKS like use cases but with names specified for interfaces.
+func getSingleNetNSMultiIfaceWithNameTestData(testTaskID string) (*ecsacs.Task, tasknetworkconfig.TaskNetworkConfig) {
+	taskPayload, taskNetConfig := getSingleNetNSMultiIfaceAWSVPCTestData(testTaskID)
+	for i, iface := range taskPayload.ElasticNetworkInterfaces {
+		eniName := fmt.Sprintf("eni-%d", i)
+		iface.Name = aws.String(eniName)
+		taskNetConfig.NetworkNamespaces[0].NetworkInterfaces[i].Name = eniName
+	}
+
+	netNSName := fmt.Sprintf(netNSNamePattern, testTaskID, "eni-0")
+	netNSPath := netNSPathDir + netNSName
+	taskNetConfig.NetworkNamespaces[0].Name = netNSName
+	taskNetConfig.NetworkNamespaces[0].Path = netNSPath
 
 	return taskPayload, taskNetConfig
 }

--- a/ecs-agent/netlib/network_builder_linux_test.go
+++ b/ecs-agent/netlib/network_builder_linux_test.go
@@ -59,6 +59,7 @@ func TestNetworkBuilder_BuildTaskNetworkConfiguration(t *testing.T) {
 	// Warmpool test cases.
 	t.Run("containerd-default", getTestFunc(getSingleNetNSAWSVPCTestData, platform.WarmpoolPlatform))
 	t.Run("containerd-multi-interface", getTestFunc(getSingleNetNSMultiIfaceAWSVPCTestData, platform.WarmpoolPlatform))
+	t.Run("containerd-multi-interface-with-names", getTestFunc(getSingleNetNSMultiIfaceWithNameTestData, platform.WarmpoolPlatform))
 	t.Run("containerd-multi-netns", getTestFunc(getMultiNetNSMultiIfaceAWSVPCTestData, platform.WarmpoolPlatform))
 
 	// Firecracker test cases.

--- a/ecs-agent/netlib/platform/common_linux.go
+++ b/ecs-agent/netlib/platform/common_linux.go
@@ -186,7 +186,8 @@ func (c *common) buildAWSVPCNetworkNamespaces(
 	// This case is identified if the singleNetNS flag is set, or if the ENIs have an empty 'Name' field,
 	// or if there is only on ENI in the payload.
 	if singleNetNS || len(taskPayload.ElasticNetworkInterfaces) == 1 ||
-		aws.StringValue(taskPayload.ElasticNetworkInterfaces[0].Name) == "" {
+		aws.StringValue(taskPayload.ElasticNetworkInterfaces[0].Name) == "" ||
+		len(taskPayload.Containers[0].NetworkInterfaceNames) == 0 {
 		primaryNetNS, err := c.buildNetNS(taskID,
 			0,
 			taskPayload.ElasticNetworkInterfaces,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fixes a bug in the creation of network namespace models for AWSVPC mode tasks which causes the agent to crash in an edge case situation.

### Implementation details
<!-- How are the changes implemented? -->
This change the condition which decides if the task requires a single network namespace or multiple. Previously, presence of ENI names in task payload indicated that the task multiple network namespaces, but we encountered a customer that included ENI names in the run task API for single netns tasks. This change also checks container's interface names to make the decision.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Manually verified tasks start successful with the fix.
Added tests

New tests cover the changes: <!-- yes|no -->
Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Fixes a bug in the creation of network namespace models for AWSVPC mode tasks which causes the agent to crash in an edge case situation.

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
