### PR TITLE
pull the image with the <image>@<digest> format

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -1564,16 +1564,9 @@ func (c *Container) GetImageName() string {
 
 // Checks if the container has a resolved image manifest digest.
 // Always returns false for internal containers as those are out-of-scope of digest resolution.
+// Always returns false when container's image reference contains digest as no digest resolution is needed in that case.
 func (c *Container) DigestResolved() bool {
-	return !c.IsInternal() && c.GetImageDigest() != ""
-}
-
-// Checks if the container's image requires manifest digest resolution.
-// Manifest digest resolution is required if the container's image reference does not
-// have a digest.
-// Always returns false for internal containers as those are out-of-scope of digest resolution.
-func (c *Container) DigestResolutionRequired() bool {
-	return !c.IsInternal() && referenceutil.GetDigestFromImageRef(c.Image) == ""
+	return !c.IsInternal() && c.GetImageDigest() != "" && !referenceutil.DigestExists(c.Image)
 }
 
 // GetRestartAggregationDataForStats gets the restart aggregation data for stats of a container.

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -1468,17 +1468,9 @@ func TestDigestResolved(t *testing.T) {
 	t.Run("digest not resolved if it is not populated", func(t *testing.T) {
 		assert.False(t, (&Container{}).DigestResolved())
 	})
-}
-
-func TestDigestResolutionRequired(t *testing.T) {
-	t.Run("never required for internal containers", func(t *testing.T) {
-		assert.False(t, (&Container{Type: ContainerServiceConnectRelay}).DigestResolutionRequired())
-	})
-	t.Run("required if not found in image reference", func(t *testing.T) {
-		assert.True(t, (&Container{Image: "alpine"}).DigestResolutionRequired())
-	})
-	t.Run("not required if found in image reference", func(t *testing.T) {
+	t.Run("never resolved for container if digest found in image reference", func(t *testing.T) {
 		image := "ubuntu@sha256:ed6d2c43c8fbcd3eaa44c9dab6d94cb346234476230dc1681227aa72d07181ee"
-		assert.False(t, (&Container{Image: image}).DigestResolutionRequired())
+		imageDigest := "sha256:ed6d2c43c8fbcd3eaa44c9dab6d94cb346234476230dc1681227aa72d07181ee"
+		assert.False(t, (&Container{Image: image, ImageDigest: imageDigest}).DigestResolved())
 	})
 }

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -4160,8 +4160,9 @@ func TestPullContainerManifest(t *testing.T) {
 			containerName:        "my-sc-container",
 		},
 		{
-			name:  "digest is not resolved if already available in image reference",
-			image: "public.ecr.aws/library/alpine@" + testDigest.String(),
+			name:           "digest is copied if already available in image reference",
+			image:          "public.ecr.aws/library/alpine@" + testDigest.String(),
+			expectedDigest: testDigest.String(),
 		},
 		{
 			name:              "image pull not required - image inspect fails",

--- a/agent/utils/reference/reference.go
+++ b/agent/utils/reference/reference.go
@@ -73,7 +73,7 @@ func GetDigestFromRepoDigests(repoDigests []string, imageRef string) (digest.Dig
 	return "", fmt.Errorf("found no repo digest matching '%s'", imageRef)
 }
 
-// Given an image reference and a manifest digest string, returns a canonical reference
+// Given an image reference and a manifest digest string, returns an untagged canonical reference
 // for the image.
 // If the image reference has a digest then the canonical reference will still use the provided
 // manifest digest overwriting the existing digest in the image reference.
@@ -94,6 +94,8 @@ func GetCanonicalRef(imageRef string, manifestDigest string) (reference.Canonica
 			imageRef, parsedImageRef)
 	}
 
+	namedImageRef = reference.TrimNamed(namedImageRef)
+
 	canonicalRef, err := reference.WithDigest(namedImageRef, parsedDigest)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -102,4 +104,15 @@ func GetCanonicalRef(imageRef string, manifestDigest string) (reference.Canonica
 	}
 
 	return canonicalRef, nil
+}
+
+// check if image reference contains digest
+func DigestExists(imageRef string) bool {
+
+	parsedImageRef, err := reference.Parse(imageRef)
+	if err != nil {
+		return false
+	}
+	_, ok := parsedImageRef.(reference.Digested)
+	return ok
 }

--- a/agent/utils/reference/reference_test.go
+++ b/agent/utils/reference/reference_test.go
@@ -213,7 +213,7 @@ func TestGetCanonicalRef(t *testing.T) {
 			name:           "has tag",
 			imageRef:       "alpine:latest",
 			manifestDigest: "sha256:c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
-			expected:       "alpine:latest@sha256:c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
+			expected:       "alpine@sha256:c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
 		},
 		{
 			name:           "image reference's digest is overwritten",
@@ -231,7 +231,13 @@ func TestGetCanonicalRef(t *testing.T) {
 			name:           "has tag ecr",
 			imageRef:       "public.ecr.aws/library/alpine:latest",
 			manifestDigest: "sha256:c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
-			expected:       "public.ecr.aws/library/alpine:latest@sha256:c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
+			expected:       "public.ecr.aws/library/alpine@sha256:c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
+		},
+		{
+			name:           "has tag and digest ecr",
+			imageRef:       "public.ecr.aws/library/alpine:latest@sha256:c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
+			manifestDigest: "sha256:c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
+			expected:       "public.ecr.aws/library/alpine@sha256:c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
 		},
 	}
 	for _, tc := range tcs {
@@ -243,6 +249,46 @@ func TestGetCanonicalRef(t *testing.T) {
 			} else {
 				assert.EqualError(t, err, tc.expectedError)
 			}
+		})
+	}
+}
+
+func TestDigestExists(t *testing.T) {
+	tcs := []struct {
+		name     string
+		imageRef string
+		expected bool
+	}{
+		{
+			name:     "invalid imageRef",
+			imageRef: "invalid imageRef",
+			expected: false,
+		},
+		{
+			name:     "no tag no digest",
+			imageRef: "public.ecr.aws/library/alpine",
+			expected: false,
+		},
+		{
+			name:     "has tag",
+			imageRef: "public.ecr.aws/library/alpine:latest",
+			expected: false,
+		},
+		{
+			name:     "has tag and digest",
+			imageRef: "public.ecr.aws/library/alpine:latest@sha256:c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
+			expected: true,
+		},
+		{
+			name:     "has digest no tag",
+			imageRef: "public.ecr.aws/library/alpine@sha256:c3839dd800b9eb7603340509769c43e146a74c63dca3045a8e7dc8ee07e53966",
+			expected: true,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ok := DigestExists(tc.imageRef)
+			assert.Equal(t, ok, tc.expected)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Currently, when agent receives a container image with a tag, the agent first attempts to resolve that tag to its digest. If successful, that digest is sent back to the control plane, while subsequently pulling and launching that image via digest rather than the original tag. This behavior results in the container being shown as launched with the `<image>@<digest> `rather than the customer defined `<image>:<tag>` format , so customers have lost information previously available to them, notably the image tag, thus Control Plane will be changing `image@sha256:abcd` to `image:latest@sha256:abcd` for subsequence tasks.

* On newer Docker versions (>= 1.13), Docker simply ignores the tag during image pull. 
    docker image pull busybox:latest@sha256:abcd is the same as docker image pull busybox@sha256:abcd 
* On older Docker versions (< 1.13), the behavior is to fail pulling the image IFF the manifest does not match the tag, potentially resulting in an image pull failure for customers who’s tags no longer matches the digest. So, Agent should ignore the tag when pulling the image. Just like how newer Docker versions do.
 
This pr makes agent to pull the image with the `<image>@<digest>` format instead of `<image>:tag@<digest>` format no matter what docker version is used
### Implementation details
<!-- How are the changes implemented? -->

- Update method`CanonicalRef` agent/utils/reference package that returns a canonical image reference without tag given an image reference and a manifest digest.
- Add a new method`DigestExists` agent/utils/reference package that check if image reference contains digest
- Update *DockerTaskEngine.pullAndUpdateContainerReference method that is used for pulling container images so that it uses the container's image reference to prepare a canonical reference without tag to the image to be pulled when image name contains tag and digest e.t.`<image>:tag@<digest>`. The method tags the pulled image with Container.Image if a different image reference was used to pull the image and container image name not contains digest (`<image>:tag@<digest>`  will not be tagged)
- Test updates and new tests.

### Testing

<!-- How was this tested? -->
- updated TestPullContainerWithAndWithoutDigestInteg to check that *DockerTaskEngine.pullContainer can pull images for containers with `<image>:tag@<digest>` format
- update *DockerTaskEngine.pullContainer pulls the same image with or without a tag and the image can be inspected with container.Image field in both cases.
- Ran tasks with image in `<image>@<digest>`, `<image>:tag>` and `<image>:tag@<digest>`format with an Agent built with changes in this PR, Checked that all tasks ran as expected. Images were pulled using digests and tagged with the image reference in the task definition. 
-  Create a service with desired task count 2 with image `<image>:tag>`, verified that a additional STSC is not being made for the second task.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
