### PR TITLE
Add BackendStatusString method to ContainerStatus

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status/containerstatus.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status/containerstatus.go
@@ -120,16 +120,26 @@ func (cs *ContainerStatus) BackendStatus(steadyStateStatus ContainerStatus) Cont
 
 // BackendStatusString maps the internal container status in Agent to a backend recognized
 // status string.
-func (cs ContainerStatus) BackendStatusString(steadyStateStatus ContainerStatus) string {
-	if cs == steadyStateStatus {
+//
+// Container steady state can be provided as an option. If provided, it will be used to
+// determine if the backend status is "RUNNING". If not provided, then ContainerRunning is
+// used as the default steady state.
+func (cs ContainerStatus) BackendStatusString(steadyStateStatusPtr *ContainerStatus) string {
+	var steadyState ContainerStatus
+	if steadyStateStatusPtr != nil {
+		steadyState = *steadyStateStatusPtr
+	} else {
+		steadyState = ContainerRunning
+	}
+
+	switch cs {
+	case steadyState:
 		return "RUNNING"
-	}
-
-	if cs == ContainerStopped {
+	case ContainerStopped:
 		return "STOPPED"
+	default:
+		return "PENDING"
 	}
-
-	return "PENDING"
 }
 
 // Terminal returns true if the container status is STOPPED

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status/containerstatus.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status/containerstatus.go
@@ -104,6 +104,8 @@ func (cs *ContainerStatus) ShouldReportToBackend(steadyStateStatus ContainerStat
 
 // BackendStatus maps the internal container status in the agent to that in the
 // backend
+//
+// Deprecated: Use BackendStatusString instead
 func (cs *ContainerStatus) BackendStatus(steadyStateStatus ContainerStatus) ContainerStatus {
 	if *cs == steadyStateStatus {
 		return ContainerRunning
@@ -114,6 +116,20 @@ func (cs *ContainerStatus) BackendStatus(steadyStateStatus ContainerStatus) Cont
 	}
 
 	return ContainerStatusNone
+}
+
+// BackendStatusString maps the internal container status in Agent to a backend recognized
+// status string.
+func (cs ContainerStatus) BackendStatusString(steadyStateStatus ContainerStatus) string {
+	if cs == steadyStateStatus {
+		return "RUNNING"
+	}
+
+	if cs == ContainerStopped {
+		return "STOPPED"
+	}
+
+	return "PENDING"
 }
 
 // Terminal returns true if the container status is STOPPED

--- a/ecs-agent/api/container/status/containerstatus.go
+++ b/ecs-agent/api/container/status/containerstatus.go
@@ -120,16 +120,26 @@ func (cs *ContainerStatus) BackendStatus(steadyStateStatus ContainerStatus) Cont
 
 // BackendStatusString maps the internal container status in Agent to a backend recognized
 // status string.
-func (cs ContainerStatus) BackendStatusString(steadyStateStatus ContainerStatus) string {
-	if cs == steadyStateStatus {
+//
+// Container steady state can be provided as an option. If provided, it will be used to
+// determine if the backend status is "RUNNING". If not provided, then ContainerRunning is
+// used as the default steady state.
+func (cs ContainerStatus) BackendStatusString(steadyStateStatusPtr *ContainerStatus) string {
+	var steadyState ContainerStatus
+	if steadyStateStatusPtr != nil {
+		steadyState = *steadyStateStatusPtr
+	} else {
+		steadyState = ContainerRunning
+	}
+
+	switch cs {
+	case steadyState:
 		return "RUNNING"
-	}
-
-	if cs == ContainerStopped {
+	case ContainerStopped:
 		return "STOPPED"
+	default:
+		return "PENDING"
 	}
-
-	return "PENDING"
 }
 
 // Terminal returns true if the container status is STOPPED

--- a/ecs-agent/api/container/status/containerstatus.go
+++ b/ecs-agent/api/container/status/containerstatus.go
@@ -104,6 +104,8 @@ func (cs *ContainerStatus) ShouldReportToBackend(steadyStateStatus ContainerStat
 
 // BackendStatus maps the internal container status in the agent to that in the
 // backend
+//
+// Deprecated: Use BackendStatusString instead
 func (cs *ContainerStatus) BackendStatus(steadyStateStatus ContainerStatus) ContainerStatus {
 	if *cs == steadyStateStatus {
 		return ContainerRunning
@@ -114,6 +116,20 @@ func (cs *ContainerStatus) BackendStatus(steadyStateStatus ContainerStatus) Cont
 	}
 
 	return ContainerStatusNone
+}
+
+// BackendStatusString maps the internal container status in Agent to a backend recognized
+// status string.
+func (cs ContainerStatus) BackendStatusString(steadyStateStatus ContainerStatus) string {
+	if cs == steadyStateStatus {
+		return "RUNNING"
+	}
+
+	if cs == ContainerStopped {
+		return "STOPPED"
+	}
+
+	return "PENDING"
 }
 
 // Terminal returns true if the container status is STOPPED

--- a/ecs-agent/api/container/status/containerstatus_test.go
+++ b/ecs-agent/api/container/status/containerstatus_test.go
@@ -339,13 +339,14 @@ func TestContainerBackendStatusString(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("%d", tc.status), func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.status.BackendStatusString(ContainerRunning))
+			assert.Equal(t, tc.expected, tc.status.BackendStatusString(nil))
 		})
 	}
 	t.Run("steady state can be provided and maps to RUNNING status", func(t *testing.T) {
+		resourcesProvisioned := ContainerResourcesProvisioned
 		assert.Equal(t, "RUNNING",
-			ContainerResourcesProvisioned.BackendStatusString(ContainerResourcesProvisioned))
+			ContainerResourcesProvisioned.BackendStatusString(&resourcesProvisioned))
 		assert.Equal(t, "PENDING",
-			ContainerRunning.BackendStatusString(ContainerResourcesProvisioned))
+			ContainerRunning.BackendStatusString(&resourcesProvisioned))
 	})
 }

