### PR TITLE
Integrate restart policy into the container object

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart/restart_tracker.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart/restart_tracker.go
@@ -1,0 +1,99 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package restart
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
+)
+
+type RestartTracker struct {
+	RestartCount  int       `json:"restartCount,omitempty"`
+	LastRestartAt time.Time `json:"lastRestartAt,omitempty"`
+	restartPolicy RestartPolicy
+	lock          sync.RWMutex
+}
+
+// RestartPolicy represents a policy that contains key information considered when
+// deciding whether or not a container should be restarted after it has exited.
+type RestartPolicy struct {
+	Enabled              bool          `json:"enabled"`
+	IgnoredExitCodes     []int         `json:"ignoredExitCodes"`
+	RestartAttemptPeriod time.Duration `json:"restartAttemptPeriod"`
+}
+
+func NewRestartTracker(restartPolicy RestartPolicy) *RestartTracker {
+	return &RestartTracker{
+		restartPolicy: restartPolicy,
+	}
+}
+
+func (rt *RestartTracker) GetLastRestartAt() time.Time {
+	rt.lock.RLock()
+	defer rt.lock.RUnlock()
+	return rt.LastRestartAt
+}
+
+func (rt *RestartTracker) GetRestartCount() int {
+	rt.lock.RLock()
+	defer rt.lock.RUnlock()
+	return rt.RestartCount
+}
+
+// RecordRestart updates the restart tracker's metadata after a restart has occurred.
+// This metadata is used to calculate when restarts should occur and track how many
+// have occurred. It is not the job of this method to determine if a restart should
+// occur or restart the container.
+func (rt *RestartTracker) RecordRestart() {
+	rt.lock.Lock()
+	defer rt.lock.Unlock()
+	rt.RestartCount++
+	rt.LastRestartAt = time.Now()
+}
+
+// ShouldRestart returns whether the container should restart and a reason string
+// explaining why not. The reset attempt period will be calculated first
+// with LastRestart at, using the passed in startedAt if it does not exist.
+func (rt *RestartTracker) ShouldRestart(exitCode *int, startedAt time.Time,
+	desiredStatus apicontainerstatus.ContainerStatus) (bool, string) {
+	rt.lock.RLock()
+	defer rt.lock.RUnlock()
+
+	if !rt.restartPolicy.Enabled {
+		return false, "restart policy is not enabled"
+	}
+	if desiredStatus == apicontainerstatus.ContainerStopped {
+		return false, "container's desired status is stopped"
+	}
+	if exitCode == nil {
+		return false, "exit code is nil"
+	}
+	for _, ignoredCode := range rt.restartPolicy.IgnoredExitCodes {
+		if ignoredCode == *exitCode {
+			return false, fmt.Sprintf("exit code %d should be ignored", *exitCode)
+		}
+	}
+
+	startTime := startedAt
+	if !rt.LastRestartAt.IsZero() {
+		startTime = rt.LastRestartAt
+	}
+	if time.Since(startTime) < rt.restartPolicy.RestartAttemptPeriod {
+		return false, "attempt reset period has not elapsed"
+	}
+	return true, ""
+}

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -16,6 +16,7 @@ github.com/aws/amazon-ecs-agent/ecs-agent/api/appnet/mocks
 github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment
 github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment/resource
 github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment/resource/mocks
+github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart
 github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status
 github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs
 github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

- Integrates restart policy into the Container object, with a helper function to check if the container restart policy is defined and enabled.
- Initializes the RestartTracker object when unmarshaling the task payload, if the container has a restart policy defined and enabled.
- `go mod vendor` in the agent/ dir to pull in ecs-agent/ shared lib changes.

Exact struct naming is still subject to change but this should roughly match the GA feature.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
