### PR TITLE
Add MANIFEST_PULLED internal container and task states

### DIFF
--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -96,7 +96,10 @@ func TestIsKnownSteadyState(t *testing.T) {
 func TestGetNextStateProgression(t *testing.T) {
 	// This creates a container with `iota` ContainerStatus (NONE)
 	container := &Container{}
-	// NONE should transition to PULLED
+	// NONE should transition to MANIFEST_PULLED
+	assert.Equal(t, container.GetNextKnownStateProgression(), apicontainerstatus.ContainerManifestPulled)
+	container.SetKnownStatus(apicontainerstatus.ContainerManifestPulled)
+	// MANIFEST_PULLED should transition to PULLED
 	assert.Equal(t, container.GetNextKnownStateProgression(), apicontainerstatus.ContainerPulled)
 	container.SetKnownStatus(apicontainerstatus.ContainerPulled)
 	// PULLED should transition to CREATED

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1053,6 +1053,9 @@ func (task *Task) initializeASMAuthResource(credentialsManager credentials.Manag
 			container.BuildResourceDependency(asmAuthResource.GetName(),
 				resourcestatus.ResourceStatus(asmauth.ASMAuthStatusCreated),
 				apicontainerstatus.ContainerManifestPulled)
+			container.BuildResourceDependency(asmAuthResource.GetName(),
+				resourcestatus.ResourceStatus(asmauth.ASMAuthStatusCreated),
+				apicontainerstatus.ContainerPulled)
 		}
 	}
 }

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1052,7 +1052,7 @@ func (task *Task) initializeASMAuthResource(credentialsManager credentials.Manag
 		if container.ShouldPullWithASMAuth() {
 			container.BuildResourceDependency(asmAuthResource.GetName(),
 				resourcestatus.ResourceStatus(asmauth.ASMAuthStatusCreated),
-				apicontainerstatus.ContainerPulled)
+				apicontainerstatus.ContainerManifestPulled)
 		}
 	}
 }
