### PR TITLE
Add restart count to TMDE v4 response

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -1381,7 +1381,7 @@ func testTMDSRequest[R TMDSResponse](t *testing.T, tc TMDSTestCase[R]) {
 	// Parse the response body
 	var actualResponseBody R
 	err = json.Unmarshal(recorder.Body.Bytes(), &actualResponseBody)
-	require.NoError(t, err)
+	require.NoError(t, err, recorder.Body.String())
 
 	// Assert status code and body
 	assert.Equal(t, tc.expectedStatusCode, recorder.Code)
@@ -1801,8 +1801,9 @@ func TestV4ContainerMetadata(t *testing.T) {
 			setStateExpectations: func(state *mock_dockerstate.MockTaskEngineState) {
 				gomock.InOrder(
 					state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
-					state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true),
+					state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 					state.EXPECT().TaskByID(containerID).Return(task, true).Times(2),
+					state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 				)
 			},
 			expectedStatusCode:   http.StatusOK,
@@ -1817,7 +1818,7 @@ func TestV4ContainerMetadata(t *testing.T) {
 					state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
 					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true),
 					state.EXPECT().TaskByID(containerID).Return(bridgeTask, true),
-					state.EXPECT().ContainerByID(containerID).Return(nil, false),
+					state.EXPECT().ContainerByID(containerID).Return(nil, false).AnyTimes(),
 				)
 			},
 			expectedStatusCode:   http.StatusInternalServerError,
@@ -1832,7 +1833,7 @@ func TestV4ContainerMetadata(t *testing.T) {
 					state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
 					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true),
 					state.EXPECT().TaskByID(containerID).Return(bridgeTask, true),
-					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true).AnyTimes(),
 				)
 			},
 			expectedStatusCode: http.StatusInternalServerError,
@@ -1846,9 +1847,9 @@ func TestV4ContainerMetadata(t *testing.T) {
 			setStateExpectations: func(state *mock_dockerstate.MockTaskEngineState) {
 				gomock.InOrder(
 					state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
-					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true).AnyTimes(),
 					state.EXPECT().TaskByID(containerID).Return(bridgeTask, true),
-					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true).AnyTimes(),
 				)
 			},
 			expectedStatusCode:   http.StatusOK,
@@ -1939,8 +1940,10 @@ func TestV4TaskMetadata(t *testing.T) {
 				gomock.InOrder(
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(task, true).Times(2),
+					state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 					state.EXPECT().TaskByArn(taskARN).Return(task, true),
+					state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
 				)
 			},
@@ -1955,8 +1958,10 @@ func TestV4TaskMetadata(t *testing.T) {
 				gomock.InOrder(
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(pulledTask, true).Times(2),
+					state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 					state.EXPECT().TaskByArn(taskARN).Return(pulledTask, true),
+					state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(pulledContainerNameToDockerContainer, true),
 				)
 			},
@@ -1972,8 +1977,9 @@ func TestV4TaskMetadata(t *testing.T) {
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true).Times(2),
 					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
-					state.EXPECT().ContainerByID(containerID).Return(nil, false),
+					state.EXPECT().ContainerByID(containerID).Return(nil, false).AnyTimes(),
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
+					state.EXPECT().ContainerByID(containerID).Return(nil, false).AnyTimes(),
 				)
 			},
 			expectedStatusCode:   http.StatusOK,
@@ -1988,8 +1994,9 @@ func TestV4TaskMetadata(t *testing.T) {
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true).Times(2),
 					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
-					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true).AnyTimes(),
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true).AnyTimes(),
 				)
 			},
 			expectedStatusCode:   http.StatusOK,
@@ -2004,8 +2011,9 @@ func TestV4TaskMetadata(t *testing.T) {
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true).Times(2),
 					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
-					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true).AnyTimes(),
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true).AnyTimes(),
 				)
 			},
 			expectedStatusCode:   http.StatusOK,
