### PR TITLE
Add enhancements to stats queue unit testing

### DIFF
--- a/agent/stats/queue_unix_test.go
+++ b/agent/stats/queue_unix_test.go
@@ -145,7 +145,7 @@ func TestAggregateOSDependentStats(t *testing.T) {
 	}
 
 	dockerStat = aggregateOSDependentStats(dockerStat, lastStatBeforeLastRestart)
-	require.Equal(t, *dockerStat, expectedAggregatedStat)
+	require.Equal(t, expectedAggregatedStat, *dockerStat)
 }
 
 func getTestStatsJSONForOSDependentStats(usageCoreA, usageCoreB, periods, throttledPeriods, throttledTime, maxUsage,

--- a/agent/stats/queue_windows_test.go
+++ b/agent/stats/queue_windows_test.go
@@ -47,7 +47,7 @@ func TestAggregateOSDependentStats(t *testing.T) {
 	}
 
 	dockerStat = aggregateOSDependentStats(dockerStat, lastStatBeforeLastRestart)
-	require.Equal(t, *dockerStat, expectedAggregatedStat)
+	require.Equal(t, expectedAggregatedStat, *dockerStat)
 }
 
 func getTestStatsJSONForOSDependentStats(commitPeak, readCountNormalized, readSizeBytes, writeCountNormalized,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add enhancements to stats queue unit testing.

### Implementation details
<!-- How are the changes implemented? -->
- Add unit tests that directly call/test the `Queue.Add` and `Queue.AddContainerStat` functions
- Update the order of arguments passed to `require.Equal` in existing tests `TestAggregateOSIndependentStats`, `TestAggregateOSDependentStats` (Linux), and `TestAggregateOSDependentStats` (Windows) since the order of "expected" argument  and "actual" argument in some calls in these tests are currently swapped ([ref](https://pkg.go.dev/github.com/stretchr/testify/require#Assertions.Equal))

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes (or N/A, since only unit tests are changed as part of this pull request)

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A (Add enhancements to stats queue unit testing)

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
