### PR TITLE
Implement TextMarshaler for ContainerStatus

### DIFF
--- a/agent/api/container/transitiondependency_test.go
+++ b/agent/api/container/transitiondependency_test.go
@@ -20,42 +20,90 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestUnmarshalOldTransitionDependencySet(t *testing.T) {
-	bytes := []byte(`{
-	  "ContainerDependencies": [
-	    {
-	      "ContainerName": "container",
-	      "SatisfiedStatus": "RUNNING",
-	      "DependentStatus": "RUNNING"
-	    }
-	  ]
-	}`)
-	unmarshalledTdMap := TransitionDependenciesMap{}
-	err := json.Unmarshal(bytes, &unmarshalledTdMap)
-	assert.NoError(t, err)
-	assert.Len(t, unmarshalledTdMap, 1)
-	assert.NotNil(t, unmarshalledTdMap[apicontainerstatus.ContainerRunning])
-	dep := unmarshalledTdMap[apicontainerstatus.ContainerRunning].ContainerDependencies
-	assert.Len(t, dep, 1)
-	assert.Equal(t, "container", dep[0].ContainerName)
-	assert.Equal(t, apicontainerstatus.ContainerRunning, dep[0].SatisfiedStatus)
-	assert.Equal(t, apicontainerstatus.ContainerStatusNone, dep[0].DependentStatus)
+// Tests that TransitionDependencySet marshaled in different formats (as changes are introduced)
+// can all be unmarshaled.
+func TestUnmarshalTransitionDependencySet(t *testing.T) {
+	tcs := []struct {
+		name      string
+		marshaled []byte
+	}{
+		{
+			name:      "with dependent status - this is the oldest format",
+			marshaled: []byte(`{"ContainerDependencies": [{"ContainerName": "container", "SatisfiedStatus": "RUNNING", "DependentStatus": "PULLED"}]}`),
+		},
+		{
+			name:      "as a map with integer keys for statuses - this is an older format",
+			marshaled: []byte(`{"1":{"ContainerDependencies":[{"ContainerName":"container","SatisfiedStatus":"RUNNING"}]}}`),
+		},
+		{
+			name:      "as a map with string keys for statuses - this is the latest format",
+			marshaled: []byte(`{"PULLED":{"ContainerDependencies":[{"ContainerName":"container","SatisfiedStatus":"RUNNING"}]}}`),
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			unmarshalledTdMap := TransitionDependenciesMap{}
+			err := json.Unmarshal(tc.marshaled, &unmarshalledTdMap)
+			require.NoError(t, err)
+			require.Len(t, unmarshalledTdMap, 1)
+			require.NotNil(t, unmarshalledTdMap[apicontainerstatus.ContainerPulled])
+			dep := unmarshalledTdMap[apicontainerstatus.ContainerPulled].ContainerDependencies
+			require.Len(t, dep, 1)
+			assert.Equal(t, "container", dep[0].ContainerName)
+			assert.Equal(t, apicontainerstatus.ContainerRunning, dep[0].SatisfiedStatus)
+			assert.Equal(t, apicontainerstatus.ContainerStatusNone, dep[0].DependentStatus)
+		})
+	}
 }
 
-func TestUnmarshalNewTransitionDependencySet(t *testing.T) {
-	bytes := []byte(`{"1":{"ContainerDependencies":[{"ContainerName":"container","SatisfiedStatus":"RUNNING"}]}}`)
-	unmarshalledTdMap := TransitionDependenciesMap{}
-	err := json.Unmarshal(bytes, &unmarshalledTdMap)
-	assert.NoError(t, err)
-	assert.Len(t, unmarshalledTdMap, 1)
-	assert.NotNil(t, unmarshalledTdMap[apicontainerstatus.ContainerPulled])
-	dep := unmarshalledTdMap[apicontainerstatus.ContainerPulled].ContainerDependencies
-	assert.Len(t, dep, 1)
-	assert.Equal(t, "container", dep[0].ContainerName)
-	assert.Equal(t, apicontainerstatus.ContainerRunning, dep[0].SatisfiedStatus)
-	assert.Equal(t, apicontainerstatus.ContainerStatusNone, dep[0].DependentStatus)
+// Tests that marshaled TransitionDependenciesMap can be unmarshaled.
+func TestMarshalUnmarshalTransitionDependencySet(t *testing.T) {
+	var depMap TransitionDependenciesMap = map[apicontainerstatus.ContainerStatus]TransitionDependencySet{
+		apicontainerstatus.ContainerRunning: {
+			ContainerDependencies: []ContainerDependency{
+				{
+					ContainerName:   "db",
+					SatisfiedStatus: apicontainerstatus.ContainerRunning,
+				},
+			},
+			ResourceDependencies: []ResourceDependency{
+				{
+					Name:           "config",
+					RequiredStatus: status.ResourceCreated,
+				},
+			},
+		},
+	}
+	marshaled, err := json.Marshal(depMap)
+	require.NoError(t, err)
+	var unmarshaled TransitionDependenciesMap
+	err = json.Unmarshal(marshaled, &unmarshaled)
+	require.NoError(t, err)
+	assert.Equal(t, depMap, unmarshaled)
+}
+
+// Tests that marshaling of TransitionDependenciesMap works as expected.
+func TestMarshalTransitionDependencySet(t *testing.T) {
+	var depMap TransitionDependenciesMap = map[apicontainerstatus.ContainerStatus]TransitionDependencySet{
+		apicontainerstatus.ContainerPulled: {
+			ContainerDependencies: []ContainerDependency{
+				{
+					ContainerName:   "pre",
+					SatisfiedStatus: apicontainerstatus.ContainerStopped,
+				},
+			},
+		},
+	}
+	marshaled, err := json.Marshal(depMap)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		`{"PULLED":{"ContainerDependencies":[{"ContainerName":"pre","SatisfiedStatus":"STOPPED"}],"ResourceDependencies":null}}`,
+		string(marshaled))
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status/containerstatus.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status/containerstatus.go
@@ -15,6 +15,7 @@ package status
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 )
 
