### PR TITLE
Pass clusterARN in task state change struct to account for Fargate FC tasks.

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
@@ -507,8 +507,10 @@ func (client *ecsClient) SubmitTaskStateChange(change ecs.TaskStateChange) error
 
 func (client *ecsClient) submitTaskStateChange(change ecs.TaskStateChange) error {
 
-	clusterARN := convertTaskToClusterARN(change.TaskARN)
-
+	clusterARN := client.configAccessor.Cluster()
+	if len(change.ClusterARN) != 0 {
+		clusterARN = change.ClusterARN
+	}
 	if change.Attachment != nil {
 		// Confirm attachment by submitting attachment state change via SubmitTaskStateChange API (specifically in
 		// the input's Attachments field).
@@ -563,20 +565,10 @@ func (client *ecsClient) submitTaskStateChange(change ecs.TaskStateChange) error
 	return nil
 }
 
-func convertTaskToClusterARN(taskarn string) string {
-
-	taskarnsplit := strings.Split(taskarn, "/")
-	accountsplit := strings.ReplaceAll(taskarnsplit[0], "task", "cluster")
-	clusterARN := accountsplit + "/" + taskarnsplit[1]
-	return clusterARN
-
-}
-
 func (client *ecsClient) SubmitContainerStateChange(change ecs.ContainerStateChange) error {
 
-	clusterARN := convertTaskToClusterARN(change.TaskArn)
 	input := ecsmodel.SubmitContainerStateChangeInput{
-		Cluster:       aws.String(clusterARN),
+		Cluster:       aws.String(client.configAccessor.Cluster()),
 		ContainerName: aws.String(change.ContainerName),
 		Task:          aws.String(change.TaskArn),
 	}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/statechange.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/statechange.go
@@ -73,6 +73,8 @@ type ContainerStateChange struct {
 type TaskStateChange struct {
 	// Attachment is the ENI attachment object to send.
 	Attachment *ni.ENIAttachment
+	// ClusterARN is the unique identifier for the cluster.
+	ClusterARN string
 	// TaskArn is the unique identifier for the task.
 	TaskARN string
 	// Status is the status to send.
@@ -124,6 +126,9 @@ func (c *ContainerStateChange) String() string {
 // String returns a human readable string representation of a TaskStateChange.
 func (change *TaskStateChange) String() string {
 	res := fmt.Sprintf("%s -> %s", change.TaskARN, change.Status.String())
+	if len(change.ClusterARN) != 0 {
+		res += fmt.Sprintf(", ClusterARN: %s", change.ClusterARN)
+	}
 	if change.MetadataGetter != nil && !change.MetadataGetter.GetTaskIsNil() {
 		res += fmt.Sprintf(", Known Sent: %s, PullStartedAt: %s, PullStoppedAt: %s, ExecutionStoppedAt: %s",
 			change.MetadataGetter.GetTaskSentStatusString(),

--- a/ecs-agent/api/ecs/client/ecs_client.go
+++ b/ecs-agent/api/ecs/client/ecs_client.go
@@ -507,8 +507,10 @@ func (client *ecsClient) SubmitTaskStateChange(change ecs.TaskStateChange) error
 
 func (client *ecsClient) submitTaskStateChange(change ecs.TaskStateChange) error {
 
-	clusterARN := convertTaskToClusterARN(change.TaskARN)
-
+	clusterARN := client.configAccessor.Cluster()
+	if len(change.ClusterARN) != 0 {
+		clusterARN = change.ClusterARN
+	}
 	if change.Attachment != nil {
 		// Confirm attachment by submitting attachment state change via SubmitTaskStateChange API (specifically in
 		// the input's Attachments field).
@@ -563,20 +565,10 @@ func (client *ecsClient) submitTaskStateChange(change ecs.TaskStateChange) error
 	return nil
 }
 
-func convertTaskToClusterARN(taskarn string) string {
-
-	taskarnsplit := strings.Split(taskarn, "/")
-	accountsplit := strings.ReplaceAll(taskarnsplit[0], "task", "cluster")
-	clusterARN := accountsplit + "/" + taskarnsplit[1]
-	return clusterARN
-
-}
-
 func (client *ecsClient) SubmitContainerStateChange(change ecs.ContainerStateChange) error {
 
-	clusterARN := convertTaskToClusterARN(change.TaskArn)
 	input := ecsmodel.SubmitContainerStateChangeInput{
-		Cluster:       aws.String(clusterARN),
+		Cluster:       aws.String(client.configAccessor.Cluster()),
 		ContainerName: aws.String(change.ContainerName),
 		Task:          aws.String(change.TaskArn),
 	}

--- a/ecs-agent/api/ecs/statechange.go
+++ b/ecs-agent/api/ecs/statechange.go
@@ -73,6 +73,8 @@ type ContainerStateChange struct {
 type TaskStateChange struct {
 	// Attachment is the ENI attachment object to send.
 	Attachment *ni.ENIAttachment
+	// ClusterARN is the unique identifier for the cluster.
+	ClusterARN string
 	// TaskArn is the unique identifier for the task.
 	TaskARN string
 	// Status is the status to send.
@@ -124,6 +126,9 @@ func (c *ContainerStateChange) String() string {
 // String returns a human readable string representation of a TaskStateChange.
 func (change *TaskStateChange) String() string {
 	res := fmt.Sprintf("%s -> %s", change.TaskARN, change.Status.String())
+	if len(change.ClusterARN) != 0 {
+		res += fmt.Sprintf(", ClusterARN: %s", change.ClusterARN)
+	}
 	if change.MetadataGetter != nil && !change.MetadataGetter.GetTaskIsNil() {
 		res += fmt.Sprintf(", Known Sent: %s, PullStartedAt: %s, PullStoppedAt: %s, ExecutionStoppedAt: %s",
 			change.MetadataGetter.GetTaskSentStatusString(),


### PR DESCRIPTION

### Summary
<!-- What does this pull request do? -->
This PR fixes an issue in SubmitTaskStateChange API where the clusterARN populated in change request is incorrect. For one specific platform, the clusterARN is different for different tasks.

### Implementation details
<!-- How are the changes implemented? -->
1. Add clusterarn to taskstatechange struct.
2. In submitStatechange api, check if the clusterarn in taskstatechange struct is not nil. If not nil, then use the passed clusterarn instead of clusterarn from configaccessor.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Pass clusterARN in task state change struct.
**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
