### PR TITLE
Fix AL2023 integration tests

### DIFF
--- a/agent/stats/common_unix_test.go
+++ b/agent/stats/common_unix_test.go
@@ -30,7 +30,7 @@ import (
 var (
 	testImageName    = "amazon/amazon-ecs-gremlin:make"
 	endpoint         = utils.DefaultIfBlank(os.Getenv(ecsengine.DockerEndpointEnvVariable), ecsengine.DockerDefaultEndpoint)
-	client, _        = sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint), sdkClient.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
 	sdkClientFactory = sdkclientfactory.NewFactory(context.TODO(), endpoint)
+	client, _        = sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint), sdkClient.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
 	ctx              = context.TODO()
 )

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -52,6 +52,7 @@ fi
 # Remove the tag so this image can be deleted successfully in the docker image cleanup integ tests
 docker rmi amazon/image-cleanup-test-image1:make amazon/image-cleanup-test-image2:make amazon/image-cleanup-test-image3:make
 
+docker pull public.ecr.aws/docker/library/busybox:1.34.1
 mirror_local_image public.ecr.aws/docker/library/busybox:1.34.1 "127.0.0.1:51670/busybox:latest"
 
 # create a context folder used by docker build. It will only have a file


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR fix failed AL2023 integration tests. 

### Implementation details
<!-- How are the changes implemented? -->
- pull image before tagging it to fix the issue
`Error response from daemon: No such image: public.ecr.aws/docker/library/busybox:1.34.1`
- swapping the order of factory initialization and client initialization as factory initialization initializes dockerclient.MinDockerAPIVersion to fix the error
`Error response from daemon: client version 1.21 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version`
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Fix AL2023 integration tests

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->   no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
