### PR TITLE
S3 config changes to use S3 FIPS endpoints on FIPS hosts

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -665,3 +665,9 @@ func (cfg *Config) String() string {
 func IsFIPSEnabled() bool {
 	return isFIPSEnabled
 }
+
+// SetFIPSEnabled sets the isFIPSEnabled variable for testing purposes
+// that is used in s3/factory/factory_test.go
+func SetFIPSEnabled(enabled bool) {
+	isFIPSEnabled = enabled
+}

--- a/agent/s3/factory/factory.go
+++ b/agent/s3/factory/factory.go
@@ -14,6 +14,7 @@
 package factory
 
 import (
+	"context"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -21,17 +22,18 @@ import (
 	agentversion "github.com/aws/amazon-ecs-agent/agent/version"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/httpclient"
-
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/aws-sdk-go/aws"
 	awscreds "github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
 const (
-	bucketLocationDefault = "us-east-1"
-	roundtripTimeout      = 5 * time.Second
+	roundtripTimeout = 5 * time.Second
 )
 
 type S3ClientCreator interface {
@@ -39,7 +41,7 @@ type S3ClientCreator interface {
 	NewS3Client(bucket, region string, creds credentials.IAMRoleCredentials) (s3client.S3Client, error)
 }
 
-// NewS3ClientCreator provide 2 implementations
+// NewS3ClientCreator provides 2 implementations
 // NewS3ManagerClient implements methods from aws-sdk-go/service/s3manager.
 // NewS3Client implements methods from aws-sdk-go/service/s3.
 func NewS3ClientCreator() S3ClientCreator {
@@ -56,17 +58,22 @@ func (*s3ClientCreator) NewS3ManagerClient(bucket, region string,
 		WithCredentials(
 			awscreds.NewStaticCredentials(creds.AccessKeyID, creds.SecretAccessKey,
 				creds.SessionToken)).WithRegion(region)
+	if config.IsFIPSEnabled() {
+		logger.Debug("FIPS mode detected, using FIPS-compliant S3 endpoint")
+		cfg.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+	}
 	sess := session.Must(session.NewSession(cfg))
 	svc := s3.New(sess)
 	bucketRegion, err := getRegionFromBucket(svc, bucket)
 	if err != nil {
 		return nil, err
 	}
-	sessWithRegion := session.Must(session.NewSession(cfg.WithRegion(bucketRegion)))
+	cfg.WithRegion(bucketRegion)
+	sessWithRegion := session.Must(session.NewSession(cfg))
 	return s3manager.NewDownloaderWithClient(s3.New(sessWithRegion)), nil
 }
 
-// NewS3Client returns a new S3 client to support s3 operations which are not provided by s3manager.
+// NewS3Client returns a new S3 client to support S3 operations which are not provided by s3manager.
 func (*s3ClientCreator) NewS3Client(bucket, region string,
 	creds credentials.IAMRoleCredentials) (s3client.S3Client, error) {
 	cfg := aws.NewConfig().
@@ -74,25 +81,32 @@ func (*s3ClientCreator) NewS3Client(bucket, region string,
 		WithCredentials(
 			awscreds.NewStaticCredentials(creds.AccessKeyID, creds.SecretAccessKey,
 				creds.SessionToken)).WithRegion(region)
+	if config.IsFIPSEnabled() {
+		logger.Debug("FIPS mode detected, using FIPS-compliant S3 endpoint")
+		cfg.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+	}
 	sess := session.Must(session.NewSession(cfg))
 	svc := s3.New(sess)
 	bucketRegion, err := getRegionFromBucket(svc, bucket)
 	if err != nil {
 		return nil, err
 	}
-	sessWithRegion := session.Must(session.NewSession(cfg.WithRegion(bucketRegion)))
+	cfg.WithRegion(bucketRegion)
+	sessWithRegion := session.Must(session.NewSession(cfg))
 	return s3.New(sessWithRegion), nil
 }
 func getRegionFromBucket(svc *s3.S3, bucket string) (string, error) {
-	input := &s3.GetBucketLocationInput{
-		Bucket: aws.String(bucket),
+	ctx := context.Background()
+	opts := []request.Option{}
+	if config.IsFIPSEnabled() {
+		logger.Debug("FIPS mode detected, using virtual-host–style URLs for bucket location")
+		opts = append(opts, func(r *request.Request) {
+			r.Config.S3ForcePathStyle = aws.Bool(false)
+		})
 	}
-	result, err := svc.GetBucketLocation(input)
+	region, err := s3manager.GetBucketRegionWithClient(ctx, svc, bucket, opts...)
 	if err != nil {
 		return "", err
 	}
-	if result.LocationConstraint == nil { // GetBucketLocation returns nil for bucket in us-east-1.
-		return bucketLocationDefault, nil
-	}
-	return aws.StringValue(result.LocationConstraint), nil
+	return region, nil
 }

--- a/agent/s3/factory/factory_test.go
+++ b/agent/s3/factory/factory_test.go
@@ -1,0 +1,61 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package factory
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateAWSConfig(t *testing.T) {
+	creds := credentials.IAMRoleCredentials{
+		AccessKeyID:     "dummyAccessKeyID",
+		SecretAccessKey: "dummySecretAccessKey",
+		SessionToken:    "dummySessionToken",
+	}
+	region := "us-west-2"
+	// Test without FIPS enabled
+	config.SetFIPSEnabled(false)
+	cfg := createAWSConfig(region, creds)
+	assert.Equal(t, roundtripTimeout, cfg.HTTPClient.Timeout, "HTTPClient timeout should be set")
+	assert.Equal(t, region, aws.StringValue(cfg.Region), "Region should be set")
+	credsValue, err := cfg.Credentials.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, "dummyAccessKeyID", credsValue.AccessKeyID, "AccessKeyID should be set")
+	assert.Equal(t, "dummySecretAccessKey", credsValue.SecretAccessKey, "SecretAccessKey should be set")
+	assert.Equal(t, "dummySessionToken", credsValue.SessionToken, "SessionToken should be set")
+	assert.Equal(t, endpoints.FIPSEndpointStateUnset, cfg.UseFIPSEndpoint, "UseFIPSEndpoint should not be set")
+	assert.Nil(t, cfg.S3ForcePathStyle, "S3ForcePathStyle should not be set")
+
+	// Test with FIPS enabled
+	config.SetFIPSEnabled(true)
+	cfg = createAWSConfig(region, creds)
+	assert.Equal(t, roundtripTimeout, cfg.HTTPClient.Timeout, "HTTPClient timeout should be set")
+	assert.Equal(t, region, aws.StringValue(cfg.Region), "Region should be set")
+	credsValue, err = cfg.Credentials.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, "dummyAccessKeyID", credsValue.AccessKeyID, "AccessKeyID should be set")
+	assert.Equal(t, "dummySecretAccessKey", credsValue.SecretAccessKey, "SecretAccessKey should be set")
+	assert.Equal(t, "dummySessionToken", credsValue.SessionToken, "SessionToken should be set")
+	assert.Equal(t, endpoints.FIPSEndpointStateEnabled, cfg.UseFIPSEndpoint, "UseFIPSEndpoint should be set to FIPSEndpointStateEnabled")
+	assert.False(t, aws.BoolValue(cfg.S3ForcePathStyle), "S3ForcePathStyle should be set to false")
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request enables ECS Agent on linux to make S3 calls using S3 FIPS Endpoints when FIPS mode is enabled on the host machine.
### Implementation details
<!-- How are the changes implemented? -->
* Updated the `NewS3ManagerClient` and `NewS3Client` functions to use `cfg.UseFIPSEndpoint` to call FIPS S3 endpoints when FIPS mode is detected on the host.
* Modified the `getRegionFromBucket` function to use `s3manager.GetBucketRegionWithClient` with options to ensure virtual-hosted-style URLs are used when FIPS mode is enabled on the host.
* Added logging statements to indicate when FIPS compliant S3 endpoints and virtual-hosted-style URLs are being used.   
### Testing
<!-- How was this tested? -->
* Built test agent using the changes made in the PR and ran agent on FIPS Enabled host. 
* Agent was able to identify it running in a FIPS enabled env based on the following log
```
/var/log/ecs/ecs-agent.log.2024-06-10-18:level=info time=2024-06-10T18:33:19Z msg="FIPS mode detected on the host"
```
* Created an S3 bucket and placed a `test1.env` file in the S3 bucket with the following content
```
TEST1=ABC
TEST2=XYZ
```
* Ran a task with the following task definition
```
{
    "taskDefinitionArn": "arn:aws:ecs:us-west-2:redacted:task-definition/fips-test:2",
    "containerDefinitions": [
        {
            "name": "sleepy300",
            "image": "busybox",
            "cpu": 100,
            "memory": 10,
            "portMappings": [],
            "essential": true,
            "command": [
                "sleep",
                "10000000"
            ],
            "environment": [],
            "environmentFiles": [
                {
                    "value": "arn:aws:s3:::redacted/test1.env",
                    "type": "s3"
                }
            ],
            "mountPoints": [],
            "volumesFrom": [],
            "systemControls": []
        }
    ],
    "family": "fips-test",
    "taskRoleArn": "arn:aws:iam::redacted:role/TaskIAMRoleArn",
    "executionRoleArn": "arn:aws:iam::redacted:role/TaskExecutionRoleARN",
    "networkMode": "host",
    "revision": 2,
    "volumes": [],
    "status": "ACTIVE",
    "requiresAttributes": [
        {
            "name": "com.amazonaws.ecs.capability.task-iam-role-network-host"
        },
        {
            "name": "ecs.capability.env-files.s3"
        },
        {
            "name": "com.amazonaws.ecs.capability.task-iam-role"
        },
        {
            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
        }
    ],
    "placementConstraints": [],
    "compatibilities": [
        "EXTERNAL",
        "EC2"
    ],
    "cpu": "256",
    "memory": "512",
    "registeredAt": "2024-05-28T22:54:48.812Z",
    "registeredBy": "arn:aws:sts::redacted:assumed-role/Admin/test",
    "tags": []
}
```
* Verified in the ECS console for the running task under **Environment Variables and Files** that the env file was attached to the container.
* Logged onto the running container using `docker exec -it <container_id> sh` and executed the following commands to access the values defined in the env files
```
/ # echo $TEST1
ABC
/ # echo $TEST2
XYZ
```
* Verified using the logs that FIPS S3 Endpoints are being used
```
/var/log/ecs/ecs-agent.log.2024-06-10-18:level=debug time=2024-06-10T18:35:24Z msg="FIPS mode detected, using FIPS-compliant S3 endpoint"
/var/log/ecs/ecs-agent.log.2024-06-10-18:level=debug time=2024-06-10T18:35:24Z msg="FIPS mode detected, using virtual-host–style URLs for bucket location"
```
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
Yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
S3 config changes to use S3 FIPS endpoints on FIPS hosts
**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

### References
* virtual-hosted–style URL - https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
* GetBucketRegionWithClient function - https://docs.aws.amazon.com/sdk-for-go/api/service/s3/s3manager/#GetBucketRegionWithClient
* `s3manager.GetBucketRegionWithClient` will cover the special region case `EU` and `us-east-1` per https://github.com/aws/aws-sdk-go/blob/main/service/s3/bucket_location.go#L27

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
