### PR TITLE
Resolving cloudwatch endpoint for all regions

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1876,32 +1876,31 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 		}
 	}
 
-	// This is a short term solution only for specific regions until AWS SDK Go is upgraded to V2
+	// We're currently relying on AWS SDK Go V1 to obtain/format the correct cloudwatch endpoint.
+	// This is will need to be updated once we upgrade to AWS SDK Go V2.
 	if hostConfig.LogConfig.Type == logDriverTypeAwslogs {
-		region := engine.cfg.AWSRegion
-		if region == "eu-isoe-west-1" || region == "us-isof-south-1" || region == "us-isof-east-1" {
-			endpoint := ""
-			dnsSuffix := ""
-			partition, ok := ep.PartitionForRegion(ep.DefaultPartitions(), region)
-			if !ok {
-				logger.Warn("No partition resolved for region. Using AWS default", logger.Fields{
-					"region":           region,
-					"defaultDNSSuffix": ep.AwsPartition().DNSSuffix(),
-				})
-				dnsSuffix = ep.AwsPartition().DNSSuffix()
+		region := hostConfig.LogConfig.Config["awslogs-region"]
+		endpoint := ""
+		dnsSuffix := ""
+		partition, ok := ep.PartitionForRegion(ep.DefaultPartitions(), region)
+		if !ok {
+			logger.Warn("No partition resolved for region. Using AWS default", logger.Fields{
+				"region":           region,
+				"defaultDNSSuffix": ep.AwsPartition().DNSSuffix(),
+			})
+			dnsSuffix = ep.AwsPartition().DNSSuffix()
+		} else {
+			resolvedEndpoint, err := partition.EndpointFor("logs", region)
+			if err == nil {
+				endpoint = resolvedEndpoint.URL
 			} else {
-				resolvedEndpoint, err := partition.EndpointFor("logs", region)
-				if err == nil {
-					endpoint = resolvedEndpoint.URL
-				} else {
-					dnsSuffix = partition.DNSSuffix()
-				}
+				dnsSuffix = partition.DNSSuffix()
 			}
-			if endpoint == "" {
-				endpoint = fmt.Sprintf("https://logs.%s.%s", region, dnsSuffix)
-			}
-			hostConfig.LogConfig.Config["awslogs-endpoint"] = endpoint
 		}
+		if endpoint == "" {
+			endpoint = fmt.Sprintf("https://logs.%s.%s", region, dnsSuffix)
+		}
+		hostConfig.LogConfig.Config["awslogs-endpoint"] = endpoint
 	}
 
 	//Apply the log driver secret into container's LogConfig and Env secrets to container.Environment

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -2955,7 +2955,17 @@ func TestCreateContainerAwslogsLogDriver(t *testing.T) {
 		{
 			name:                      "test container that uses awslogs log driver in IAD",
 			region:                    "us-east-1",
-			expectedLogConfigEndpoint: "",
+			expectedLogConfigEndpoint: "https://logs.us-east-1.amazonaws.com",
+		},
+		{
+			name:                      "test container that uses awslogs log driver in BJS",
+			region:                    "cn-north-1",
+			expectedLogConfigEndpoint: "https://logs.cn-north-1.amazonaws.com.cn",
+		},
+		{
+			name:                      "test container that uses awslogs log driver in OSU",
+			region:                    "us-gov-east-1",
+			expectedLogConfigEndpoint: "https://logs.us-gov-east-1.amazonaws.com",
 		},
 		{
 			name:                      "test container that uses awslogs log driver in NCL",
@@ -2984,8 +2994,10 @@ func TestCreateContainerAwslogsLogDriver(t *testing.T) {
 
 			rawHostConfigInput := dockercontainer.HostConfig{
 				LogConfig: dockercontainer.LogConfig{
-					Type:   "awslogs",
-					Config: map[string]string{},
+					Type: "awslogs",
+					Config: map[string]string{
+						"awslogs-region": tc.region,
+					},
 				},
 			}
 			rawHostConfig, err := json.Marshal(&rawHostConfigInput)


### PR DESCRIPTION
### Summary
This PR will aim to have agent resolve the correct AWS Cloudwatch endpoint for all regions in the case where tasks are using `awslogs` as the log driver type. Previously, we ran into an issue where the current docker version we're relying on is unable to resolve the correct Cloudwatch endpoints for the new regions and as a immediate remediation we're now relying on agent to resolve the endpoints. We should have this behavior be consistent across all regions.

Note: We will be relying on AWS SDK Go V1 to attempt to resolve the correct endpoint (similar to moby). This will need to be updated once we upgrade to AWS SDK Go V2.

### Implementation details
* Removed specific region checks to in order to obtain the cloudwatch endpoint
* Relying on `awslogs-region` to obtain the correct region of the Cloudwatch endpoint

### Testing
Manual testing

Used the following task definition:
```
{
    "family": "test",
    "containerDefinitions": [
        {
            "name": "awslogs-test",
            "image": "busybox",
            "cpu": 256,
            "memory": 64,
            "portMappings": [],
            "essential": true,
            "command": [
                "sh",
                "-c",
                "echo hello world"
            ],
            "environment": [],
            "mountPoints": [],
            "volumesFrom": [],
            "logConfiguration": {
                "logDriver": "awslogs",
                "options": {
                    "awslogs-group": "test-log-group",
                    "awslogs-region": "ca-central-1",
                    "awslogs-stream-prefix": "cw-test"
                }
            },
            "systemControls": []
        }
    ]
}
```
Task transitioned to running
```
evel=debug time=2024-05-23T18:38:03Z msg="Transitioned container" task="78959252ccc04cdd88aec25340bb824d" container="awslogs-test" runtimeID="528be3477391117131c42722d6089a0430852f5177fad30a2e949907e2bf51be" nextState="RUNNING" error=<nil>
level=debug time=2024-05-23T18:38:03Z msg="Received non-transition events" task="78959252ccc04cdd88aec25340bb824d"
level=debug time=2024-05-23T18:38:03Z msg="Updating task's known status" task="78959252ccc04cdd88aec25340bb824d"
level=debug time=2024-05-23T18:38:03Z msg="Found container with earliest known status" knownStatus=RUNNING desiredStatus=RUNNING task="78959252ccc04cdd88aec25340bb824d" container="awslogs-test"
level=debug time=2024-05-23T18:38:03Z msg="Updating task's desired status" taskFamily="test" taskVersion="1" taskArn="arn:aws:ecs:us-west-2:113424923516:task/default/78959252ccc04cdd88aec25340bb824d" taskKnownStatus="RUNNING" taskDesiredStatus="RUNNING" nContainers=1 nENIs=0
```

Task container exited gracefully
```
[ec2-user@ip-172-31-46-255 amazon-ecs-agent]$ docker ps -a
CONTAINER ID   IMAGE                            COMMAND                  CREATED              STATUS                        PORTS     NAMES
528be3477391   busybox                          "sh -c 'echo hello w…"   15 seconds ago       Exited (0) 14 seconds ago               ecs-test-1-awslogs-test-82d4d4a0989bc08b1400
```

Task was able to successfully write to Cloudwatch log group in `ca-central-1` from `us-west-2`
```
2024-05-23T18:38:03.408Z	hello world
```

New tests cover the changes: Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

enhancement: Resolving Cloudwatch endpoint in all regions

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