--- a/ecs-agent/api/container/status/containerstatus_test.go
+++ b/ecs-agent/api/container/status/containerstatus_test.go
@@ -322,3 +322,30 @@ func TestContainerStatusJSONUnmarshalInt(t *testing.T) {
 		})
 	}
 }
+
+func TestContainerBackendStatusString(t *testing.T) {
+	tcs := []struct {
+		status   ContainerStatus
+		expected string
+	}{
+		{ContainerStatusNone, "PENDING"},
+		{ContainerManifestPulled, "PENDING"},
+		{ContainerPulled, "PENDING"},
+		{ContainerCreated, "PENDING"},
+		{ContainerRunning, "RUNNING"},
+		{ContainerResourcesProvisioned, "PENDING"},
+		{ContainerStopped, "STOPPED"},
+		{ContainerZombie, "PENDING"},
+	}
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", tc.status), func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.status.BackendStatusString(ContainerRunning))
+		})
+	}
+	t.Run("steady state can be provided and maps to RUNNING status", func(t *testing.T) {
+		assert.Equal(t, "RUNNING",
+			ContainerResourcesProvisioned.BackendStatusString(ContainerResourcesProvisioned))
+		assert.Equal(t, "PENDING",
+			ContainerRunning.BackendStatusString(ContainerResourcesProvisioned))
+	})
+}

--- a/ecs-agent/api/container/status/containerstatus_test.go
+++ b/ecs-agent/api/container/status/containerstatus_test.go
@@ -323,7 +323,8 @@ func TestContainerStatusJSONUnmarshalInt(t *testing.T) {
 	}
 }
 
