### PR TITLE
Add retries to DockerClient's manifest pull functionality and add utils/reference package

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -376,7 +376,7 @@ func (dg *dockerGoClient) PullImageManifest(
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		// Context was done before manifest could be pulled
 		if errors.Is(ctxErr, context.DeadlineExceeded) {
-			timeoutErr := &DockerTimeoutError{time.Now().Sub(startTime), "MANIFEST_PULLED"}
+			timeoutErr := &DockerTimeoutError{time.Since(startTime), "MANIFEST_PULLED"}
 			return registry.DistributionInspect{}, timeoutErr
 		}
 		return registry.DistributionInspect{}, wrapManifestPullErrorAsNamedError(imageRef, ctxErr)

--- a/agent/dockerclient/dockerapi/errors.go
+++ b/agent/dockerclient/dockerapi/errors.go
@@ -151,6 +151,20 @@ func (err CannotPullContainerError) ErrorName() string {
 	return "CannotPullContainerError"
 }
 
+// CannotPullImageManifestError indicates any error when trying to pull a container image manifest.
+type CannotPullImageManifestError struct {
+	FromError error
+}
+
+func (err CannotPullImageManifestError) Error() string {
+	return err.FromError.Error()
+}
+
+// ErrorName returns the name of CannotPullImageManifestError.
+func (err CannotPullImageManifestError) ErrorName() string {
+	return "CannotPullImageManifestError"
+}
+
 // CannotPullECRContainerError indicates any error when trying to pull
 // a container image from ECR
 type CannotPullECRContainerError struct {

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -28,6 +28,7 @@ import (
 	dockerclient "github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	status "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
+	errors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
 	types "github.com/docker/docker/api/types"
 	container0 "github.com/docker/docker/api/types/container"
 	filters "github.com/docker/docker/api/types/filters"
@@ -320,11 +321,11 @@ func (mr *MockDockerClientMockRecorder) PullImage(arg0, arg1, arg2, arg3 interfa
 }
 
 // PullImageManifest mocks base method.
-func (m *MockDockerClient) PullImageManifest(arg0 context.Context, arg1 string, arg2 *container.RegistryAuthenticationData) (registry.DistributionInspect, error) {
+func (m *MockDockerClient) PullImageManifest(arg0 context.Context, arg1 string, arg2 *container.RegistryAuthenticationData) (registry.DistributionInspect, errors.NamedError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PullImageManifest", arg0, arg1, arg2)
 	ret0, _ := ret[0].(registry.DistributionInspect)
-	ret1, _ := ret[1].(error)
+	ret1, _ := ret[1].(errors.NamedError)
 	return ret0, ret1
 }
 

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.4.1
 	github.com/deniswernert/udev v0.0.0-20170418162847-a12666f7b5a1
+	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0
@@ -42,7 +43,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/didip/tollbooth v4.0.2+incompatible // indirect
-	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/agent/utils/reference/reference.go
+++ b/agent/utils/reference/reference.go
@@ -1,0 +1,35 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Utilities for container image reference strings.
+package reference
+
+import (
+	"github.com/docker/distribution/reference"
+	"github.com/opencontainers/go-digest"
+)
+
+// Helper function to parse an image reference and get digest from it if found.
+// The caller must check that the returned digest is non-empty before using it.
+func GetDigestFromImageRef(imageRef string) digest.Digest {
+	parsedRef, err := reference.Parse(imageRef)
+	if err != nil {
+		return ""
+	}
+	switch v := parsedRef.(type) {
+	case reference.Digested:
+		return v.Digest()
+	default:
+		return ""
+	}
+}

--- a/agent/utils/reference/reference_test.go
+++ b/agent/utils/reference/reference_test.go
@@ -1,0 +1,56 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package reference
+
+import (
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageFromDigest(t *testing.T) {
+	tcs := []struct {
+		image          string
+		expectedDigest string
+	}{
+		{"", ""},
+		{"c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966", ""},
+		{"sha256:c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966", ""},
+		{"ubuntu", ""},
+		{"ubuntu:latest", ""},
+		{
+			"ubuntu@sha256:c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
+			"c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
+		},
+		{"public.ecr.aws/library/ubuntu", ""},
+		{"public.ecr.aws/library/ubuntu:latest", ""},
+		{
+			"public.ecr.aws/library/ubuntu@sha256:c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
+			"c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.image, func(t *testing.T) {
+			dgst := GetDigestFromImageRef(tc.image)
+			if tc.expectedDigest == "" {
+				assert.Empty(t, dgst)
+			} else {
+				expected, err := digest.Parse("sha256:" + tc.expectedDigest)
+				require.NoError(t, err)
+				assert.Equal(t, expected, dgst)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…a NamedError

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This is a follow-up to https://github.com/aws/amazon-ecs-agent/pull/4140 which added a new `PullImageManifest` method to `DockerClient` that can be used to pull image manifest from a registry. The changes in this PR are - 
* Add retry logic to the implementation of `PullImageManifest` so that transient issues do not cause transition failure. The retry strategy is the same as that for `PullImage`.
* Update return type of `PullImageManifest` so that it returns a more concrete `NamedError` type instead of the more general `error` type to make it in-line with other methods of the interface. 

In addition to the changes above, this PR also introduces a new `utils/reference` package that offers util functions that deal with container image references. The only function added to the package in this PR is `GetDigestFromImageRef` that can be used to parse a container image reference string and get a digest from it. This package will be used in an upcoming PR.

### Implementation details
<!-- How are the changes implemented? -->
* Update `PullImageManifest` method so that it returns a `apierrors.NamedError` instead of `error`.
* Add a new `manifestPullBackoff retry.Backoff` field to `dockerGoClient`. This is the retry strategy for manifest pulls. It is initialized with the same settings as the existing `imagePullBackoff` field that is the retry strategy for image pulls. The reason to use same retry strategy is that both methods call image registries.
* Update the implementation of `*dockerGoClient.PullImageManifest` so that it retries if `DistributionInspect` API fails. Also update the returned errors so that they are of type `apierrors.NamedError`. 
* Add `agent/utils/reference/reference.go` and add `GetDigestFromImageRef` function to it. The function implements logic to parse an image reference string and retrieve a digest from it if available. Add unit tests for this function.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: Add retries to DockerClient's image pull functionality and add utils/reference package.

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
