### PR TITLE
Fix ECS installation command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The best source of information on running this software is the
 ### On the Amazon Linux AMI
 
 On the [Amazon Linux AMI](https://aws.amazon.com/amazon-linux-ami/), we provide an installable RPM which can be used via
-`sudo yum install ecs-init && sudo start ecs`. This is the recommended way to run it in this environment.
+`sudo yum install ecs-init && sudo systemctl start ecs`. This is the recommended way to run it in this environment.
 
 ### On Other Linux AMIs
 


### PR DESCRIPTION
### Summary
The installation command for ECS in the README.md file was incorrect. This pull request fixes the command by replacing `sudo start ecs` with `sudo systemctl start ecs`.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

No, it does not include any breaking model change.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
