### PR TITLE
Use ECS_EBSTA_SUPPORTED env variable to add EBSTA capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Additionally, the following environment variable(s) can be used to configure the
 | `ECS_OFFHOST_INTROSPECTION_INTERFACE_NAME` | `eth0` | Primary network interface name to be used for blocking offhost agent introspection port access. By default, this value is `eth0` | `eth0` |
 | `ECS_AGENT_LABELS` | `{"test.label.1":"value1","test.label.2":"value2"}` | The labels to add to the ECS Agent container. | |
 | `ECS_AGENT_APPARMOR_PROFILE` | `unconfined` | Specifies the name of the AppArmor profile to run the ecs-agent container under. This only applies to AppArmor-enabled systems, such as Ubuntu, Debian, and SUSE. If unset, defaults to the profile written out by ecs-init (ecs-agent-default). | `ecs-agent-default` |
+| `ECS_EBSTA_SUPPORTED` | `true` | Whether to use the container instance with EBS Task Attach support. ecs-init sets this variable for the ECS Agent if the instance support can support mounting EBS volumes or not. | `false` | `false` |
 
 
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ additional details on each available environment variable.
 | `CREDENTIALS_FETCHER_SECRET_NAME_FOR_DOMAINLESS_GMSA`   | `secretmanager-secretname` | Used to support scaling option for gMSA on Linux [credentials-fetcher daemon](https://github.com/aws/credentials-fetcher). If user is configuring gMSA on a non-domain joined instance, they need to create an Active Directory user with access to retrieve principals for the gMSA account and store it in secrets manager | `secretmanager-secretname` | Not Applicable |
 | `ECS_DYNAMIC_HOST_PORT_RANGE` | `100-200` | This specifies the dynamic host port range that the agent uses to assign host ports from, for container ports mapping. If there are no available ports in the range for containers, including customer containers and Service Connect Agent containers (if Service Connect is enabled), service deployments would fail. | Defined by `/proc/sys/net/ipv4/ip_local_port_range` | `49152-65535` |
 | `ECS_TASK_PIDS_LIMIT` | `100` | Specifies the per-task pids limit cgroup setting for each task launched on the container instance. This setting maps to the pids.max cgroup setting at the ECS task level. See https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html#pid. If unset, pids will be unlimited. Min value is 1 and max value is 4194304 (4*1024*1024) | `unset` | Not Supported on Windows |
+| `ECS_EBSTA_SUPPORTED` | `true` | Whether to use the container instance with EBS Task Attach support. ecs-init sets this variable for the ECS Agent if the instance can support mounting EBS volumes or not. ECS only schedules EBSTA tasks if this feature is supported by the platform type | `true` | `true` |
 
 Additionally, the following environment variable(s) can be used to configure the behavior of the ecs-init service. When using ECS-Init, all env variables, including the ECS Agent variables above, are read from path `/etc/ecs/ecs.config`:
 | Environment Variable Name | Example Value(s)            | Description | Default value |
@@ -267,7 +268,6 @@ Additionally, the following environment variable(s) can be used to configure the
 | `ECS_OFFHOST_INTROSPECTION_INTERFACE_NAME` | `eth0` | Primary network interface name to be used for blocking offhost agent introspection port access. By default, this value is `eth0` | `eth0` |
 | `ECS_AGENT_LABELS` | `{"test.label.1":"value1","test.label.2":"value2"}` | The labels to add to the ECS Agent container. | |
 | `ECS_AGENT_APPARMOR_PROFILE` | `unconfined` | Specifies the name of the AppArmor profile to run the ecs-agent container under. This only applies to AppArmor-enabled systems, such as Ubuntu, Debian, and SUSE. If unset, defaults to the profile written out by ecs-init (ecs-agent-default). | `ecs-agent-default` |
-| `ECS_EBSTA_SUPPORTED` | `true` | Whether to use the container instance with EBS Task Attach support. ecs-init sets this variable for the ECS Agent if the instance support can support mounting EBS volumes or not. | `false` | `false` |
 
 
 

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -295,8 +295,10 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	// add service-connect capabilities if applicable
 	capabilities = agent.appendServiceConnectCapabilities(capabilities)
 
-	// add ebs-task-attach attribute if applicable
-	capabilities = agent.appendEBSTaskAttachCapabilities(capabilities)
+	if agent.cfg.EBSTASupportEnabled {
+		// add ebs-task-attach attribute if applicable
+		capabilities = agent.appendEBSTaskAttachCapabilities(capabilities)
+	}
 
 	if agent.cfg.External.Enabled() {
 		// Add external specific capability; remove external unsupported capabilities.

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -582,6 +582,7 @@ func environmentConfig() (Config, error) {
 		PollingMetricsWaitDuration:          parseEnvVariableDuration("ECS_POLLING_METRICS_WAIT_DURATION"),
 		DisableDockerHealthCheck:            parseBooleanDefaultFalseConfig("ECS_DISABLE_DOCKER_HEALTH_CHECK"),
 		GPUSupportEnabled:                   utils.ParseBool(os.Getenv("ECS_ENABLE_GPU_SUPPORT"), false),
+		EBSTASupportEnabled:                 utils.ParseBool(os.Getenv("ECS_EBSTA_SUPPORTED"), false),
 		InferentiaSupportEnabled:            utils.ParseBool(os.Getenv("ECS_ENABLE_INF_SUPPORT"), false),
 		NvidiaRuntime:                       os.Getenv("ECS_NVIDIA_RUNTIME"),
 		TaskMetadataAZDisabled:              utils.ParseBool(os.Getenv("ECS_DISABLE_TASK_METADATA_AZ"), false),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -582,7 +582,7 @@ func environmentConfig() (Config, error) {
 		PollingMetricsWaitDuration:          parseEnvVariableDuration("ECS_POLLING_METRICS_WAIT_DURATION"),
 		DisableDockerHealthCheck:            parseBooleanDefaultFalseConfig("ECS_DISABLE_DOCKER_HEALTH_CHECK"),
 		GPUSupportEnabled:                   utils.ParseBool(os.Getenv("ECS_ENABLE_GPU_SUPPORT"), false),
-		EBSTASupportEnabled:                 utils.ParseBool(os.Getenv("ECS_EBSTA_SUPPORTED"), false),
+		EBSTASupportEnabled:                 utils.ParseBool(os.Getenv("ECS_EBSTA_SUPPORTED"), true),
 		InferentiaSupportEnabled:            utils.ParseBool(os.Getenv("ECS_ENABLE_INF_SUPPORT"), false),
 		NvidiaRuntime:                       os.Getenv("ECS_NVIDIA_RUNTIME"),
 		TaskMetadataAZDisabled:              utils.ParseBool(os.Getenv("ECS_DISABLE_TASK_METADATA_AZ"), false),

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -302,8 +302,10 @@ type Config struct {
 	// GPUSupportEnabled specifies if the Agent is capable of launching GPU tasks
 	GPUSupportEnabled bool
 
-	// EBSTASupportEnabled specifies if the Agent can support tasks needing EBS Task Attach
+	// EBSTASupportEnabled specifies if the Agent can support tasks needing EBS Task Attach, set in ecs-init
+	// Initially Agent always advertised EBSTA capability. This defaults to true to make it compatible with older ecs-init
 	EBSTASupportEnabled bool
+
 	// InferentiaSupportEnabled specifies whether the built-in support for inferentia task is enabled.
 	InferentiaSupportEnabled bool
 

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -301,6 +301,9 @@ type Config struct {
 
 	// GPUSupportEnabled specifies if the Agent is capable of launching GPU tasks
 	GPUSupportEnabled bool
+
+	// EBSTASupportEnabled specifies if the Agent can support tasks needing EBS Task Attach
+	EBSTASupportEnabled bool
 	// InferentiaSupportEnabled specifies whether the built-in support for inferentia task is enabled.
 	InferentiaSupportEnabled bool
 

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -327,7 +327,7 @@ func (c *client) getContainerConfig(envVarsFromFiles map[string]string) *godocke
 		envVariables["ECS_ENABLE_TASK_ENI"] = "false"
 	}
 
-	if config.RunningInExternal() || !isPathValid(config.MountDirectoryEBS(), true) {
+	if !isPathValid(config.MountDirectoryEBS(), true) {
 		// EBS Task Attach (EBSTA) is not supported for external instances
 		// If EBS mount directory fails to get created, tasks requiring EBSTA can not be supported
 		// Disable EBSTA Support for these cases

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -327,6 +327,13 @@ func (c *client) getContainerConfig(envVarsFromFiles map[string]string) *godocke
 		envVariables["ECS_ENABLE_TASK_ENI"] = "false"
 	}
 
+	if config.RunningInExternal() || !isPathValid(config.MountDirectoryEBS(), true) {
+		// EBS Task Attach (EBSTA) is not supported for external instances
+		// If EBS mount directory fails to get created, tasks requiring EBSTA can not be supported
+		// Disable EBSTA Support for these cases
+		envVariables["ECS_EBSTA_SUPPORTED"] = "false"
+	}
+
 	var env []string
 	for envKey, envValue := range envVariables {
 		env = append(env, envKey+"="+envValue)

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -290,6 +290,7 @@ func (c *client) getContainerConfig(envVarsFromFiles map[string]string) *godocke
 		"ECS_AVAILABLE_LOGGING_DRIVERS":         `["json-file","syslog","awslogs","fluentd","none"]`,
 		"ECS_ENABLE_TASK_IAM_ROLE":              "true",
 		"ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST": "true",
+		"ECS_EBSTA_SUPPORTED":                   "true",
 		"ECS_AGENT_LABELS":                      "",
 		"ECS_VOLUME_PLUGIN_CAPABILITIES":        `["efsAuth"]`,
 	}

--- a/ecs-init/engine/engine.go
+++ b/ecs-init/engine/engine.go
@@ -143,12 +143,11 @@ func (e *Engine) PreStart() error {
 		return engineError("could not create route to the credentials proxy", err)
 	}
 	// Add the EBS Task Attach host mount point
-	// Skip for External, EBS Task Attach is not supported for External launch type
-	if !config.RunningInExternal() {
-		err = os.MkdirAll(config.MountDirectoryEBS(), mountFilePermission)
-		if err != nil {
-			return engineError("could not create EBS mount directory", err)
-		}
+	err = os.MkdirAll(config.MountDirectoryEBS(), mountFilePermission)
+	if err != nil {
+		// Log error and continue
+		// If directory creation fails, set ECS_EBSTA_SUPPORTED=false in docker/docker.go
+		log.Error("could not create EBS mount directory", err)
 	}
 
 	docker, err := getDockerClient()

--- a/ecs-init/engine/engine.go
+++ b/ecs-init/engine/engine.go
@@ -143,9 +143,12 @@ func (e *Engine) PreStart() error {
 		return engineError("could not create route to the credentials proxy", err)
 	}
 	// Add the EBS Task Attach host mount point
-	err = os.MkdirAll(config.MountDirectoryEBS(), mountFilePermission)
-	if err != nil {
-		return engineError("could not create EBS mount directory", err)
+	// Skip for External, EBS Task Attach is not supported for External launch type
+	if !config.RunningInExternal() {
+		err = os.MkdirAll(config.MountDirectoryEBS(), mountFilePermission)
+		if err != nil {
+			return engineError("could not create EBS mount directory", err)
+		}
 	}
 
 	docker, err := getDockerClient()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This is a fix for issue #4089

As part of ecs-init start up, init tries to create `/mnt/ecs/ebs` directory. However depending on how instances are configured, `/mnt` can be sometimes be read only. This leads to `ecs-agent` container failing to be created with following error in `ecs-init`
```
[ERROR] could not create EBS mount directory: mkdir /mnt/ecs: read-only file system
```

This PR changes this by adding an environment variable `ECS_EBSTA_SUPPORTED` to `ecs-agent`. If set to false, agent will not advertise EBSTA capabilities. This works as follows
* `ecs-init/engine/engine.go` - If the ebs mount directory `/mnt/ecs/ebs` fails to be created, we log this error in `pre-start` and continue
* `ecs-init/docker/docker.go` - Detect if ebs mount directory has been successfully created. If not set an environment variable `ECS_EBSTA_SUPPORTED` as `false` (Set default `true`)
* `agent/app/agent_capability.go` - Check the value of `ECS_EBSTA_SUPPORTED` and do not add EBSTA capabilities if the env var is set false. This is set as needed by the `ecs-init` changes. Agent defaults this to `true` for compatibility with older `ecs-init` versions

### Testing
* Mounting a Readonly file system at '/mnt' for an instance, able to launch agent and tasks
* Run Functional tests on AL2 and AL2023 AMIs with ecs-init artifacts which also test default ebs functionality

New tests cover the changes: <!-- yes|no -->
No new tests added

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bugfix: Use `ECS_EBSTA_SUPPORTED` env variable to add EBSTA capabilities

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
