### PR TITLE
Explicitly set up ECS config dir in spec files

### DIFF
--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -191,6 +191,7 @@ install -m %{no_exec_perm} -D %{SOURCE5} %{buildroot}%{_sysconfdir}/init/amazon-
 %{_libexecdir}/amazon-ecs-init
 %{_mandir}/man1/amazon-ecs-init.1*
 %{_libexecdir}/amazon-ecs-volume-plugin
+%dir %{_sysconfdir}/ecs
 %config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config
 %config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config.json
 %ghost %{_cachedir}/ecs/ecs-agent.tar

--- a/packaging/generic-rpm-integrated/amazon-ecs-init.spec
+++ b/packaging/generic-rpm-integrated/amazon-ecs-init.spec
@@ -71,6 +71,7 @@ install -m %{no_exec_perm} -D %{SOURCE3} $RPM_BUILD_ROOT/%{_unitdir}/amazon-ecs-
 %{_libexecdir}/amazon-ecs-init
 %{_mandir}/man1/amazon-ecs-init.1*
 %{_libexecdir}/amazon-ecs-volume-plugin
+%dir %{_sysconfdir}/ecs
 %config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config
 %config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config.json
 %ghost %{_cachedir}/ecs/ecs-agent.tar


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Explicitly make sure that ECS config directory (e.g., `/etc/ecs`) is created and owned by `ecs-init` package when `ecs-init` package is installed.

Current behavior is that this directory is created implicitly elsewhere and not owned by `ecs-init`, which should not be the case.

### Implementation details
<!-- How are the changes implemented? -->
Ensure `%dir %{_sysconfdir}/ecs` is present under `%files` section in spec files.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Run the following commands on an EC2 instance to build and install ecs-init RPM package with the changes from this pull request:
```
# Stop ECS service.
sudo systemctl stop ecs
# Uninstall ecs-init.
sudo yum remove -y ecs-init
# Delete any existing ECS config directory and files.
sudo rm -rf /etc/ecs
# Build ecs-init RPM package with the changes from this pull request.
make generic-rpm-integrated
# Install the ecs-init RPM built by running the previous command.
sudo yum localinstall -y /home/ec2-user/go/src/github.com/aws/amazon-ecs-agent/amazon-ecs-init-1.82.1-1.x86_64.rpm
# Start ECS service.
sudo systemctl start ecs
```

Then confirm that ECS config directory is set up correctly and owned by ecs-init:
```
$ ls -la /etc/ecs
total 16
drwxr-xr-x.  2 root root     6 Apr  1 18:25 .
drwxr-xr-x. 78 root root 16384 Apr  1 18:29 ..
$ rpm -qf /etc/ecs
amazon-ecs-init-1.82.1-1.x86_64
```

Also ran automated unit, integration, and functional tests.

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Explicitly set up ECS config dir in spec files

**Does this PR include breaking model changes? If so, Have you added transformation functions?** 
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
