### PR TITLE
Additional integration tests for digest resolution changes

### DIFF
--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -178,6 +178,14 @@ func verifyContainerStoppedStateChange(t *testing.T, taskEngine TaskEngine) {
 		"Expected container to be STOPPED")
 }
 
+func verifyContainerStoppedStateChangeWithReason(t *testing.T, taskEngine TaskEngine, reason string) {
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	event := <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).Status, apicontainerstatus.ContainerStopped,
+		"Expected container to be STOPPED")
+	assert.Equal(t, reason, event.(api.ContainerStateChange).Reason)
+}
+
 func verifyContainerStoppedStateChangeWithRuntimeID(t *testing.T, taskEngine TaskEngine) {
 	stateChangeEvents := taskEngine.StateChangeEvents()
 	event := <-stateChangeEvents

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -335,11 +335,12 @@ func TestResourceContainerProgressionFailure(t *testing.T) {
 	)
 	mockTime.EXPECT().Now().Return(time.Now()).AnyTimes()
 
-	// Prepare mock image manifest digest for test
+	// Container might progress to MANIFEST_PULLED state (there is a race condition)
 	manifestPullClient := mock_dockerapi.NewMockDockerClient(ctrl)
-	client.EXPECT().WithVersion(dockerclient.Version_1_35).Return(manifestPullClient, nil)
+	client.EXPECT().WithVersion(dockerclient.Version_1_35).AnyTimes().Return(manifestPullClient, nil)
 	manifestPullClient.EXPECT().
 		PullImageManifest(gomock.Any(), sleepContainer.Image, nil).
+		AnyTimes().
 		Return(registry.DistributionInspect{}, nil)
 
 	err := taskEngine.Init(ctx)

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -859,9 +859,6 @@ func TestInvalidImageInteg(t *testing.T) {
 	verifyContainerStoppedStateChangeWithReason(t, taskEngine,
 		"CannotPullImageManifestError: Error response from daemon: manifest unknown: manifest unknown")
 	verifyTaskStoppedStateChange(t, taskEngine)
-
-	err := taskEngine.(*DockerTaskEngine).removeContainer(task, container)
-	require.NoError(t, err, "failed to remove container during cleanup")
 }
 
 // Tests that a task with an image that has a digest specified works normally.

--- a/agent/utils/reference/reference.go
+++ b/agent/utils/reference/reference.go
@@ -82,7 +82,7 @@ func GetDigestFromRepoDigests(repoDigests []string, imageRef string) (digest.Dig
 // Given an image reference and a manifest digest string, returns a canonical reference
 // for the image.
 // If the image reference has a digest then the canonical reference will still use the provided
-// manifest digest overwriting the exiting digest in the image reference.
+// manifest digest overwriting the existing digest in the image reference.
 func GetCanonicalRef(imageRef string, manifestDigest string) (reference.Canonical, error) {
 	parsedDigest, err := digest.Parse(manifestDigest)
 	if err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds a couple of additional integration tests for changes to enable image digest resolution in ECS Agent. The tests are -
* `TestInvalidImageInteg` - tests that a task with a single container that has an invalid image fails with a `CannotPullImageManifestError` error.
* `TestImageWithDigestInteg` - tests that a task with a single container whose image has a valid digest specified works as expected.

The PR also includes a change to fix flakiness of `TestManifestPulledDoesNotDependOnContainerOrdering` integration test. The test is flaky because it assumes that `public.ecr.aws/docker/library/busybox:1.36.1` image is immutable but it's not. The PR also changes the test to use an image from local test registry instead as using a remote image does not affect the test.

Some minor refactoring changes and a typo fix is also included in this PR.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: Additional integration tests for digest resolution changes

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
