### PR TITLE
Order network interfaces according to index value

### DIFF
--- a/ecs-agent/netlib/common_test.go
+++ b/ecs-agent/netlib/common_test.go
@@ -378,6 +378,7 @@ func getTestInterfacesData_Firecracker() ([]*ecsacs.ElasticNetworkInterface, []*
 			InterfaceVethProperties: &ecsacs.NetworkInterfaceVethProperties{
 				PeerInterface: aws.String("primary"),
 			},
+			Index: aws.Int64(2),
 		},
 	}
 
@@ -445,6 +446,7 @@ func getTestInterfacesData_Firecracker() ([]*ecsacs.ElasticNetworkInterface, []*
 			GuestNetNSName: secondaryIfaceName,
 			KnownStatus:    status.NetworkNone,
 			DesiredStatus:  status.NetworkReadyPull,
+			Index:          int64(2),
 		},
 	}
 

--- a/ecs-agent/netlib/model/tasknetworkconfig/common_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/common_test.go
@@ -45,6 +45,8 @@ func getTestNetworkNamespaces() []*NetworkNamespace {
 }
 
 func getTestNetworkInterfaces() []*ni.NetworkInterface {
+	// Please DO NOT modify the order of interfaces here. Keeping the secondary interface
+	// as the first element in the list is intentional.
 	return []*ni.NetworkInterface{
 		{
 			Name:    secondaryInterfaceName,

--- a/ecs-agent/netlib/model/tasknetworkconfig/network_namespace.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/network_namespace.go
@@ -14,6 +14,7 @@
 package tasknetworkconfig
 
 import (
+	"sort"
 	"sync"
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
@@ -58,6 +59,11 @@ func NewNetworkNamespace(
 		KnownState:        status.NetworkNone,
 		DesiredState:      status.NetworkReadyPull,
 	}
+
+	// Sort interfaces as per their index values in ascending order.
+	sort.Slice(netNS.NetworkInterfaces, func(i, j int) bool {
+		return netNS.NetworkInterfaces[i].Index < netNS.NetworkInterfaces[j].Index
+	})
 
 	var err error
 	if proxyConfig != nil {

--- a/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/network_namespace_test.go
@@ -50,6 +50,10 @@ func TestNewNetworkNamespace(t *testing.T) {
 	assert.Empty(t, netns.AppMeshConfig)
 	assert.Equal(t, *netIFs[0], *netns.NetworkInterfaces[0])
 	assert.Equal(t, *netIFs[1], *netns.NetworkInterfaces[1])
+
+	// Check if interfaces are sorted by `Index` field.
+	assert.Equal(t, int64(0), netns.NetworkInterfaces[0].Index)
+	assert.Equal(t, int64(1), netns.NetworkInterfaces[1].Index)
 }
 
 func TestNetworkNamespace_IsPrimary(t *testing.T) {


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
ENIs in the task payload have an index field. Certain use cases require the network interfaces list to be sorted according to this index.

### Implementation details
<!-- How are the changes implemented? -->
All changes are in network_namespace.go file.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
`go test -tags unit ./...`


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
ENIs in the task payload have an index field. Certain use cases require the network interfaces list to be sorted according to this index.

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
