### PR TITLE
Refactor non-docker container stats and add unit tests

### DIFF
--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -119,14 +119,14 @@ func (container *StatsContainer) getApiContainer(dockerID string) (*apicontainer
 	return dockerContainer.Container, nil
 }
 
-func getNonDockerContainerStats(apiContainer *apicontainer.Container) *NonDockerContainerStats {
+func getNonDockerContainerStats(apiContainer *apicontainer.Container) NonDockerContainerStats {
+	nonDockerStats := NonDockerContainerStats{}
 	if apiContainer == nil {
-		return nil
+		return nonDockerStats
 	}
-	var nonDockerStats *NonDockerContainerStats
 	if apiContainer.RestartPolicyEnabled() {
-		nonDockerStats = &NonDockerContainerStats{}
-		nonDockerStats.restartCount = int64(apiContainer.RestartTracker.GetRestartCount())
+		restartCount := int64(apiContainer.RestartTracker.GetRestartCount())
+		nonDockerStats.restartCount = &restartCount
 	}
 	return nonDockerStats
 }

--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -61,14 +61,14 @@ func (queue *Queue) Reset() {
 }
 
 // Add adds a new set of container stats to the queue.
-func (queue *Queue) Add(dockerStat *types.StatsJSON, nonDockerStats *NonDockerContainerStats) error {
+func (queue *Queue) Add(dockerStat *types.StatsJSON, nonDockerStats NonDockerContainerStats) error {
 	queue.setLastStat(dockerStat)
 	stat, err := dockerStatsToContainerStats(dockerStat)
 	if err != nil {
 		return err
 	}
-	if nonDockerStats != nil {
-		stat.restartCount = &nonDockerStats.restartCount
+	if nonDockerStats.restartCount != nil {
+		stat.restartCount = nonDockerStats.restartCount
 	}
 	queue.add(stat)
 	return nil

--- a/agent/stats/task.go
+++ b/agent/stats/task.go
@@ -121,7 +121,7 @@ func (taskStat *StatsTask) processStatsStream() error {
 				}
 				return nil
 			}
-			if err := taskStat.StatsQueue.Add(rawStat, nil); err != nil {
+			if err := taskStat.StatsQueue.Add(rawStat, NonDockerContainerStats{}); err != nil {
 				logger.Warn("Error converting task stats", logger.Fields{
 					field.TaskID: taskId,
 					field.Error:  err,

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -38,7 +38,7 @@ type ContainerStats struct {
 // These are amended to the docker stats and added to the stats queue if they are
 // available.
 type NonDockerContainerStats struct {
-	restartCount int64
+	restartCount *int64
 }
 
 // NetworkStats contains the network stats information for a container


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This is a minor followup to https://github.com/aws/amazon-ecs-agent/pull/4196

Change NonDockerContainerStats from a pointer to a reference, and change the restartCount field from a reference to a pointer.

What this does is enables the getNonDockerContainerStats function to always return the object, but only return restartCount when it should be set to a non-nil value. This will make NonDockerContainerStats easier to extend in the future, and allows for checking if restartCount is set or not explicitly. We expect this field to not be set (nil) when the feature is not enabled. This allows for explicit testing and checking of three scenarios:

1. When restart policy is not enabled or unset, restartCount == nil
2. When restart policy is enabled but no restarts occurred, restartCount == 0
3. When restart policy is enabled and restarts occurred, restartCount > 0

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Unit tests were added to verify exact scenarios when we expect restartCount to be nil, zero, and non-zero.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
