### PR TITLE
Add functionality to pull image manifests to DockerClient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,6 +484,7 @@ clean:
 	-rm -f .generic-rpm-integrated-done
 	-rm -f amazon-ecs-volume-plugin
 	-rm -rf $(EBS_CSI_DRIVER_DIR)/bin
+	-rm -rm /tmp/private-test-registry-htpasswd # private registry credentials cleanup
 
 clean-all: clean
 	# for our dockerfree builds, we likely don't have docker

--- a/agent/dockerclient/dockerapi/docker_client_integ_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_integ_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+// +build integration
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package dockerapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
+	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const dockerEndpoint = "unix:///var/run/docker.sock"
+
+// This integration test checks that dockerGoClient can pull image manifest from registries.
+//
+// The test is skipped on environments with a Docker Engine version that does not support
+// API version 1.35 as older engine versions do not have Distribution API needed for pulling
+// image manifest. Technically, API version >1.30 have Distribution API but engine versions
+// between API version 1.30 and 1.35 can be configured to allow image pulls from v1 registries
+// but Distribution API does not work with v1 registries. v1 registry support was dropped
+// with engine version 17.12 that was shipped with API version 1.35.
+//
+// The test depends on local test registries that are set up by `make test-registry` command.
+func TestImageManifestPullInteg(t *testing.T) {
+	// Prepare a docker client that can pull image manifests
+	sdkClientFactory := sdkclientfactory.NewFactory(context.Background(), dockerEndpoint)
+	cfg := &config.Config{}
+	defaultClient, err := NewDockerGoClient(sdkClientFactory, cfg, context.Background())
+	require.NoError(t, err)
+	version := dockerclient.GetSupportedDockerAPIVersion(dockerclient.Version_1_35)
+	supportedClient, err := defaultClient.WithVersion(version)
+	if err != nil {
+		t.Skipf("Skipping test due to unsupported Docker version: %v", err)
+	}
+
+	tcs := []struct {
+		name          string
+		dockerClient  DockerClient
+		imageRef      string
+		authData      *container.RegistryAuthenticationData
+		expectedError string
+	}{
+		{
+			name:         "private registry success",
+			dockerClient: supportedClient,
+			imageRef:     "127.0.0.1:51671/busybox:latest",
+			authData: func() *container.RegistryAuthenticationData {
+				asmAuthData := &apicontainer.ASMAuthData{}
+				asmAuthData.SetDockerAuthConfig(types.AuthConfig{
+					Username: "username",
+					Password: "password",
+				})
+				return &container.RegistryAuthenticationData{Type: apicontainer.AuthTypeASM,
+					ASMAuthData: asmAuthData,
+				}
+			}(),
+		},
+		{
+			name:          "private registry auth failure",
+			dockerClient:  supportedClient,
+			imageRef:      "127.0.0.1:51671/busybox:latest",
+			expectedError: "no basic auth credentials",
+		},
+		{
+			name:         "public registry success",
+			dockerClient: supportedClient,
+			imageRef:     "127.0.0.1:51670/busybox:latest",
+		},
+		{
+			name:         "public registry success, no explicit tag",
+			dockerClient: supportedClient,
+			imageRef:     "127.0.0.1:51670/busybox",
+		},
+		{
+			name:         "public ECR success",
+			dockerClient: supportedClient,
+			imageRef:     "public.ecr.aws/amazonlinux/amazonlinux:2",
+		},
+		{
+			name: "Docker client version too old",
+			dockerClient: func() DockerClient {
+				sdkClientFactory := sdkclientfactory.NewFactory(context.Background(), dockerEndpoint)
+				cfg := &config.Config{}
+				defaultClient, err := NewDockerGoClient(sdkClientFactory, cfg, context.Background())
+				require.NoError(t, err)
+				version := dockerclient.GetSupportedDockerAPIVersion(dockerclient.Version_1_29)
+				unsupportedClient, err := defaultClient.WithVersion(version)
+				require.NoError(t, err)
+				return unsupportedClient
+			}(),
+			imageRef:      "public.ecr.aws/amazonlinux/amazonlinux:2",
+			expectedError: `"distribution inspect" requires API version 1.30`,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			distInspect, err := tc.dockerClient.PullImageManifest(
+				context.Background(), tc.imageRef, tc.authData)
+			if tc.expectedError == "" {
+				require.NoError(t, err)
+				assert.NotEmpty(t, distInspect.Descriptor.Digest.Encoded())
+			} else {
+				assert.ErrorContains(t, err, tc.expectedError)
+			}
+		})
+	}
+}

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -31,6 +31,7 @@ import (
 	types "github.com/docker/docker/api/types"
 	container0 "github.com/docker/docker/api/types/container"
 	filters "github.com/docker/docker/api/types/filters"
+	registry "github.com/docker/docker/api/types/registry"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -316,6 +317,21 @@ func (m *MockDockerClient) PullImage(arg0 context.Context, arg1 string, arg2 *co
 func (mr *MockDockerClientMockRecorder) PullImage(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockDockerClient)(nil).PullImage), arg0, arg1, arg2, arg3)
