### PR TITLE
Bugfix: Agent fails to resolve digest for a locally available image for images with docker.io prefix

### DIFF
--- a/agent/utils/reference/reference.go
+++ b/agent/utils/reference/reference.go
@@ -42,7 +42,7 @@ func GetDigestFromImageRef(imageRef string) digest.Digest {
 // and returns the repo digest's digest.
 func GetDigestFromRepoDigests(repoDigests []string, imageRef string) (digest.Digest, error) {
 	// Parse image reference
-	ref, err := reference.Parse(imageRef)
+	ref, err := reference.ParseNormalizedNamed(imageRef)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse image reference '%s': %w", imageRef, err)
 	}
@@ -55,7 +55,7 @@ func GetDigestFromRepoDigests(repoDigests []string, imageRef string) (digest.Dig
 
 	// Find a repo digest matching imageRef and return its digest
 	for _, repoDigest := range repoDigests {
-		repoDigestRef, err := reference.Parse(repoDigest)
+		repoDigestRef, err := reference.ParseNormalizedNamed(repoDigest)
 		if err != nil {
 			logger.Error("Error in parsing repo digest. Skipping it.", logger.Fields{
 				"repoDigest": repoDigest,

--- a/agent/utils/reference/reference.go
+++ b/agent/utils/reference/reference.go
@@ -42,15 +42,9 @@ func GetDigestFromImageRef(imageRef string) digest.Digest {
 // and returns the repo digest's digest.
 func GetDigestFromRepoDigests(repoDigests []string, imageRef string) (digest.Digest, error) {
 	// Parse image reference
-	ref, err := reference.ParseNormalizedNamed(imageRef)
+	namedRef, err := reference.ParseNormalizedNamed(imageRef)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse image reference '%s': %w", imageRef, err)
-	}
-	namedRef, ok := ref.(reference.Named)
-	if !ok {
-		return "", fmt.Errorf(
-			"failed to parse image reference '%s' as a named reference, it was parsed as '%v'",
-			imageRef, ref)
 	}
 
 	// Find a repo digest matching imageRef and return its digest

--- a/agent/utils/reference/reference_test.go
+++ b/agent/utils/reference/reference_test.go
@@ -75,6 +75,38 @@ func TestGetDigestFromRepoDigests(t *testing.T) {
 			expectedDigest: testDigest2,
 		},
 		{
+			name: "docker.io prefix",
+			repoDigests: []string{
+				"alpine@" + testDigest2,
+			},
+			imageRef:       "docker.io/alpine",
+			expectedDigest: testDigest2,
+		},
+		{
+			name: "docker.io with library prefix",
+			repoDigests: []string{
+				"alpine@" + testDigest2,
+			},
+			imageRef:       "docker.io/library/alpine",
+			expectedDigest: testDigest2,
+		},
+		{
+			name: "docker.io with non-standard image",
+			repoDigests: []string{
+				"repo/image@" + testDigest2,
+			},
+			imageRef:       "docker.io/repo/image",
+			expectedDigest: testDigest2,
+		},
+		{
+			name: "registry-1.docker.io prefix",
+			repoDigests: []string{
+				"registry-1.docker.io/library/alpine@" + testDigest2,
+			},
+			imageRef:       "registry-1.docker.io/library/alpine",
+			expectedDigest: testDigest2,
+		},
+		{
 			name: "repo digest matching imageRef is used - ecr",
 			repoDigests: []string{
 				"public.ecr.aws/library/alpine@" + testDigest1,
@@ -109,7 +141,7 @@ func TestGetDigestFromRepoDigests(t *testing.T) {
 		{
 			name:          "image ref not named",
 			imageRef:      "",
-			expectedError: "failed to parse image reference '': repository name must have at least one component",
+			expectedError: "failed to parse image reference '': invalid reference format",
 		},
 		{
 			name:           "invalid repo digests are skipped",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
ECS Agent has a bug that prevents it from resolving image manifest digest for locally cached images if the image reference in the task payload has a `docker.io` or `docker.io/library` prefix which is optional. 

Agent resolves image manifest digest for a locally cached image by inspecting the image (equivalent of `docker image inspect <image-reference>`) and then finding a repoDigest element whose repository name matches that of the image reference. However, if the image reference has `docker.io` or `docker.io/library` prefix then Docker doesn't add the prefix to the repoDigest while Agent does not take that into account. 

The change in this PR makes Agent normalize image reference from the task payload and repoDigests when comparing them to fix this bug.

### Implementation details
<!-- How are the changes implemented? -->
* Update `GetDigestFromRepoDigests` in `utils/reference` package to parse image references and repoDigests using `ParseNormalizedNamed` function that normalizes image references in addition to parsing them. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit tests for `GetDigestFromRepoDigests` have been updated to cover the missing cases. I also ran many tasks with and without `docker.io` and `docker.io/library` prefixes on an instance with `IMAGE_PULL_BEHAVIOR` set to `once`. All tasks ran without issues.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bugfix: Fix digest resolution for locally cached images when image reference in the task payload contains `docker.io` or `docker.io/library` prefix.

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
