### PR TITLE
UpdateDesiredStatus for task stop verification ACK

### DIFF
--- a/agent/acs/session/task_manifest_responder_test.go
+++ b/agent/acs/session/task_manifest_responder_test.go
@@ -34,11 +34,14 @@ import (
 )
 
 const (
-	initialSeqNum = 11
-	nextSeqNum    = 12
-	taskARN1      = "arn1"
-	taskARN2      = "arn2"
-	taskARN3      = "arn3"
+	initialSeqNum  = 11
+	nextSeqNum     = 12
+	taskARN1       = "arn1"
+	taskARN2       = "arn2"
+	taskARN3       = "arn3"
+	containerName1 = "name1"
+	containerName2 = "name2"
+	containerName3 = "name3"
 )
 
 var expectedTaskManifestAck = &ecsacs.AckRequest{

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -1044,7 +1044,7 @@ func (agent *ecsAgent) startACSSession(
 	manifestMessageIDAccessor := agentacs.NewManifestMessageIDAccessor()
 	sequenceNumberAccessor := agentacs.NewSequenceNumberAccessor(agent.latestSeqNumberTaskManifest, agent.dataClient)
 	taskComparer := agentacs.NewTaskComparer(taskEngine)
-	taskStopper := agentacs.NewTaskStopper(taskEngine)
+	taskStopper := agentacs.NewTaskStopper(taskEngine, agent.dataClient)
 
 	acsSession := session.NewSession(agent.containerInstanceARN,
 		agent.cfg.Cluster,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update ECS Agent to update containers' (desired) statuses when stopping a task as part of responding to a task stop verification ACK received from ACS.

ECS Agent does not call [`UpdateDesiredStatus`](https://github.com/aws/amazon-ecs-agent/blob/0a1a88d83d7ee34c593f663979b8abd920f55481/agent/api/task/task.go#L2620) when [stopping tasks in response to task stop verification ACKs sent from ACS](https://github.com/aws/amazon-ecs-agent/blob/0a1a88d83d7ee34c593f663979b8abd920f55481/agent/acs/session/task_stop_verification_ack_responder.go#L35-L48). This does not align with [how tasks are stopped in response to ACS payload messages to stop a task](https://github.com/aws/amazon-ecs-agent/blob/0a1a88d83d7ee34c593f663979b8abd920f55481/agent/engine/task_manager.go#L432-L433), which calls `UpdatedDesiredStatus` (which also updates the container statuses).

For supplementary information on when ACS may send a task stop verification ACK to ECS Agent, please refer to [the original pull request for full task sync feature](https://github.com/aws/amazon-ecs-agent/pull/2191).

### Implementation details
<!-- How are the changes implemented? -->
- Call `UpdateDesiredStatus` after setting desired status for the task [here](https://github.com/aws/amazon-ecs-agent/blob/0a1a88d83d7ee34c593f663979b8abd920f55481/agent/acs/session/task_stop_verification_ack_responder.go#L41) (refer to Summary above)
- Remove redundant call to `AddTask`
- Add logic to save task state to Agent local state DB when setting task's status to STOPPED as part of processing task stop verification ACK from ACS

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Manually test using a custom ECS Agent built with the changes in this pull request against an internal bug repro environment. With the custom ECS Agent, bug behavior is no longer observed.

New tests cover the changes: existing tests updated (additional verification of containers' desired statuses being updated when stopping a task in response to a task stop verification ACK)

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
UpdateDesiredStatus for task stop verification ACK

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
