### PR TITLE
Fix restartAttemptPeriod time.Duration/int parsing

### DIFF
--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -824,7 +824,7 @@ func TestPullContainerWithAndWithoutDigestInteg(t *testing.T) {
 // Tests that pullContainer pulls the same image when a digest is used versus when a digest
 // is not used.
 func TestPullContainerWithAndWithoutDigestConsistency(t *testing.T) {
-	image := "public.ecr.aws/docker/library/alpine:3.19"
+	image := "public.ecr.aws/docker/library/alpine:3.19.1"
 	imageDigest := "sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b"
 
 	// Prepare task

--- a/ecs-agent/api/container/restart/restart_tracker.go
+++ b/ecs-agent/api/container/restart/restart_tracker.go
@@ -31,9 +31,9 @@ type RestartTracker struct {
 // RestartPolicy represents a policy that contains key information considered when
 // deciding whether or not a container should be restarted after it has exited.
 type RestartPolicy struct {
-	Enabled              bool          `json:"enabled"`
-	IgnoredExitCodes     []int         `json:"ignoredExitCodes"`
-	RestartAttemptPeriod time.Duration `json:"restartAttemptPeriod"`
+	Enabled              bool  `json:"enabled"`
+	IgnoredExitCodes     []int `json:"ignoredExitCodes"`
+	RestartAttemptPeriod int   `json:"restartAttemptPeriod"`
 }
 
 func NewRestartTracker(restartPolicy RestartPolicy) *RestartTracker {
@@ -92,7 +92,7 @@ func (rt *RestartTracker) ShouldRestart(exitCode *int, startedAt time.Time,
 	if !rt.LastRestartAt.IsZero() {
 		startTime = rt.LastRestartAt
 	}
-	if time.Since(startTime) < rt.RestartPolicy.RestartAttemptPeriod {
+	if time.Since(startTime) < time.Duration(rt.RestartPolicy.RestartAttemptPeriod)*time.Second {
 		return false, "attempt reset period has not elapsed"
 	}
 	return true, ""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

The RestartPolicy struct governs the restart policy of the container. Because the API model is an integer, and we had previously made the `restartAttemptPeriod` field a `time.Duration` type, JSON parsing was interpreting a value of `300` as `300 nanoseconds`.

Instead, `restartAttemptPeriod: 300` should be interpreted as `300 seconds`.

This PR changes the agent RestartPolicy struct to use `int` to match the API model, and caste this int to seconds where needed (in the ShouldRestart function).

Unit tests have also been updated to unmarshal the object from a JSON blob, so that issues like this would be caught in unit tests.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

- unit tests updated to catch this scenario (JSON integer being erroneously marshaled to nanoseconds)
- tested end-to-end in gamma environment

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
