### PR TITLE
Bring in latest ecs-agent/ lib changes to RestartTracker

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart/restart_tracker.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart/restart_tracker.go
@@ -31,9 +31,9 @@ type RestartTracker struct {
 // RestartPolicy represents a policy that contains key information considered when
 // deciding whether or not a container should be restarted after it has exited.
 type RestartPolicy struct {
-	Enabled              bool          `json:"enabled"`
-	IgnoredExitCodes     []int         `json:"ignoredExitCodes"`
-	RestartAttemptPeriod time.Duration `json:"restartAttemptPeriod"`
+	Enabled              bool  `json:"enabled"`
+	IgnoredExitCodes     []int `json:"ignoredExitCodes"`
+	RestartAttemptPeriod int   `json:"restartAttemptPeriod"`
 }
 
 func NewRestartTracker(restartPolicy RestartPolicy) *RestartTracker {
@@ -92,7 +92,7 @@ func (rt *RestartTracker) ShouldRestart(exitCode *int, startedAt time.Time,
 	if !rt.LastRestartAt.IsZero() {
 		startTime = rt.LastRestartAt
 	}
-	if time.Since(startTime) < rt.RestartPolicy.RestartAttemptPeriod {
+	if time.Since(startTime) < time.Duration(rt.RestartPolicy.RestartAttemptPeriod)*time.Second {
 		return false, "attempt reset period has not elapsed"
 	}
 	return true, ""


### PR DESCRIPTION
ran
`cd agent && go mod vendor && cd ..`

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

bring in latest ecs-agent/ lib changes from https://github.com/aws/amazon-ecs-agent/pull/4218 into feature/crp branch


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

NA

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
