### PR TITLE
Update ca-certs base image

### DIFF
--- a/misc/certs/Dockerfile
+++ b/misc/certs/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:stable-20211201-slim
+FROM public.ecr.aws/docker/library/debian:stable-20240110-slim
 
 RUN apt-get update &&  \
     apt-get install -y ca-certificates && \

--- a/misc/certs/Dockerfile
+++ b/misc/certs/Dockerfile
@@ -3,8 +3,3 @@ FROM public.ecr.aws/docker/library/debian:stable-20240110-slim
 RUN apt-get update &&  \
     apt-get install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-
-# If anyone has a better idea for how to trim undesired certs or a better ca list to use, I'm all ears
-RUN cp /etc/ca-certificates.conf /tmp/caconf && cat /tmp/caconf | \
-  grep -v "mozilla/CNNIC_ROOT\.crt" > /etc/ca-certificates.conf && \
-  update-ca-certificates --fresh


### PR DESCRIPTION
re-opening of https://github.com/aws/amazon-ecs-agent/pull/4079 due to CI issues

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
With this PR, ecs-agent will pull in a newer ca-certificates package, from the current stable release of Debian, and will no longer attempt to remove the CNNIC certs, which have already been removed upstream

### Implementation details
<!-- How are the changes implemented? -->
The `stable-20211201-slim` image that is currently used to source `ca-certificates` is running Debian's `bullseye` release (a.k.a. `oldstable`), and as such, pulls in [ca-certificates version 20210119](https://packages.debian.org/bullseye/ca-certificates). By using a newer stable image (`stable-20240110-slim`), the newer [ca-certificates version 20230311](https://packages.debian.org/bookworm/ca-certificates) will be used.

I also noticed that the certs Dockerfile was performing an extra step to attempt to remove the `CNNIC_ROOT` certificate, however this cert [no longer appears to be present](https://packages.debian.org/bookworm/all/ca-certificates/filelist) in current versions of the package.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
`make test` was run. There were some upgrade related tests that failed there (`TestCNIPluginVersionUpgrade` mainly), however it appears to be the same result from an unmodified `master` branch.

New tests cover the changes: <!-- yes|no --> no; There is no change in functionality to test

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Update ca-certificates
**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No functionality changes were made.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

