### PR TITLE
Add container-restart-policy capability

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -81,6 +81,7 @@ const (
 	capabilityServiceConnect                               = "service-connect-v1"
 	capabilityGpuDriverVersion                             = "gpu-driver-version"
 	capabilityEBSTaskAttach                                = "storage.ebs-task-volume-attach"
+	capabilityContainerRestartPolicy                       = "container-restart-policy"
 
 	// network capabilities, going forward, please append "network." prefix to any new networking capability we introduce
 	networkCapabilityPrefix      = "network."
@@ -110,6 +111,8 @@ var (
 		capabilityEnvFilesS3,
 		// support container port range in container definition - port mapping field
 		capabilityContainerPortRange,
+		// support container restart policy
+		capabilityContainerRestartPolicy,
 	}
 	// use empty struct as value type to simulate set
 	capabilityExecInvalidSsmVersions = map[string]struct{}{}
@@ -194,6 +197,7 @@ var (
 //	ecs.capability.external
 //	ecs.capability.service-connect-v1
 //	ecs.capability.network.container-port-range
+//	ecs.capability.container-restart-policy
 func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	var capabilities []*ecs.Attribute
 

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -143,6 +143,7 @@ func TestCapabilities(t *testing.T) {
 		attributePrefix + capabilityExec,
 		attributePrefix + capabilityServiceConnect,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilityContainerRestartPolicy,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -1314,6 +1315,7 @@ func TestCapabilitiesNoServiceConnect(t *testing.T) {
 		attributePrefix + taskENIBlockInstanceMetadataAttributeSuffix,
 		attributePrefix + capabilityExec,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilityContainerRestartPolicy,
 	}
 
 	var expectedCapabilities []*ecs.Attribute

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -530,6 +530,7 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesUnix(t *testing.T) {
 		attributePrefix + capabilityEnvFilesS3,
 		attributePrefix + capabiltyPIDAndIPCNamespaceSharing,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilityContainerRestartPolicy,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -681,6 +682,7 @@ func TestAppMeshCapabilitiesUnix(t *testing.T) {
 		attributePrefix + capabiltyPIDAndIPCNamespaceSharing,
 		attributePrefix + appMeshAttributeSuffix,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilityContainerRestartPolicy,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -879,6 +881,7 @@ func TestCapabilitiesUnix(t *testing.T) {
 		attributePrefix + capabilityFirelensLoggingDriver + capabilityFireLensLoggingDriverConfigBufferLimitSuffix,
 		attributePrefix + capabilityEnvFilesS3,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilityContainerRestartPolicy,
 	}
 
 	var expectedCapabilities []*ecs.Attribute

--- a/agent/app/agent_capability_windows_test.go
+++ b/agent/app/agent_capability_windows_test.go
@@ -184,6 +184,7 @@ func TestSupportedCapabilitiesWindows(t *testing.T) {
 		attributePrefix + capabilityEnvFilesS3,
 		attributePrefix + taskENIBlockInstanceMetadataAttributeSuffix,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilityContainerRestartPolicy,
 	}
 
 	var expectedCapabilities []*ecs.Attribute


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Adds ecs.capability.container-restart-policy capability to agent

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
