### PR TITLE
Make restart tracker's restart policy field public

### DIFF
--- a/ecs-agent/api/container/restart/restart_tracker.go
+++ b/ecs-agent/api/container/restart/restart_tracker.go
@@ -22,9 +22,9 @@ import (
 )
 
 type RestartTracker struct {
-	RestartCount  int       `json:"restartCount,omitempty"`
-	LastRestartAt time.Time `json:"lastRestartAt,omitempty"`
-	restartPolicy RestartPolicy
+	RestartCount  int           `json:"restartCount,omitempty"`
+	LastRestartAt time.Time     `json:"lastRestartAt,omitempty"`
+	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty"`
 	lock          sync.RWMutex
 }
 
@@ -38,7 +38,7 @@ type RestartPolicy struct {
 
 func NewRestartTracker(restartPolicy RestartPolicy) *RestartTracker {
 	return &RestartTracker{
-		restartPolicy: restartPolicy,
+		RestartPolicy: restartPolicy,
 	}
 }
 
@@ -73,7 +73,7 @@ func (rt *RestartTracker) ShouldRestart(exitCode *int, startedAt time.Time,
 	rt.lock.RLock()
 	defer rt.lock.RUnlock()
 
-	if !rt.restartPolicy.Enabled {
+	if !rt.RestartPolicy.Enabled {
 		return false, "restart policy is not enabled"
 	}
 	if desiredStatus == apicontainerstatus.ContainerStopped {
@@ -82,7 +82,7 @@ func (rt *RestartTracker) ShouldRestart(exitCode *int, startedAt time.Time,
 	if exitCode == nil {
 		return false, "exit code is nil"
 	}
-	for _, ignoredCode := range rt.restartPolicy.IgnoredExitCodes {
+	for _, ignoredCode := range rt.RestartPolicy.IgnoredExitCodes {
 		if ignoredCode == *exitCode {
 			return false, fmt.Sprintf("exit code %d should be ignored", *exitCode)
 		}
@@ -92,7 +92,7 @@ func (rt *RestartTracker) ShouldRestart(exitCode *int, startedAt time.Time,
 	if !rt.LastRestartAt.IsZero() {
 		startTime = rt.LastRestartAt
 	}
-	if time.Since(startTime) < rt.restartPolicy.RestartAttemptPeriod {
+	if time.Since(startTime) < rt.RestartPolicy.RestartAttemptPeriod {
 		return false, "attempt reset period has not elapsed"
 	}
 	return true, ""

--- a/ecs-agent/api/container/restart/restart_tracker_test.go
+++ b/ecs-agent/api/container/restart/restart_tracker_test.go
@@ -116,7 +116,7 @@ func TestShouldRestart(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			rt.restartPolicy = tc.rp
+			rt.RestartPolicy = tc.rp
 
 			// Because we cannot instantiate int pointers directly,
 			// check for the exit code and leave this int pointer as nil
@@ -171,6 +171,6 @@ func TestRecordRestartPolicy(t *testing.T) {
 		RestartAttemptPeriod: 60 * time.Second,
 	})
 	assert.Equal(t, 0, rt.RestartCount)
-	assert.Equal(t, 0, len(rt.restartPolicy.IgnoredExitCodes))
-	assert.NotNil(t, rt.restartPolicy)
+	assert.Equal(t, 0, len(rt.RestartPolicy.IgnoredExitCodes))
+	assert.NotNil(t, rt.RestartPolicy)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Make restart tracker's restart policy field public. This is necessary in case Agent consuming restart tracker needs to marshal/unmarshal this field to/from JSON, such as while saving Agent state to a local file.

### Implementation details
<!-- How are the changes implemented? -->
See above.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no (existing tests updated)

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Make restart tracker's restart policy field public

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