@@ -3682,7 +3682,8 @@ func (task *Task) ToHostResources() map[string]*ecs.Resource {
 func (task *Task) HasActiveContainers() bool {
 	for _, container := range task.Containers {
 		containerStatus := container.GetKnownStatus()
-		if containerStatus >= apicontainerstatus.ContainerPulled && containerStatus <= apicontainerstatus.ContainerResourcesProvisioned {
+		if containerStatus >= apicontainerstatus.ContainerManifestPulled &&
+			containerStatus <= apicontainerstatus.ContainerResourcesProvisioned {
 			return true
 		}
 	}

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -2843,7 +2843,15 @@ func TestPostUnmarshalTaskASMDockerAuth(t *testing.T) {
 	}
 
 	err := task.PostUnmarshalTask(cfg, credentialsManager, resFields, nil, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	assert.Equal(t,
+		apicontainer.ResourceDependency{
+			Name:           asmauth.ResourceName,
+			RequiredStatus: resourcestatus.ResourceStatus(asmauth.ASMAuthStatusCreated),
+		},
+		task.Containers[0].
+			TransitionDependenciesMap[apicontainerstatus.ContainerManifestPulled].
+			ResourceDependencies[0])
 }
 
 func TestPostUnmarshalTaskSecret(t *testing.T) {

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -2844,6 +2844,7 @@ func TestPostUnmarshalTaskASMDockerAuth(t *testing.T) {
 
 	err := task.PostUnmarshalTask(cfg, credentialsManager, resFields, nil, nil)
 	require.NoError(t, err)
+	require.Len(t, task.Containers[0].TransitionDependenciesMap, 2)
 	assert.Equal(t,
 		apicontainer.ResourceDependency{
 			Name:           asmauth.ResourceName,
@@ -2851,6 +2852,14 @@ func TestPostUnmarshalTaskASMDockerAuth(t *testing.T) {
 		},
 		task.Containers[0].
 			TransitionDependenciesMap[apicontainerstatus.ContainerManifestPulled].
+			ResourceDependencies[0])
+	assert.Equal(t,
+		apicontainer.ResourceDependency{
+			Name:           asmauth.ResourceName,
+			RequiredStatus: resourcestatus.ResourceStatus(asmauth.ASMAuthStatusCreated),
+		},
+		task.Containers[0].
+			TransitionDependenciesMap[apicontainerstatus.ContainerPulled].
 			ResourceDependencies[0])
 }
 

--- a/agent/engine/dependencygraph/graph.go
+++ b/agent/engine/dependencygraph/graph.go
@@ -415,6 +415,12 @@ func containerOrderingDependenciesIsResolved(target *apicontainer.Container,
 	targetContainerKnownStatus := target.GetKnownStatus()
 	dependsOnContainerKnownStatus := dependsOnContainer.GetKnownStatus()
 
+	// Containers are allowed to transition to MANIFEST_PULLED irrespective of any container
+	// ordering dependencies.
+	if targetContainerKnownStatus < apicontainerstatus.ContainerManifestPulled {
+		return true
+	}
+
 	// The 'target' container desires to be moved to 'Created' or the 'steady' state.
 	// Allow this only if the environment variable ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT is enabled and
 	// known status of the `target` container state has not reached to 'Pulled' state;

--- a/agent/engine/dependencygraph/graph_unix_test.go
+++ b/agent/engine/dependencygraph/graph_unix_test.go
@@ -38,12 +38,19 @@ func TestVerifyCgroupDependenciesResolved(t *testing.T) {
 		ExpectedResolved bool
 	}{
 		{
-			Name:            "resource none,container pull depends on resource created",
-			TargetKnown:     apicontainerstatus.ContainerStatusNone,
-			TargetDep:       apicontainerstatus.ContainerPulled,
-			DependencyKnown: resourcestatus.ResourceStatus(cgroup.CgroupStatusNone),
-			RequiredStatus:  resourcestatus.ResourceStatus(cgroup.CgroupCreated),
-
+			Name:             "resource none, container pull depends on resource created",
+			TargetKnown:      apicontainerstatus.ContainerStatusNone,
+			TargetDep:        apicontainerstatus.ContainerPulled,
+			DependencyKnown:  resourcestatus.ResourceStatus(cgroup.CgroupStatusNone),
+			RequiredStatus:   resourcestatus.ResourceStatus(cgroup.CgroupCreated),
+			ExpectedResolved: true,
+		},
+		{
+			Name:             "resource none, current is manifest_pulled, container pull depends on resource created",
+			TargetKnown:      apicontainerstatus.ContainerManifestPulled,
+			TargetDep:        apicontainerstatus.ContainerPulled,
+			DependencyKnown:  resourcestatus.ResourceStatus(cgroup.CgroupStatusNone),
+			RequiredStatus:   resourcestatus.ResourceStatus(cgroup.CgroupCreated),
 			ExpectedResolved: false,
 		},
 		{

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -289,6 +289,7 @@ func (engine *DockerTaskEngine) reconcileHostResources() {
 
 func (engine *DockerTaskEngine) initializeContainerStatusToTransitionFunction() {
 	containerStatusToTransitionFunction := map[apicontainerstatus.ContainerStatus]transitionApplyFunc{
+		apicontainerstatus.ContainerManifestPulled:       engine.pullContainerManifest,
 		apicontainerstatus.ContainerPulled:               engine.pullContainer,
 		apicontainerstatus.ContainerCreated:              engine.createContainer,
 		apicontainerstatus.ContainerRunning:              engine.startContainer,
@@ -1229,6 +1230,19 @@ func (engine *DockerTaskEngine) SetDaemonTask(daemonName string, task *apitask.T
 
 func (engine *DockerTaskEngine) GetDaemonManagers() map[string]dm.DaemonManager {
 	return engine.daemonManagers
+}
+
+// Pulls the manifest of the container image.
+func (engine *DockerTaskEngine) pullContainerManifest(
+	task *apitask.Task, container *apicontainer.Container,
+) dockerapi.DockerContainerMetadata {
+	// Currently a no-op
+	logger.Debug("Manifest pull is currently a no-op", logger.Fields{
+		field.TaskID:    task.GetID(),
+		field.Container: container.Name,
+		field.Image:     container.Image,
+	})
+	return dockerapi.DockerContainerMetadata{}
 }
 
 func (engine *DockerTaskEngine) pullContainer(task *apitask.Task, container *apicontainer.Container) dockerapi.DockerContainerMetadata {

--- a/agent/taskresource/asmauth/asmauth_test.go
+++ b/agent/taskresource/asmauth/asmauth_test.go
@@ -18,6 +18,7 @@ package asmauth
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -126,22 +127,42 @@ func TestMarshalUnmarshalJSON(t *testing.T) {
 }
 
 func TestInitialize(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	credentialsManager := mock_credentials.NewMockManager(ctrl)
-	asmClientCreator := mock_factory.NewMockClientCreator(ctrl)
-	asmRes := &ASMAuthResource{
-		knownStatusUnsafe:   resourcestatus.ResourceCreated,
-		desiredStatusUnsafe: resourcestatus.ResourceCreated,
+	tcs := []struct {
+		taskKnownStatus   apitaskstatus.TaskStatus
+		taskDesiredStatus apitaskstatus.TaskStatus
+		expectReset       bool
+	}{
+		{apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning, true},
+		{apitaskstatus.TaskManifestPulled, apitaskstatus.TaskRunning, true},
+		{apitaskstatus.TaskPulled, apitaskstatus.TaskRunning, false},
+		{apitaskstatus.TaskStatusNone, apitaskstatus.TaskStopped, false},
+		{apitaskstatus.TaskManifestPulled, apitaskstatus.TaskStopped, false},
 	}
-	asmRes.Initialize(&taskresource.ResourceFields{
-		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
-			ASMClientCreator:   asmClientCreator,
-			CredentialsManager: credentialsManager,
-		},
-	}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
-	assert.Equal(t, resourcestatus.ResourceStatusNone, asmRes.GetKnownStatus())
-	assert.Equal(t, resourcestatus.ResourceCreated, asmRes.GetDesiredStatus())
+	for _, tc := range tcs {
+		t.Run(
+			fmt.Sprintf("Known: %s; Desired: %s", tc.taskKnownStatus, tc.taskDesiredStatus),
+			func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
 
+				credentialsManager := mock_credentials.NewMockManager(ctrl)
+				asmClientCreator := mock_factory.NewMockClientCreator(ctrl)
+				asmRes := &ASMAuthResource{
+					knownStatusUnsafe:   resourcestatus.ResourceCreated,
+					desiredStatusUnsafe: resourcestatus.ResourceCreated,
+				}
+				asmRes.Initialize(&taskresource.ResourceFields{
+					ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
+						ASMClientCreator:   asmClientCreator,
+						CredentialsManager: credentialsManager,
+					},
+				}, tc.taskKnownStatus, tc.taskDesiredStatus)
+				if tc.expectReset {
+					assert.Equal(t, resourcestatus.ResourceStatusNone, asmRes.GetKnownStatus())
+				} else {
+					assert.Equal(t, resourcestatus.ResourceCreated, asmRes.GetKnownStatus())
+				}
+				assert.Equal(t, resourcestatus.ResourceCreated, asmRes.GetDesiredStatus())
+			})
+	}
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status/containerstatus.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status/containerstatus.go
@@ -22,6 +22,8 @@ import (
 const (
 	// ContainerStatusNone is the zero state of a container; this container has not completed pull
 	ContainerStatusNone ContainerStatus = iota
+	// ContainerManifestPulled represents a container which has had its image manifest pulled
+	ContainerManifestPulled
 	// ContainerPulled represents a container which has had the image pulled
 	ContainerPulled
 	// ContainerCreated represents a container that has been created
@@ -58,6 +60,7 @@ type ContainerHealthStatus int32
 
 var containerStatusMap = map[string]ContainerStatus{
 	"NONE":                  ContainerStatusNone,
+	"MANIFEST_PULLED":       ContainerManifestPulled,
 	"PULLED":                ContainerPulled,
 	"CREATED":               ContainerCreated,
 	"RUNNING":               ContainerRunning,

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status/statusmapping.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status/statusmapping.go
@@ -20,15 +20,17 @@ import (
 // MapContainerToTaskStatus maps the container status to the corresponding task status. The
 // transition map is illustrated below.
 //
-// Container: None -> Pulled -> Created -> Running -> Provisioned -> Stopped -> Zombie
+// Container: None -> ManifestPulled -> Pulled -> Created -> Running -> Provisioned -> Stopped -> Zombie
 //
-// Task     : None ->     Created       ->         Running        -> Stopped
+// Task     : None -> ManifestPulled ->           Created -> Running ->                Stopped
 func MapContainerToTaskStatus(knownState apicontainerstatus.ContainerStatus, steadyState apicontainerstatus.ContainerStatus) TaskStatus {
 	switch knownState {
 	case apicontainerstatus.ContainerStatusNone:
 		return TaskStatusNone
 	case steadyState:
 		return TaskRunning
+	case apicontainerstatus.ContainerManifestPulled, apicontainerstatus.ContainerPulled:
+		return TaskManifestPulled
 	case apicontainerstatus.ContainerCreated:
 		return TaskCreated
 	case apicontainerstatus.ContainerStopped:

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status/taskstatus.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status/taskstatus.go
@@ -21,6 +21,8 @@ import (
 const (
 	// TaskStatusNone is the zero state of a task; this task has been received but no further progress has completed
 	TaskStatusNone TaskStatus = iota
+	// TaskManifestPulled represents a task which has had all its container image manifests pulled
+	TaskManifestPulled
 	// TaskPulled represents a task which has had all its container images pulled, but not all have yet progressed passed pull
 	TaskPulled
 	// TaskCreated represents a task which has had all its containers created
@@ -37,6 +39,8 @@ const (
 	TaskRunningString = "RUNNING"
 	//TaskCreatedString represents task created status string
 	TaskCreatedString = "CREATED"
+	// TaskManifestPulledString represents task manifest_pulled status string
+	TaskManifestPulledString = "MANIFEST_PULLED"
 	// TaskNoneString represents task none status string
 	TaskNoneString = "NONE"
 )
@@ -45,10 +49,11 @@ const (
 type TaskStatus int32
 
 var taskStatusMap = map[string]TaskStatus{
-	TaskNoneString:    TaskStatusNone,
-	TaskCreatedString: TaskCreated,
-	TaskRunningString: TaskRunning,
-	TaskStoppedString: TaskStopped,
+	TaskNoneString:           TaskStatusNone,
+	TaskManifestPulledString: TaskManifestPulled,
+	TaskCreatedString:        TaskCreated,
+	TaskRunningString:        TaskRunning,
+	TaskStoppedString:        TaskStopped,
 }
 
 // String returns a human readable string representation of this object

--- a/ecs-agent/api/container/status/containerstatus.go
+++ b/ecs-agent/api/container/status/containerstatus.go
@@ -22,6 +22,8 @@ import (
 const (
 	// ContainerStatusNone is the zero state of a container; this container has not completed pull
 	ContainerStatusNone ContainerStatus = iota
+	// ContainerManifestPulled represents a container which has had its image manifest pulled
+	ContainerManifestPulled
 	// ContainerPulled represents a container which has had the image pulled
 	ContainerPulled
 	// ContainerCreated represents a container that has been created
@@ -58,6 +60,7 @@ type ContainerHealthStatus int32
 
 var containerStatusMap = map[string]ContainerStatus{
 	"NONE":                  ContainerStatusNone,
+	"MANIFEST_PULLED":       ContainerManifestPulled,
 	"PULLED":                ContainerPulled,
 	"CREATED":               ContainerCreated,
 	"RUNNING":               ContainerRunning,

--- a/ecs-agent/api/task/status/statusmapping.go
+++ b/ecs-agent/api/task/status/statusmapping.go
@@ -20,15 +20,17 @@ import (
 // MapContainerToTaskStatus maps the container status to the corresponding task status. The
 // transition map is illustrated below.
 //
-// Container: None -> Pulled -> Created -> Running -> Provisioned -> Stopped -> Zombie
+// Container: None -> ManifestPulled -> Pulled -> Created -> Running -> Provisioned -> Stopped -> Zombie
 //
-// Task     : None ->     Created       ->         Running        -> Stopped
+// Task     : None -> ManifestPulled ->           Created -> Running ->                Stopped
 func MapContainerToTaskStatus(knownState apicontainerstatus.ContainerStatus, steadyState apicontainerstatus.ContainerStatus) TaskStatus {
 	switch knownState {
 	case apicontainerstatus.ContainerStatusNone:
 		return TaskStatusNone
 	case steadyState:
 		return TaskRunning
+	case apicontainerstatus.ContainerManifestPulled, apicontainerstatus.ContainerPulled:
+		return TaskManifestPulled
 	case apicontainerstatus.ContainerCreated:
 		return TaskCreated
 	case apicontainerstatus.ContainerStopped:

--- a/ecs-agent/api/task/status/statusmapping_test.go
+++ b/ecs-agent/api/task/status/statusmapping_test.go
@@ -30,10 +30,19 @@ func TestTaskStatus(t *testing.T) {
 	assert.Equal(t, MapContainerToTaskStatus(containerStatus, apicontainerstatus.ContainerRunning), TaskStatusNone)
 	assert.Equal(t, MapContainerToTaskStatus(containerStatus, apicontainerstatus.ContainerResourcesProvisioned), TaskStatusNone)
 
-	// When container state is PULLED, Task state is still NONE
+	// When container state is MANIFEST_PULLED, Task state is MANIFEST_PULLED as well
+	containerStatus = apicontainerstatus.ContainerManifestPulled
+	assert.Equal(t,
+		MapContainerToTaskStatus(containerStatus, apicontainerstatus.ContainerRunning),
+		TaskManifestPulled)
+	assert.Equal(t,
+		MapContainerToTaskStatus(containerStatus, apicontainerstatus.ContainerResourcesProvisioned),
+		TaskManifestPulled)
+
+	// When container state is PULLED, Task state is still MANIFEST_PULLED
 	containerStatus = apicontainerstatus.ContainerPulled
-	assert.Equal(t, MapContainerToTaskStatus(containerStatus, apicontainerstatus.ContainerRunning), TaskStatusNone)
-	assert.Equal(t, MapContainerToTaskStatus(containerStatus, apicontainerstatus.ContainerResourcesProvisioned), TaskStatusNone)
+	assert.Equal(t, MapContainerToTaskStatus(containerStatus, apicontainerstatus.ContainerRunning), TaskManifestPulled)
+	assert.Equal(t, MapContainerToTaskStatus(containerStatus, apicontainerstatus.ContainerResourcesProvisioned), TaskManifestPulled)
 
 	// When container state is CREATED, Task state is CREATED as well
 	containerStatus = apicontainerstatus.ContainerCreated

--- a/ecs-agent/api/task/status/taskstatus.go
+++ b/ecs-agent/api/task/status/taskstatus.go
@@ -21,6 +21,8 @@ import (
 const (
 	// TaskStatusNone is the zero state of a task; this task has been received but no further progress has completed
 	TaskStatusNone TaskStatus = iota
+	// TaskManifestPulled represents a task which has had all its container image manifests pulled
+	TaskManifestPulled
 	// TaskPulled represents a task which has had all its container images pulled, but not all have yet progressed passed pull
 	TaskPulled
 	// TaskCreated represents a task which has had all its containers created
@@ -37,6 +39,8 @@ const (
 	TaskRunningString = "RUNNING"
 	//TaskCreatedString represents task created status string
 	TaskCreatedString = "CREATED"
+	// TaskManifestPulledString represents task manifest_pulled status string
+	TaskManifestPulledString = "MANIFEST_PULLED"
 	// TaskNoneString represents task none status string
 	TaskNoneString = "NONE"
 )
@@ -45,10 +49,11 @@ const (
 type TaskStatus int32
 
 var taskStatusMap = map[string]TaskStatus{
-	TaskNoneString:    TaskStatusNone,
-	TaskCreatedString: TaskCreated,
-	TaskRunningString: TaskRunning,
-	TaskStoppedString: TaskStopped,
+	TaskNoneString:           TaskStatusNone,
+	TaskManifestPulledString: TaskManifestPulled,
+	TaskCreatedString:        TaskCreated,
+	TaskRunningString:        TaskRunning,
+	TaskStoppedString:        TaskStopped,
 }
 
 // String returns a human readable string representation of this object

--- a/ecs-agent/api/task/status/taskstatus_test.go
+++ b/ecs-agent/api/task/status/taskstatus_test.go
@@ -18,30 +18,86 @@ package status
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testTaskStatus struct {
 	SomeStatus TaskStatus `json:"status"`
 }
 
-func TestUnmarshalTaskStatus(t *testing.T) {
-	status := TaskStatusNone
-
-	err := json.Unmarshal([]byte(`"RUNNING"`), &status)
-	if err != nil {
-		t.Error(err)
+func TestUnmarshalTaskStatusSimple(t *testing.T) {
+	tcs := []struct {
+		statusString string
+		expected     TaskStatus
+	}{
+		{"NONE", TaskStatusNone},
+		{"MANIFEST_PULLED", TaskManifestPulled},
+		{"CREATED", TaskCreated},
+		{"RUNNING", TaskRunning},
+		{"STOPPED", TaskStopped},
 	}
-	if status != TaskRunning {
-		t.Error("RUNNING should unmarshal to RUNNING, not " + status.String())
+	for _, tc := range tcs {
+		t.Run(tc.statusString, func(t *testing.T) {
+			status := TaskStatusNone
+			err := json.Unmarshal([]byte(fmt.Sprintf("%q", tc.statusString)), &status)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, status)
+		})
 	}
+}
 
+func TestMarshaTaskStatusPointer(t *testing.T) {
+	tcs := []struct {
+		status   TaskStatus
+		expected string
+	}{
+		{status: TaskStatusNone, expected: `"NONE"`},
+		{status: TaskManifestPulled, expected: `"MANIFEST_PULLED"`},
+		{status: TaskCreated, expected: `"CREATED"`},
+		{status: TaskRunning, expected: `"RUNNING"`},
+		{status: TaskStopped, expected: `"STOPPED"`},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.expected, func(t *testing.T) {
+			marshled, err := json.Marshal(&tc.status)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, string(marshled))
+		})
+	}
+}
+
+func TestUnmarshalTaskStatusNested(t *testing.T) {
 	var test testTaskStatus
-	err = json.Unmarshal([]byte(`{"status":"STOPPED"}`), &test)
+	err := json.Unmarshal([]byte(`{"status":"STOPPED"}`), &test)
 	if err != nil {
 		t.Error(err)
 	}
 	if test.SomeStatus != TaskStopped {
 		t.Error("STOPPED should unmarshal to STOPPED, not " + test.SomeStatus.String())
+	}
+}
+
+// Tests that a pointer to a struct that has a TaskStatus is marshaled correctly.
+func TestMarshalTaskStatusNestedPointer(t *testing.T) {
+	tcs := []struct {
+		status   TaskStatus
+		expected string
+	}{
+		{status: TaskStatusNone, expected: "NONE"},
+		{status: TaskManifestPulled, expected: "MANIFEST_PULLED"},
+		{status: TaskCreated, expected: "CREATED"},
+		{status: TaskRunning, expected: "RUNNING"},
+		{status: TaskStopped, expected: "STOPPED"},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.status.String(), func(t *testing.T) {
+			marshaled, err := json.Marshal(&testTaskStatus{tc.status})
+			require.NoError(t, err)
+			assert.Equal(t, fmt.Sprintf(`{"status":%q}`, tc.expected), string(marshaled))
+		})
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds a new `ContainerState` named `ContainerManifestPulled` and a new `TaskState` called `TaskManifestPulled`. `ContainerManifestPulled` is added between `ContainerStatusNone` and `ContainerPulled` states and similarly `TaskManifestPulled` is added between `TaskStatusNone` and `TaskPulled` states. 

A new state transition function `pullContainerManifest` is added to `DockerTaskEngine` for handling transition of a container to `ContainerManifestPulled` state. The transition function is a no-op currently but will be updated in a future change to pull the manifest of the container image. This is a part of a project to expedite the reporting of container image manifest digests to ECS backend. 

Containers that want to reach steady state are allowed to transition to `ContainerManifestPulled` state under either of the following conditions - 
* If the container image pull depends on ASM ([AWS Secrets Manager](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html)) auth for private registry then ASM auth resource has been created. 
* If the container image pull depends on task execution role then task execution role credentials have been resolved. 
* All other cases.

[Container ordering dependencies](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDependency.html) are disregarded for transition to `ContainerManifestPulled` state. This is so that image manifest digests of all images of a task can be reported as soon as possible. 

`ContainerManifestPulled` state maps to `TaskManifestPulled` state when computing the known status of a task. 

None of the new states generate new state change events as of this PR, so container and tasks transitioning to these new states will not result in any new STSC calls. 

### Implementation details
<!-- How are the changes implemented? -->
* Add `ContainerManifestPulled ContainerStatus` constant to `containerstatus` package and update string mappings of `ContainerStatus` so that `ContainerManifestPulled` is mapped to "MANIFEST_PULLED" string. Update tests accordingly.
* Add `TaskManifestPulled TaskStatus` constant to `taskstatus` package and update string mappings of `TaskStatus` so that `TaskManifestPulled` is mapped to "MANIFEST_PULLED" string. Update tests accordingly.
* Add a new `pullContainerManifest` method to `DockerTaskEngine` type. This method is the transition function for transitioning a container to `ContainerManifestPulled` state. The method is currently a no-op. Update `DockerTaskEngine.containerStatusToTransitionFunction` map with a new `apicontainerstatus.ContainerManifestPulled: engine.pullContainerManifest` entry accordingly.
* Update `managedTask.handleEventError` method to handle errors generated in the new state transition function. The error handling logic is the same as that for `ContainerPulled` state transition errors. This is because we want to treat manifest pulls as a part of image pulls and hence we want to have the same error handling for both.
* Update `Task.initializeASMAuthResource` method so that a container's transition to `ContainerManifestPulled` state depends on the creation of the task's ASM Auth resource that is used to resolve private registry credentials. This is because private registry credentials will be needed for manifest pulls. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Updated existing unit tests and added new unit tests. 

Added a new integration test that checks - 
* Containers reach `MANIFEST_PULLED` state.
* Transition to `MANIFEST_PULLED` state does not depend on container ordering.

Following manual tests were also performed.

Ran a simple task with a single container and observed the following in the logs. 
* The container transitioned to `MANIFEST_PULLED` state before transitioning to `PULLED` state as expected. 
```
level=debug time=2024-04-10T16:54:57Z msg="Transitioned container" task="a73d8211344746749c4dd07d5b15ad26" container="sleep" runtimeID="" nextState="MANIFEST_PULLED" error=<nil>
```
* Container's state change to `MANIFEST_PULLED` did not qualify for a state change event as expected. 
```
level=debug time=2024-04-10T16:54:57Z msg="should not send events for internal tasks or containers: create container state change event api: status not recognized by ECS: MANIFEST_PULLED"
```
* Task transitioned to `MANIFEST_PULLED` state after the container transitioned to `MANIFEST_PULLED` state as expected.
```
level=info time=2024-04-10T16:54:57Z msg="Container change also resulted in task change" task="a73d8211344746749c4dd07d5b15ad26" container="sleep" runtimeID="" desiredStatus="RUNNING" knownStatus="MANIFEST_PULLED"
```
* Task's state transition to `MANIFEST_PULLED` state did not qualify for a state change event as expected. 
```
level=debug time=2024-04-10T16:54:57Z msg="Skipping event emission for task" knownStatus="MANIFEST_PULLED" task="a73d8211344746749c4dd07d5b15ad26" error="status not recognized by ECS"
```
* Task completed its lifecycle as usual. The stop code for the task was `EssentialContainerExited` and the container stopped with successful exit code `0`. 

Ran a task with two containers with one container depending on other container's completion. Both containers passed `MANIFEST_PULLED` state with the dependent container waiting in `MANIFEST_PULLED` state until the dependency container completed. 

Ran a task with one container whose image is in a private Dockerhub registry. The container did not transition to `MANIFEST_PULLED` state until the task's ASM Auth resource for private registry credentials reached `CREATED` state which is expected. 

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
Enhancement: Add a new `MANIFEST_PULLED` container and task state. The transition function for this state is currently a no-op.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
