### PR TITLE
disable digest resolution for manifest v2 schema 1 manifests

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1365,7 +1365,7 @@ func (engine *DockerTaskEngine) pullContainerManifest(
 			field.ImageMediaType: imageManifestMediaType,
 			field.Image:          container.Image,
 		})
-		if strings.Contains(imageManifestMediaType, mediaTypeManifestV1) || strings.Contains(imageManifestMediaType, mediaTypeSignedManifestV1) {
+		if imageManifestMediaType == mediaTypeManifestV1 || imageManifestMediaType == mediaTypeSignedManifestV1 {
 			logger.Info("skipping digest resolution for manifest v2 schema 1", logger.Fields{
 				field.TaskARN:        task.Arn,
 				field.ContainerName:  container.Name,

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
@@ -49,6 +49,7 @@ const (
 	ImageLastUsedAt         = "imageLastUsedAt"
 	ImagePullSucceeded      = "imagePullSucceeded"
 	ImageDigest             = "imageDigest"
+	ImageMediaType          = "imageMediaType"
 	ContainerName           = "containerName"
 	ContainerImage          = "containerImage"
 	ContainerExitCode       = "containerExitCode"

--- a/ecs-agent/logger/field/constants.go
+++ b/ecs-agent/logger/field/constants.go
@@ -49,6 +49,7 @@ const (
 	ImageLastUsedAt         = "imageLastUsedAt"
 	ImagePullSucceeded      = "imagePullSucceeded"
 	ImageDigest             = "imageDigest"
+	ImageMediaType          = "imageMediaType"
 	ContainerName           = "containerName"
 	ContainerImage          = "containerImage"
 	ContainerExitCode       = "containerExitCode"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
ECS Agent will disable the digest resolution for Schema 1 manifest as a workaround for a bug in ECR that ECR will reports an incorrect digest during digest resolution phase for Schema V1 manifests which then causes image pull using the digest to fail. 
### Implementation details
<!-- How are the changes implemented? -->
skip digest resolution for manifest v2 schema 1 manifests 
### Testing
<!-- How was this tested? -->
Reproduce the issue by setting Up Pull-Through Cache Rule
```
aws ecr create-pull-through-cache-rule \
     --ecr-repository-prefix quay \
     --upstream-registry-url quay.io \
     --region us-west-2
docker pull  130669029530.dkr.ecr.us-west-2.amazonaws.com/quay/coreos/etcd:v2.0.4
```
Manually ran a task with schema 1 image 130669029530.dkr.ecr.us-west-2.amazonaws.com/quay/coreos/etcd:v2.0.4, we can see error " image verification failed for digest "

```
level=debug time=2024-07-22T05:06:56Z msg="Setting image digest on container" taskARN="arn:aws:ecs:us-west-2:130669029530:task/tssbug/ca80402ec1ff44e398c7a88bef4bef7f" containerName="container" imageDigest="sha256:d1f9e51bf7f3f7940faf11553d08f8815d2f0f999f6eafd6a6b8f765adba5895"
level=error time=2024-07-22T05:07:07Z msg="DockerGoClient: failed to pull image 130669029530.dkr.ecr.us-west-2.amazonaws.com/quay/coreos/etcd:v2.0.4@sha256:d1f9e51bf7f3f7940faf11553d08f8815d2f0f999f6eafd6a6b8f765adba5895: [CannotPullContainerError] image verification failed for digest sha256:d1f9e51bf7f3f7940faf11553d08f8815d2f0f999f6eafd6a6b8f765adba5895" module=docker_client.go
```
Manually ran a task with schema 1 image 130669029530.dkr.ecr.us-west-2.amazonaws.com/quay/coreos/etcd:v2.0.4 with  test agent(changes of this pr), we can see digest resolution is skipped and pulling image complete.

```
level=info time=2024-07-22T05:14:24Z msg="skipping digest resolution for manifest v2 schema 1," taskARN="arn:aws:ecs:us-west-2:130669029530:task/default/eb9cf2168d9c406388966b6e2584dae5" containerName="container" ImageMediatype="application/vnd.docker.distribution.manifest.v1+prettyjws" image="130669029530.dkr.ecr.us-west-2.amazonaws.com/quay/coreos/etcd:v2.0.4"
l

level=debug time=2024-07-22T05:14:25Z msg="DockerGoClient: pulling image 130669029530.dkr.ecr.us-west-2.amazonaws.com/quay/coreos/etcd:v2.0.4, status Status: Downloaded newer image for 130669029530.dkr.ecr.us-west-2.amazonaws.com/quay/coreos/etcd:v2.0.4" module=docker_client.go
level=debug time=2024-07-22T05:14:25Z msg="DockerGoClient: pulling image complete: 130669029530.dkr.ecr.us-west-2.amazonaws.com/quay/coreos/etcd:v2.0.4" module=docker_client.go
```


<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bugfix: Disable Digest Resolution for Manifest V2 Schema 1

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
