### PR TITLE
Enable agent to detect FIPS enabled hosts

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -229,7 +229,7 @@ func NewConfig(ec2client ec2.EC2MetadataClient) (*Config, error) {
 		errs = append(errs, err)
 	}
 	config := &envConfig
-	isFIPSEnabled = utils.DetectFIPSMode()
+	isFIPSEnabled = utils.DetectFIPSMode(utils.FIPSModeFilePath)
 
 	if config.External.Enabled() {
 		if config.AWSRegion == "" {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -188,6 +188,9 @@ var (
 
 	// CgroupV2 Specifies whether or not to run in Cgroups V2 mode.
 	CgroupV2 = false
+
+	// isFIPSEnabled indicates whether FIPS mode is enabled on the host
+	isFIPSEnabled = false
 )
 
 // Merge merges two config files, preferring the ones on the left. Any nil or
@@ -226,6 +229,7 @@ func NewConfig(ec2client ec2.EC2MetadataClient) (*Config, error) {
 		errs = append(errs, err)
 	}
 	config := &envConfig
+	isFIPSEnabled = utils.DetectFIPSMode()
 
 	if config.External.Enabled() {
 		if config.AWSRegion == "" {
@@ -656,4 +660,8 @@ func (cfg *Config) String() string {
 		cfg.DynamicHostPortRange,
 		cfg.platformString(),
 	)
+}
+
+func IsFIPSEnabled() bool {
+	return isFIPSEnabled
 }

--- a/agent/utils/fips_linux.go
+++ b/agent/utils/fips_linux.go
@@ -23,10 +23,11 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 )
 
-const fipsModeFilePath = "/proc/sys/crypto/fips_enabled"
+const FIPSModeFilePath = "/proc/sys/crypto/fips_enabled"
 
-func DetectFIPSMode() bool {
-	data, err := os.ReadFile(fipsModeFilePath)
+// DetectFIPSMode checks if FIPS mode is enabled based on the provided file path.
+func DetectFIPSMode(filePath string) bool {
+	data, err := os.ReadFile(filePath)
 	if err == nil && strings.TrimSpace(string(data)) == "1" {
 		logger.Debug("FIPS mode detected on the host")
 		return true

--- a/agent/utils/fips_linux.go
+++ b/agent/utils/fips_linux.go
@@ -1,0 +1,36 @@
+//go:build linux
+// +build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"os"
+	"strings"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+)
+
+const fipsModeFilePath = "/proc/sys/crypto/fips_enabled"
+
+func DetectFIPSMode() bool {
+	data, err := os.ReadFile(fipsModeFilePath)
+	if err == nil && strings.TrimSpace(string(data)) == "1" {
+		logger.Debug("FIPS mode detected on the host")
+		return true
+	}
+	logger.Debug("FIPS mode not detected on the host")
+	return false
+}

--- a/agent/utils/fips_linux_test.go
+++ b/agent/utils/fips_linux_test.go
@@ -1,5 +1,5 @@
-//go:build !windows && unit
-// +build !windows,unit
+//go:build linux && unit
+// +build linux,unit
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/utils/fips_linux_test.go
+++ b/agent/utils/fips_linux_test.go
@@ -20,20 +20,11 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// detectFIPSModeWithPath is a helper function for testing
-func detectFIPSModeWithPath(filePath string) bool {
-	data, err := ioutil.ReadFile(filePath)
-	if err == nil && strings.TrimSpace(string(data)) == "1" {
-		return true
-	}
-	return false
-}
 func TestDetectFIPSMode(t *testing.T) {
 	// Create a temporary file to mock the FIPS mode file
 	tempFile, err := ioutil.TempFile("", "fips_enabled")
@@ -45,7 +36,7 @@ func TestDetectFIPSMode(t *testing.T) {
 	tempFile.Sync()
 	// Initialize the logger
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
-	result := detectFIPSModeWithPath(tempFile.Name())
+	result := DetectFIPSMode(tempFile.Name())
 	assert.True(t, result, "FIPS mode should be detected")
 	// Test FIPS mode disabled
 	tempFile.Truncate(0)
@@ -53,6 +44,9 @@ func TestDetectFIPSMode(t *testing.T) {
 	_, err = tempFile.WriteString("0\n")
 	assert.NoError(t, err)
 	tempFile.Sync()
-	result = detectFIPSModeWithPath(tempFile.Name())
+	result = DetectFIPSMode(tempFile.Name())
 	assert.False(t, result, "FIPS mode should not be detected")
+	// Test when the FIPS file does not exist
+	result = DetectFIPSMode("nonexistent_file")
+	assert.False(t, result, "FIPS mode should not be detected when file is missing")
 }

--- a/agent/utils/fips_linux_test.go
+++ b/agent/utils/fips_linux_test.go
@@ -1,0 +1,58 @@
+//go:build !windows && unit
+// +build !windows,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// detectFIPSModeWithPath is a helper function for testing
+func detectFIPSModeWithPath(filePath string) bool {
+	data, err := ioutil.ReadFile(filePath)
+	if err == nil && strings.TrimSpace(string(data)) == "1" {
+		return true
+	}
+	return false
+}
+func TestDetectFIPSMode(t *testing.T) {
+	// Create a temporary file to mock the FIPS mode file
+	tempFile, err := ioutil.TempFile("", "fips_enabled")
+	assert.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+	// Test FIPS mode enabled
+	_, err = tempFile.WriteString("1\n")
+	assert.NoError(t, err)
+	tempFile.Sync()
+	// Initialize the logger
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	result := detectFIPSModeWithPath(tempFile.Name())
+	assert.True(t, result, "FIPS mode should be detected")
+	// Test FIPS mode disabled
+	tempFile.Truncate(0)
+	tempFile.Seek(0, 0)
+	_, err = tempFile.WriteString("0\n")
+	assert.NoError(t, err)
+	tempFile.Sync()
+	result = detectFIPSModeWithPath(tempFile.Name())
+	assert.False(t, result, "FIPS mode should not be detected")
+}

--- a/agent/utils/fips_unsupported.go
+++ b/agent/utils/fips_unsupported.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build !windows && !linux
+// +build !windows,!linux
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
@@ -17,29 +17,12 @@
 package utils
 
 import (
-	"fmt"
-	"os"
-	"strings"
-
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 )
 
-const FIPSModeFilePath = "/proc/sys/crypto/fips_enabled"
+const FIPSModeFilePath = ""
 
-// DetectFIPSMode checks if FIPS mode is enabled based on the provided file path.
-func DetectFIPSMode(filePath string) bool {
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		logger.Debug(fmt.Sprintf("Error while detecting FIPS is enabled or not, err: %v", err))
-		return false
-	}
-
-	fipsValue := strings.TrimSpace(string(data))
-	if fipsValue == "1" {
-		logger.Info("FIPS mode detected on the host")
-		return true
-	}
-
-	logger.Debug(fmt.Sprintf("FIPS mode not enabled. FIPS mode explicitly set to %v", fipsValue))
+func DetectFIPSMode(filepath string) bool {
+	logger.Debug("FIPS mode detection is not supported on this platform")
 	return false
 }

--- a/agent/utils/fips_windows.go
+++ b/agent/utils/fips_windows.go
@@ -1,5 +1,5 @@
-//go:build windows
-// +build windows
+//go:build windows && !linux
+// +build windows,!linux
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/utils/fips_windows.go
+++ b/agent/utils/fips_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+)
+
+func DetectFIPSMode() bool {
+	logger.Debug("set isFIPSEnabled to false by default on Windows")
+	return false
+}

--- a/agent/utils/fips_windows.go
+++ b/agent/utils/fips_windows.go
@@ -20,7 +20,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 )
 
-func DetectFIPSMode() bool {
+const FIPSModeFilePath = ""
+
+func DetectFIPSMode(filepath string) bool {
 	logger.Debug("set isFIPSEnabled to false by default on Windows")
 	return false
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request enables ECS Agent on linux to detect if FIPS mode is enabled on the host machine and store the detected value.
### Implementation details
<!-- How are the changes implemented? -->
* Added a new function `DetectFIPSMode` in the utils package (utils/fips_linux.go). This function reads the `/proc/sys/crypto/fips_enabled` file to check if FIPS mode is enabled.
* Introduced a new variable `isFIPSEnabled` in the config package (config.go), which is initialized during the package initialization using the `IsFIPSEnabled` function.
* Added logic to log the FIPS mode status during initialization for debugging purposes.
* Created unit tests to ensure correct identification of the FIPS mode status.
* Added a stub function `DetectFIPSMode` in the utils package (utils/fips_windows.go). This function will set `isFIPSEnabled` to `false` by default on Windows hosts.

### Testing
<!-- How was this tested? -->
* Unit tests were added to the utils package (utils/fips_linux_test.go)
* The unit tests cover the following scenarios:
   * FIPS mode is enabled (/proc/sys/crypto/fips_enabled contains 1).
   * FIPS mode is disabled (/proc/sys/crypto/fips_enabled contains 0).
   * FIPS mode file is non-existent.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
Enable agent to detect FIPS enabled hosts

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
