### PR TITLE
Fix restartAttemptPeriod comparison in restart tracker

### DIFF
--- a/ecs-agent/api/container/restart/restart_tracker.go
+++ b/ecs-agent/api/container/restart/restart_tracker.go
@@ -92,7 +92,7 @@ func (rt *RestartTracker) ShouldRestart(exitCode *int, startedAt time.Time,
 	if !rt.LastRestartAt.IsZero() {
 		startTime = rt.LastRestartAt
 	}
-	if time.Since(startTime) < time.Duration(rt.RestartPolicy.RestartAttemptPeriod)*time.Second {
+	if time.Since(startTime).Seconds() < float64(rt.RestartPolicy.RestartAttemptPeriod) {
 		return false, "attempt reset period has not elapsed"
 	}
 	return true, ""


### PR DESCRIPTION
### Summary
This change fixes a bug with the restart tracker whereby nanosecond time.Durations were being compared to the restartAttemptPeriod in seconds. 

### Implementation details
Very quick container exits seem to allow for a situation where the restartAttemptPeriod appears elapsed, even if it is not. Instead of comparing two time.Duration objects we can compare the float64 seconds representation of the elapsed exit time to our reset attempt period. 

### Testing
`make test`

New tests cover the changes: <!-- no -->

### Description for the changelog
Fix restartAttemptPeriod comparison in ecs-agent restart tracker

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
