### PR TITLE
Do container restart on exit

### DIFF
--- a/agent/engine/testdata/test_tasks/sleep5RestartPolicy.json
+++ b/agent/engine/testdata/test_tasks/sleep5RestartPolicy.json
@@ -1,0 +1,42 @@
+{
+    "Arn":"arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1",
+    "Family":"sleep5RestartPolicy",
+    "Version":"2",
+    "Containers":
+    [
+      {
+        "Name":"sleep5",
+        "RuntimeID": "12345678-ctrr-cdef-ctrr-56780abcdef1",
+        "Image":"busybox",
+        "Command":["sleep","5"],
+        "Cpu":10,
+        "Memory":10,
+        "Links":null,
+        "volumesFrom":[],
+        "mountPoints":[],
+        "portMappings":[],
+        "Essential":true,
+        "EntryPoint":null,
+        "environment":{},
+        "overrides":{"command":null},
+        "desiredStatus":"NONE",
+        "KnownStatus":"NONE",
+        "RunDependencies":null,
+        "IsInternal":false,
+        "AppliedStatus":"NONE",
+        "ApplyingError":null,
+        "SentStatus":"NONE",
+        "KnownExitCode":null,
+        "KnownPortBindingsUnsafe":null,
+        "StatusLock":{},
+        "RestartPolicy": {
+            "Enabled":true
+        }
+      }
+    ],
+    "volumes":[],
+    "DesiredStatus":"RUNNING",
+    "KnownStatus":"NONE",
+    "KnownTime":"0001-01-01T00:00:00Z",
+    "SentStatus":"NONE"
+  }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

In the function that handles container change events, we will evaluate if an exiting container has a restart policy defined.

If the container does have a restart policy, we will evaluate if we _should_ restart the container using the [`RestartTracker.ShouldRestart`](https://pkg.go.dev/github.com/aws/amazon-ecs-agent/ecs-agent@v0.0.0-20240509232427-1133dd999145/api/container/restart#RestartTracker) function from the common library.

If we do do a container restart, we record it using the `RestartTracker.RecordRestart` function.

If the restart fails, we proceed with the regular container stop workflow.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
