### PR TITLE
Enable SubmitTaskStateChange for early digest reporting

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+	referenceutil "github.com/aws/amazon-ecs-agent/agent/utils/reference"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
@@ -1520,4 +1521,18 @@ func (c *Container) GetImageName() string {
 	defer c.lock.RUnlock()
 	containerImage := strings.Split(c.Image, ":")[0]
 	return containerImage
+}
+
+// Checks if the container has a resolved image manifest digest.
+// Always returns false for internal containers as those are out-of-scope of digest resolution.
+func (c *Container) DigestResolved() bool {
+	return !c.IsInternal() && c.GetImageDigest() != ""
+}
+
+// Checks if the container's image requires manifest digest resolution.
+// Manifest digest resolution is required if the container's image reference does not
+// have a digest.
+// Always returns false for internal containers as those are out-of-scope of digest resolution.
+func (c *Container) DigestResolutionRequired() bool {
+	return !c.IsInternal() && referenceutil.GetDigestFromImageRef(c.Image) == ""
 }

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -1342,3 +1342,28 @@ func getContainer(hostConfig string, credentialSpecs []string) *Container {
 	c.CredentialSpecs = credentialSpecs
 	return c
 }
+
+func TestDigestResolved(t *testing.T) {
+	t.Run("never resolved for internal container", func(t *testing.T) {
+		assert.False(t, (&Container{Type: ContainerServiceConnectRelay}).DigestResolved())
+	})
+	t.Run("digest resolved if it is populated", func(t *testing.T) {
+		assert.True(t, (&Container{ImageDigest: "digest"}).DigestResolved())
+	})
+	t.Run("digest not resolved if it is not populated", func(t *testing.T) {
+		assert.False(t, (&Container{}).DigestResolved())
+	})
+}
+
+func TestDigestResolutionRequired(t *testing.T) {
+	t.Run("never required for internal containers", func(t *testing.T) {
+		assert.False(t, (&Container{Type: ContainerServiceConnectRelay}).DigestResolutionRequired())
+	})
+	t.Run("required if not found in image reference", func(t *testing.T) {
+		assert.True(t, (&Container{Image: "alpine"}).DigestResolutionRequired())
+	})
+	t.Run("not required if found in image reference", func(t *testing.T) {
+		image := "ubuntu@sha256:ed6d2c43c8fbcd3eaa44c9dab6d94cb346234476230dc1681227aa72d07181ee"
+		assert.False(t, (&Container{Image: image}).DigestResolutionRequired())
+	})
+}

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -141,10 +141,12 @@ func NewTaskStateChangeEvent(task *apitask.Task, reason string) (TaskStateChange
 			taskKnownStatus.String())
 	}
 	if taskKnownStatus == apitaskstatus.TaskManifestPulled && !task.HasAContainerWithResolvedDigest() {
-		return event, fmt.Errorf(
-			"create task state change event api: status %s not eligible for backend reporting as"+
-				" no digests were resolved",
-			apitaskstatus.TaskManifestPulled.String())
+		return event, ErrShouldNotSendEvent{
+			fmt.Sprintf(
+				"create task state change event api: status %s not eligible for backend reporting as"+
+					" no digests were resolved",
+				apitaskstatus.TaskManifestPulled.String()),
+		}
 	}
 
 	event = TaskStateChange{

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -130,7 +130,7 @@ func NewTaskStateChangeEvent(task *apitask.Task, reason string) (TaskStateChange
 		return event, ErrShouldNotSendEvent{task.Arn}
 	}
 	taskKnownStatus := task.GetKnownStatus()
-	if !taskKnownStatus.BackendRecognized() {
+	if taskKnownStatus != apitaskstatus.TaskManifestPulled && !taskKnownStatus.BackendRecognized() {
 		return event, errors.Errorf(
 			"create task state change event api: status not recognized by ECS: %v",
 			taskKnownStatus)
@@ -139,6 +139,12 @@ func NewTaskStateChangeEvent(task *apitask.Task, reason string) (TaskStateChange
 		return event, errors.Errorf(
 			"create task state change event api: status [%s] already sent",
 			taskKnownStatus.String())
+	}
+	if taskKnownStatus == apitaskstatus.TaskManifestPulled && !task.HasAContainerWithResolvedDigest() {
+		return event, fmt.Errorf(
+			"create task state change event api: status %s not eligible for backend reporting as"+
+				" no digests were resolved",
+			apitaskstatus.TaskManifestPulled.String())
 	}
 
 	event = TaskStateChange{
@@ -161,10 +167,20 @@ func NewContainerStateChangeEvent(task *apitask.Task, cont *apicontainer.Contain
 		return event, err
 	}
 	contKnownStatus := cont.GetKnownStatus()
-	if !contKnownStatus.ShouldReportToBackend(cont.GetSteadyStateStatus()) {
+	if contKnownStatus != apicontainerstatus.ContainerManifestPulled &&
+		!contKnownStatus.ShouldReportToBackend(cont.GetSteadyStateStatus()) {
 		return event, ErrShouldNotSendEvent{fmt.Sprintf(
 			"create container state change event api: status not recognized by ECS: %v",
 			contKnownStatus)}
+	}
+	if contKnownStatus == apicontainerstatus.ContainerManifestPulled && !cont.DigestResolved() {
+		// Transition to MANIFEST_PULLED state is sent to the backend only to report a resolved
+		// image manifest digest. No need to generate an event if the digest was not resolved
+		// which could happen due to various reasons.
+		return event, ErrShouldNotSendEvent{fmt.Sprintf(
+			"create container state change event api:"+
+				" no need to send %s event as no resolved digests were found",
+			apicontainerstatus.ContainerManifestPulled.String())}
 	}
 	if cont.GetSentStatus() >= contKnownStatus {
 		return event, ErrShouldNotSendEvent{fmt.Sprintf(
@@ -196,7 +212,7 @@ func newUncheckedContainerStateChangeEvent(task *apitask.Task, cont *apicontaine
 		TaskArn:       task.Arn,
 		ContainerName: cont.Name,
 		RuntimeID:     cont.GetRuntimeID(),
-		Status:        contKnownStatus.BackendStatus(cont.GetSteadyStateStatus()),
+		Status:        containerStatusChangeStatus(contKnownStatus, cont.GetSteadyStateStatus()),
 		ExitCode:      cont.GetKnownExitCode(),
 		PortBindings:  portBindings,
 		ImageDigest:   cont.GetImageDigest(),
@@ -204,6 +220,27 @@ func newUncheckedContainerStateChangeEvent(task *apitask.Task, cont *apicontaine
 		Container:     cont,
 	}
 	return event, nil
+}
+
+// Maps container known status to a suitable status for ContainerStateChange.
+//
+// Returns ContainerRunning if known status matches steady state status,
+// returns knownStatus if it is ContainerManifestPulled or ContainerStopped,
+// returns ContainerStatusNone for all other cases.
+func containerStatusChangeStatus(
+	knownStatus apicontainerstatus.ContainerStatus,
+	steadyStateStatus apicontainerstatus.ContainerStatus,
+) apicontainerstatus.ContainerStatus {
+	switch knownStatus {
+	case steadyStateStatus:
+		return apicontainerstatus.ContainerRunning
+	case apicontainerstatus.ContainerManifestPulled:
+		return apicontainerstatus.ContainerManifestPulled
+	case apicontainerstatus.ContainerStopped:
+		return apicontainerstatus.ContainerStopped
+	default:
+		return apicontainerstatus.ContainerStatusNone
+	}
 }
 
 // NewManagedAgentChangeEvent creates a new managedAgent change event to convey managed agent state changes
@@ -320,24 +357,6 @@ func (change *TaskStateChange) SetTaskTimestamps() {
 	if timestamp := change.Task.GetExecutionStoppedAt(); !timestamp.IsZero() {
 		change.ExecutionStoppedAt = aws.Time(timestamp.UTC())
 	}
-}
-
-// ShouldBeReported checks if the statechange should be reported to backend
-func (change *TaskStateChange) ShouldBeReported() bool {
-	// Events that should be reported:
-	// 1. Normal task state change: RUNNING/STOPPED
-	// 2. Container state change, with task status in CREATED/RUNNING/STOPPED
-	// The task timestamp will be sent in both of the event type
-	// TODO Move the Attachment statechange check into this method
-	if change.Status == apitaskstatus.TaskRunning || change.Status == apitaskstatus.TaskStopped {
-		return true
-	}
-
-	if len(change.Containers) != 0 {
-		return true
-	}
-
-	return false
 }
 
 func (change *TaskStateChange) ToFields() logger.Fields {
@@ -494,8 +513,11 @@ func buildContainerStateChangePayload(change ContainerStateChange) (*ecsmodel.Co
 		statechange.ImageDigest = aws.String(change.ImageDigest)
 	}
 
-	stat := change.Status.String()
-	if stat != apicontainerstatus.ContainerStopped.String() && stat != apicontainerstatus.ContainerRunning.String() {
+	// TODO: This check already exists in NewContainerStateChangeEvent and shouldn't be repeated here; remove after verifying
+	stat := change.Status
+	if stat != apicontainerstatus.ContainerManifestPulled &&
+		stat != apicontainerstatus.ContainerStopped &&
+		stat != apicontainerstatus.ContainerRunning {
 		logger.Warn("Not submitting unsupported upstream container state", logger.Fields{
 			field.Status:        stat,
 			field.ContainerName: change.ContainerName,
@@ -503,10 +525,11 @@ func buildContainerStateChangePayload(change ContainerStateChange) (*ecsmodel.Co
 		})
 		return nil, nil
 	}
-	if stat == "DEAD" {
-		stat = apicontainerstatus.ContainerStopped.String()
+	// TODO: This check is probably redundant as String() method never returns "DEAD"; remove after verifying
+	if stat.String() == "DEAD" {
+		stat = apicontainerstatus.ContainerStopped
 	}
-	statechange.Status = aws.String(stat)
+	statechange.Status = aws.String(stat.BackendStatusString())
 
 	if change.ExitCode != nil {
 		exitCode := int64(aws.IntValue(change.ExitCode))

--- a/agent/api/statechange_test.go
+++ b/agent/api/statechange_test.go
@@ -481,8 +481,9 @@ func TestNewTaskStateChangeEvent(t *testing.T) {
 					{ImageDigest: "digest", Type: apicontainer.ContainerCNIPause},
 				},
 			},
-			expectedError: "create task state change event api: status MANIFEST_PULLED not" +
-				" eligible for backend reporting as no digests were resolved",
+			expectedError: "should not send events for internal tasks or containers:" +
+				" create task state change event api: status MANIFEST_PULLED not eligible" +
+				" for backend reporting as no digests were resolved",
 		},
 		{
 			name: "manifest_pulled state is reported",

--- a/agent/api/statechange_test.go
+++ b/agent/api/statechange_test.go
@@ -27,50 +27,12 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/model/ecs"
+	ecsmodel "github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/model/ecs"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func TestShouldBeReported(t *testing.T) {
-	cases := []struct {
-		status          apitaskstatus.TaskStatus
-		containerChange []ContainerStateChange
-		result          bool
-	}{
-		{ // Normal task state change to running
-			status: apitaskstatus.TaskRunning,
-			result: true,
-		},
-		{ // Normal task state change to stopped
-			status: apitaskstatus.TaskStopped,
-			result: true,
-		},
-		{ // Container changed while task is not in steady state
-			status: apitaskstatus.TaskCreated,
-			containerChange: []ContainerStateChange{
-				{TaskArn: "taskarn"},
-			},
-			result: true,
-		},
-		{ // No container change and task status not recognized
-			status: apitaskstatus.TaskCreated,
-			result: false,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(fmt.Sprintf("task change status: %s, container change: %t", tc.status, len(tc.containerChange) > 0),
-			func(t *testing.T) {
-				taskChange := TaskStateChange{
-					Status:     tc.status,
-					Containers: tc.containerChange,
-				}
-
-				assert.Equal(t, tc.result, taskChange.ShouldBeReported())
-			})
-	}
-}
 
 func TestSetTaskTimestamps(t *testing.T) {
 	t1 := time.Now()
@@ -494,4 +456,374 @@ func getTestContainerStateChange() ContainerStateChange {
 	}
 
 	return testContainerStateChange
+}
+
+func TestNewTaskStateChangeEvent(t *testing.T) {
+	tcs := []struct {
+		name          string
+		task          *apitask.Task
+		reason        string
+		expected      TaskStateChange
+		expectedError string
+	}{
+		{
+			name:          "internal tasks are never reported",
+			task:          &apitask.Task{IsInternal: true, Arn: "arn"},
+			expectedError: "should not send events for internal tasks or containers: arn",
+		},
+		{
+			name: "manifest_pulled state is not reported if there are no resolved digests",
+			task: &apitask.Task{
+				Arn:               "arn",
+				KnownStatusUnsafe: apitaskstatus.TaskManifestPulled,
+				Containers: []*apicontainer.Container{
+					{ImageDigest: ""},
+					{ImageDigest: "digest", Type: apicontainer.ContainerCNIPause},
+				},
+			},
+			expectedError: "create task state change event api: status MANIFEST_PULLED not" +
+				" eligible for backend reporting as no digests were resolved",
+		},
+		{
+			name: "manifest_pulled state is reported",
+			task: &apitask.Task{
+				Arn:               "arn",
+				KnownStatusUnsafe: apitaskstatus.TaskManifestPulled,
+				Containers:        []*apicontainer.Container{{ImageDigest: "digest"}},
+			},
+			expected: TaskStateChange{TaskARN: "arn", Status: apitaskstatus.TaskManifestPulled},
+		},
+		{
+			name:          "created state is not reported",
+			task:          &apitask.Task{Arn: "arn", KnownStatusUnsafe: apitaskstatus.TaskCreated},
+			expectedError: "create task state change event api: status not recognized by ECS: CREATED",
+		},
+		{
+			name:     "running state is reported",
+			task:     &apitask.Task{Arn: "arn", KnownStatusUnsafe: apitaskstatus.TaskRunning},
+			expected: TaskStateChange{TaskARN: "arn", Status: apitaskstatus.TaskRunning},
+		},
+		{
+			name:   "stopped state is reported",
+			task:   &apitask.Task{Arn: "arn", KnownStatusUnsafe: apitaskstatus.TaskRunning},
+			reason: "container stopped",
+			expected: TaskStateChange{
+				TaskARN: "arn", Status: apitaskstatus.TaskRunning, Reason: "container stopped",
+			},
+		},
+		{
+			name: "already sent status is not reported again",
+			task: &apitask.Task{
+				Arn:               "arn",
+				KnownStatusUnsafe: apitaskstatus.TaskManifestPulled,
+				SentStatusUnsafe:  apitaskstatus.TaskManifestPulled,
+			},
+			expectedError: "create task state change event api: status [MANIFEST_PULLED] already sent",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := NewTaskStateChangeEvent(tc.task, tc.reason)
+			if tc.expectedError == "" {
+				require.NoError(t, err)
+				tc.expected.Task = tc.task
+				assert.Equal(t, tc.expected, res)
+			} else {
+				assert.EqualError(t, err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestNewContainerStateChangeEvent(t *testing.T) {
+	tcs := []struct {
+		name          string
+		task          *apitask.Task
+		reason        string
+		expected      ContainerStateChange
+		expectedError string
+	}{
+		{
+			name: "internal containers are not reported",
+			task: &apitask.Task{
+				Arn: "arn",
+				Containers: []*apicontainer.Container{
+					{Name: "container", Type: apicontainer.ContainerCNIPause},
+				},
+			},
+			expectedError: "should not send events for internal tasks or containers: container",
+		},
+		{
+			name: "MANIFEST_PULLED state is reported if digest was resolved",
+			task: &apitask.Task{
+				Arn: "arn",
+				Containers: []*apicontainer.Container{
+					{
+						Name:              "container",
+						ImageDigest:       "digest",
+						KnownStatusUnsafe: apicontainerstatus.ContainerManifestPulled,
+					},
+				},
+			},
+			expected: ContainerStateChange{
+				TaskArn:       "arn",
+				ContainerName: "container",
+				Status:        apicontainerstatus.ContainerManifestPulled,
+				ImageDigest:   "digest",
+			},
+		},
+		{
+			name: "MANIFEST_PULLED state not is not reported if digest was not resolved",
+			task: &apitask.Task{
+				Arn: "arn",
+				Containers: []*apicontainer.Container{
+					{
+						Name:              "container",
+						ImageDigest:       "",
+						KnownStatusUnsafe: apicontainerstatus.ContainerManifestPulled,
+					},
+				},
+			},
+			expectedError: "should not send events for internal tasks or containers:" +
+				" create container state change event api:" +
+				" no need to send MANIFEST_PULLED event" +
+				" as no resolved digests were found",
+		},
+		{
+			name: "PULLED state is not reported",
+			task: &apitask.Task{
+				Arn: "arn",
+				Containers: []*apicontainer.Container{
+					{
+						Name:              "container",
+						ImageDigest:       "digest",
+						KnownStatusUnsafe: apicontainerstatus.ContainerPulled,
+					},
+				},
+			},
+			expectedError: "should not send events for internal tasks or containers:" +
+				" create container state change event api: " +
+				"status not recognized by ECS: PULLED",
+		},
+		{
+			name: "RUNNING state is reported",
+			task: &apitask.Task{
+				Arn: "arn",
+				Containers: []*apicontainer.Container{
+					{
+						Name:              "container",
+						ImageDigest:       "digest",
+						KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
+					},
+				},
+			},
+			expected: ContainerStateChange{
+				TaskArn:       "arn",
+				ContainerName: "container",
+				Status:        apicontainerstatus.ContainerRunning,
+				ImageDigest:   "digest",
+			},
+		},
+		{
+			name: "STOPPED state is reported",
+			task: &apitask.Task{
+				Arn: "arn",
+				Containers: []*apicontainer.Container{
+					{
+						Name:              "container",
+						ImageDigest:       "digest",
+						KnownStatusUnsafe: apicontainerstatus.ContainerStopped,
+					},
+				},
+			},
+			reason: "container stopped",
+			expected: ContainerStateChange{
+				TaskArn:       "arn",
+				ContainerName: "container",
+				Status:        apicontainerstatus.ContainerStopped,
+				ImageDigest:   "digest",
+				Reason:        "container stopped",
+			},
+		},
+		{
+			name: "already sent state is not reported again",
+			task: &apitask.Task{
+				Arn: "arn",
+				Containers: []*apicontainer.Container{
+					{
+						Name:              "container",
+						ImageDigest:       "digest",
+						KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
+						SentStatusUnsafe:  apicontainerstatus.ContainerRunning,
+					},
+				},
+			},
+			expectedError: "should not send events for internal tasks or containers:" +
+				" create container state change event api:" +
+				" status [RUNNING] already sent for container container, task arn",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := NewContainerStateChangeEvent(tc.task, tc.task.Containers[0], tc.reason)
+			if tc.expectedError == "" {
+				require.NoError(t, err)
+				tc.expected.Container = tc.task.Containers[0]
+				assert.Equal(t, tc.expected, res)
+			} else {
+				assert.EqualError(t, err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestContainerStatusChangeStatus(t *testing.T) {
+	// Mapped status is ContainerStatusNone when container status is ContainerStatusNone
+	var containerStatus apicontainerstatus.ContainerStatus
+	assert.Equal(t,
+		containerStatusChangeStatus(containerStatus, apicontainerstatus.ContainerRunning),
+		apicontainerstatus.ContainerStatusNone)
+	assert.Equal(t,
+		containerStatusChangeStatus(containerStatus, apicontainerstatus.ContainerResourcesProvisioned),
+		apicontainerstatus.ContainerStatusNone)
+
+	// Mapped status is ContainerManifestPulled when container status is ContainerManifestPulled
+	containerStatus = apicontainerstatus.ContainerManifestPulled
+	assert.Equal(t,
+		containerStatusChangeStatus(containerStatus, apicontainerstatus.ContainerRunning),
+		apicontainerstatus.ContainerManifestPulled)
+	assert.Equal(t,
+		containerStatusChangeStatus(containerStatus, apicontainerstatus.ContainerResourcesProvisioned),
+		apicontainerstatus.ContainerManifestPulled)
+
+	// Mapped status is ContainerStatusNone when container status is ContainerPulled
+	containerStatus = apicontainerstatus.ContainerPulled
+	assert.Equal(t,
+		containerStatusChangeStatus(containerStatus, apicontainerstatus.ContainerRunning),
+		apicontainerstatus.ContainerStatusNone)
+	assert.Equal(t,
+		containerStatusChangeStatus(containerStatus, apicontainerstatus.ContainerResourcesProvisioned),
+		apicontainerstatus.ContainerStatusNone)
+
+	// Mapped status is ContainerStatusNone when container status is ContainerCreated
+	containerStatus = apicontainerstatus.ContainerCreated
+	assert.Equal(t,
+		containerStatusChangeStatus(containerStatus, apicontainerstatus.ContainerRunning),
+		apicontainerstatus.ContainerStatusNone)
+	assert.Equal(t,
+		containerStatusChangeStatus(containerStatus, apicontainerstatus.ContainerResourcesProvisioned),
+		apicontainerstatus.ContainerStatusNone)
+
+	containerStatus = apicontainerstatus.ContainerRunning
+	// Mapped status is ContainerRunning when container status is ContainerRunning
+	// and steady state is ContainerRunning
+	assert.Equal(t,
+		containerStatusChangeStatus(containerStatus, apicontainerstatus.ContainerRunning),
+		apicontainerstatus.ContainerRunning)
+	// Mapped status is ContainerStatusNone when container status is ContainerRunning
+	// and steady state is ContainerResourcesProvisioned
+	assert.Equal(t,
+		containerStatusChangeStatus(containerStatus, apicontainerstatus.ContainerResourcesProvisioned),
+		apicontainerstatus.ContainerStatusNone)
+
+	containerStatus = apicontainerstatus.ContainerResourcesProvisioned
+	// Mapped status is ContainerRunning when container status is ContainerResourcesProvisioned
+	// and steady state is ContainerResourcesProvisioned
+	assert.Equal(t,
+		containerStatusChangeStatus(containerStatus, apicontainerstatus.ContainerResourcesProvisioned),
+		apicontainerstatus.ContainerRunning)
+
+	// Mapped status is ContainerStopped when container status is ContainerStopped
+	containerStatus = apicontainerstatus.ContainerStopped
+	assert.Equal(t,
+		containerStatusChangeStatus(containerStatus, apicontainerstatus.ContainerRunning),
+		apicontainerstatus.ContainerStopped)
+	assert.Equal(t,
+		containerStatusChangeStatus(containerStatus, apicontainerstatus.ContainerResourcesProvisioned),
+		apicontainerstatus.ContainerStopped)
+}
+
+func TestBuildContainerStateChangePayload(t *testing.T) {
+	tcs := []struct {
+		name          string
+		change        ContainerStateChange
+		expected      *ecsmodel.ContainerStateChange
+		expectedError string
+	}{
+		{
+			name:          "fails when no container name",
+			change:        ContainerStateChange{},
+			expectedError: "container state change has no container name",
+		},
+		{
+			name: "no result no error when container state is unsupported",
+			change: ContainerStateChange{
+				ContainerName: "container",
+				Status:        apicontainerstatus.ContainerStatusNone,
+			},
+			expected: nil,
+		},
+		{
+			name: "MANIFEST_PULLED state maps to PENDING",
+			change: ContainerStateChange{
+				ContainerName: "container",
+				Container:     &apicontainer.Container{},
+				Status:        apicontainerstatus.ContainerManifestPulled,
+				ImageDigest:   "digest",
+			},
+			expected: &ecsmodel.ContainerStateChange{
+				ContainerName:   aws.String("container"),
+				ImageDigest:     aws.String("digest"),
+				NetworkBindings: []*ecs.NetworkBinding{},
+				Status:          aws.String("PENDING"),
+			},
+		},
+		{
+			name: "RUNNING maps to RUNNING",
+			change: ContainerStateChange{
+				ContainerName: "container",
+				Container:     &apicontainer.Container{},
+				Status:        apicontainerstatus.ContainerRunning,
+				ImageDigest:   "digest",
+				RuntimeID:     "runtimeid",
+			},
+			expected: &ecsmodel.ContainerStateChange{
+				ContainerName:   aws.String("container"),
+				ImageDigest:     aws.String("digest"),
+				RuntimeId:       aws.String("runtimeid"),
+				NetworkBindings: []*ecs.NetworkBinding{},
+				Status:          aws.String("RUNNING"),
+			},
+		},
+		{
+			name: "STOPPED maps to STOPPED",
+			change: ContainerStateChange{
+				ContainerName: "container",
+				Container:     &apicontainer.Container{},
+				Status:        apicontainerstatus.ContainerStopped,
+				ImageDigest:   "digest",
+				RuntimeID:     "runtimeid",
+				ExitCode:      aws.Int(1),
+			},
+			expected: &ecsmodel.ContainerStateChange{
+				ContainerName:   aws.String("container"),
+				ImageDigest:     aws.String("digest"),
+				RuntimeId:       aws.String("runtimeid"),
+				ExitCode:        aws.Int64(1),
+				NetworkBindings: []*ecs.NetworkBinding{},
+				Status:          aws.String("STOPPED"),
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := buildContainerStateChangePayload(tc.change)
+			if tc.expectedError == "" {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, res)
+			} else {
+				assert.EqualError(t, err, tc.expectedError)
+			}
+		})
+	}
 }

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3732,13 +3732,3 @@ func (task *Task) HasAContainerWithResolvedDigest() bool {
 	}
 	return false
 }
-
-// Checks if a task has at least one container that would require image manifest digest resolution.
-func (task *Task) HasAContainerRequiringDigestResolution() bool {
-	for _, c := range task.Containers {
-		if c.DigestResolutionRequired() {
-			return true
-		}
-	}
-	return false
-}

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3721,3 +3721,24 @@ func (task *Task) IsRunning() bool {
 
 	return taskStatus == apitaskstatus.TaskRunning
 }
+
+// Checks if the task has at least one container with a successfully
+// resolved image manifest digest.
+func (task *Task) HasAContainerWithResolvedDigest() bool {
+	for _, c := range task.Containers {
+		if c.DigestResolved() {
+			return true
+		}
+	}
+	return false
+}
+
+// Checks if a task has at least one container that would require image manifest digest resolution.
+func (task *Task) HasAContainerRequiringDigestResolution() bool {
+	for _, c := range task.Containers {
+		if c.DigestResolutionRequired() {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -5449,23 +5449,3 @@ func TestHasAContainerWithResolvedDigest(t *testing.T) {
 		assert.True(t, task.HasAContainerWithResolvedDigest())
 	})
 }
-
-func TestHasAContainerRequiringDigestResolution(t *testing.T) {
-	t.Run("false if no containers require digest resolution", func(t *testing.T) {
-		task := &Task{
-			Containers: []*apicontainer.Container{
-				{Image: "ubuntu@sha256:ed6d2c43c8fbcd3eaa44c9dab6d94cb346234476230dc1681227aa72d07181ee"},
-			},
-		}
-		assert.False(t, task.HasAContainerRequiringDigestResolution())
-	})
-	t.Run("true if there is a container that would require digest resolution", func(t *testing.T) {
-		task := &Task{
-			Containers: []*apicontainer.Container{
-				{Image: "ubuntu@sha256:ed6d2c43c8fbcd3eaa44c9dab6d94cb346234476230dc1681227aa72d07181ee"},
-				{Image: "ubuntu:latest"},
-			},
-		}
-		assert.True(t, task.HasAContainerRequiringDigestResolution())
-	})
-}

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -5431,3 +5431,41 @@ func TestIsManagedDaemonTask(t *testing.T) {
 			})
 	}
 }
+
+func TestHasAContainerWithResolvedDigest(t *testing.T) {
+	t.Run("false if no containers with a resolved digest", func(t *testing.T) {
+		task := &Task{
+			Containers: []*apicontainer.Container{{}},
+		}
+		assert.False(t, task.HasAContainerWithResolvedDigest())
+	})
+	t.Run("true if there is a container with a resolved digest", func(t *testing.T) {
+		task := &Task{
+			Containers: []*apicontainer.Container{
+				{},
+				{ImageDigest: "digest"},
+			},
+		}
+		assert.True(t, task.HasAContainerWithResolvedDigest())
+	})
+}
+
+func TestHasAContainerRequiringDigestResolution(t *testing.T) {
+	t.Run("false if no containers require digest resolution", func(t *testing.T) {
+		task := &Task{
+			Containers: []*apicontainer.Container{
+				{Image: "ubuntu@sha256:ed6d2c43c8fbcd3eaa44c9dab6d94cb346234476230dc1681227aa72d07181ee"},
+			},
+		}
+		assert.False(t, task.HasAContainerRequiringDigestResolution())
+	})
+	t.Run("true if there is a container that would require digest resolution", func(t *testing.T) {
+		task := &Task{
+			Containers: []*apicontainer.Container{
+				{Image: "ubuntu@sha256:ed6d2c43c8fbcd3eaa44c9dab6d94cb346234476230dc1681227aa72d07181ee"},
+				{Image: "ubuntu:latest"},
+			},
+		}
+		assert.True(t, task.HasAContainerRequiringDigestResolution())
+	})
+}

--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -141,11 +141,32 @@ func loggerConfigIntegrationTest(logfile string) string {
 	return config
 }
 
+func verifyContainerManifestPulledStateChange(t *testing.T, taskEngine TaskEngine) {
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	event := <-stateChangeEvents
+	assert.Equal(t, apicontainerstatus.ContainerManifestPulled, event.(api.ContainerStateChange).Status,
+		"Expected container to be at MANIFEST_PULLED state")
+}
+
+func verifyTaskManifestPulledStateChange(t *testing.T, taskEngine TaskEngine) {
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	event := <-stateChangeEvents
+	assert.Equal(t, apitaskstatus.TaskManifestPulled, event.(api.TaskStateChange).Status,
+		"Expected task to reach MANIFEST_PULLED state")
+}
+
 func verifyContainerRunningStateChange(t *testing.T, taskEngine TaskEngine) {
 	stateChangeEvents := taskEngine.StateChangeEvents()
 	event := <-stateChangeEvents
 	assert.Equal(t, event.(api.ContainerStateChange).Status, apicontainerstatus.ContainerRunning,
 		"Expected container to be RUNNING")
+}
+
+func verifyTaskRunningStateChange(t *testing.T, taskEngine TaskEngine) {
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	event := <-stateChangeEvents
+	assert.Equal(t, apitaskstatus.TaskRunning, event.(api.TaskStateChange).Status,
+		"Expected task to be RUNNING")
 }
 
 func verifyContainerRunningStateChangeWithRuntimeID(t *testing.T, taskEngine TaskEngine) {

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -981,10 +981,7 @@ func (engine *DockerTaskEngine) EmitTaskEvent(task *apitask.Task, reason string)
 	event, err := api.NewTaskStateChangeEvent(task, reason)
 	if err != nil {
 		if _, ok := err.(api.ErrShouldNotSendEvent); ok {
-			logger.Debug(err.Error(), logger.Fields{
-				field.TaskID: task.GetID(),
-				field.Error:  err,
-			})
+			logger.Debug(err.Error(), logger.Fields{field.TaskID: task.GetID()})
 		} else {
 			logger.Error("Unable to create task state change event", logger.Fields{
 				field.TaskID: task.GetID(),

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -47,7 +47,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/aws/amazon-ecs-agent/agent/api"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -130,6 +129,9 @@ func TestStartStopWithCgroup(t *testing.T) {
 	}
 	go taskEngine.AddTask(testTask)
 
+	verifyContainerManifestPulledStateChange(t, taskEngine)
+	verifyTaskManifestPulledStateChange(t, taskEngine)
+
 	verifyContainerRunningStateChange(t, taskEngine)
 	verifyTaskIsRunning(stateChangeEvents, testTask)
 
@@ -167,6 +169,8 @@ func TestLocalHostVolumeMount(t *testing.T) {
 	stateChangeEvents := taskEngine.StateChangeEvents()
 	go taskEngine.AddTask(testTask)
 
+	verifyContainerManifestPulledStateChange(t, taskEngine)
+	verifyTaskManifestPulledStateChange(t, taskEngine)
 	verifyContainerRunningStateChange(t, taskEngine)
 	verifyTaskIsRunning(stateChangeEvents, testTask)
 	verifyContainerStoppedStateChange(t, taskEngine)
@@ -434,6 +438,8 @@ func TestExecCommandAgent(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
+	verifyContainerManifestPulledStateChange(t, taskEngine)
+	verifyTaskManifestPulledStateChange(t, taskEngine)
 	verifyContainerRunningStateChange(t, taskEngine)
 	verifyTaskRunningStateChange(t, taskEngine)
 
@@ -526,6 +532,8 @@ func TestManagedAgentEvent(t *testing.T) {
 
 			go taskEngine.AddTask(testTask)
 
+			verifyContainerManifestPulledStateChange(t, taskEngine)
+			verifyTaskManifestPulledStateChange(t, taskEngine)
 			verifyContainerRunningStateChange(t, taskEngine)
 			verifyTaskRunningStateChange(t, taskEngine)
 
@@ -792,13 +800,6 @@ func killMockExecCommandAgent(t *testing.T, client *sdkClient.Client, containerI
 		Detach: true,
 	})
 	require.NoError(t, err)
-}
-
-func verifyTaskRunningStateChange(t *testing.T, taskEngine TaskEngine) {
-	stateChangeEvents := taskEngine.StateChangeEvents()
-	event := <-stateChangeEvents
-	assert.Equal(t, event.(api.TaskStateChange).Status, apitaskstatus.TaskRunning,
-		"Expected task to be RUNNING")
 }
 
 func TestGMSATaskFile(t *testing.T) {

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -269,6 +269,8 @@ func TestStartStopUnpulledImage(t *testing.T) {
 	testTask := createTestTask("testStartUnpulled")
 
 	go taskEngine.AddTask(testTask)
+	verifyContainerManifestPulledStateChange(t, taskEngine)
+	verifyTaskManifestPulledStateChange(t, taskEngine)
 	verifyContainerRunningStateChange(t, taskEngine)
 	verifyTaskRunningStateChange(t, taskEngine)
 	verifyContainerStoppedStateChange(t, taskEngine)
@@ -449,6 +451,10 @@ func TestDynamicPortForward(t *testing.T) {
 	go taskEngine.AddTask(testTask)
 
 	event := <-stateChangeEvents
+	require.Equal(t, apicontainerstatus.ContainerManifestPulled, event.(api.ContainerStateChange).Status, "Expected container to reach MANIFEST_PULLED state")
+	event = <-stateChangeEvents
+	require.Equal(t, apitaskstatus.TaskManifestPulled, event.(api.TaskStateChange).Status, "Expected task to reach MANIFEST_PULLED state")
+	event = <-stateChangeEvents
 	require.Equal(t, event.(api.ContainerStateChange).Status, apicontainerstatus.ContainerRunning, "Expected container to be RUNNING")
 
 	portBindings := event.(api.ContainerStateChange).PortBindings
@@ -504,6 +510,10 @@ func TestMultipleDynamicPortForward(t *testing.T) {
 	go taskEngine.AddTask(testTask)
 
 	event := <-stateChangeEvents
+	require.Equal(t, apicontainerstatus.ContainerManifestPulled, event.(api.ContainerStateChange).Status, "Expected container to reach MANIFEST_PULLED state")
+	event = <-stateChangeEvents
+	require.Equal(t, apitaskstatus.TaskManifestPulled, event.(api.TaskStateChange).Status, "Expected task to reach MANIFEST_PULLED state")
+	event = <-stateChangeEvents
 	require.Equal(t, event.(api.ContainerStateChange).Status, apicontainerstatus.ContainerRunning, "Expected container to be RUNNING")
 
 	portBindings := event.(api.ContainerStateChange).PortBindings
@@ -699,6 +709,8 @@ func TestInitOOMEvent(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
+	verifyContainerManifestPulledStateChange(t, taskEngine)
+	verifyTaskManifestPulledStateChange(t, taskEngine)
 	verifyContainerRunningStateChange(t, taskEngine)
 	verifyTaskRunningStateChange(t, taskEngine)
 
@@ -753,6 +765,8 @@ func TestSignalEvent(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
+	verifyContainerManifestPulledStateChange(t, taskEngine)
+	verifyTaskManifestPulledStateChange(t, taskEngine)
 	verifyContainerRunningStateChange(t, taskEngine)
 	verifyTaskRunningStateChange(t, taskEngine)
 
@@ -814,6 +828,8 @@ func TestDockerStopTimeout(t *testing.T) {
 
 	go dockerTaskEngine.AddTask(testTask)
 
+	verifyContainerManifestPulledStateChange(t, taskEngine)
+	verifyTaskManifestPulledStateChange(t, taskEngine)
 	verifyContainerRunningStateChange(t, taskEngine)
 	verifyTaskRunningStateChange(t, taskEngine)
 
@@ -840,6 +856,8 @@ func TestStartStopWithSecurityOptionNoNewPrivileges(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
+	verifyContainerManifestPulledStateChange(t, taskEngine)
+	verifyTaskManifestPulledStateChange(t, taskEngine)
 	verifyContainerRunningStateChange(t, taskEngine)
 	verifyTaskRunningStateChange(t, taskEngine)
 
@@ -883,6 +901,8 @@ func TestSwapConfigurationTask(t *testing.T) {
 	testTask.Containers[0].DockerConfig = apicontainer.DockerConfig{HostConfig: aws.String(`{"MemorySwap":314572800, "MemorySwappiness":90}`)}
 
 	go taskEngine.AddTask(testTask)
+	verifyContainerManifestPulledStateChange(t, taskEngine)
+	verifyTaskManifestPulledStateChange(t, taskEngine)
 	verifyContainerRunningStateChange(t, taskEngine)
 	verifyTaskRunningStateChange(t, taskEngine)
 
@@ -930,6 +950,8 @@ func TestPerContainerStopTimeout(t *testing.T) {
 
 	go dockerTaskEngine.AddTask(testTask)
 
+	verifyContainerManifestPulledStateChange(t, taskEngine)
+	verifyTaskManifestPulledStateChange(t, taskEngine)
 	verifyContainerRunningStateChange(t, taskEngine)
 	verifyTaskRunningStateChange(t, taskEngine)
 
@@ -961,6 +983,8 @@ func TestMemoryOverCommit(t *testing.T) {
 	"MemoryReservation": 52428800 }`)}
 
 	go taskEngine.AddTask(testTask)
+	verifyContainerManifestPulledStateChange(t, taskEngine)
+	verifyTaskManifestPulledStateChange(t, taskEngine)
 	verifyContainerRunningStateChange(t, taskEngine)
 	verifyTaskRunningStateChange(t, taskEngine)
 
@@ -1021,6 +1045,8 @@ func TestFluentdTag(t *testing.T) {
 		SourceVolume: "logs"}}
 	testTaskFleuntdDriver.Containers[0].Ports = []apicontainer.PortBinding{{ContainerPort: 24224, HostPort: 24224}}
 	go taskEngine.AddTask(testTaskFleuntdDriver)
+	verifyContainerManifestPulledStateChange(t, taskEngine)
+	verifyTaskManifestPulledStateChange(t, taskEngine)
 	verifyContainerRunningStateChange(t, taskEngine)
 	verifyTaskRunningStateChange(t, taskEngine)
 
@@ -1041,6 +1067,8 @@ func TestFluentdTag(t *testing.T) {
 	}}`)}
 
 	go taskEngine.AddTask(testTaskFluentdLogTag)
+	verifyContainerManifestPulledStateChange(t, taskEngine)
+	verifyTaskManifestPulledStateChange(t, taskEngine)
 	verifyContainerRunningStateChange(t, taskEngine)
 	verifyTaskRunningStateChange(t, taskEngine)
 
@@ -1101,6 +1129,8 @@ func TestDockerExecAPI(t *testing.T) {
 	finished := make(chan interface{})
 	go func() {
 		// Both containers should start
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyTaskIsRunning(stateChangeEvents, testTask)
 
@@ -1176,9 +1206,13 @@ func TestHostResourceManagerTrickleQueue(t *testing.T) {
 	// goroutine to verify task running order
 	go func() {
 		// Tasks go RUNNING in order
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyTaskIsRunning(stateChangeEvents, tasks[0])
 
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyTaskIsRunning(stateChangeEvents, tasks[1])
 
@@ -1186,6 +1220,8 @@ func TestHostResourceManagerTrickleQueue(t *testing.T) {
 		verifyContainerStoppedStateChange(t, taskEngine)
 		verifyTaskIsStopped(stateChangeEvents, tasks[0])
 
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyTaskIsRunning(stateChangeEvents, tasks[2])
 
@@ -1264,9 +1300,13 @@ func TestHostResourceManagerResourceUtilization(t *testing.T) {
 	go func() {
 		// Tasks go RUNNING in order, 2nd task doesn't wait for 1st task
 		// to transition to STOPPED as resources are available
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyTaskIsRunning(stateChangeEvents, tasks[0])
 
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyTaskIsRunning(stateChangeEvents, tasks[1])
 
@@ -1350,6 +1390,10 @@ func TestHostResourceManagerStopTaskNotBlockWaitingTasks(t *testing.T) {
 
 	// goroutine to verify task running order and verify assertions
 	go func() {
+		// First task goes to MANIFEST_PULLED
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
+
 		// 1st task goes to RUNNING
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyTaskIsRunning(stateChangeEvents, tasks[0])
@@ -1455,6 +1499,8 @@ func TestHostResourceManagerLaunchTypeBehavior(t *testing.T) {
 			// goroutine to verify task running order and verify assertions
 			go func() {
 				// Task goes to RUNNING
+				verifyContainerManifestPulledStateChange(t, taskEngine)
+				verifyTaskManifestPulledStateChange(t, taskEngine)
 				verifyContainerRunningStateChange(t, taskEngine)
 				verifyTaskIsRunning(stateChangeEvents, testTask)
 

--- a/agent/engine/ordering_integ_test.go
+++ b/agent/engine/ordering_integ_test.go
@@ -75,6 +75,9 @@ func TestDependencyHealthCheck(t *testing.T) {
 	finished := make(chan interface{})
 	go func() {
 		// Both containers should start
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyTaskIsRunning(stateChangeEvents, testTask)
@@ -131,6 +134,11 @@ func TestDependencyComplete(t *testing.T) {
 
 	finished := make(chan interface{})
 	go func() {
+		// Both containers and the task should reach MANIFEST_PULLED regardless of ordering
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
+
 		// First container should run to completion and then exit
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyContainerStoppedStateChange(t, taskEngine)
@@ -186,6 +194,11 @@ func TestDependencyStart(t *testing.T) {
 
 	finished := make(chan interface{})
 	go func() {
+		// Both containers and the task should go to MANIFEST_PULLED state
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
+
 		// 'dependency' container should run first, followed by the 'parent' container
 		verifySpecificContainerStateChange(t, taskEngine, "dependency", status.ContainerRunning)
 		verifySpecificContainerStateChange(t, taskEngine, "parent", status.ContainerRunning)
@@ -245,6 +258,11 @@ func TestDependencySuccess(t *testing.T) {
 
 	finished := make(chan interface{})
 	go func() {
+		// All containers and the task should reach MANIFEST_PULLED
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
+
 		// First container should run to completion
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyContainerStoppedStateChange(t, taskEngine)
@@ -304,6 +322,11 @@ func TestDependencySuccessErrored(t *testing.T) {
 
 	finished := make(chan interface{})
 	go func() {
+		// Both containers and the task should reach MANIFEST_PULLED state
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
+
 		// First container should run to completion
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyContainerStoppedStateChange(t, taskEngine)
@@ -360,6 +383,12 @@ func TestDependencySuccessTimeout(t *testing.T) {
 
 	finished := make(chan interface{})
 	go func() {
+		// All containers and the task should reach MANIFEST_PULLED
+		for _ = range testTask.Containers {
+			verifyContainerManifestPulledStateChange(t, taskEngine)
+		}
+		verifyTaskManifestPulledStateChange(t, taskEngine)
+
 		// First container should run to completion
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyContainerStoppedStateChange(t, taskEngine)
@@ -423,6 +452,11 @@ func TestDependencyHealthyTimeout(t *testing.T) {
 
 	finished := make(chan interface{})
 	go func() {
+		// Both containers and the task should reach MANIFEST_PULLED
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
+
 		// First container should run to completion
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyContainerStoppedStateChange(t, taskEngine)
@@ -500,6 +534,11 @@ func TestShutdownOrder(t *testing.T) {
 	finished := make(chan interface{})
 	go func() {
 		// Everything should first progress to running
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyContainerRunningStateChange(t, taskEngine)
@@ -589,6 +628,12 @@ func TestMultipleContainerDependency(t *testing.T) {
 
 	finished := make(chan interface{})
 	go func() {
+		// All containers and the task should reach MANIFEST_PULLED regardless of dependency
+		for _ = range testTask.Containers {
+			verifyContainerManifestPulledStateChange(t, taskEngine)
+		}
+		verifyTaskManifestPulledStateChange(t, taskEngine)
+
 		// Only exit should first progress to running
 		verifyContainerRunningStateChange(t, taskEngine)
 

--- a/agent/engine/ordering_integ_unix_test.go
+++ b/agent/engine/ordering_integ_unix_test.go
@@ -77,6 +77,11 @@ func TestGranularStopTimeout(t *testing.T) {
 	finished := make(chan interface{})
 	go func() {
 
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyContainerManifestPulledStateChange(t, taskEngine)
+		verifyTaskManifestPulledStateChange(t, taskEngine)
+
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyContainerRunningStateChange(t, taskEngine)
 		verifyContainerRunningStateChange(t, taskEngine)

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -702,7 +702,6 @@ func (mtask *managedTask) emitContainerEvent(task *apitask.Task, cont *apicontai
 			logger.Debug(err.Error(), logger.Fields{
 				field.TaskID:    mtask.GetID(),
 				field.Container: cont.Name,
-				field.Error:     err,
 			})
 		} else {
 			logger.Error("Skipping emitting event for container due to error", logger.Fields{

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -630,7 +630,7 @@ func (mtask *managedTask) emitTaskEvent(task *apitask.Task, reason string) {
 	event, err := api.NewTaskStateChangeEvent(task, reason)
 	if err != nil {
 		if _, ok := err.(api.ErrShouldNotSendEvent); ok {
-			logger.Debug(err.Error())
+			logger.Debug(err.Error(), logger.Fields{field.TaskID: mtask.GetID()})
 		} else {
 			logger.Error("Skipping emitting event for task due to error", logger.Fields{
 				field.TaskID: mtask.GetID(),

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -604,6 +604,7 @@ func getContainerEventLogFields(c api.ContainerStateChange) logger.Fields {
 	if c.Container != nil {
 		f["KnownSent"] = c.Container.GetSentStatus().String()
 	}
+	f["KnownStatus"] = c.Container.GetKnownStatus()
 	return f
 }
 
@@ -618,7 +619,7 @@ func (mtask *managedTask) emitTaskEvent(task *apitask.Task, reason string) {
 			logger.Critical("Failed to release resources after tast stopped", logger.Fields{field.TaskARN: mtask.Arn})
 		}
 	}
-	if !taskKnownStatus.BackendRecognized() {
+	if taskKnownStatus != apitaskstatus.TaskManifestPulled && !taskKnownStatus.BackendRecognized() {
 		logger.Debug("Skipping event emission for task", logger.Fields{
 			field.TaskID:      mtask.GetID(),
 			field.Error:       "status not recognized by ECS",
@@ -698,7 +699,11 @@ func (mtask *managedTask) emitContainerEvent(task *apitask.Task, cont *apicontai
 	event, err := api.NewContainerStateChangeEvent(task, cont, reason)
 	if err != nil {
 		if _, ok := err.(api.ErrShouldNotSendEvent); ok {
-			logger.Debug(err.Error())
+			logger.Debug(err.Error(), logger.Fields{
+				field.TaskID:    mtask.GetID(),
+				field.Container: cont.Name,
+				field.Error:     err,
+			})
 		} else {
 			logger.Error("Skipping emitting event for container due to error", logger.Fields{
 				field.TaskID:    mtask.GetID(),

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status/containerstatus.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status/containerstatus.go
@@ -102,38 +102,15 @@ func (cs *ContainerStatus) ShouldReportToBackend(steadyStateStatus ContainerStat
 	return *cs == steadyStateStatus || *cs == ContainerStopped
 }
 
-// BackendStatus maps the internal container status in the agent to that in the
-// backend
-//
-// Deprecated: Use BackendStatusString instead
-func (cs *ContainerStatus) BackendStatus(steadyStateStatus ContainerStatus) ContainerStatus {
-	if *cs == steadyStateStatus {
-		return ContainerRunning
-	}
-
-	if *cs == ContainerStopped {
-		return ContainerStopped
-	}
-
-	return ContainerStatusNone
-}
-
 // BackendStatusString maps the internal container status in Agent to a backend recognized
 // status string.
 //
 // Container steady state can be provided as an option. If provided, it will be used to
 // determine if the backend status is "RUNNING". If not provided, then ContainerRunning is
 // used as the default steady state.
-func (cs ContainerStatus) BackendStatusString(steadyStateStatusPtr *ContainerStatus) string {
-	var steadyState ContainerStatus
-	if steadyStateStatusPtr != nil {
-		steadyState = *steadyStateStatusPtr
-	} else {
-		steadyState = ContainerRunning
-	}
-
+func (cs ContainerStatus) BackendStatusString() string {
 	switch cs {
-	case steadyState:
+	case ContainerRunning:
 		return "RUNNING"
 	case ContainerStopped:
 		return "STOPPED"

--- a/ecs-agent/api/container/status/containerstatus.go
+++ b/ecs-agent/api/container/status/containerstatus.go
@@ -102,38 +102,15 @@ func (cs *ContainerStatus) ShouldReportToBackend(steadyStateStatus ContainerStat
 	return *cs == steadyStateStatus || *cs == ContainerStopped
 }
 
-// BackendStatus maps the internal container status in the agent to that in the
-// backend
-//
-// Deprecated: Use BackendStatusString instead
-func (cs *ContainerStatus) BackendStatus(steadyStateStatus ContainerStatus) ContainerStatus {
-	if *cs == steadyStateStatus {
-		return ContainerRunning
-	}
-
-	if *cs == ContainerStopped {
-		return ContainerStopped
-	}
-
-	return ContainerStatusNone
-}
-
 // BackendStatusString maps the internal container status in Agent to a backend recognized
 // status string.
 //
 // Container steady state can be provided as an option. If provided, it will be used to
 // determine if the backend status is "RUNNING". If not provided, then ContainerRunning is
 // used as the default steady state.
-func (cs ContainerStatus) BackendStatusString(steadyStateStatusPtr *ContainerStatus) string {
-	var steadyState ContainerStatus
-	if steadyStateStatusPtr != nil {
-		steadyState = *steadyStateStatusPtr
-	} else {
-		steadyState = ContainerRunning
-	}
-
+func (cs ContainerStatus) BackendStatusString() string {
 	switch cs {
-	case steadyState:
+	case ContainerRunning:
 		return "RUNNING"
 	case ContainerStopped:
 		return "STOPPED"

--- a/ecs-agent/api/container/status/containerstatus_test.go
+++ b/ecs-agent/api/container/status/containerstatus_test.go
@@ -64,46 +64,6 @@ func TestShouldReportToBackend(t *testing.T) {
 
 }
 
-func TestBackendStatus(t *testing.T) {
-	// BackendStatus is ContainerStatusNone when container status is ContainerStatusNone
-	var containerStatus ContainerStatus
-	assert.Equal(t, containerStatus.BackendStatus(ContainerRunning), ContainerStatusNone)
-	assert.Equal(t, containerStatus.BackendStatus(ContainerResourcesProvisioned), ContainerStatusNone)
-
-	// BackendStatus is still ContainerStatusNone when container status is ContainerManifestPulled
-	containerStatus = ContainerManifestPulled
-	assert.Equal(t, containerStatus.BackendStatus(ContainerRunning), ContainerStatusNone)
-	assert.Equal(t, containerStatus.BackendStatus(ContainerResourcesProvisioned), ContainerStatusNone)
-
-	// BackendStatus is still ContainerStatusNone when container status is ContainerPulled
-	containerStatus = ContainerPulled
-	assert.Equal(t, containerStatus.BackendStatus(ContainerRunning), ContainerStatusNone)
-	assert.Equal(t, containerStatus.BackendStatus(ContainerResourcesProvisioned), ContainerStatusNone)
-
-	// BackendStatus is still ContainerStatusNone when container status is ContainerCreated
-	containerStatus = ContainerCreated
-	assert.Equal(t, containerStatus.BackendStatus(ContainerRunning), ContainerStatusNone)
-	assert.Equal(t, containerStatus.BackendStatus(ContainerResourcesProvisioned), ContainerStatusNone)
-
-	containerStatus = ContainerRunning
-	// BackendStatus is ContainerRunning when container status is ContainerRunning
-	// and steady state is ContainerRunning
-	assert.Equal(t, containerStatus.BackendStatus(ContainerRunning), ContainerRunning)
-	// BackendStatus is still ContainerStatusNone when container status is ContainerRunning
-	// and steady state is ContainerResourcesProvisioned
-	assert.Equal(t, containerStatus.BackendStatus(ContainerResourcesProvisioned), ContainerStatusNone)
-
-	containerStatus = ContainerResourcesProvisioned
-	// BackendStatus is still ContainerRunning when container status is ContainerResourcesProvisioned
-	// and steady state is ContainerResourcesProvisioned
-	assert.Equal(t, containerStatus.BackendStatus(ContainerResourcesProvisioned), ContainerRunning)
-
-	// BackendStatus is ContainerStopped when container status is ContainerStopped
-	containerStatus = ContainerStopped
-	assert.Equal(t, containerStatus.BackendStatus(ContainerRunning), ContainerStopped)
-	assert.Equal(t, containerStatus.BackendStatus(ContainerResourcesProvisioned), ContainerStopped)
-}
-
 type testContainerStatus struct {
 	SomeStatus ContainerStatus `json:"status"`
 }
@@ -340,47 +300,7 @@ func TestContainerBackendStatusStringDefaultSteadyState(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("%d", tc.status), func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.status.BackendStatusString(nil))
+			assert.Equal(t, tc.expected, tc.status.BackendStatusString())
 		})
 	}
-}
-
-// Tests for BackendStatusString method when a steady state is provided.
-func TestBackendStatusSteadyStateProvided(t *testing.T) {
-	containerRunning := ContainerRunning
-	containerResourcesProvisioned := ContainerResourcesProvisioned
-
-	// Test states that should map to PENDING regardless of steady state
-	pendingStates := []ContainerStatus{
-		ContainerStatusNone, ContainerManifestPulled, ContainerPulled,
-		ContainerCreated, ContainerZombie,
-	}
-	for _, tc := range pendingStates {
-		t.Run(fmt.Sprintf("pending - %d", tc), func(t *testing.T) {
-			assert.Equal(t, "PENDING", tc.BackendStatusString(&containerRunning))
-			assert.Equal(t, "PENDING", tc.BackendStatusString(&containerResourcesProvisioned))
-		})
-	}
-
-	// Test that ContainerStopped maps to STOPPED regardless of steady state
-	t.Run("ContainerStopped maps to STOPPED", func(t *testing.T) {
-		assert.Equal(t, "STOPPED", ContainerStopped.BackendStatusString(&containerRunning))
-		assert.Equal(t, "STOPPED", ContainerStopped.BackendStatusString(&containerResourcesProvisioned))
-	})
-
-	// Test that steady state maps to RUNNING
-	t.Run("ContainerRunning maps to RUNNING when steady state is ContainerRunning", func(t *testing.T) {
-		assert.Equal(t, "RUNNING", ContainerRunning.BackendStatusString(&containerRunning))
-	})
-	t.Run("ContainerResourcesProvisioned maps to RUNNING when steady state is ContainerResourcesProvisioned", func(t *testing.T) {
-		assert.Equal(t, "RUNNING", ContainerResourcesProvisioned.BackendStatusString(&containerResourcesProvisioned))
-	})
-
-	// Test that non-steady non-STOPPED state maps to PENDING
-	t.Run("ContainerRunning maps to PENDING when steady state is ContainerResourcesProvisioned", func(t *testing.T) {
-		assert.Equal(t, "PENDING", ContainerRunning.BackendStatusString(&containerResourcesProvisioned))
-	})
-	t.Run("ContainerResourcesProvisioned maps to PENDING when steady state is ContainerRunning", func(t *testing.T) {
-		assert.Equal(t, "PENDING", ContainerResourcesProvisioned.BackendStatusString(&containerRunning))
-	})
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR enables SubmitTaskStateChange (STSC) calls from Agent to ECS backend for early reporting of container image manifest digests. Containers that are in-scope of digest resolution (non-internal containers and containers whose image reference does not already have a digest) will have their image manifest digests reported to ECS backend with an additional STSC call that Agent will make after the task has reached `MANIFEST_PULLED` state. The container states in this additional STSC call will be "PENDING" which is a backend-recognized state for pending containers. 

This additional STSC call will be made only if there is at least one container for which digest was successfully resolved during transition to `MANIFEST_PULLED` state.

An example of this new STSC call is shown below. 
```
    {
      "clusterReference": {
        "accountId": "<account-id>",
        "name": "test"
      },
      "containers": [
        {
          "containerName": "second",
          "imageDigest": "sha256:5eef5ed34e1e1ff0a4ae850395cbf665c4de6b4b83a32a0bc7bcb998e24e7bbb",
          "status": "PENDING"
        },
        {
          "containerName": "first",
          "imageDigest": "sha256:32e76d4f34f80e479964a0fbd4c5b4f6967b5322c8d004e9cf0cb81c93510766",
          "status": "PENDING"
        }
      ],
      "identity": <redacted>,
      "reason": "",
      "requestDate": 1715292586,
      "status": "PENDING",
      "taskId": <redacted>
    }
```

### Implementation details
* Add a new `*Container.DigestResolutionRequired` method that checks if a container requires digest resolution. This method is now called in container state transition function for `MANIFEST_PULLED` state to perform digest resolution only for containers that need it. The method returns `true` for non-internal containers whose `Image` field does not already contain a digest. 
* Add a new `*Container.DigestResolved` method that checks if the container has had its image manifest digest resolved. The method is used to prevent emitting a container change event for containers ineligible for digest reporting (due to it being internal or having digest available in its `Image`  field or due to a failure in digest resolution).
* Add a new `*Task.HasAContainerWithResolvedDigest` method that checks if the task has at least one container with a successfully resolved digest. The method is used to prevent emitting a task change event for tasks that don't have any resolved digests to report.
* Existing `NewTaskStateChangeEvent` method is updated to generate a task state change event for transition to `MANIFEST_PULLED` state if at least one of task's containers has a resolved digest. 
* Existing `NewContainerStateChangeEvent` method is updated to generate a container state change event for transition to `MANIFEST_PULLED` state if the container's digest was resolved. A new helper function `containerStatusChangeStatus` for mapping container's known status to a status eligible for STSC reporting is added which replaces `*ContainerStatus.BackendStatus` method from `ecs-agent` module. The reason to move the function to `agent` module is that the function has implementation details of ECS Agent which are unrelated to the more general nature of `ecs-agent` module. In addition to the existing logic of `*ContainerStatus.BackendStatus` method, the new function also maps `ContainerManifestPulled` state to `ContainerManifestPulled` state making the state eligible for STSC reporting.
* `api.buildContainerStateChangePayload` method, that builds a container state change payload for STSC calls, is updated to allow `ContainerManifestPulled` state changes to go through and use the recently added (#4167) `ContainerStatus.BackendStatusString` method to map the state to "PENDING" container state which is backend-recognized. 
* `*DockerTaskEngine.pullContainerManifest` method, which is the container state transition function for `MANIFEST_PULLED` state, is updated to _not_ resolve digest for containers that have digest populated in their `Image` field. This is because digest resolution is not needed for such containers and not populating `ImageDigest` field during transition to `MANIFEST_PULLED` state helps detect that the container's digest does not need to be reported early. It will be reported as usual after the container's image is pulled. 
* `*managedTask.emitTaskEvent` method, that is used to generate and submit task state change events, is updated to allow transitions to `MANIFEST_PULLED` states to be reported. This gating is probably redundant given that it's performed in `NewTaskStateChangeEvent` method also but this PR is keeping this additional gating as removing it is considered out-of-scope. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Given that the change affects all tasks, a LOT of existing unit and integration tests have been updated to check that state change events for `MANIFEST_PULLED` container and task states are emitted or not emitted depending on the specific test cases. 

Thorough unit tests are added for all new functions introduced in this PR. 

Manual testing was performed and it was observed that - 
* An additional STSC call is made with "PENDING" container states with "ImageDigest" fields populated for each container for which digest was resolved successfully. 
* Containers that had digest already populated in their "Image" field in the task definition did not have their digest resolved or reported early by Agent. These containers did have their digest reported as usual when the task transitioned to "RUNNING". 
* Containers that had a failure during digest resolution (due to intentional usage of an invalid image) did not have a container change event generated.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Feature: Early reporting of image manifest digests for eligible containers

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
