### PR TITLE
Aggregate container metadata across restarts

### DIFF
--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -25,6 +25,7 @@ import (
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
+	"github.com/docker/docker/api/types"
 
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	dockercontainer "github.com/docker/docker/api/types/container"
@@ -1401,6 +1402,51 @@ func TestRestartPolicy(t *testing.T) {
 			require.Equal(t, tc.restartCount, tc.container.RestartTracker.GetRestartCount())
 		}
 	}
+}
+
+func TestGetAndSetStartedAt(t *testing.T) {
+	testTime := time.Date(1969, 12, 31, 23, 59, 59, 0, time.UTC)
+	c := &Container{}
+
+	// Test getting started at time when it has never been set is the zero value of time.
+	require.True(t, c.GetStartedAt().IsZero())
+
+	// Test setting started at time sets the started at time.
+	c.SetStartedAt(testTime)
+	require.Equal(t, testTime, c.GetStartedAt())
+
+	// Test setting started at time after it has already been set does not change the originally set started at time.
+	c.SetStartedAt(time.Now())
+	require.Equal(t, testTime, c.GetStartedAt())
+}
+
+func TestGetAndSetRestartAggregationDataForStats(t *testing.T) {
+	testTime := time.Date(1969, 12, 31, 23, 59, 59, 0, time.UTC)
+	testStatsJSON := types.StatsJSON{
+		Stats: types.Stats{
+			CPUStats: types.CPUStats{
+				CPUUsage: types.CPUUsage{
+					TotalUsage: 100,
+				},
+			},
+			MemoryStats: types.MemoryStats{
+				MaxUsage: 200,
+			},
+		},
+	}
+	testRestartAggregationDataForStats := ContainerRestartAggregationDataForStats{
+		LastRestartDetectedAt:     testTime,
+		LastStatBeforeLastRestart: testStatsJSON,
+	}
+	c := &Container{}
+
+	// Test getting restart aggregation data for stats when it has never been set is the zero value of the
+	// ContainerRestartAggregationDataForStats struct.
+	require.Equal(t, ContainerRestartAggregationDataForStats{}, c.GetRestartAggregationDataForStats())
+
+	// Test setting restart aggregation data for stats sets the restart aggregation data for stats.
+	c.SetRestartAggregationDataForStats(testRestartAggregationDataForStats)
+	require.Equal(t, testRestartAggregationDataForStats, c.GetRestartAggregationDataForStats())
 }
 
 func getContainer(hostConfig string, credentialSpecs []string) *Container {

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -935,7 +935,7 @@ func (agent *ecsAgent) startAsyncRoutines(
 	telemetryMessages := make(chan ecstcs.TelemetryMessage, telemetryChannelDefaultBufferSize)
 	healthMessages := make(chan ecstcs.HealthMessage, telemetryChannelDefaultBufferSize)
 
-	statsEngine := stats.NewDockerStatsEngine(agent.cfg, agent.dockerClient, containerChangeEventStream, telemetryMessages, healthMessages)
+	statsEngine := stats.NewDockerStatsEngine(agent.cfg, agent.dockerClient, containerChangeEventStream, telemetryMessages, healthMessages, agent.dataClient)
 
 	// Start serving the endpoint to fetch IAM Role credentials and other task metadata
 	if agent.cfg.TaskMetadataAZDisabled {

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/rootless-containers/rootlesskit v1.1.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -228,6 +228,8 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -60,6 +60,9 @@ const (
 	taskDefinitionVersion       = "1"
 	containerName               = "gremlin-container"
 	serviceConnectContainerName = "service-connect-container"
+
+	testNetworkNameA = "eth0"
+	testNetworkNameB = "eth1"
 )
 
 var (

--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -15,22 +15,23 @@ package stats
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/stats/resolver"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	loggerfield "github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 	"github.com/cihub/seelog"
+	"github.com/pkg/errors"
 )
 
-func newStatsContainer(dockerID string, client dockerapi.DockerClient, resolver resolver.ContainerMetadataResolver,
-	cfg *config.Config) (*StatsContainer, error) {
+func newStatsContainer(dockerID string, client dockerapi.DockerClient, resolver resolver.ContainerMetadataResolver, cfg *config.Config, dataClient data.Client) (*StatsContainer, error) {
 	dockerContainer, err := resolver.ResolveContainer(dockerID)
 	if err != nil {
 		return nil, err
@@ -43,11 +44,13 @@ func newStatsContainer(dockerID string, client dockerapi.DockerClient, resolver 
 			NetworkMode: dockerContainer.Container.GetNetworkMode(),
 			StartedAt:   dockerContainer.Container.GetStartedAt(),
 		},
-		ctx:      ctx,
-		cancel:   cancel,
-		client:   client,
-		resolver: resolver,
-		config:   cfg,
+		ctx:                    ctx,
+		cancel:                 cancel,
+		client:                 client,
+		resolver:               resolver,
+		config:                 cfg,
+		restartAggregationData: dockerContainer.Container.GetRestartAggregationDataForStats(),
+		dataClient:             dataClient,
 	}, nil
 }
 
@@ -169,8 +172,23 @@ func (container *StatsContainer) processStatsStream() error {
 				return err
 			}
 
-			if err := container.statsQueue.Add(rawStat, getNonDockerContainerStats(apiContainer)); err != nil {
+			isFirstStatAfterContainerRestart := apiContainer != nil && apiContainer.RestartPolicyEnabled() &&
+				container.syncContainerRestartAggregationData()
+			err = container.statsQueue.AddContainerStat(rawStat, getNonDockerContainerStats(apiContainer),
+				&container.restartAggregationData.LastStatBeforeLastRestart, container.hasRestartedBefore())
+			if err != nil {
 				seelog.Warnf("Container [%s]: error converting stats for container: %v", dockerID, err)
+				continue
+			}
+			if isFirstStatAfterContainerRestart {
+				err = container.saveRestartAggregationData(apiContainer)
+				if err != nil {
+					logger.Error("Failed to update container's stats restart aggregation data in database",
+						logger.Fields{
+							loggerfield.DockerId: dockerID,
+							loggerfield.Error:    err,
+						})
+				}
 			}
 		}
 	}
@@ -182,4 +200,45 @@ func (container *StatsContainer) terminal() (bool, error) {
 		return false, err
 	}
 	return dockerContainer.Container.KnownTerminal(), nil
+}
+
+// syncContainerRestartAggregationData updates a container's restart aggregation data if a container restart has been
+// detected. This method returns true if a restart was detected and returns false otherwise.
+func (container *StatsContainer) syncContainerRestartAggregationData() bool {
+	_, dockerContainerData := container.client.DescribeContainer(container.ctx, container.containerMetadata.DockerID)
+	restartDetected := dockerContainerData.StartedAt.Sub(container.containerMetadata.StartedAt) > 0
+	if container.hasRestartedBefore() {
+		restartDetected = dockerContainerData.StartedAt.Sub(container.restartAggregationData.LastRestartDetectedAt) > 0
+	}
+
+	if restartDetected {
+		container.restartAggregationData.LastRestartDetectedAt = time.Now()
+
+		logger.Debug("Received first stat for container after a container restart", logger.Fields{
+			loggerfield.DockerId: container.containerMetadata.DockerID,
+		})
+
+		lastStat := container.statsQueue.GetLastStat()
+		if lastStat != nil {
+			container.restartAggregationData.LastStatBeforeLastRestart = *lastStat
+		}
+	}
+
+	return restartDetected
+}
+
+// saveRestartAggregationData is used to save a container's restart aggregation data in Agent's local state database.
+func (container *StatsContainer) saveRestartAggregationData(apiContainer *apicontainer.Container) error {
+	apiContainer.SetRestartAggregationDataForStats(container.restartAggregationData)
+	err := container.dataClient.SaveContainer(apiContainer)
+	if err != nil {
+		return errors.Wrap(err, "failed to save data for container")
+	}
+
+	return nil
+}
+
+// hasRestartedBefore determines if a container has ever restarted before.
+func (container *StatsContainer) hasRestartedBefore() bool {
+	return !container.restartAggregationData.LastRestartDetectedAt.IsZero()
 }

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -63,7 +63,7 @@ func createRunningTask(networkMode string) *apitask.Task {
 
 func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithExistingContainersWithoutHealth"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithExistingContainersWithoutHealth"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -131,7 +131,7 @@ func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 
 func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"), nil, nil, nil)
 	defer engine.removeAll()
 
 	// Assign ContainerStop timeout to addressable variable
@@ -206,7 +206,7 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 
 func TestStatsEngineWithExistingContainers(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithExistingContainers"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithExistingContainers"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -280,7 +280,7 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 
 func TestStatsEngineWithNewContainers(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"), nil, nil, nil)
 	defer engine.removeAll()
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -365,7 +365,7 @@ func TestStatsEngineWithNewContainersWithPolling(t *testing.T) {
 	// Create a new docker client with new config
 	dockerClientForNewContainersWithPolling, _ := dockerapi.NewDockerGoClient(sdkClientFactory, &cfg, ctx)
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClientForNewContainersWithPolling, eventStream("TestStatsEngineWithNewContainers"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClientForNewContainersWithPolling, eventStream("TestStatsEngineWithNewContainers"), nil, nil, nil)
 	defer engine.removeAll()
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -475,7 +475,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 		testTask)
 
 	// Create a new docker stats engine
-	statsEngine := NewDockerStatsEngine(&cfg, dockerClient, containerChangeEventStream, nil, nil)
+	statsEngine := NewDockerStatsEngine(&cfg, dockerClient, containerChangeEventStream, nil, nil, nil)
 	err = statsEngine.MustInit(ctx, taskEngine, defaultCluster, defaultContainerInstance)
 	require.NoError(t, err, "initializing stats engine failed")
 	defer statsEngine.removeAll()
@@ -561,7 +561,7 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 		testTask)
 
 	// Create a new docker stats engine
-	statsEngine := NewDockerStatsEngine(&cfg, dockerClient, containerChangeEventStream, nil, nil)
+	statsEngine := NewDockerStatsEngine(&cfg, dockerClient, containerChangeEventStream, nil, nil, nil)
 	err = statsEngine.MustInit(ctx, taskEngine, defaultCluster, defaultContainerInstance)
 	require.NoError(t, err, "initializing stats engine failed")
 	defer statsEngine.removeAll()
@@ -607,7 +607,7 @@ func TestStatsEngineWithNetworkStatsDefaultMode(t *testing.T) {
 
 func testNetworkModeStatsInteg(t *testing.T, networkMode string, statsEmpty bool) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNetworkStats"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNetworkStats"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -691,7 +691,7 @@ func testNetworkModeStatsInteg(t *testing.T, networkMode string, statsEmpty bool
 
 func TestStorageStats(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithStorageStats"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithStorageStats"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -78,7 +78,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	mockStatsChannel := make(chan *types.StatsJSON)
 	defer close(mockStatsChannel)
 	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStatsChannel, nil).AnyTimes()
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineAddRemoveContainers"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineAddRemoveContainers"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -229,7 +229,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	resolver.EXPECT().ResolveTaskByARN(gomock.Any()).Return(t1, nil).AnyTimes()
 
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineMetadataInStatsSets"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineMetadataInStatsSets"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -279,7 +279,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 }
 
 func TestStatsEngineInvalidTaskEngine(t *testing.T) {
-	statsEngine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineInvalidTaskEngine"), nil, nil)
+	statsEngine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineInvalidTaskEngine"), nil, nil, nil)
 	taskEngine := &MockTaskEngine{}
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -290,7 +290,7 @@ func TestStatsEngineInvalidTaskEngine(t *testing.T) {
 }
 
 func TestStatsEngineUninitialized(t *testing.T) {
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineUninitialized"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineUninitialized"), nil, nil, nil)
 	defer engine.removeAll()
 
 	engine.resolver = &DockerContainerMetadataResolver{}
@@ -309,7 +309,7 @@ func TestStatsEngineTerminalTask(t *testing.T) {
 		KnownStatusUnsafe: apitaskstatus.TaskStopped,
 		Family:            "f1",
 	}, nil)
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineTerminalTask"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineTerminalTask"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -426,7 +426,7 @@ func TestStartMetricsPublish(t *testing.T) {
 			telemetryMessages := make(chan ecstcs.TelemetryMessage, tc.channelSize)
 			healthMessages := make(chan ecstcs.HealthMessage, tc.channelSize)
 
-			engine := NewDockerStatsEngine(&publishMetricsCfg, nil, eventStream("TestStartMetricsPublish"), telemetryMessages, healthMessages)
+			engine := NewDockerStatsEngine(&publishMetricsCfg, nil, eventStream("TestStartMetricsPublish"), telemetryMessages, healthMessages, nil)
 			ctx, cancel := context.WithCancel(context.TODO())
 			engine.ctx = ctx
 			engine.resolver = resolver
@@ -521,7 +521,7 @@ func TestGetInstanceMetricsNonIdleEmptyError(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetInstanceMetrics"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetInstanceMetrics"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -558,7 +558,7 @@ func TestGetTaskHealthMetrics(t *testing.T) {
 		},
 	}, nil).Times(3)
 
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -566,7 +566,7 @@ func TestGetTaskHealthMetrics(t *testing.T) {
 
 	containerToStats := make(map[string]*StatsContainer)
 	var err error
-	containerToStats[containerID], err = newStatsContainer(containerID, nil, resolver, nil)
+	containerToStats[containerID], err = newStatsContainer(containerID, nil, resolver, nil, nil)
 	assert.NoError(t, err)
 	engine.tasksToHealthCheckContainers["t1"] = containerToStats
 	engine.tasksToDefinitions["t1"] = &taskDefinition{
@@ -602,7 +602,7 @@ func TestGetTaskHealthMetricsStoppedContainer(t *testing.T) {
 		},
 	}, nil).Times(2)
 
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -610,7 +610,7 @@ func TestGetTaskHealthMetricsStoppedContainer(t *testing.T) {
 
 	containerToStats := make(map[string]*StatsContainer)
 	var err error
-	containerToStats[containerID], err = newStatsContainer(containerID, nil, resolver, nil)
+	containerToStats[containerID], err = newStatsContainer(containerID, nil, resolver, nil, nil)
 	assert.NoError(t, err)
 	engine.tasksToHealthCheckContainers["t1"] = containerToStats
 	engine.tasksToDefinitions["t1"] = &taskDefinition{
@@ -628,7 +628,7 @@ func TestGetTaskHealthMetricsEmptyError(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -669,7 +669,7 @@ func TestMetricsDisabled(t *testing.T) {
 		},
 	}, nil).Times(2)
 
-	engine := NewDockerStatsEngine(&disableMetricsConfig, nil, eventStream("TestMetricsDisabled"), nil, nil)
+	engine := NewDockerStatsEngine(&disableMetricsConfig, nil, eventStream("TestMetricsDisabled"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -690,7 +690,7 @@ func TestSynchronizeOnRestart(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	resolver := mock_resolver.NewMockContainerMetadataResolver(ctrl)
 
-	engine := NewDockerStatsEngine(&cfg, client, eventStream("TestSynchronizeOnRestart"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, client, eventStream("TestSynchronizeOnRestart"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -789,7 +789,7 @@ func testNetworkModeStats(t *testing.T, netMode string, enis []*ni.NetworkInterf
 			State: &types.ContainerState{Pid: 23},
 		},
 	}, nil).AnyTimes()
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestTaskNetworkStatsSet"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestTaskNetworkStatsSet"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx

--- a/agent/stats/engine_unix_integ_test.go
+++ b/agent/stats/engine_unix_integ_test.go
@@ -90,7 +90,7 @@ func TestStatsEngineWithServiceConnectMetrics(t *testing.T) {
 			}
 
 			// Create a new docker stats engine
-			engine := NewDockerStatsEngine(&testConfig, dockerClient, eventStream("TestStatsEngineWithServiceConnectMetrics"), nil, nil)
+			engine := NewDockerStatsEngine(&testConfig, dockerClient, eventStream("TestStatsEngineWithServiceConnectMetrics"), nil, nil, nil)
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
 

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -90,7 +90,7 @@ func TestNetworkModeStatsAWSVPCMode(t *testing.T) {
 			State: &types.ContainerState{Pid: 23},
 		},
 	}, nil).AnyTimes()
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestTaskNetworkStatsSet"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestTaskNetworkStatsSet"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -148,7 +148,7 @@ func TestServiceConnectWithDisabledMetrics(t *testing.T) {
 		Container: &container,
 	}, nil).Times(2)
 
-	engine := NewDockerStatsEngine(&disableMetricsConfig, nil, eventStream("TestServiceConnectWithDisabledMetrics"), nil, nil)
+	engine := NewDockerStatsEngine(&disableMetricsConfig, nil, eventStream("TestServiceConnectWithDisabledMetrics"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -234,7 +234,7 @@ func TestFetchEBSVolumeMetrics(t *testing.T) {
 					},
 				},
 			}
-			engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestFetchEBSVolumeMetrics"), nil, nil)
+			engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestFetchEBSVolumeMetrics"), nil, nil, nil)
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
 			engine.ctx = ctx

--- a/agent/stats/queue_unix.go
+++ b/agent/stats/queue_unix.go
@@ -1,0 +1,146 @@
+//go:build linux
+// +build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
+	"github.com/docker/docker/api/types"
+)
+
+type BlockStatKey struct {
+	Major uint64
+	Minor uint64
+	Op    string
+}
+
+type BlockStatValue struct {
+	HasBeenRetrieved bool
+	Value            uint64
+}
+
+// aggregateOSDependentStats aggregates stats that are measured cumulatively against container start time and
+// populated only for Linux OS.
+func aggregateOSDependentStats(dockerStat, lastStatBeforeLastRestart *types.StatsJSON) *types.StatsJSON {
+	// CPU stats.
+	aggregateUsagePerCore(&dockerStat.CPUStats.CPUUsage.PercpuUsage,
+		lastStatBeforeLastRestart.CPUStats.CPUUsage.PercpuUsage)
+	dockerStat.CPUStats.ThrottlingData.Periods += lastStatBeforeLastRestart.CPUStats.ThrottlingData.Periods
+	dockerStat.CPUStats.ThrottlingData.ThrottledPeriods +=
+		lastStatBeforeLastRestart.CPUStats.ThrottlingData.ThrottledPeriods
+	dockerStat.CPUStats.ThrottlingData.ThrottledTime += lastStatBeforeLastRestart.CPUStats.ThrottlingData.ThrottledTime
+
+	// Memory stats.
+	dockerStat.MemoryStats.MaxUsage = utils.MaxNum(dockerStat.MemoryStats.MaxUsage,
+		lastStatBeforeLastRestart.MemoryStats.MaxUsage)
+	dockerStat.MemoryStats.Failcnt += lastStatBeforeLastRestart.MemoryStats.Failcnt
+
+	// Block I/O stats.
+	aggregateBlockStat(&dockerStat.BlkioStats.IoServiceBytesRecursive,
+		lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive)
+	aggregateBlockStat(&dockerStat.BlkioStats.IoServicedRecursive,
+		lastStatBeforeLastRestart.BlkioStats.IoServicedRecursive)
+	aggregateBlockStat(&dockerStat.BlkioStats.IoServiceTimeRecursive,
+		lastStatBeforeLastRestart.BlkioStats.IoServiceTimeRecursive)
+	aggregateBlockStat(&dockerStat.BlkioStats.IoWaitTimeRecursive,
+		lastStatBeforeLastRestart.BlkioStats.IoWaitTimeRecursive)
+	aggregateBlockStat(&dockerStat.BlkioStats.IoMergedRecursive, lastStatBeforeLastRestart.BlkioStats.IoMergedRecursive)
+	aggregateBlockStat(&dockerStat.BlkioStats.IoTimeRecursive, lastStatBeforeLastRestart.BlkioStats.IoTimeRecursive)
+	aggregateBlockStat(&dockerStat.BlkioStats.SectorsRecursive, lastStatBeforeLastRestart.BlkioStats.SectorsRecursive)
+
+	// Network stats.
+	for key, dockerStatNetwork := range dockerStat.Networks {
+		lastStatBeforeLastRestartNetwork, ok := lastStatBeforeLastRestart.Networks[key]
+		if ok {
+			dockerStatNetwork.RxErrors += lastStatBeforeLastRestartNetwork.RxErrors
+			dockerStatNetwork.TxErrors += lastStatBeforeLastRestartNetwork.TxErrors
+		}
+		dockerStat.Networks[key] = dockerStatNetwork
+	}
+
+	return dockerStat
+}
+
+// aggregateUsagePerCore aggregates the total CPU time consumed per core.
+func aggregateUsagePerCore(dockerStatUsageSlice *[]uint64, lastStatBeforeLastRestartStatUsageSlice []uint64) {
+	if len(*dockerStatUsageSlice) == 0 && len(lastStatBeforeLastRestartStatUsageSlice) == 0 {
+		return
+	}
+
+	var aggregatedUsageSlice []uint64
+	peakNumCores := utils.MaxNum(len(*dockerStatUsageSlice), len(lastStatBeforeLastRestartStatUsageSlice))
+	for i := 0; i < peakNumCores; i++ {
+		coreUsage := uint64(0)
+		if i < len(lastStatBeforeLastRestartStatUsageSlice) {
+			coreUsage += lastStatBeforeLastRestartStatUsageSlice[i]
+		}
+		if i < len(*dockerStatUsageSlice) {
+			coreUsage += (*dockerStatUsageSlice)[i]
+		}
+		aggregatedUsageSlice = append(aggregatedUsageSlice, coreUsage)
+	}
+	*dockerStatUsageSlice = aggregatedUsageSlice
+}
+
+// aggregateBlockStat aggregates block I/O stats for the specified I/O service stat.
+func aggregateBlockStat(dockerStatBlockStatSlice *[]types.BlkioStatEntry,
+	lastStatBeforeLastRestartStatBlockStatSlice []types.BlkioStatEntry) {
+	if len(*dockerStatBlockStatSlice) == 0 && len(lastStatBeforeLastRestartStatBlockStatSlice) == 0 {
+		return
+	}
+
+	var aggregatedBlockStatSlice []types.BlkioStatEntry
+	blockStatsMap := make(map[BlockStatKey]BlockStatValue)
+
+	// Add block stat entries from stats to map (merging duplicates).
+	addBlockStatEntriesFromSliceToMap(lastStatBeforeLastRestartStatBlockStatSlice, blockStatsMap)
+	addBlockStatEntriesFromSliceToMap(*dockerStatBlockStatSlice, blockStatsMap)
+
+	// Get entries from map and add them to the result slice in the same order they were originally encountered.
+	addCorrespondingMapEntriesOfSliceToAggregatedSlice(blockStatsMap,
+		lastStatBeforeLastRestartStatBlockStatSlice, &aggregatedBlockStatSlice)
+	addCorrespondingMapEntriesOfSliceToAggregatedSlice(blockStatsMap,
+		*dockerStatBlockStatSlice, &aggregatedBlockStatSlice)
+
+	*dockerStatBlockStatSlice = aggregatedBlockStatSlice
+}
+
+func addBlockStatEntriesFromSliceToMap(statSlice []types.BlkioStatEntry, statMap map[BlockStatKey]BlockStatValue) {
+	for _, blockStat := range statSlice {
+		blkStatKey := BlockStatKey{blockStat.Major, blockStat.Minor, blockStat.Op}
+		blkStatVal, ok := statMap[blkStatKey]
+		if ok {
+			blkStatVal.Value += blockStat.Value
+		} else {
+			blkStatVal = BlockStatValue{false, blockStat.Value}
+		}
+		statMap[blkStatKey] = blkStatVal
+	}
+}
+
+func addCorrespondingMapEntriesOfSliceToAggregatedSlice(statMap map[BlockStatKey]BlockStatValue,
+	statSlice []types.BlkioStatEntry, aggregatedSlice *[]types.BlkioStatEntry) {
+	for _, blockStat := range statSlice {
+		blkStatKey := BlockStatKey{blockStat.Major, blockStat.Minor, blockStat.Op}
+		blkStatVal, ok := statMap[blkStatKey]
+		if ok && !blkStatVal.HasBeenRetrieved {
+			*aggregatedSlice = append(*aggregatedSlice, types.BlkioStatEntry{
+				Major: blockStat.Major, Minor: blockStat.Minor, Op: blockStat.Op, Value: blkStatVal.Value})
+			blkStatVal.HasBeenRetrieved = true
+			statMap[blkStatKey] = blkStatVal
+		}
+	}
+}

--- a/agent/stats/queue_unix_test.go
+++ b/agent/stats/queue_unix_test.go
@@ -1,0 +1,184 @@
+//go:build linux && unit
+// +build linux,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
+	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregateOSDependentStats(t *testing.T) {
+	dockerStat := getTestStatsJSONForOSDependentStats(1, 2, 3, 4, 5, 6, 7, 8, 9,
+		[]types.BlkioStatEntry{
+			{
+				Major: 202,
+				Minor: 192,
+				Op:    "Read",
+				Value: 1,
+			},
+			{
+				Major: 202,
+				Minor: 192,
+				Op:    "Write",
+				Value: 2,
+			},
+			{
+				Major: 253,
+				Minor: 1,
+				Op:    "Read",
+				Value: 3,
+			},
+			{
+				Major: 253,
+				Minor: 1,
+				Op:    "Write",
+				Value: 4,
+			},
+		})
+	lastStatBeforeLastRestart := getTestStatsJSONForOSDependentStats(1, 2, 3, 4, 5, 6, 7, 8, 9,
+		[]types.BlkioStatEntry{
+			{
+				Major: 253,
+				Minor: 1,
+				Op:    "Read",
+				Value: 1234,
+			},
+			{
+				Major: 253,
+				Minor: 1,
+				Op:    "Write",
+				Value: 5678,
+			},
+		})
+
+	// Sanity length checks/enforcement.
+	require.Equal(t, 2, len(dockerStat.CPUStats.CPUUsage.PercpuUsage))
+	require.Equal(t, 2, len(lastStatBeforeLastRestart.CPUStats.CPUUsage.PercpuUsage))
+	require.Equal(t, 4, len(dockerStat.BlkioStats.IoServiceBytesRecursive))
+	require.Equal(t, 2, len(lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive))
+
+	expectedAggregatedStat := types.StatsJSON{
+		Stats: types.Stats{
+			CPUStats: types.CPUStats{
+				CPUUsage: types.CPUUsage{
+					PercpuUsage: []uint64{
+						dockerStat.Stats.CPUStats.CPUUsage.PercpuUsage[0] +
+							lastStatBeforeLastRestart.Stats.CPUStats.CPUUsage.PercpuUsage[0],
+						dockerStat.Stats.CPUStats.CPUUsage.PercpuUsage[1] +
+							lastStatBeforeLastRestart.Stats.CPUStats.CPUUsage.PercpuUsage[1]},
+				},
+				ThrottlingData: types.ThrottlingData{
+					Periods: dockerStat.Stats.CPUStats.ThrottlingData.Periods +
+						lastStatBeforeLastRestart.Stats.CPUStats.ThrottlingData.Periods,
+					ThrottledPeriods: dockerStat.Stats.CPUStats.ThrottlingData.ThrottledPeriods +
+						lastStatBeforeLastRestart.Stats.CPUStats.ThrottlingData.ThrottledPeriods,
+					ThrottledTime: dockerStat.Stats.CPUStats.ThrottlingData.ThrottledTime +
+						lastStatBeforeLastRestart.Stats.CPUStats.ThrottlingData.ThrottledTime,
+				},
+			},
+			MemoryStats: types.MemoryStats{
+				MaxUsage: utils.MaxNum(dockerStat.MemoryStats.MaxUsage, lastStatBeforeLastRestart.MemoryStats.MaxUsage),
+				Failcnt:  dockerStat.MemoryStats.Failcnt + lastStatBeforeLastRestart.MemoryStats.Failcnt,
+			},
+			BlkioStats: types.BlkioStats{
+				IoServiceBytesRecursive: []types.BlkioStatEntry{
+					{
+						Major: lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[0].Major,
+						Minor: lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[0].Minor,
+						Op:    lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[0].Op,
+						Value: lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[0].Value +
+							dockerStat.BlkioStats.IoServiceBytesRecursive[2].Value,
+					},
+					{
+						Major: lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[1].Major,
+						Minor: lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[1].Minor,
+						Op:    lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[1].Op,
+						Value: lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[1].Value +
+							dockerStat.BlkioStats.IoServiceBytesRecursive[3].Value,
+					},
+					{
+						Major: dockerStat.BlkioStats.IoServiceBytesRecursive[0].Major,
+						Minor: dockerStat.BlkioStats.IoServiceBytesRecursive[0].Minor,
+						Op:    dockerStat.BlkioStats.IoServiceBytesRecursive[0].Op,
+						Value: dockerStat.BlkioStats.IoServiceBytesRecursive[0].Value,
+					},
+					{
+						Major: dockerStat.BlkioStats.IoServiceBytesRecursive[1].Major,
+						Minor: dockerStat.BlkioStats.IoServiceBytesRecursive[1].Minor,
+						Op:    dockerStat.BlkioStats.IoServiceBytesRecursive[1].Op,
+						Value: dockerStat.BlkioStats.IoServiceBytesRecursive[1].Value,
+					},
+				},
+			},
+		},
+		Networks: map[string]types.NetworkStats{
+			testNetworkNameA: {
+				RxErrors: dockerStat.Networks[testNetworkNameA].RxErrors +
+					lastStatBeforeLastRestart.Networks[testNetworkNameA].RxErrors,
+				TxErrors: dockerStat.Networks[testNetworkNameA].TxErrors +
+					lastStatBeforeLastRestart.Networks[testNetworkNameA].TxErrors,
+			},
+			testNetworkNameB: {
+				RxErrors: dockerStat.Networks[testNetworkNameB].RxErrors +
+					lastStatBeforeLastRestart.Networks[testNetworkNameB].RxErrors,
+				TxErrors: dockerStat.Networks[testNetworkNameB].TxErrors +
+					lastStatBeforeLastRestart.Networks[testNetworkNameB].TxErrors,
+			},
+		},
+	}
+
+	dockerStat = aggregateOSDependentStats(dockerStat, lastStatBeforeLastRestart)
+	require.Equal(t, *dockerStat, expectedAggregatedStat)
+}
+
+func getTestStatsJSONForOSDependentStats(usageCoreA, usageCoreB, periods, throttledPeriods, throttledTime, maxUsage,
+	failCnt, rxErrors, txErrors uint64, ioServiceBytesRecursive []types.BlkioStatEntry) *types.StatsJSON {
+	return &types.StatsJSON{
+		Stats: types.Stats{
+			CPUStats: types.CPUStats{
+				CPUUsage: types.CPUUsage{
+					PercpuUsage: []uint64{usageCoreA, usageCoreB},
+				},
+				ThrottlingData: types.ThrottlingData{
+					Periods:          periods,
+					ThrottledPeriods: throttledPeriods,
+					ThrottledTime:    throttledTime,
+				},
+			},
+			MemoryStats: types.MemoryStats{
+				MaxUsage: maxUsage,
+				Failcnt:  failCnt,
+			},
+			BlkioStats: types.BlkioStats{
+				IoServiceBytesRecursive: ioServiceBytesRecursive,
+			},
+		},
+		Networks: map[string]types.NetworkStats{
+			testNetworkNameA: {
+				RxErrors: rxErrors,
+				TxErrors: txErrors,
+			},
+			testNetworkNameB: {
+				RxErrors: rxErrors + 1,
+				TxErrors: txErrors + 1,
+			},
+		},
+	}
+}

--- a/agent/stats/queue_windows.go
+++ b/agent/stats/queue_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
+	"github.com/docker/docker/api/types"
+)
+
+// aggregateOSDependentStats aggregates stats that are measured cumulatively against container start time and
+// populated only for Windows OS.
+func aggregateOSDependentStats(dockerStat, lastStatBeforeLastRestart *types.StatsJSON) *types.StatsJSON {
+	// Memory stats.
+	dockerStat.MemoryStats.CommitPeak = utils.MaxNum(dockerStat.MemoryStats.CommitPeak,
+		lastStatBeforeLastRestart.MemoryStats.CommitPeak)
+
+	// Disk I/O stats.
+	dockerStat.StorageStats.ReadCountNormalized += lastStatBeforeLastRestart.StorageStats.ReadCountNormalized
+	dockerStat.StorageStats.ReadSizeBytes += lastStatBeforeLastRestart.StorageStats.ReadSizeBytes
+	dockerStat.StorageStats.WriteCountNormalized += lastStatBeforeLastRestart.StorageStats.WriteCountNormalized
+	dockerStat.StorageStats.WriteSizeBytes += lastStatBeforeLastRestart.StorageStats.WriteSizeBytes
+
+	return dockerStat
+}

--- a/agent/stats/queue_windows_test.go
+++ b/agent/stats/queue_windows_test.go
@@ -1,0 +1,68 @@
+//go:build windows && unit
+// +build windows,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
+	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregateOSDependentStats(t *testing.T) {
+	dockerStat := getTestStatsJSONForOSDependentStats(1, 2, 3, 4, 5)
+	lastStatBeforeLastRestart := getTestStatsJSONForOSDependentStats(5, 4, 3, 2, 1)
+	expectedAggregatedStat := types.StatsJSON{
+		Stats: types.Stats{
+			MemoryStats: types.MemoryStats{
+				CommitPeak: utils.MaxNum(dockerStat.MemoryStats.CommitPeak,
+					lastStatBeforeLastRestart.MemoryStats.CommitPeak),
+			},
+			StorageStats: types.StorageStats{
+				ReadCountNormalized: dockerStat.StorageStats.ReadCountNormalized +
+					lastStatBeforeLastRestart.StorageStats.ReadCountNormalized,
+				ReadSizeBytes: dockerStat.StorageStats.ReadSizeBytes +
+					lastStatBeforeLastRestart.StorageStats.ReadSizeBytes,
+				WriteCountNormalized: dockerStat.StorageStats.WriteCountNormalized +
+					lastStatBeforeLastRestart.StorageStats.WriteCountNormalized,
+				WriteSizeBytes: dockerStat.StorageStats.WriteSizeBytes +
+					lastStatBeforeLastRestart.StorageStats.WriteSizeBytes,
+			},
+		},
+	}
+
+	dockerStat = aggregateOSDependentStats(dockerStat, lastStatBeforeLastRestart)
+	require.Equal(t, *dockerStat, expectedAggregatedStat)
+}
+
+func getTestStatsJSONForOSDependentStats(commitPeak, readCountNormalized, readSizeBytes, writeCountNormalized,
+	writeSizeBytes uint64) *types.StatsJSON {
+	return &types.StatsJSON{
+		Stats: types.Stats{
+			MemoryStats: types.MemoryStats{
+				CommitPeak: commitPeak,
+			},
+			StorageStats: types.StorageStats{
+				ReadCountNormalized:  readCountNormalized,
+				ReadSizeBytes:        readSizeBytes,
+				WriteCountNormalized: writeCountNormalized,
+				WriteSizeBytes:       writeSizeBytes,
+			},
+		},
+	}
+}

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -14,11 +14,12 @@
 package stats
 
 import (
+	"context"
 	"time"
 
-	"context"
-
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/stats/resolver"
 )
@@ -89,13 +90,15 @@ type TaskMetadata struct {
 
 // StatsContainer abstracts methods to gather and aggregate utilization data for a container.
 type StatsContainer struct {
-	containerMetadata *ContainerMetadata
-	ctx               context.Context
-	cancel            context.CancelFunc
-	client            dockerapi.DockerClient
-	statsQueue        *Queue
-	resolver          resolver.ContainerMetadataResolver
-	config            *config.Config
+	containerMetadata      *ContainerMetadata
+	ctx                    context.Context
+	cancel                 context.CancelFunc
+	client                 dockerapi.DockerClient
+	statsQueue             *Queue
+	resolver               resolver.ContainerMetadataResolver
+	config                 *config.Config
+	restartAggregationData apicontainer.ContainerRestartAggregationDataForStats
+	dataClient             data.Client
 }
 
 // taskDefinition encapsulates family and version strings for a task definition

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"golang.org/x/exp/constraints"
 )
 
 func ZeroOrNil(obj interface{}) bool {
@@ -58,4 +59,12 @@ func Int64PtrToIntPtr(int64ptr *int64) *int {
 		return nil
 	}
 	return aws.Int(int(aws.Int64Value(int64ptr)))
+}
+
+// MaxNum returns the maximum value between two numbers.
+func MaxNum[T constraints.Integer | constraints.Float](a, b T) T {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/agent/vendor/golang.org/x/exp/LICENSE
+++ b/agent/vendor/golang.org/x/exp/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/agent/vendor/golang.org/x/exp/PATENTS
+++ b/agent/vendor/golang.org/x/exp/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/agent/vendor/golang.org/x/exp/constraints/constraints.go
+++ b/agent/vendor/golang.org/x/exp/constraints/constraints.go
@@ -1,0 +1,50 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package constraints defines a set of useful constraints to be used
+// with type parameters.
+package constraints
+
+// Signed is a constraint that permits any signed integer type.
+// If future releases of Go add new predeclared signed integer types,
+// this constraint will be modified to include them.
+type Signed interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+// Unsigned is a constraint that permits any unsigned integer type.
+// If future releases of Go add new predeclared unsigned integer types,
+// this constraint will be modified to include them.
+type Unsigned interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+// Integer is a constraint that permits any integer type.
+// If future releases of Go add new predeclared integer types,
+// this constraint will be modified to include them.
+type Integer interface {
+	Signed | Unsigned
+}
+
+// Float is a constraint that permits any floating-point type.
+// If future releases of Go add new predeclared floating-point types,
+// this constraint will be modified to include them.
+type Float interface {
+	~float32 | ~float64
+}
+
+// Complex is a constraint that permits any complex numeric type.
+// If future releases of Go add new predeclared complex numeric types,
+// this constraint will be modified to include them.
+type Complex interface {
+	~complex64 | ~complex128
+}
+
+// Ordered is a constraint that permits any ordered type: any type
+// that supports the operators < <= >= >.
+// If future releases of Go add new ordered types,
+// this constraint will be modified to include them.
+type Ordered interface {
+	Integer | Float | ~string
+}

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -371,6 +371,9 @@ github.com/vishvananda/netns
 # go.etcd.io/bbolt v1.3.9
 ## explicit; go 1.17
 go.etcd.io/bbolt
+# golang.org/x/exp v0.0.0-20231006140011-7918f672742d
+## explicit; go 1.20
+golang.org/x/exp/constraints
 # golang.org/x/mod v0.14.0
 ## explicit; go 1.18
 golang.org/x/mod/internal/lazyregexp

--- a/ecs-agent/go.mod
+++ b/ecs-agent/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	go.etcd.io/bbolt v1.3.9
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/net v0.23.0
 	golang.org/x/sys v0.18.0
 	golang.org/x/tools v0.17.0

--- a/ecs-agent/go.sum
+++ b/ecs-agent/go.sum
@@ -227,6 +227,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/ecs-agent/utils/utils.go
+++ b/ecs-agent/utils/utils.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"golang.org/x/exp/constraints"
 )
 
 func ZeroOrNil(obj interface{}) bool {
@@ -58,4 +59,12 @@ func Int64PtrToIntPtr(int64ptr *int64) *int {
 		return nil
 	}
 	return aws.Int(int(aws.Int64Value(int64ptr)))
+}
+
+// MaxNum returns the maximum value between two numbers.
+func MaxNum[T constraints.Integer | constraints.Float](a, b T) T {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/ecs-agent/utils/utils_test.go
+++ b/ecs-agent/utils/utils_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type dummyStruct struct {
@@ -106,4 +107,25 @@ func TestInt64PtrToIntPtr(t *testing.T) {
 			assert.Equal(t, tc.expectedOutput, Int64PtrToIntPtr(tc.input))
 		})
 	}
+}
+
+func TestMaxNum(t *testing.T) {
+	testMaxNumInt(t)
+	testMaxNumFloat(t)
+}
+
+func testMaxNumInt(t *testing.T) {
+	smallerVal := 8
+	largerVal := 88
+
+	require.Equal(t, largerVal, MaxNum(smallerVal, largerVal))
+	require.Equal(t, largerVal, MaxNum(largerVal, largerVal))
+}
+
+func testMaxNumFloat(t *testing.T) {
+	smallerVal := 2.718283
+	largerVal := 3.14159
+
+	require.Equal(t, largerVal, MaxNum(largerVal, smallerVal))
+	require.Equal(t, largerVal, MaxNum(largerVal, largerVal))
 }

--- a/ecs-agent/vendor/golang.org/x/exp/LICENSE
+++ b/ecs-agent/vendor/golang.org/x/exp/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ecs-agent/vendor/golang.org/x/exp/PATENTS
+++ b/ecs-agent/vendor/golang.org/x/exp/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/ecs-agent/vendor/golang.org/x/exp/constraints/constraints.go
+++ b/ecs-agent/vendor/golang.org/x/exp/constraints/constraints.go
@@ -1,0 +1,50 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package constraints defines a set of useful constraints to be used
+// with type parameters.
+package constraints
+
+// Signed is a constraint that permits any signed integer type.
+// If future releases of Go add new predeclared signed integer types,
+// this constraint will be modified to include them.
+type Signed interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+// Unsigned is a constraint that permits any unsigned integer type.
+// If future releases of Go add new predeclared unsigned integer types,
+// this constraint will be modified to include them.
+type Unsigned interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+// Integer is a constraint that permits any integer type.
+// If future releases of Go add new predeclared integer types,
+// this constraint will be modified to include them.
+type Integer interface {
+	Signed | Unsigned
+}
+
+// Float is a constraint that permits any floating-point type.
+// If future releases of Go add new predeclared floating-point types,
+// this constraint will be modified to include them.
+type Float interface {
+	~float32 | ~float64
+}
+
+// Complex is a constraint that permits any complex numeric type.
+// If future releases of Go add new predeclared complex numeric types,
+// this constraint will be modified to include them.
+type Complex interface {
+	~complex64 | ~complex128
+}
+
+// Ordered is a constraint that permits any ordered type: any type
+// that supports the operators < <= >= >.
+// If future releases of Go add new ordered types,
+// this constraint will be modified to include them.
+type Ordered interface {
+	Integer | Float | ~string
+}

--- a/ecs-agent/vendor/modules.txt
+++ b/ecs-agent/vendor/modules.txt
@@ -249,6 +249,9 @@ go.opencensus.io/internal
 go.opencensus.io/trace
 go.opencensus.io/trace/internal
 go.opencensus.io/trace/tracestate
+# golang.org/x/exp v0.0.0-20231006140011-7918f672742d
+## explicit; go 1.20
+golang.org/x/exp/constraints
 # golang.org/x/mod v0.14.0
 ## explicit; go 1.18
 golang.org/x/mod/internal/lazyregexp


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Aggregate container metadata that Docker measures against the last time the container was (re)started time across container restarts. This ensures that such container metadata is tracked cumulatively relative to when the container was originally started and does not get reset upon container restart.

Additionally, save relevant aggregation data in ECS Agent's local state DB so that the behavior mentioned above is persisted in the event ECS Agent goes down and comes back up while containers are still running.

_Listed below are container metadata that Docker measures against the last time the container was (re)started:_

<details>

<summary>Container Metadata Tracked Relative to Container’s Last (Re)start Time by Docker</summary>

### Not sourced from Docker `ContainerStats` API:
* Timestamp that the container started at

### Sourced from Docker `ContainerStats` API:
**CPU:**
* Time consumed
* Time consumed per core (Linux only)
* Time spent in kernel mode by tasks of the cgroup for Linux and by all container processes for Windows
* Time spent in user mode by tasks of the cgroup in user mode for Linux and by all container processes for Windows
* Number of periods with CPU throttling active (Linux only)
* Number of periods that the CPU throttling limit is hit (Linux only)
* Time spent during which the container was CPU throttled (Linux only)

**Memory:**
* Peak memory consumed (Linux only)
* Number of times memory usage hits limits (Linux only)
* Peak memory committed (Windows only)

**Block I/O / Storage:**
* For each specific type of I/O operation (Linux only):
    * For each block device:
        * Number of bytes transferred to the device
        * Number of operations performed on the device
        * Time spent by device to actively service I/O requests from the container
        * Time spent by container waiting for I/O operations to execute
        * Number of merged I/O operations performed on the device
        * Time spent by device to both actively and passively service I/O requests from the container
        * Number of sectors transferred as part of I/O operations
* Number of read operations from the container storage device (Windows only)
* Number of bytes read from the container storage device (Windows only)
* Number of write operations to the container storage device (Windows only)
* Number of bytes written to the container storage device (Windows only)

**Networks:**
* For each container network:
    * Number of bytes received
    * Number of packets received
    * Number of errors received (Linux only)
    * Number of incoming packets dropped
    * Number of bytes sent
    * Number of packets sent
    * Number of errors sent (Linux only)
    * Number of outgoing packets dropped

</details>

### Implementation details
<!-- How are the changes implemented? -->
- Ensure `Container` started at time is set to be when the container was first started (and is unchanged across container restarts)
- When a `StatsContainer` is processing a Docker stat and that Docker stat is detected to be the first stat received from Docker after a container restart, cache:
   1. the time which this detection occurred
   1. the last Docker stat from before the restart 
-  Prior to adding a Docker stat for a container to a stats `Queue`, first check if the container has ever restarted before. If it has, then first aggregate metadata from that stat which Docker tracks relative to the container’s last (re)start time with the corresponding metadata from the last Docker stat added to the queue before the most recent container restart
- Leverage existing ECS Agent mechanism that saves `Container` data to BoltDB to store required container restart aggregation data in Agent's local state DB
   - Provide Agent's data client to Agent's stats engine so that whenever aggregation data for a container is updated, it can also be saved in BoltDB 
   - Make `Container` started at time field public so that Agent can marshal/unmarshal this field to/from JSON when Agent saves state
- Add generic `MaxNum` function to `utils` package in ecs-agent module that returns the max value between two numbers. This functionality is required in multiple places for the aggregation logic

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

Manually tested by building and running a custom ECS Agent with the changes from this pull request and having container restart policy enabled. Verified that container metadata is aggregated as expected upon container restarts and that in the event of ECS Agent restart the container restart aggregation data is persisted in and loaded from ECS Agent's local state DB.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Aggregate container metadata across restarts

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