@@ -138,6 +139,28 @@ func (cs *ContainerStatus) UnmarshalJSON(b []byte) error {
 		return nil
 	}
 
+	// Before MarshalText method was implemented for ContainerStatus, ContainerStatus was
+	// marshaled as an integer in cases that depend on MarshalText such as keys in a JSON object.
+	// To make unmarshaling backwards-compatible, check if the marshaled text is an integer
+	// and map it to container status.
+	if intStatus, err := strconv.Atoi(strStatus); err == nil {
+		// This map is only for making text unmarshaling compatible with old state files.
+		// Updates are NOT needed to this map as newer container states are introduced.
+		intContainerStatusMap := map[int]ContainerStatus{
+			0: ContainerStatusNone,
+			1: ContainerPulled,
+			2: ContainerCreated,
+			3: ContainerRunning,
+			4: ContainerResourcesProvisioned,
+			5: ContainerStopped,
+			6: ContainerZombie,
+		}
+		if stat, ok := intContainerStatusMap[intStatus]; ok {
+			*cs = stat
+			return nil
+		}
+	}
+
 	stat, ok := containerStatusMap[strStatus]
 	if !ok {
 		*cs = ContainerStatusNone
@@ -153,6 +176,26 @@ func (cs *ContainerStatus) MarshalJSON() ([]byte, error) {
 		return nil, nil
 	}
 	return []byte(`"` + cs.String() + `"`), nil
+}
+
+// Marshals a container status to its text form.
+// In some cases such as a map with ContainerStatus as keys, MarshalText method is used to
+// marshal container statuses by functions in the encoding package. Without this method
+// container statuses will be marshaled as integers which is undesirable.
+func (cs ContainerStatus) MarshalText() ([]byte, error) {
+	return []byte(cs.String()), nil
+}
+
+// Unmarshals a container status from its text form.
+func (cs *ContainerStatus) UnmarshalText(b []byte) error {
+	strStatus := string(b)
+	stat, ok := containerStatusMap[strStatus]
+	if !ok {
+		*cs = ContainerStatusNone
+		return errors.New("container status text unmarshal: unrecognized status: " + strStatus)
+	}
+	*cs = stat
+	return nil
 }
 
 // UnmarshalJSON overrides the logic for parsing the JSON-encoded container health data

--- a/ecs-agent/api/container/status/containerstatus.go
+++ b/ecs-agent/api/container/status/containerstatus.go
@@ -15,6 +15,7 @@ package status
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 )
 
@@ -138,6 +139,28 @@ func (cs *ContainerStatus) UnmarshalJSON(b []byte) error {
 		return nil
 	}
 
+	// Before MarshalText method was implemented for ContainerStatus, ContainerStatus was
+	// marshaled as an integer in cases that depend on MarshalText such as keys in a JSON object.
+	// To make unmarshaling backwards-compatible, check if the marshaled text is an integer
+	// and map it to container status.
+	if intStatus, err := strconv.Atoi(strStatus); err == nil {
+		// This map is only for making text unmarshaling compatible with old state files.
+		// Updates are NOT needed to this map as newer container states are introduced.
+		intContainerStatusMap := map[int]ContainerStatus{
+			0: ContainerStatusNone,
+			1: ContainerPulled,
+			2: ContainerCreated,
+			3: ContainerRunning,
+			4: ContainerResourcesProvisioned,
+			5: ContainerStopped,
+			6: ContainerZombie,
+		}
+		if stat, ok := intContainerStatusMap[intStatus]; ok {
+			*cs = stat
+			return nil
+		}
+	}
+
 	stat, ok := containerStatusMap[strStatus]
 	if !ok {
 		*cs = ContainerStatusNone
@@ -153,6 +176,26 @@ func (cs *ContainerStatus) MarshalJSON() ([]byte, error) {
 		return nil, nil
 	}
 	return []byte(`"` + cs.String() + `"`), nil
+}
+
+// Marshals a container status to its text form.
+// In some cases such as a map with ContainerStatus as keys, MarshalText method is used to
+// marshal container statuses by functions in the encoding package. Without this method
+// container statuses will be marshaled as integers which is undesirable.
+func (cs ContainerStatus) MarshalText() ([]byte, error) {
+	return []byte(cs.String()), nil
+}
+
+// Unmarshals a container status from its text form.
+func (cs *ContainerStatus) UnmarshalText(b []byte) error {
+	strStatus := string(b)
+	stat, ok := containerStatusMap[strStatus]
+	if !ok {
+		*cs = ContainerStatusNone
+		return errors.New("container status text unmarshal: unrecognized status: " + strStatus)
+	}
+	*cs = stat
+	return nil
 }
 
 // UnmarshalJSON overrides the logic for parsing the JSON-encoded container health data

