### PR TITLE
ecs-init support for old docker engines (pre docker 17.x) and future docker engines (when api 1.25 is deprecated).

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -59,7 +59,7 @@ const (
 	minBackoffDuration = time.Second
 	// maxBackoffDuration specifies the maximum backoff duration for ping to
 	// return a success response from docker socket
-	maxBackoffDuration = 5 * time.Second
+	maxBackoffDuration = 3 * time.Second
 	// backoffJitterMultiple specifies the backoff jitter multiplier
 	// coefficient when pinging the docker socket
 	backoffJitterMultiple = 0.2
@@ -325,6 +325,10 @@ func (c *client) getContainerConfig(envVarsFromFiles map[string]string) *godocke
 	}
 	if config.RunningInExternal() {
 		// Task networking is not supported when not running on EC2. Explicitly disable since it's enabled by default.
+		envVariables["ECS_ENABLE_TASK_ENI"] = "false"
+	}
+	if dockerVersionCompare(dockerAPIVersion, enableTaskENIDockerClientAPIVersion) < 0 {
+		// Task networking is not supported before docker API version 1.25
 		envVariables["ECS_ENABLE_TASK_ENI"] = "false"
 	}
 

--- a/ecs-init/docker/docker_config.go
+++ b/ecs-init/docker/docker_config.go
@@ -62,7 +62,12 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 		NetworkMode: networkMode,
 		UsernsMode:  usernsMode,
 		CapAdd:      caps,
-		Init:        true,
+	}
+
+	// Task ENI feature requires agent to be "init" process, so set it if docker API
+	// version is new enough for this feature.
+	if dockerVersionCompare(dockerAPIVersion, enableTaskENIDockerClientAPIVersion) >= 0 {
+		hostConfig.Init = true
 	}
 
 	if ctrdapparmor.HostSupports() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

**note**: this is an ecs-init followup to a similar change already made to the agent codebase: https://github.com/aws/amazon-ecs-agent/pull/4075

Recently, docker engine has deprecated docker API versions 1.17-1.23: https://docs.docker.com/engine/deprecated/#deprecate-legacy-api-versions

In the above announcement, they state that the minimum supported API version (currently 1.24) would continue to be raised in future versions:
> Support for API versions lower than 1.24 will be permanently removed in Docker Engine v26, and the minimum supported API version will be incrementally raised in releases following that.

This will soon be a problem for ecs-init, because currently ecs-init hardcodes it's API version to 1.25 and does not have any ability to detect or switch to supported versions.

### Implementation details
<!-- How are the changes implemented? -->

This PR changes ecs-init to keep a list of known API versions rather than a single API version. When ecs-init starts up, it will retry creating the docker client until it finds an API version that works.

As part of this PR, we are both supporting future versions of docker and very old versions of docker which did not have support for API version 1.25.

For example on docker 1.10 ecs-init previously failed, but will now startup with messages like this (note that it fails on versions 1.25-1.44, then succeeds on 1.21):

```
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] start
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.25: API error (400): client is newer than server (client API version: 1.25, server API version: 1.22)
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.26: API error (400): client is newer than server (client API version: 1.26, server API version: 1.22)
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.27: API error (400): client is newer than server (client API version: 1.27, server API version: 1.22)
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.28: API error (400): client is newer than server (client API version: 1.28, server API version: 1.22)
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.29: API error (400): client is newer than server (client API version: 1.29, server API version: 1.22)
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.30: API error (400): client is newer than server (client API version: 1.30, server API version: 1.22)
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.31: API error (400): client is newer than server (client API version: 1.31, server API version: 1.22)
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.32: API error (400): client is newer than server (client API version: 1.32, server API version: 1.22)
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.33: API error (400): client is newer than server (client API version: 1.33, server API version: 1.22)
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.34: API error (400): client is newer than server (client API version: 1.34, server API version: 1.22)
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.35: API error (400): client is newer than server (client API version: 1.35, server API version: 1.22)
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.36: API error (400): client is newer than server (client API version: 1.36, server API version: 1.22)
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.37: API error (400): client is newer than server (client API version: 1.37, server API version: 1.22)
Jan 29 17:34:46 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.38: API error (400): client is newer than server (client API version: 1.38, server API version: 1.22)
Jan 29 17:34:47 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:46Z [INFO] Could not create docker client with API version 1.39: API error (400): client is newer than server (client API version: 1.39, server API version: 1.22)
Jan 29 17:34:47 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:47Z [INFO] Could not create docker client with API version 1.40: API error (400): client is newer than server (client API version: 1.40, server API version: 1.22)
Jan 29 17:34:47 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:47Z [INFO] Could not create docker client with API version 1.41: API error (400): client is newer than server (client API version: 1.41, server API version: 1.22)
Jan 29 17:34:47 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:47Z [INFO] Could not create docker client with API version 1.42: API error (400): client is newer than server (client API version: 1.42, server API version: 1.22)
Jan 29 17:34:47 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:47Z [INFO] Could not create docker client with API version 1.43: API error (400): client is newer than server (client API version: 1.43, server API version: 1.22)
Jan 29 17:34:47 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:47Z [INFO] Could not create docker client with API version 1.44: API error (400): client is newer than server (client API version: 1.44, server API version: 1.22)
Jan 29 17:34:47 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:47Z [INFO] Successfully created docker client with API version 1.21
Jan 29 17:34:47 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:47Z [INFO] Container name: /ecs-agent
Jan 29 17:34:47 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:47Z [INFO] Removing existing agent container ID: 257af52c52388e77eb75eb840df5f8264b52c8c561b61b50bca6b4075e8bbe12
Jan 29 17:34:47 ip-10-0-7-14 amazon-ecs-init[1281]: 2024-01-29T17:34:47Z [INFO] Starting Amazon Elastic Container Service Agent
```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

1. new unit tests
2. functional testing suites
3. manually tested on ubuntu 16.04 using docker engine version 1.10 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement: ecs-init support for old docker engines (pre docker 17.x) and future docker engines (when api 1.25 is deprecated).

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
