### PR TITLE
Add RestartCount to introspection endpoint container response

### DIFF
--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -48,16 +48,17 @@ type TasksResponse struct {
 
 // ContainerResponse is the schema for the container response JSON object
 type ContainerResponse struct {
-	DockerID   string                        `json:"DockerId"`
-	DockerName string                        `json:"DockerName"`
-	Name       string                        `json:"Name"`
-	Image      string                        `json:"Image"`
-	ImageID    string                        `json:"ImageID"`
-	CreatedAt  *time.Time                    `json:"CreatedAt,omitempty"`
-	StartedAt  *time.Time                    `json:"StartedAt,omitempty"`
-	Ports      []tmdsresponse.PortResponse   `json:"Ports,omitempty"`
-	Networks   []tmdsresponse.Network        `json:"Networks,omitempty"`
-	Volumes    []tmdsresponse.VolumeResponse `json:"Volumes,omitempty"`
+	DockerID     string                        `json:"DockerId"`
+	DockerName   string                        `json:"DockerName"`
+	Name         string                        `json:"Name"`
+	Image        string                        `json:"Image"`
+	ImageID      string                        `json:"ImageID"`
+	CreatedAt    *time.Time                    `json:"CreatedAt,omitempty"`
+	StartedAt    *time.Time                    `json:"StartedAt,omitempty"`
+	Ports        []tmdsresponse.PortResponse   `json:"Ports,omitempty"`
+	Networks     []tmdsresponse.Network        `json:"Networks,omitempty"`
+	Volumes      []tmdsresponse.VolumeResponse `json:"Volumes,omitempty"`
+	RestartCount *int                          `json:"RestartCount,omitempty"`
 }
 
 // NewTaskResponse creates a TaskResponse for a task.
@@ -120,6 +121,10 @@ func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *ni
 	if startedAt := container.GetStartedAt(); !startedAt.IsZero() {
 		startedAt = startedAt.UTC()
 		resp.StartedAt = &startedAt
+	}
+	if container.RestartPolicyEnabled() {
+		restartCount := container.RestartTracker.GetRestartCount()
+		resp.RestartCount = &restartCount
 	}
 	return resp
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Adding RestartCount to the container response of the introspection endpoint.

This is to match the response of the TMDE v4 endpoint change: https://github.com/aws/amazon-ecs-agent/pull/4166

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

unit tests added

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