--- a/ecs-agent/api/container/status/containerstatus_test.go
+++ b/ecs-agent/api/container/status/containerstatus_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShouldReportToBackend(t *testing.T) {
@@ -170,4 +171,115 @@ func TestUnmarshalContainerHealthStatus(t *testing.T) {
 			assert.Equal(t, status, tc.Status)
 		})
 	}
+}
+
+// Tests that all container statuses are marshaled to JSON with a quoted string.
+// Also tests that JSON marshaled container status can be unmarshaled.
+func TestContainerStatusMarshalUnmarshalJSON(t *testing.T) {
+	for strStatus, status := range containerStatusMap {
+		t.Run(fmt.Sprintf("marshal-unmarshal %v", strStatus), func(t *testing.T) {
+			marshaled, err := json.Marshal(status)
+			require.NoError(t, err)
+			require.Equal(t, fmt.Sprintf("%q", strStatus), string(marshaled))
+
+			var unmarshaled ContainerStatus
+			err = json.Unmarshal(marshaled, &unmarshaled)
+			require.NoError(t, err)
+			require.Equal(t, status, unmarshaled)
+		})
+	}
+}
+
+// Tests that a container status marshaled as text can be unmarshaled.
+func TestContainerStatusMarshalUnmarshalText(t *testing.T) {
+	for strStatus, status := range containerStatusMap {
+		t.Run(fmt.Sprintf("marshal-unmarshal %v", strStatus), func(t *testing.T) {
+			marshaled, err := status.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, fmt.Sprintf("%s", strStatus), string(marshaled))
+
+			var unmarshaled ContainerStatus
+			err = unmarshaled.UnmarshalText(marshaled)
+			require.NoError(t, err)
+			require.Equal(t, status, unmarshaled)
+		})
+	}
+}
+
+// Tests that MarshalText works as expected for container status pointers.
+func TestContainerStatusMarshalPointer(t *testing.T) {
+	status := ContainerPulled
+	ptr := &status
+	marshaled, err := ptr.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, "PULLED", string(marshaled))
+}
+
+// Tests that unmarshaling an invalid text to container status fails.
+func TestContainerStatusTextUnmarshalError(t *testing.T) {
+	var status ContainerStatus
+	assert.EqualError(t, status.UnmarshalText([]byte("invalidStatus")),
+		"container status text unmarshal: unrecognized status: invalidStatus")
+}
+
+// Tests that string based statuses are used when a map with container status as keys is
+// marshaled to JSON.
+func TestContainerStatusKeyMarshal(t *testing.T) {
+	someMap := map[ContainerStatus]string{
+		ContainerStatusNone:           "",
+		ContainerPulled:               "",
+		ContainerCreated:              "",
+		ContainerRunning:              "",
+		ContainerResourcesProvisioned: "",
+		ContainerStopped:              "",
+	}
+	marshaled, err := json.Marshal(someMap)
+	require.NoError(t, err)
+
+	var unmarshaledMap map[string]string
+	err = json.Unmarshal(marshaled, &unmarshaledMap)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{
+		`NONE`:                  "",
+		`PULLED`:                "",
+		`CREATED`:               "",
+		`RUNNING`:               "",
+		`RESOURCES_PROVISIONED`: "",
+		`STOPPED`:               "",
+	}, unmarshaledMap)
+
+	var unmarshaled map[ContainerStatus]string
+	err = json.Unmarshal(marshaled, &unmarshaled)
+	require.NoError(t, err)
+	assert.Equal(t, someMap, unmarshaled)
+}
+
+// Tests that JSON unmarshal of container status is backwards-compatible with legacy integer
+// based representations for JSON object keys.
+func TestContainerStatusJSONUnmarshalInt(t *testing.T) {
+	tcs := map[string]ContainerStatus{
+		`"0"`: ContainerStatusNone,
+		`"1"`: ContainerPulled,
+		`"2"`: ContainerCreated,
+		`"3"`: ContainerRunning,
+		`"4"`: ContainerResourcesProvisioned,
+		`"5"`: ContainerStopped,
+		`"6"`: ContainerZombie,
+	}
+	for intStatus, status := range tcs {
+		t.Run(fmt.Sprintf("%s - %s", intStatus, status.String()), func(t *testing.T) {
+			var unmarshaled ContainerStatus
+			err := json.Unmarshal([]byte(intStatus), &unmarshaled)
+			require.NoError(t, err)
+			assert.Equal(t, status, unmarshaled)
+		})
+	}
+}
+
+func TestTemporary(t *testing.T) {
+	marshaled := `{"1": "ok"}`
+	unmarshaled := map[ContainerStatus]string{}
+	err := json.Unmarshal([]byte(marshaled), &unmarshaled)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
`ContainerStatus` currently does not implement [encoding.TestMarshaler](https://pkg.go.dev/encoding#TextMarshaler) interface which causes it to be marshaled as integers (such as "1") instead of strings (such as "PULLED") in some cases that depend on `TextMarshaler` interface. An example of such a case is when `ContainerStatus` is a key in a `map`. Due to this issue, `TransitionDependenciesMap` type, which is a type alias for `map[ContainerStatus]TransitionDependencySet`, is marshaled with integer keys as shown below.
```
{
  "1": {
    "ContainerDependencies": [
      {
        "ContainerName": "container",
        "SatisfiedStatus": "RUNNING"
      }
    ]
  }
}
```

This behavior of [json.Marshal function is documented](https://pkg.go.dev/encoding/json#Marshal).
> Map values encode as JSON objects. The map's key type must either be a string, an integer type, or implement [encoding.TextMarshaler](https://pkg.go.dev/encoding#TextMarshaler). The map keys are sorted and used as JSON object keys by applying the following rules, subject to the UTF-8 coercion described for string values above:
> 
> * keys of any string type are used directly
> * encoding.TextMarshalers are marshaled
> * integer keys are converted to strings

It is problematic to marshal `ContainerStatus` as integers because when a new container state is introduced data marshaled by an older Agent version will be _silently_ unmarshaled incorrectly by a newer Agent version. For example, an older Agent version would marshal `ContainerPulled` state as "1" but if a new state is introduced between `ContainerStatusNone` and `ContainerPulled` then a newer Agent version will unmarshal "1" as that new state. We will be introducing a new container state in an upcoming PR which is why this PR is needed first.

To solve this issue, this PR implements [encoding.TestMarshaler](https://pkg.go.dev/encoding#TextMarshaler) and its counterpart [encoding.TestUnmarshaler](https://pkg.go.dev/encoding#TextUnmarshaler) interfaces for `ContainerStatus` type so that text marshaling of `ContainerStatus` uses strings instead of integers. 

On the other hand, when unmarshaling JSON object keys, [json.Unmarshal](https://pkg.go.dev/encoding/json#Unmarshal) function gives preference to [json.Unmarshaler](https://pkg.go.dev/encoding/json#Unmarshaler) interface over [encoding.TextUnmarshaler](https://pkg.go.dev/encoding#TextUnmarshaler). 

> To unmarshal a JSON object into a map, Unmarshal first establishes a map to use. If the map is nil, Unmarshal allocates a new map. Otherwise Unmarshal reuses the existing map, keeping existing entries. Unmarshal then stores key-value pairs from the JSON object into the map. The map's key type must either be any string type, an integer, implement [json.Unmarshaler](https://pkg.go.dev/encoding/json#Unmarshaler), or implement [encoding.TextUnmarshaler](https://pkg.go.dev/encoding#TextUnmarshaler).

For this reason, we need to make `ContainerStatus.UnmarshalJSON` method backwards-compatible with integer based marshaling of `ContainerStatus`. This PR adds code in `UnmarshalJSON` to handle integer to `ContainerStatus` mapping for old state files.

### Implementation details
<!-- How are the changes implemented? -->
* Implement `MarshalText` method for `ContainerStatus`. The method has a value receiver as otherwise the method is not invoked for `ContainerStatus` values. The method is invoked for pointers to `ContainerStatus` too so both cases are covered. The method simply calls `String()` method.
* Implement `UnmarshalText` method for `ContainerStatus` which unmarshals `ContainerStatus` from its text form.
* Update `MarshalJSON` method of `ContainerStatus` to capture current integer to `ContainerStatus` mapping and use it unmarshal `ContainerStatus` from its old integer based marshaling. The mapping from integer to `ContainerStatus` does not need to be updated as we add new states as it is only for backwards compatibility with old Agent state files that won't ever have new states. 
* Add new tests for `TransitionDependenciesMap` type to ensure that `ContainerStatus` keys are marshaled as strings now and unmarshaling from older formats works (for backward-compatibility).

### Forward compatibility
This change is not forward compatible (but it is backward compatible) with older Agent versions as [Agent's state loading logic does not take into account the version of the persisted state](https://github.com/aws/amazon-ecs-agent/blob/ff5590b7c5242169eaae234eff2fe761b516042c/agent/data/container_client.go#L74-L89). This is true for all changes made to state format and contents. If Agent is downgraded after running an Agent version with this change, then the downgraded version will not have any state transition dependencies loaded for any containers. Agent will still start-up and run.

The following error will show in the logs. 

```
level=debug time=2024-04-08T14:48:13Z msg="Unmarshal 'TransitionDependencySet': {\"PULLED\":{\"ContainerDependencies\":[{\"ContainerName\":\"~internal~ecs~pause\",\"SatisfiedStatus\":\"RESOURCES_PROVISIONED\"}],\"ResourceDependencies\":[{\"Name\":\"cgroup\",\"RequiredStatus\":1}]}}, not a map: json: cannot unmarshal number PULLED into Go value of type status.ContainerStatus" module=transitiondependency.go
level=debug time=2024-04-08T14:48:13Z msg="Unmarshal 'TransitionDependencySet': {\"STOPPED\":{\"ContainerDependencies\":[{\"ContainerName\":\"sleep\",\"SatisfiedStatus\":\"STOPPED\"}],\"ResourceDependencies\":null}}, not a map: json: cannot unmarshal number STOPPED into Go value of type status.ContainerStatus" module=transitiondependency.go
level=debug time=2024-04-08T14:48:13Z msg="Unmarshal 'TransitionDependencySet': {\"PULLED\":{\"ContainerDependencies\":[{\"ContainerName\":\"~internal~ecs~pause\",\"SatisfiedStatus\":\"RESOURCES_PROVISIONED\"}],\"ResourceDependencies\":[{\"Name\":\"cgroup\",\"RequiredStatus\":1}]}}, not a map: json: cannot unmarshal number PULLED into Go value of type status.ContainerStatus" module=transitiondependency.go
level=debug time=2024-04-08T14:48:13Z msg="Unmarshal 'TransitionDependencySet': {\"STOPPED\":{\"ContainerDependencies\":[{\"ContainerName\":\"sleep\",\"SatisfiedStatus\":\"STOPPED\"}],\"ResourceDependencies\":null}}, not a map: json: cannot unmarshal number STOPPED into Go value of type status.ContainerStatus" module=transitiondependency.go
```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
* Thorough unit tests are added. 

Performed the following manual test. 
* Ran an Agent without the changes in this PR and launched an awsvpc task. Awsvpc tasks make use of `TransitionDependenciesMap` to ensure that task containers are started after the pause container reaches `RUNNING` and the pause container is stopped after task containers reach `STOPPED`.
* While the task is running, stopped Agent and started a new Agent with the changes in this PR. Some extra logs were added to observe parsing of containers from the state file. Observed the logs below. 
```
level=debug time=2024-04-05T17:30:00Z msg="Parsing container: {\"DockerId\":\"3ac5b45fca171d7047a7b870c26ce5765c42a9d0d02b9adbf7bafe31c478a435\",\"DockerName\":\"ecs-tss-sleep-awsvpc-2-sleep-f0b4b7c6c0cfe1b23a00\",\"Container\":{\"Name\":\"sleep\",\"RuntimeID\":\"3ac5b45fca171d7047a7b870c26ce5765c42a9d0d02b9adbf7bafe31c478a435\",\"taskARN\":\"arn:aws:ecs:us-west-2:979604884904:task/test/53a8a19f210b43a0aa727f7d3b3d6865\",\"V3EndpointID\":\"fe5d2f12-9ec9-4ac5-81f4-454118021fe2\",\"Image\":\"busybox:latest\",\"ImageID\":\"sha256:ba5dc23f65d4cc4a4535bce55cf9e63b068eb02946e3422d3587e8ce803b6aab\",\"ImageDigest\":\"sha256:650fd573e056b679a5110a70aabeb01e26b76e545ec4b9c70a9523f2dfaf18c6\",\"Command\":[\"sh\",\"-c\",\"sleep 600\"],\"Cpu\":128,\"GPUIDs\":null,\"Memory\":16,\"Links\":null,\"firelensConfiguration\":null,\"volumesFrom\":[],\"mountPoints\":[],\"portMappings\":null,\"secrets\":null,\"Essential\":true,\"EntryPoint\":null,\"environment\":{\"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI\":\"/v2/credentials/1b9f82aa-68d8-48b7-aa93-9e9c50b7d3d8\",\"AWS_EXECUTION_ENV\":\"AWS_ECS_EC2\",\"ECS_AGENT_URI\":\"http://169.254.170.2/api/fe5d2f12-9ec9-4ac5-81f4-454118021fe2\",\"ECS_CONTAINER_METADATA_URI\":\"http://169.254.170.2/v3/fe5d2f12-9ec9-4ac5-81f4-454118021fe2\",\"ECS_CONTAINER_METADATA_URI_V4\":\"http://169.254.170.2/v4/fe5d2f12-9ec9-4ac5-81f4-454118021fe2\"},\"environmentFiles\":null,\"overrides\":{\"command\":null},\"dockerConfig\":{\"config\":\"{}\",\"hostConfig\":\"{\\\"NetworkMode\\\":\\\"awsvpc\\\",\\\"CapAdd\\\":[],\\\"CapDrop\\\":[],\\\"Sysctls\\\":{}}\",\"version\":\"1.18\"},\"registryAuthentication\":null,\"LogsAuthStrategy\":\"\",\"StartTimeout\":0,\"StopTimeout\":0,\"desiredStatus\":\"RUNNING\",\"KnownStatus\":\"RUNNING\",\"TransitionDependencySet\":{\"1\":{\"ContainerDependencies\":[{\"ContainerName\":\"~internal~ecs~pause\",\"SatisfiedStatus\":\"RESOURCES_PROVISIONED\"}],\"ResourceDependencies\":[{\"Name\":\"cgroup\",\"RequiredStatus\":1}]}},\"RunDependencies\":null,\"IsInternal\":\"NORMAL\",\"ApplyingError\":null,\"SentStatus\":\"RUNNING\",\"metadataFileUpdated\":false,\"KnownExitCode\":null,\"KnownPortBindings\":null,\"ContainerArn\":\"arn:aws:ecs:us-west-2:979604884904:container/test/53a8a19f210b43a0aa727f7d3b3d6865/7ffcfd76-0bc8-4cdd-8651-024e383973b2\",\"containerTornDown\":false,\"ContainerHasPortRange\":false,\"ContainerPortSet\":{},\"ContainerPortRangeMap\":{}}}" module=container_client.go
level=debug time=2024-04-05T17:30:00Z msg="Parsed container transition dependencies: map[PULLED:{ContainerDependencies:[{ContainerName:~internal~ecs~pause SatisfiedStatus:RESOURCES_PROVISIONED DependentStatus:NONE}] ResourceDependencies:[{Name:cgroup RequiredStatus:1}]}]" module=container_client.go
level=debug time=2024-04-05T17:30:00Z msg="Parsing container: {\"DockerId\":\"9834bcaed23aafd2c9d19fad81ba4bda145600e3e5fe877046aff28ec598cb29\",\"DockerName\":\"ecs-tss-sleep-awsvpc-2-internalecspause-bca291b5db8f88fd3400\",\"Container\":{\"Name\":\"~internal~ecs~pause\",\"RuntimeID\":\"9834bcaed23aafd2c9d19fad81ba4bda145600e3e5fe877046aff28ec598cb29\",\"taskARN\":\"arn:aws:ecs:us-west-2:979604884904:task/test/53a8a19f210b43a0aa727f7d3b3d6865\",\"V3EndpointID\":\"\",\"Image\":\"amazon/amazon-ecs-pause:0.1.0\",\"ImageID\":\"\",\"ImageDigest\":\"\",\"Command\":null,\"Cpu\":0,\"GPUIDs\":null,\"Memory\":0,\"Links\":null,\"firelensConfiguration\":null,\"volumesFrom\":null,\"mountPoints\":null,\"portMappings\":null,\"secrets\":null,\"Essential\":true,\"EntryPoint\":null,\"environment\":null,\"environmentFiles\":null,\"overrides\":{\"command\":null},\"dockerConfig\":{\"config\":null,\"hostConfig\":null,\"version\":null},\"registryAuthentication\":null,\"LogsAuthStrategy\":\"\",\"StartTimeout\":0,\"StopTimeout\":0,\"desiredStatus\":\"RESOURCES_PROVISIONED\",\"KnownStatus\":\"RESOURCES_PROVISIONED\",\"TransitionDependencySet\":{\"5\":{\"ContainerDependencies\":[{\"ContainerName\":\"sleep\",\"SatisfiedStatus\":\"STOPPED\"}],\"ResourceDependencies\":null}},\"RunDependencies\":null,\"IsInternal\":\"CNI_PAUSE\",\"ApplyingError\":null,\"SentStatus\":\"NONE\",\"metadataFileUpdated\":false,\"KnownExitCode\":null,\"KnownPortBindings\":null,\"SteadyStateStatus\":\"RESOURCES_PROVISIONED\",\"containerTornDown\":false,\"ContainerHasPortRange\":false,\"ContainerPortSet\":{},\"ContainerPortRangeMap\":{}}}" module=container_client.go
level=debug time=2024-04-05T17:30:00Z msg="Parsed container transition dependencies: map[STOPPED:{ContainerDependencies:[{ContainerName:sleep SatisfiedStatus:STOPPED DependentStatus:NONE}] ResourceDependencies:[]}]" module=container_client.go
```

The logs show that the new Agent parsed 
```
\"TransitionDependencySet\":{\"1\":{\"ContainerDependencies\":[{\"ContainerName\":\"~internal~ecs~pause\",\"SatisfiedStatus\":\"RESOURCES_PROVISIONED\"}],\"ResourceDependencies\":[{\"Name\":\"cgroup\",\"RequiredStatus\":1}]}}
```
as
```
map[PULLED:{ContainerDependencies:[{ContainerName:~internal~ecs~pause SatisfiedStatus:RESOURCES_PROVISIONED DependentStatus:NONE}] ResourceDependencies:[{Name:cgroup RequiredStatus:1}]}]
```
and
```
\"TransitionDependencySet\":{\"5\":{\"ContainerDependencies\":[{\"ContainerName\":\"sleep\",\"SatisfiedStatus\":\"STOPPED\"}],\"ResourceDependencies\":null}}
```
as
```
map[STOPPED:{ContainerDependencies:[{ContainerName:sleep SatisfiedStatus:STOPPED DependentStatus:NONE}] ResourceDependencies:[]}]
```
which shows that "1" was unmarshaled as `ContainerPulled` and "5" was unmarshaled as `ContainerStopped` which is expected.

* Restarted Agent and observed the logs again.
```
level=debug time=2024-04-05T17:31:54Z msg="Parsing container: {\"DockerId\":\"3ac5b45fca171d7047a7b870c26ce5765c42a9d0d02b9adbf7bafe31c478a435\",\"DockerName\":\"ecs-tss-sleep-awsvpc-2-sleep-f0b4b7c6c0cfe1b23a00\",\"Container\":{\"Name\":\"sleep\",\"RuntimeID\":\"3ac5b45fca171d7047a7b870c26ce5765c42a9d0d02b9adbf7bafe31c478a435\",\"taskARN\":\"arn:aws:ecs:us-west-2:979604884904:task/test/53a8a19f210b43a0aa727f7d3b3d6865\",\"V3EndpointID\":\"fe5d2f12-9ec9-4ac5-81f4-454118021fe2\",\"Image\":\"busybox:latest\",\"ImageID\":\"sha256:ba5dc23f65d4cc4a4535bce55cf9e63b068eb02946e3422d3587e8ce803b6aab\",\"ImageDigest\":\"sha256:650fd573e056b679a5110a70aabeb01e26b76e545ec4b9c70a9523f2dfaf18c6\",\"Command\":[\"sh\",\"-c\",\"sleep 600\"],\"Cpu\":128,\"GPUIDs\":null,\"Memory\":16,\"Links\":null,\"firelensConfiguration\":null,\"volumesFrom\":[],\"mountPoints\":[],\"portMappings\":null,\"secrets\":null,\"Essential\":true,\"EntryPoint\":null,\"environment\":{\"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI\":\"/v2/credentials/1b9f82aa-68d8-48b7-aa93-9e9c50b7d3d8\",\"AWS_EXECUTION_ENV\":\"AWS_ECS_EC2\",\"ECS_AGENT_URI\":\"http://169.254.170.2/api/fe5d2f12-9ec9-4ac5-81f4-454118021fe2\",\"ECS_CONTAINER_METADATA_URI\":\"http://169.254.170.2/v3/fe5d2f12-9ec9-4ac5-81f4-454118021fe2\",\"ECS_CONTAINER_METADATA_URI_V4\":\"http://169.254.170.2/v4/fe5d2f12-9ec9-4ac5-81f4-454118021fe2\"},\"environmentFiles\":null,\"overrides\":{\"command\":null},\"dockerConfig\":{\"config\":\"{}\",\"hostConfig\":\"{\\\"NetworkMode\\\":\\\"awsvpc\\\",\\\"CapAdd\\\":[],\\\"CapDrop\\\":[],\\\"Sysctls\\\":{}}\",\"version\":\"1.18\"},\"registryAuthentication\":null,\"LogsAuthStrategy\":\"\",\"StartTimeout\":0,\"StopTimeout\":0,\"desiredStatus\":\"RUNNING\",\"KnownStatus\":\"RUNNING\",\"TransitionDependencySet\":{\"PULLED\":{\"ContainerDependencies\":[{\"ContainerName\":\"~internal~ecs~pause\",\"SatisfiedStatus\":\"RESOURCES_PROVISIONED\"}],\"ResourceDependencies\":[{\"Name\":\"cgroup\",\"RequiredStatus\":1}]}},\"RunDependencies\":null,\"IsInternal\":\"NORMAL\",\"ApplyingError\":null,\"SentStatus\":\"RUNNING\",\"metadataFileUpdated\":false,\"KnownExitCode\":null,\"KnownPortBindings\":null,\"ContainerArn\":\"arn:aws:ecs:us-west-2:979604884904:container/test/53a8a19f210b43a0aa727f7d3b3d6865/7ffcfd76-0bc8-4cdd-8651-024e383973b2\",\"containerTornDown\":false,\"ContainerHasPortRange\":false,\"ContainerPortSet\":{},\"ContainerPortRangeMap\":{}}}" module=container_client.go
level=debug time=2024-04-05T17:31:54Z msg="Parsed container transition dependencies: map[PULLED:{ContainerDependencies:[{ContainerName:~internal~ecs~pause SatisfiedStatus:RESOURCES_PROVISIONED DependentStatus:NONE}] ResourceDependencies:[{Name:cgroup RequiredStatus:1}]}]" module=container_client.go
level=debug time=2024-04-05T17:31:54Z msg="Parsing container: {\"DockerId\":\"9834bcaed23aafd2c9d19fad81ba4bda145600e3e5fe877046aff28ec598cb29\",\"DockerName\":\"ecs-tss-sleep-awsvpc-2-internalecspause-bca291b5db8f88fd3400\",\"Container\":{\"Name\":\"~internal~ecs~pause\",\"RuntimeID\":\"9834bcaed23aafd2c9d19fad81ba4bda145600e3e5fe877046aff28ec598cb29\",\"taskARN\":\"arn:aws:ecs:us-west-2:979604884904:task/test/53a8a19f210b43a0aa727f7d3b3d6865\",\"V3EndpointID\":\"\",\"Image\":\"amazon/amazon-ecs-pause:0.1.0\",\"ImageID\":\"sha256:9dd4685d3644733005b3f933b3323c7a3b0e2a1cbcdf9a5264fd0a40861a3379\",\"ImageDigest\":\"\",\"Command\":null,\"Cpu\":0,\"GPUIDs\":null,\"Memory\":0,\"Links\":null,\"firelensConfiguration\":null,\"volumesFrom\":null,\"mountPoints\":null,\"portMappings\":null,\"secrets\":null,\"Essential\":true,\"EntryPoint\":null,\"environment\":null,\"environmentFiles\":null,\"overrides\":{\"command\":null},\"dockerConfig\":{\"config\":null,\"hostConfig\":null,\"version\":null},\"registryAuthentication\":null,\"LogsAuthStrategy\":\"\",\"StartTimeout\":0,\"StopTimeout\":0,\"desiredStatus\":\"RESOURCES_PROVISIONED\",\"KnownStatus\":\"RESOURCES_PROVISIONED\",\"TransitionDependencySet\":{\"STOPPED\":{\"ContainerDependencies\":[{\"ContainerName\":\"sleep\",\"SatisfiedStatus\":\"STOPPED\"}],\"ResourceDependencies\":null}},\"RunDependencies\":null,\"IsInternal\":\"CNI_PAUSE\",\"ApplyingError\":null,\"SentStatus\":\"NONE\",\"metadataFileUpdated\":false,\"KnownExitCode\":null,\"KnownPortBindings\":null,\"SteadyStateStatus\":\"RESOURCES_PROVISIONED\",\"containerTornDown\":false,\"ContainerHasPortRange\":false,\"ContainerPortSet\":{},\"ContainerPortRangeMap\":{}}}" module=container_client.go
level=debug time=2024-04-05T17:31:54Z msg="Parsed container transition dependencies: map[STOPPED:{ContainerDependencies:[{ContainerName:sleep SatisfiedStatus:STOPPED DependentStatus:NONE}] ResourceDependencies:[]}]" module=container_client.go
``` 
This time Agent saw string based keys for `ContainerStatus` when parsing containers from the state file which means that the new Agent correctly marshaled `ContainerStatus` keys as strings instead of integers. 
```
\"TransitionDependencySet\":{\"PULLED\":{\"ContainerDependencies\":[{\"ContainerName\":\"~internal~ecs~pause\",\"SatisfiedStatus\":\"RESOURCES_PROVISIONED\"}],\"ResourceDependencies\":[{\"Name\":\"cgroup\",\"RequiredStatus\":1}]}}
\"TransitionDependencySet\":{\"STOPPED\":{\"ContainerDependencies\":[{\"ContainerName\":\"sleep\",\"SatisfiedStatus\":\"STOPPED\"}],\"ResourceDependencies\":null}}
```
After parsing both containers had the same value as before for `TransitionDependencySet`.
```
map[PULLED:{ContainerDependencies:[{ContainerName:~internal~ecs~pause SatisfiedStatus:RESOURCES_PROVISIONED DependentStatus:NONE}] ResourceDependencies:[{Name:cgroup RequiredStatus:1}]}]
map[STOPPED:{ContainerDependencies:[{ContainerName:sleep SatisfiedStatus:STOPPED DependentStatus:NONE}] ResourceDependencies:[]}]
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: Marshal ContainerStatus as strings instead of integers for JSON keys by implementing encoding.TextMarshaler.

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
