### PR TITLE
Use resolved digest for image pulls

### DIFF
--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -462,6 +462,20 @@ func (mr *MockDockerClientMockRecorder) SystemPing(arg0, arg1 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemPing", reflect.TypeOf((*MockDockerClient)(nil).SystemPing), arg0, arg1)
 }
 
+// TagImage mocks base method.
+func (m *MockDockerClient) TagImage(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TagImage", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TagImage indicates an expected call of TagImage.
+func (mr *MockDockerClientMockRecorder) TagImage(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagImage", reflect.TypeOf((*MockDockerClient)(nil).TagImage), arg0, arg1, arg2)
+}
+
 // Version mocks base method.
 func (m *MockDockerClient) Version(arg0 context.Context, arg1 time.Duration) (string, error) {
 	m.ctrl.T.Helper()

--- a/agent/dockerclient/sdkclient/interface.go
+++ b/agent/dockerclient/sdkclient/interface.go
@@ -55,6 +55,7 @@ type Client interface {
 	ImagePull(ctx context.Context, refStr string, options types.ImagePullOptions) (io.ReadCloser, error)
 	ImageRemove(ctx context.Context, imageID string, options types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem,
 		error)
+	ImageTag(ctx context.Context, source, target string) error
 	Ping(ctx context.Context) (types.Ping, error)
 	PluginList(ctx context.Context, filter filters.Args) (types.PluginsListResponse, error)
 	VolumeCreate(ctx context.Context, options volume.CreateOptions) (volume.Volume, error)

--- a/agent/dockerclient/sdkclient/mocks/sdkclient_mocks.go
+++ b/agent/dockerclient/sdkclient/mocks/sdkclient_mocks.go
@@ -353,6 +353,20 @@ func (mr *MockClientMockRecorder) ImageRemove(arg0, arg1, arg2 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageRemove", reflect.TypeOf((*MockClient)(nil).ImageRemove), arg0, arg1, arg2)
 }
 
+// ImageTag mocks base method.
+func (m *MockClient) ImageTag(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ImageTag", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ImageTag indicates an expected call of ImageTag.
+func (mr *MockClientMockRecorder) ImageTag(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageTag", reflect.TypeOf((*MockClient)(nil).ImageTag), arg0, arg1, arg2)
+}
+
 // Info mocks base method.
 func (m *MockClient) Info(arg0 context.Context) (types.Info, error) {
 	m.ctrl.T.Helper()

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry/constant_backoff.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry/constant_backoff.go
@@ -1,0 +1,33 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package retry
+
+import "time"
+
+// A simple backoff strategy that backs off the same amount of time for each iteration.
+type ConstantBackoff struct {
+	interval time.Duration
+}
+
+func NewConstantBackoff(interval time.Duration) ConstantBackoff {
+	return ConstantBackoff{interval: interval}
+}
+
+func (cb ConstantBackoff) Duration() time.Duration {
+	return cb.interval
+}
+
+func (cb ConstantBackoff) Reset() {
+	// Nothing to reset
+}

--- a/ecs-agent/utils/retry/constant_backoff.go
+++ b/ecs-agent/utils/retry/constant_backoff.go
@@ -1,0 +1,33 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package retry
+
+import "time"
+
+// A simple backoff strategy that backs off the same amount of time for each iteration.
+type ConstantBackoff struct {
+	interval time.Duration
+}
+
+func NewConstantBackoff(interval time.Duration) ConstantBackoff {
+	return ConstantBackoff{interval: interval}
+}
+
+func (cb ConstantBackoff) Duration() time.Duration {
+	return cb.interval
+}
+
+func (cb ConstantBackoff) Reset() {
+	// Nothing to reset
+}

--- a/ecs-agent/utils/retry/constant_backoff_test.go
+++ b/ecs-agent/utils/retry/constant_backoff_test.go
@@ -1,0 +1,28 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package retry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConstantBackoff(t *testing.T) {
+	backoff := NewConstantBackoff(2 * time.Second)
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, 2*time.Second, backoff.Duration())
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR updates image pull logic to use a resolved image manifest digest if one is available. Image manifest digests are resolved during container transition to `MANIFEST_PULLED` state. The change ensures that the pulled image is the same as pointed by the resolved digest. 

### Implementation details
<!-- How are the changes implemented? -->
* Add a new method `TagImage` to `DockerClient` interface and its implementation. The method tags an image on the host. The implementation performs retries using a new `ConstantBackoff` strategy that backs off the same duration every time. A constant backoff retry strategy is fine in this case as there is no external service involved. 
* Add a new `ConstantBackoff` backoff strategy under `ecs-agent` module. The strategy returns the same amount of backoff duration regardless of how many times its `Duration` method is called. 
* Update `*DockerTaskEngine.pullAndUpdateContainerReference` method that is used for pulling container images so that it uses the container's `ImageDigest` field to prepare a canonical reference to the image to be pulled. The method tags the pulled image with `Container.Image` if a different image reference was used to pull the image so that image caching and image cleanup continue to work as before. 
* Add a new method `GetCanonicalRef` to `agent/utils/reference` package that returns a canonical image reference given an image reference and a manifest digest. 
* Test updates and new tests.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
* Added a new integration test named `TestPullContainerWithAndWithoutDigestInteg` to check that `*DockerTaskEngine.pullContainer` can pull images for containers with and without an `ImageDigest` set. 
* Added a new integration test named `TestPullContainerWithAndWithoutDigestConsistency` to check that `*DockerTaskEngine.pullContainer` pulls the same image with or without a digest set and the image can be inspected with `container.Image` field in both cases. 

In addition to the integration tests above, performed the following manual tests. 
* Ran a variety of tasks with Agent configured to use `always` image pull behavior. Checked that all tasks ran as expected. Images were pulled using digests and tagged with the image reference in the task definition. Images were cleaned up without any issues. 
* Ran a variety of tasks with Agent configured to use `once` and then `prefer-cached` image pull behavior. Checked that all tasks ran as expected. Cached images were used in both cases when found. Image cleanup worked as expected with `once` image pull behavior. Image pull is disabled when `prefer-cached` image pull behavior is used. 
* Ran a simple task multiple times with an Agent built with changes in this PR and again with an Agent built against master branch. Both Agents were configured to use `always` image pull behavior to force image pulls. Measured the task average start times (`startedAt` - `createdAt`) and task pull times (`pullStoppedAt` - `pullStartedAt`) for both cases. Changes to resolve image manifest digest in https://github.com/aws/amazon-ecs-agent/pull/4152 caused an additional delay in task start times that ranged from 300ms (ECR) to 900ms (Dockerhub), however, with this PR the image pulls are now slightly faster. Pull time for an image that's already available on the host is reduced from ~700ms (Dockerhub), ~250ms (public ECR), and ~130ms (private ECR) to ~260ms (Dockerhub), ~100ms (public ECR), and ~50ms (private ECR). Combined with changes to resolve image manifest digests (#4152) the overall average increase in task start time in my test environment is ~500ms (Dockerhub) and ~150ms (ECR). 

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