+}
+
+// PullImageManifest mocks base method.
+func (m *MockDockerClient) PullImageManifest(arg0 context.Context, arg1 string, arg2 *container.RegistryAuthenticationData) (registry.DistributionInspect, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PullImageManifest", arg0, arg1, arg2)
+	ret0, _ := ret[0].(registry.DistributionInspect)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PullImageManifest indicates an expected call of PullImageManifest.
+func (mr *MockDockerClientMockRecorder) PullImageManifest(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImageManifest", reflect.TypeOf((*MockDockerClient)(nil).PullImageManifest), arg0, arg1, arg2)
 }
 
 // RemoveContainer mocks base method.

--- a/agent/dockerclient/sdkclient/interface.go
+++ b/agent/dockerclient/sdkclient/interface.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/volume"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -44,6 +45,7 @@ type Client interface {
 	ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error)
 	ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error
 	ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error)
+	DistributionInspect(ctx context.Context, imageRef, encodedRegistryAuth string) (registry.DistributionInspect, error)
 	Events(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error)
 	ImageImport(ctx context.Context, source types.ImageImportSource, ref string,
 		options types.ImageImportOptions) (io.ReadCloser, error)

--- a/agent/dockerclient/sdkclient/mocks/sdkclient_mocks.go
+++ b/agent/dockerclient/sdkclient/mocks/sdkclient_mocks.go
@@ -28,6 +28,7 @@ import (
 	events "github.com/docker/docker/api/types/events"
 	filters "github.com/docker/docker/api/types/filters"
 	network "github.com/docker/docker/api/types/network"
+	registry "github.com/docker/docker/api/types/registry"
 	volume "github.com/docker/docker/api/types/volume"
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -229,6 +230,21 @@ func (m *MockClient) ContainerTop(arg0 context.Context, arg1 string, arg2 []stri
 func (mr *MockClientMockRecorder) ContainerTop(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerTop", reflect.TypeOf((*MockClient)(nil).ContainerTop), arg0, arg1, arg2)
+}
+
+// DistributionInspect mocks base method.
+func (m *MockClient) DistributionInspect(arg0 context.Context, arg1, arg2 string) (registry.DistributionInspect, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DistributionInspect", arg0, arg1, arg2)
+	ret0, _ := ret[0].(registry.DistributionInspect)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DistributionInspect indicates an expected call of DistributionInspect.
+func (mr *MockClientMockRecorder) DistributionInspect(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DistributionInspect", reflect.TypeOf((*MockClient)(nil).DistributionInspect), arg0, arg1, arg2)
 }
 
 // Events mocks base method.

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc3
 	github.com/opencontainers/runtime-spec v1.1.0
 	github.com/pborman/uuid v1.2.1
@@ -56,7 +57,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -21,39 +21,86 @@ REGISTRY_IMAGE="public.ecr.aws/docker/library/registry:2.7.1"
 ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 cd "${ROOT}"
 
-REGISTRY_CONTAINER_NAME="test-ecs-registry"
+# Starts a registry container
+start_registry() {
+    local REGISTRY_CONTAINER_NAME=$1
+    local HOST_ADDRESS=$2
+    local HOST_HTPASSWD_PATH=$3 # Optional
 
-echo "Removing $REGISTRY_CONTAINER_NAME"
-# stop and remove the registry container. The script will not exit if the container is not running
-docker stop "$REGISTRY_CONTAINER_NAME" || true && docker rm "$REGISTRY_CONTAINER_NAME" || true
+    echo "Removing $REGISTRY_CONTAINER_NAME"
+    # stop and remove the registry container. The script will not exit if the container is not running
+    docker stop "$REGISTRY_CONTAINER_NAME" || true && docker rm "$REGISTRY_CONTAINER_NAME" || true
 
-echo "Running $REGISTRY_CONTAINER_NAME"
-docker run -d --name="$REGISTRY_CONTAINER_NAME" -e SETTINGS_FLAVOR=local -p "127.0.0.1:51670:5000" "${REGISTRY_IMAGE}"
-# give the registry some seconds to get ready for pushes
-sleep 7
+    echo "Running $REGISTRY_CONTAINER_NAME"
+    if [ -z "$HOST_HTPASSWD_PATH" ]; then
+        docker run -d --name="$REGISTRY_CONTAINER_NAME" \
+            -e SETTINGS_FLAVOR=local \
+            -p "${HOST_ADDRESS}:5000" "${REGISTRY_IMAGE}"
+    else
+        local HOST_HTPASSWD_DIR HTPASSWD_FILENAME
+        HOST_HTPASSWD_DIR=$(dirname "$HOST_HTPASSWD_PATH")
+        HTPASSWD_FILENAME=$(basename "$HOST_HTPASSWD_PATH")
+        docker run -d --name="$REGISTRY_CONTAINER_NAME" \
+            -e SETTINGS_FLAVOR=local \
+            -e REGISTRY_AUTH_HTPASSWD_REALM=basic-realm \
+            -e REGISTRY_AUTH_HTPASSWD_PATH="/agent-integ-htpasswd/${HTPASSWD_FILENAME}" \
+            -v "${HOST_HTPASSWD_DIR}:/agent-integ-htpasswd" \
+            -p "${HOST_ADDRESS}:5000" "${REGISTRY_IMAGE}"
+    fi
+
+    # give the registry some seconds to get ready for pushes
+    sleep 7
+
+}
 
 mirror_local_image() {
   echo "Mirroring $1"
-  docker tag $1 $2
-  docker push $2
-  docker rmi $2
+  docker tag "$1" "$2"
+  docker push "$2"
+  docker rmi "$2"
 }
+
+# Pull busybox image for later use
+docker pull public.ecr.aws/docker/library/busybox:1.34.1
+
+# --- Start public registry ---
+REGISTRY_CONTAINER_NAME="test-ecs-registry"
+HOST_ADDRESS="127.0.0.1:51670"
+start_registry $REGISTRY_CONTAINER_NAME $HOST_ADDRESS 
 
 for image in "amazon/amazon-ecs-netkitten" "amazon/amazon-ecs-volumes-test" \
 				"amazon/image-cleanup-test-image1" "amazon/image-cleanup-test-image2" \
 				"amazon/image-cleanup-test-image3" "amazon/amazon-ecs-exec-command-agent-test"; do
-  mirror_local_image "${image}:make" "127.0.0.1:51670/${image}:latest"
+    mirror_local_image "${image}:make" "${HOST_ADDRESS}/${image}:latest"
 done
 
 if [[ "$(uname -m)" == "x86_64" ]]; then
-    mirror_local_image "amazon/fluentd:make" "127.0.0.1:51670/amazon/fluentd:latest"
+    mirror_local_image "amazon/fluentd:make" "${HOST_ADDRESS}/amazon/fluentd:latest"
 fi
 
 # Remove the tag so this image can be deleted successfully in the docker image cleanup integ tests
 docker rmi amazon/image-cleanup-test-image1:make amazon/image-cleanup-test-image2:make amazon/image-cleanup-test-image3:make
 
-docker pull public.ecr.aws/docker/library/busybox:1.34.1
-mirror_local_image public.ecr.aws/docker/library/busybox:1.34.1 "127.0.0.1:51670/busybox:latest"
+# Add a busybox image to the registry
+mirror_local_image public.ecr.aws/docker/library/busybox:1.34.1 "${HOST_ADDRESS}/busybox:latest"
+
+# --- Start private registry ---
+
+# Set up an htpasswd file containing test auth credentials for the registry
+# Username is 'username' and password is 'password'
+# The password is hashed with bcrypt
+HOST_HTPASSWD_PATH="/tmp/private-test-registry-htpasswd/htpasswd"
+mkdir -p "$(dirname "$HOST_HTPASSWD_PATH")"
+# shellcheck disable=SC2016
+echo 'username:$2y$10$agMyRiMiqDWu.W6RpS3LS.qowb3wwee5BSkonzVp.sx1phbAK.H1a' > "$HOST_HTPASSWD_PATH"
+
+REGISTRY_CONTAINER_NAME="test-ecs-registry-private"
+HOST_ADDRESS="127.0.0.1:51671"
+start_registry $REGISTRY_CONTAINER_NAME $HOST_ADDRESS $HOST_HTPASSWD_PATH
+
+# Upload images
+echo "password" | docker login -u username --password-stdin "$HOST_ADDRESS"
+mirror_local_image public.ecr.aws/docker/library/busybox:1.34.1 "${HOST_ADDRESS}/busybox:latest"
 
 # create a context folder used by docker build. It will only have a file
 # full of random bits so that the parallel pull images are different.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds `PullImageManifest` method to `DockerClient` interface and adds an implementation of the method for `*dockerGoClient`. The method is supposed to get image manifest for the provided image reference and return the manifest as a value of `registry.DistributionInspect` type. 

A new integration test is added for `*dockerGoClient`'s implementation of `PullImageManifest` that checks that the implementation works for public and private registries. For the test, `scripts/setup-test-registry` script is updated to start a private registry on the host in addition to the public registry it already starts. 

### Implementation details
<!-- How are the changes implemented? -->
* A new method `PullImageManifest` is added to `DockerClient` interface. 
* The method is implemented for `*dockerGoClient` type. The implementation resolves registry credentials in the same way as `PullImage` and then calls Docker client's [DistributionInspect](https://pkg.go.dev/github.com/docker/docker/client#Client.DistributionInspect) API to fetch the image manifest from the registry. 
* A new integration test `TestImageManifestPullInteg` is added that checks that `PullImageManifest` method of `*dockerGoClient` is able to pull image manifests from public and private registries. `scripts/setup-test-registry` script is updated to start a private registry in addition to the public registry that it already starts. The private registry is used by the test. The private registry uses basic auth credentials to authenticate and authorize requests. The script generates an [htpasswd](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) file which is provided to the registry. The file contains a single basic auth username/password pair where the username is "username" and password is "password". Password in the file is hashed using [bcrypt](https://en.wikipedia.org/wiki/Bcrypt) algorithm as required by the registry container. So, requests to the registry need to include basic auth credentials that match this username and password pair. 
* `sdkclient.Client` interface that is a wrapper around Docker client's API is updated to include `DistributionInspect` method. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Added new unit and integration tests.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
Enhancement: Add image manifest pull functionality to DockerClient

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
