### PR TITLE
Update TMDS response for restart tracker

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
@@ -57,10 +57,9 @@ type EphemeralStorageMetrics struct {
 // with the v2 container response object.
 type ContainerResponse struct {
 	*v2.ContainerResponse
-	Networks      []Network `json:"Networks,omitempty"`
-	Snapshotter   string    `json:"Snapshotter,omitempty"`
-	RestartCount  int       `json:"RestartCount,omitempty"`
-	LastRestartAt time.Time `json:"LastRestartAt,omitempty"`
+	Networks     []Network `json:"Networks,omitempty"`
+	Snapshotter  string    `json:"Snapshotter,omitempty"`
+	RestartCount *int      `json:"RestartCount,omitempty"`
 }
 
 // Network is the v4 Network response. It adds a bunch of information about network

--- a/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/ecs-agent/tmds/handlers/v4/state/response.go
@@ -57,10 +57,9 @@ type EphemeralStorageMetrics struct {
 // with the v2 container response object.
 type ContainerResponse struct {
 	*v2.ContainerResponse
-	Networks      []Network `json:"Networks,omitempty"`
-	Snapshotter   string    `json:"Snapshotter,omitempty"`
-	RestartCount  int       `json:"RestartCount,omitempty"`
-	LastRestartAt time.Time `json:"LastRestartAt,omitempty"`
+	Networks     []Network `json:"Networks,omitempty"`
+	Snapshotter  string    `json:"Snapshotter,omitempty"`
+	RestartCount *int      `json:"RestartCount,omitempty"`
 }
 
 // Network is the v4 Network response. It adds a bunch of information about network


### PR DESCRIPTION
### Summary
Updating TMDS container level response to make `RestartCount` an int pointer and remove `LastRestartedAt`. The latter is a remnant that we no longer need. `RestartCount` will be omitted from the json response as an int because 0 is the 'null' value for integers. By making it a pointer, the TMDS response will only omit if the count is null.

It was decided earlier to store `restartTracker` with non-pointer types so these will be left alone, as the code becomes awkward otherwise.

### Implementation details
N/A.

### Testing
`make test`

### Description for the changelog
Update TMDS response for container restarts

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
