### PR TITLE
fix bug where the lock is never released for FSx task resource

### DIFF
--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows.go
@@ -719,7 +719,7 @@ func (fv *FSxWindowsFileServerResource) updateAppliedStatusUnsafe(knownStatus re
 // GetAppliedStatus safely returns the currently applied status of the resource
 func (fv *FSxWindowsFileServerResource) GetAppliedStatus() resourcestatus.ResourceStatus {
 	fv.lock.RLock()
-	defer fv.lock.RLock()
+	defer fv.lock.RUnlock()
 
 	return fv.appliedStatusUnsafe
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
There is a typo/bug in the `GetAppliedStatus` method for FSx task resource wherein the lock is never released in the method. This will likely cause the agent to fail tasks with FSx volume since the lock on other methods will never be acquired.

Presently, this method is not invoked from any workflow and therefore, we have not seen any impact. Reference: https://github.com/search?q=repo%3Aaws%2Famazon-ecs-agent+path%3A%2F%5Eagent%5C%2F%2F+GetAppliedStatus&type=code
### Implementation details
<!-- How are the changes implemented? -->
Changed `RLock` to `RUnLock`.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> NA

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
fix bug where the lock is never released for FSx task resource

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
