### PR TITLE
Add new RestartStatsSet metric to TACS container metric payload

### DIFF
--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -317,8 +317,22 @@ func createFakeContainerStats() []*ContainerStats {
 		TxPackets: 60,
 	}
 	return []*ContainerStats{
-		{22400432, 1839104, uint64(100), uint64(200), netStats, parseNanoTime("2015-02-12T21:22:05.131117533Z")},
-		{116499979, 3649536, uint64(300), uint64(400), netStats, parseNanoTime("2015-02-12T21:22:05.232291187Z")},
+		{
+			cpuUsage:          22400432,
+			memoryUsage:       1839104,
+			storageReadBytes:  uint64(100),
+			storageWriteBytes: uint64(200),
+			networkStats:      netStats,
+			timestamp:         parseNanoTime("2015-02-12T21:22:05.131117533Z"),
+		},
+		{
+			cpuUsage:          116499979,
+			memoryUsage:       3649536,
+			storageReadBytes:  uint64(300),
+			storageWriteBytes: uint64(400),
+			networkStats:      netStats,
+			timestamp:         parseNanoTime("2015-02-12T21:22:05.232291187Z"),
+		},
 	}
 }
 

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -878,6 +878,19 @@ func (engine *DockerStatsEngine) taskContainerMetricsUnsafe(taskArn string) ([]*
 			containerMetric.StorageStatsSet = storageStatsSet
 		}
 