-func TestContainerBackendStatusString(t *testing.T) {
+// Tests for BackendStatusString method when a steady state is not provided.
+func TestContainerBackendStatusStringDefaultSteadyState(t *testing.T) {
 	tcs := []struct {
 		status   ContainerStatus
 		expected string
@@ -342,11 +343,44 @@ func TestContainerBackendStatusString(t *testing.T) {
 			assert.Equal(t, tc.expected, tc.status.BackendStatusString(nil))
 		})
 	}
-	t.Run("steady state can be provided and maps to RUNNING status", func(t *testing.T) {
-		resourcesProvisioned := ContainerResourcesProvisioned
-		assert.Equal(t, "RUNNING",
-			ContainerResourcesProvisioned.BackendStatusString(&resourcesProvisioned))
-		assert.Equal(t, "PENDING",
-			ContainerRunning.BackendStatusString(&resourcesProvisioned))
+}
+
+// Tests for BackendStatusString method when a steady state is provided.
+func TestBackendStatusSteadyStateProvided(t *testing.T) {
+	containerRunning := ContainerRunning
+	containerResourcesProvisioned := ContainerResourcesProvisioned
+
+	// Test states that should map to PENDING regardless of steady state
+	pendingStates := []ContainerStatus{
+		ContainerStatusNone, ContainerManifestPulled, ContainerPulled,
+		ContainerCreated, ContainerZombie,
+	}
+	for _, tc := range pendingStates {
+		t.Run(fmt.Sprintf("pending - %d", tc), func(t *testing.T) {
+			assert.Equal(t, "PENDING", tc.BackendStatusString(&containerRunning))
+			assert.Equal(t, "PENDING", tc.BackendStatusString(&containerResourcesProvisioned))
+		})
+	}
+
+	// Test that ContainerStopped maps to STOPPED regardless of steady state
+	t.Run("ContainerStopped maps to STOPPED", func(t *testing.T) {
+		assert.Equal(t, "STOPPED", ContainerStopped.BackendStatusString(&containerRunning))
+		assert.Equal(t, "STOPPED", ContainerStopped.BackendStatusString(&containerResourcesProvisioned))
+	})
+
+	// Test that steady state maps to RUNNING
+	t.Run("ContainerRunning maps to RUNNING when steady state is ContainerRunning", func(t *testing.T) {
+		assert.Equal(t, "RUNNING", ContainerRunning.BackendStatusString(&containerRunning))
+	})
+	t.Run("ContainerResourcesProvisioned maps to RUNNING when steady state is ContainerResourcesProvisioned", func(t *testing.T) {
+		assert.Equal(t, "RUNNING", ContainerResourcesProvisioned.BackendStatusString(&containerResourcesProvisioned))
+	})
+
+	// Test that non-steady non-STOPPED state maps to PENDING
+	t.Run("ContainerRunning maps to PENDING when steady state is ContainerResourcesProvisioned", func(t *testing.T) {
+		assert.Equal(t, "PENDING", ContainerRunning.BackendStatusString(&containerResourcesProvisioned))
+	})
+	t.Run("ContainerResourcesProvisioned maps to PENDING when steady state is ContainerRunning", func(t *testing.T) {
+		assert.Equal(t, "PENDING", ContainerResourcesProvisioned.BackendStatusString(&containerRunning))
 	})
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Currently `ContainerStatus` enum and backend recognized container status strings are coupled as `BackendStatus` method that is used to map former to latter returns a `ContainerStatus` and not a `string`. This is not ideal as the coupling restricts the evolution of internal container statuses in Agent. This PR decouples the two by introducing a new `BackendStatusString` method for `ContainerStatus` type that maps the internal container status to a suitable backend recognized status string. Existing `BackendStatus` method is marked as deprecated in this PR.

`BackendStatusString` method is slightly different from `BackendStatus` in that its steady state parameter is optional and defaults to `ContainerRunning`. That will be useful in cases where there is no special steady state for a container.

This decoupling already exists for `TaskStatus` type, this PR extends the same logic to `ContainerStatus`.
https://github.com/aws/amazon-ecs-agent/blob/b702281f0f6aa2fba5614050769aa337d1456853/ecs-agent/api/task/status/taskstatus.go#L69-L78

The new method is not currently used but we plan to use it in the near future. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: Decouple internal container status and backend recognized container status by introducing BackendStatusString() method to map internal container status to a backend recognized container status.

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