@@ -2340,8 +2348,10 @@ func TestV4TaskMetadataWithTags(t *testing.T) {
 		gomock.InOrder(
 			state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 			state.EXPECT().TaskByArn(taskARN).Return(task, true).AnyTimes(),
+			state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true).AnyTimes(),
 			state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 			state.EXPECT().TaskByArn(taskARN).Return(task, true).AnyTimes(),
+			state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true).AnyTimes(),
 			state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
 		)
 	}
@@ -2495,8 +2505,9 @@ func TestV4TaskMetadataWithTags(t *testing.T) {
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true).Times(2),
 					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
-					state.EXPECT().ContainerByID(containerID).Return(nil, false),
+					state.EXPECT().ContainerByID(containerID).Return(nil, false).AnyTimes(),
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
+					state.EXPECT().ContainerByID(containerID).Return(nil, false).AnyTimes(),
 				)
 			},
 			setECSClientExpectations: happyECSClientExpectations,
@@ -2515,8 +2526,9 @@ func TestV4TaskMetadataWithTags(t *testing.T) {
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true).Times(2),
 					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
-					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true).AnyTimes(),
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true).AnyTimes(),
 				)
 			},
 			setECSClientExpectations: happyECSClientExpectations,
@@ -3002,6 +3014,7 @@ func TestGetTaskProtection(t *testing.T) {
 			state.EXPECT().TaskByArn(taskARN).Return(task, true).Times(2),
 			state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 			state.EXPECT().TaskByArn(taskARN).Return(task, true),
+			state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 			state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
 		)
 	}
@@ -3273,6 +3286,7 @@ func TestUpdateTaskProtection(t *testing.T) {
 			state.EXPECT().TaskByArn(taskARN).Return(task, true).Times(2),
 			state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 			state.EXPECT().TaskByArn(taskARN).Return(task, true),
+			state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 			state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
 		)
 	}

--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -19,6 +19,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
@@ -135,6 +137,10 @@ func augmentContainerResponse(
 		// did not find container, continue on and try next container(s)
 		// we don't return error here to avoid disrupting all of a TMDS response
 		// on a single missing container.
+		logger.Warn("V4 container response: unable to find container in internal state",
+			logger.Fields{
+				field.RuntimeID: containerID,
+			})
 		return v4Response
 	}
 	if dockerContainer.Container.RestartPolicyEnabled() {

--- a/agent/handlers/v4/response_test.go
+++ b/agent/handlers/v4/response_test.go
@@ -132,11 +132,10 @@ func TestNewTaskContainerResponses(t *testing.T) {
 	containerNameToDockerContainer := map[string]*apicontainer.DockerContainer{
 		taskARN: dockerContainer,
 	}
-	gomock.InOrder(
-		state.EXPECT().TaskByArn(taskARN).Return(task, true),
-		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
-		state.EXPECT().TaskByArn(taskARN).Return(task, true),
-	)
+	state.EXPECT().TaskByArn(taskARN).Return(task, true)
+	state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes()
+	state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true)
+	state.EXPECT().TaskByArn(taskARN).Return(task, true)
 
 	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster,
 		availabilityZone, vpcID, containerInstanceArn, task.ServiceName, false)
@@ -150,10 +149,8 @@ func TestNewTaskContainerResponses(t *testing.T) {
 	assert.Equal(t, subnetGatewayIPV4Address, taskResponse.Containers[0].Networks[0].SubnetGatewayIPV4Address)
 	assert.Equal(t, serviceName, taskResponse.ServiceName)
 
-	gomock.InOrder(
-		state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true),
-		state.EXPECT().TaskByID(containerID).Return(task, true).Times(2),
-	)
+	state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes()
+	state.EXPECT().TaskByID(containerID).Return(task, true).Times(2)
 	containerResponse, err := NewContainerResponse(containerID, state)
 	require.NoError(t, err)
 	_, err = json.Marshal(containerResponse)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Update [v4 TMDE](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html) with the restart count of the container, if the container has a restart policy enabled.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

unit tests updated, manual check on restart count being incremented as expected

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