+		restartStatsSet, err := container.statsQueue.GetRestartStatsSet()
+		if err != nil && age > gracePeriod {
+			// we expect to get an error here if there are no restart metrics,
+			// which would be common as it just means there is no restart policy on
+			// the container, so just log a debug message here.
+			logger.Debug("Unable to get restart stats for container", logger.Fields{
+				field.Container: dockerID,
+				field.Error:     err,
+			})
+		} else {
+			containerMetric.RestartStatsSet = restartStatsSet
+		}
+
 		task, err := engine.resolver.ResolveTask(dockerID)
 		if err != nil {
 			logger.Warn("Task not found for container", logger.Fields{

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -324,6 +324,7 @@ func TestStatsEngineTerminalTask(t *testing.T) {
 }
 
 func TestStartMetricsPublish(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name                       string
 		hasPublishTicker           bool
@@ -378,6 +379,7 @@ func TestStartMetricsPublish(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 
@@ -714,7 +716,7 @@ func TestSynchronizeOnRestart(t *testing.T) {
 		Container: &apicontainer.Container{
 			HealthCheckType: "docker",
 		},
-	}, nil).Times(3)
+	}, nil).AnyTimes()
 	err := engine.synchronizeState()
 	assert.NoError(t, err)
 

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -29,7 +29,6 @@ import (
 	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	apiresource "github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment/resource"
-	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/csiclient"
 	mock_csiclient "github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/mocks"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
@@ -75,17 +74,7 @@ func TestNetworkModeStatsAWSVPCMode(t *testing.T) {
 		},
 	}
 
-	t1 := &apitask.Task{
-		Arn:               "t1",
-		Family:            "f1",
-		ENIs:              []*ni.NetworkInterface{{ID: "ec2Id"}},
-		NetworkMode:       apitask.AWSVPCNetworkMode,
-		KnownStatusUnsafe: apitaskstatus.TaskRunning,
-		Containers: []*apicontainer.Container{
-			{Name: "test"},
-			{Name: "test1"},
-		},
-	}
+	t1 := getTestTask()
 
 	resolver.EXPECT().ResolveTask("c1").AnyTimes().Return(t1, nil)
 	resolver.EXPECT().ResolveTask("c2").AnyTimes().Return(t1, nil)
@@ -148,15 +137,12 @@ func TestServiceConnectWithDisabledMetrics(t *testing.T) {
 		HealthCheckType: "docker",
 	}
 	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
-	resolver.EXPECT().ResolveTask(containerID).Return(&apitask.Task{
-		Arn:               "t1",
-		KnownStatusUnsafe: apitaskstatus.TaskRunning,
-		Family:            "f1",
-		ServiceConnectConfig: &serviceconnect.Config{
-			ContainerName: "service-connect",
-		},
-		Containers: []*apicontainer.Container{&container},
-	}, nil)
+	t1 := getTestTask()
+	t1.ServiceConnectConfig = &serviceconnect.Config{
+		ContainerName: "service-connect",
+	}
+	t1.Containers = []*apicontainer.Container{&container}
+	resolver.EXPECT().ResolveTask(containerID).Return(t1, nil)
 	resolver.EXPECT().ResolveContainer(containerID).Return(&apicontainer.DockerContainer{
 		DockerID:  containerID,
 		Container: &container,
@@ -233,20 +219,18 @@ func TestFetchEBSVolumeMetrics(t *testing.T) {
 			defer mockCtrl.Finish()
 			resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
 			mockDockerClient := mock_dockerapi.NewMockDockerClient(mockCtrl)
-			t1 := &apitask.Task{
-				Arn: "t1",
-				Volumes: []apitask.TaskVolume{
-					{
-						Name: "1",
-						Type: apiresource.EBSTaskAttach,
-						Volume: &taskresourcevolume.EBSTaskVolumeConfig{
-							VolumeId:             "vol-12345",
-							VolumeName:           "test-volume",
-							VolumeSizeGib:        "10",
-							SourceVolumeHostPath: "taskarn_vol-12345",
-							DeviceName:           "/dev/nvme1n1",
-							FileSystem:           "ext4",
-						},
+			t1 := getTestTask()
+			t1.Volumes = []apitask.TaskVolume{
+				{
+					Name: "1",
+					Type: apiresource.EBSTaskAttach,
+					Volume: &taskresourcevolume.EBSTaskVolumeConfig{
+						VolumeId:             "vol-12345",
+						VolumeName:           "test-volume",
+						VolumeSizeGib:        "10",
+						SourceVolumeHostPath: "taskarn_vol-12345",
+						DeviceName:           "/dev/nvme1n1",
+						FileSystem:           "ext4",
 					},
 				},
 			}

--- a/agent/stats/task.go
+++ b/agent/stats/task.go
@@ -121,7 +121,7 @@ func (taskStat *StatsTask) processStatsStream() error {
 				}
 				return nil
 			}
-			if err := taskStat.StatsQueue.Add(rawStat); err != nil {
+			if err := taskStat.StatsQueue.Add(rawStat, nil); err != nil {
 				logger.Warn("Error converting task stats", logger.Fields{
 					field.TaskID: taskId,
 					field.Error:  err,

--- a/agent/stats/task_linux_test.go
+++ b/agent/stats/task_linux_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 func TestTaskStatsCollection(t *testing.T) {
+	t.Parallel()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	resolver := mock_resolver.NewMockContainerMetadataResolver(ctrl)
@@ -97,6 +98,7 @@ func TestTaskStatsCollection(t *testing.T) {
 }
 
 func TestTaskStatsCollectionError(t *testing.T) {
+	t.Parallel()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	resolver := mock_resolver.NewMockContainerMetadataResolver(ctrl)

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -29,8 +29,16 @@ type ContainerStats struct {
 	memoryUsage       uint64
 	storageReadBytes  uint64
 	storageWriteBytes uint64
+	restartCount      *int64
 	networkStats      *NetworkStats
 	timestamp         time.Time
+}
+
+// NonDockerContainerStats contains stats for a container that are not gotten from docker.
+// These are amended to the docker stats and added to the stats queue if they are
+// available.
+type NonDockerContainerStats struct {
+	restartCount int64
 }
 
 // NetworkStats contains the network stats information for a container
@@ -54,6 +62,7 @@ type UsageStats struct {
 	StorageReadBytes  uint64        `json:"storageReadBytes"`
 	StorageWriteBytes uint64        `json:"storageWriteBytes"`
 	NetworkStats      *NetworkStats `json:"networkStats"`
+	RestartCount      *int64        `json:"restartCount"`
 	Timestamp         time.Time     `json:"timestamp"`
 	cpuUsage          uint64
 	// sent indicates if the stat has been sent to TACS already.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Adds the new RestartStatsSet metrics to the TACS container metrics payload.

These stats must be gotten from the Container object but added into the stats queue so that diffs can be calculated. For this reason we add in a new "NonDockerContainerStats" object to grab stats from the Container object rather than from docker stats. This object can be easily extended if more stats like RestartCount (stats from the container object rather than docker) arise in the future.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

- Unit tests added with a container with a restart policy. Restarts are simulated and then we verify that the expected numbers come out of the stats queue.
- Existing unit test was modified for a container _without_ a restart policy. Verify that this results in a nil RestartStatsSet being returned, so that this metric is left out of the payload for a container that doesn't have it enabled.
- stats package tests were also amended with the `t.Parallel` flag as they require sleeping and each test is fully independent. This reduces the package test time from ~60s to ~10s.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
