### PR TITLE
Add ebs-csi-driver to Windows make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,11 @@ docker-release: pause-container-release cni-plugins .out-stamp
 		--rm \
 		"amazon/amazon-ecs-agent-${BUILD}:make"
 
+ifeq (${TARGET_OS},windows)
+    CSI_DRIVER_EXE=ebs-csi-driver
+endif
 # Legacy target : Release packages our agent into a "scratch" based dockerfile
-release: certs docker-release
+release: certs docker-release ${CSI_DRIVER_EXE}
 	@./scripts/create-amazon-ecs-scratch
 	@docker build -f scripts/dockerfiles/Dockerfile.release -t "amazon/amazon-ecs-agent:latest" .
 	@echo "Built Docker image \"amazon/amazon-ecs-agent:latest\""

--- a/ecs-agent/daemonimages/csidriver/Makefile
+++ b/ecs-agent/daemonimages/csidriver/Makefile
@@ -23,14 +23,19 @@ IMAGE_REF?="ebs-csi-driver:latest"
 # caution. See `go help test`
 # unit tests include the coverage profile
 GOTEST=${GO_EXECUTABLE} test -count=1
+ifeq (${TARGET_OS},windows)
+	CSI_DRIVER_BIN=bin/ebs-csi-driver.exe
+else
+	CSI_DRIVER_BIN=bin/ebs-csi-driver
+endif
 
 all: tarfiles/ebs-csi-driver.tar
 
 bin/ebs-csi-driver:
-	CGO_ENABLED=0 go build -ldflags "\
+	GOOS=${TARGET_OS} CGO_ENABLED=0 go build -ldflags "\
 		-X \"github.com/aws/amazon-ecs-agent/ecs-agent/daemonimages/csidriver/version.version=$(CSI_DRIVER_VERSION)\" \
 		-X \"github.com/aws/amazon-ecs-agent/ecs-agent/daemonimages/csidriver/version.buildDate=$(BUILD_DATE)\"" \
-		-o bin/ebs-csi-driver .
+		-o $(CSI_DRIVER_BIN) .
 
 image:
 	docker build --build-arg GO_VERSION=$(GO_VERSION) -t $(IMAGE_REF) .


### PR DESCRIPTION
### Summary
ECS Windows pipelines use `make release` target to build our artifacts. As a part of EBS Task Attach for Windows, we need to build the `ebs-csi-driver.exe` so that we can package and build it into our AMIs.

### Implementation details
Added a conditional in the Makefile such that if `TARGET_OS=windows`, `ebs-csi-driver.exe` is built at `amazon-ecs-agent/ecs-agent/daemonimages/csidriver/bin`

### Testing
Ran `make release` for Windows and saw expected behavior. Ran `make release` for Linux and saw no changes.
New tests cover the changes: N/A

### Description for the changelog
Add support EBS-TaskAttach for Windows.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
