### PR TITLE
Simplify ContainerStatus.BackendStatusString() method

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status/containerstatus.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status/containerstatus.go
@@ -104,8 +104,6 @@ func (cs *ContainerStatus) ShouldReportToBackend(steadyStateStatus ContainerStat
 
 // BackendStatus maps the internal container status in the agent to that in the
 // backend
-//
-// Deprecated: Use BackendStatusString instead
 func (cs *ContainerStatus) BackendStatus(steadyStateStatus ContainerStatus) ContainerStatus {
 	if *cs == steadyStateStatus {
 		return ContainerRunning

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status/containerstatus.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status/containerstatus.go
@@ -120,20 +120,9 @@ func (cs *ContainerStatus) BackendStatus(steadyStateStatus ContainerStatus) Cont
 
 // BackendStatusString maps the internal container status in Agent to a backend recognized
 // status string.
-//
-// Container steady state can be provided as an option. If provided, it will be used to
-// determine if the backend status is "RUNNING". If not provided, then ContainerRunning is
-// used as the default steady state.
-func (cs ContainerStatus) BackendStatusString(steadyStateStatusPtr *ContainerStatus) string {
-	var steadyState ContainerStatus
-	if steadyStateStatusPtr != nil {
-		steadyState = *steadyStateStatusPtr
-	} else {
-		steadyState = ContainerRunning
-	}
-
+func (cs ContainerStatus) BackendStatusString() string {
 	switch cs {
-	case steadyState:
+	case ContainerRunning:
 		return "RUNNING"
 	case ContainerStopped:
 		return "STOPPED"

--- a/ecs-agent/api/container/status/containerstatus.go
+++ b/ecs-agent/api/container/status/containerstatus.go
@@ -104,8 +104,6 @@ func (cs *ContainerStatus) ShouldReportToBackend(steadyStateStatus ContainerStat
 
 // BackendStatus maps the internal container status in the agent to that in the
 // backend
-//
-// Deprecated: Use BackendStatusString instead
 func (cs *ContainerStatus) BackendStatus(steadyStateStatus ContainerStatus) ContainerStatus {
 	if *cs == steadyStateStatus {
 		return ContainerRunning

--- a/ecs-agent/api/container/status/containerstatus.go
+++ b/ecs-agent/api/container/status/containerstatus.go
@@ -120,20 +120,9 @@ func (cs *ContainerStatus) BackendStatus(steadyStateStatus ContainerStatus) Cont
 
 // BackendStatusString maps the internal container status in Agent to a backend recognized
 // status string.
-//
-// Container steady state can be provided as an option. If provided, it will be used to
-// determine if the backend status is "RUNNING". If not provided, then ContainerRunning is
-// used as the default steady state.
-func (cs ContainerStatus) BackendStatusString(steadyStateStatusPtr *ContainerStatus) string {
-	var steadyState ContainerStatus
-	if steadyStateStatusPtr != nil {
-		steadyState = *steadyStateStatusPtr
-	} else {
-		steadyState = ContainerRunning
-	}
-
+func (cs ContainerStatus) BackendStatusString() string {
 	switch cs {
-	case steadyState:
+	case ContainerRunning:
 		return "RUNNING"
 	case ContainerStopped:
 		return "STOPPED"

--- a/ecs-agent/api/container/status/containerstatus_test.go
+++ b/ecs-agent/api/container/status/containerstatus_test.go
@@ -340,47 +340,7 @@ func TestContainerBackendStatusStringDefaultSteadyState(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("%d", tc.status), func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.status.BackendStatusString(nil))
+			assert.Equal(t, tc.expected, tc.status.BackendStatusString())
 		})
 	}
-}
-
-// Tests for BackendStatusString method when a steady state is provided.
-func TestBackendStatusSteadyStateProvided(t *testing.T) {
-	containerRunning := ContainerRunning
-	containerResourcesProvisioned := ContainerResourcesProvisioned
-
-	// Test states that should map to PENDING regardless of steady state
-	pendingStates := []ContainerStatus{
-		ContainerStatusNone, ContainerManifestPulled, ContainerPulled,
-		ContainerCreated, ContainerZombie,
-	}
-	for _, tc := range pendingStates {
-		t.Run(fmt.Sprintf("pending - %d", tc), func(t *testing.T) {
-			assert.Equal(t, "PENDING", tc.BackendStatusString(&containerRunning))
-			assert.Equal(t, "PENDING", tc.BackendStatusString(&containerResourcesProvisioned))
-		})
-	}
-
-	// Test that ContainerStopped maps to STOPPED regardless of steady state
-	t.Run("ContainerStopped maps to STOPPED", func(t *testing.T) {
-		assert.Equal(t, "STOPPED", ContainerStopped.BackendStatusString(&containerRunning))
-		assert.Equal(t, "STOPPED", ContainerStopped.BackendStatusString(&containerResourcesProvisioned))
-	})
-
-	// Test that steady state maps to RUNNING
-	t.Run("ContainerRunning maps to RUNNING when steady state is ContainerRunning", func(t *testing.T) {
-		assert.Equal(t, "RUNNING", ContainerRunning.BackendStatusString(&containerRunning))
-	})
-	t.Run("ContainerResourcesProvisioned maps to RUNNING when steady state is ContainerResourcesProvisioned", func(t *testing.T) {
-		assert.Equal(t, "RUNNING", ContainerResourcesProvisioned.BackendStatusString(&containerResourcesProvisioned))
-	})
-
-	// Test that non-steady non-STOPPED state maps to PENDING
-	t.Run("ContainerRunning maps to PENDING when steady state is ContainerResourcesProvisioned", func(t *testing.T) {
-		assert.Equal(t, "PENDING", ContainerRunning.BackendStatusString(&containerResourcesProvisioned))
-	})
-	t.Run("ContainerResourcesProvisioned maps to PENDING when steady state is ContainerRunning", func(t *testing.T) {
-		assert.Equal(t, "PENDING", ContainerResourcesProvisioned.BackendStatusString(&containerRunning))
-	})
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
https://github.com/aws/amazon-ecs-agent/pull/4167 introduced `ContainerStatus.BackendStatusString()` method that maps internal container status to a backend-recognized container status string. This method takes container steady state as a parameter which still adds coupling between internal container status and backend-recognized status string. To decouple the two further, this PR removes the parameter and un-deprecates `BackendStatus` method which serves a different purpose of mapping internal container status to an internal container status which is eligible for STSC.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
Enhancement: Simplify ContainerStatus.BackendStatusString() method

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
