### PR TITLE
Update SSM Agent version to 3.2.2303.0 for ECS exec

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -637,7 +637,7 @@ find-copy-certs-exec() {
 }
 
 download-ssm-binaries-exec() {
-    BINARY_VERSION="3.2.1630.0"
+    BINARY_VERSION="3.2.2303.0"
     BINARY_PATH="/var/lib/ecs/deps/execute-command/bin/${BINARY_VERSION}"
     BINARY_DOWNLOAD_PATH="ssm-binaries"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update Amazon SSM Agent version to[ 3.2.2303.0](https://github.com/aws/amazon-ssm-agent/releases/tag/3.2.2303.0) to address CVEs listed below:

1. https://alas.aws.amazon.com/ALAS-2024-1920.html
1. https://alas.aws.amazon.com/ALAS-2023-1866.html
1. https://alas.aws.amazon.com/ALAS-2023-1825.html
1. https://alas.aws.amazon.com/AL2/ALAS-2024-2458.html
1. https://alas.aws.amazon.com/AL2/ALAS-2023-2303.html
1. https://alas.aws.amazon.com/AL2/ALAS-2023-2238.html
1. https://alas.aws.amazon.com/AL2/ALAS-2022-1807.html
1. https://alas.aws.amazon.com/AL2/ALAS-2024-2458.html
1. https://alas.aws.amazon.com/AL2023/ALAS-2024-526.html
1. https://alas.aws.amazon.com/AL2023/ALAS-2023-388.html
1. https://alas.aws.amazon.com/AL2023/ALAS-2023-373.html
1. https://alas.aws.amazon.com/AL2023/ALAS-2023-339.html
1. https://alas.aws.amazon.com/AL2023/ALAS-2024-526.html

### Implementation details
<!-- How are the changes implemented? -->
Update SSM Agent binary version to `3.2.2303.0` in scripts/ecs-anywhere-install.sh.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Use the updated ecs-anywhere-install.sh and run end-to-end SSM/exec functional tests against the ECS Anywhere platforms listed below:
- al2generic-amd64, al2generic-arm64
- centos7-amd64, centos7-arm64, centos7-gpu
- centos8-amd64, centos8-arm64, centos8-gpu
- debian10-amd64, debian10-arm64, debian10-gpu
- debian11-amd64, debian11-arm64, debian11-gpu
- debian12-amd64, debian12-arm64
- sles15-amd64
- ubuntu18-amd64, ubuntu18-arm64, ubutun18-gpu
- ubuntu20-amd64, ubuntu20-arm64, ubutun20-gpu
- ubuntu22-amd64, ubuntu22-arm64, ubutun22-gpu

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Update SSM Agent version to 3.2.2303.0 for ECS exec

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
