### PR TITLE
Revert "Defining cloudwatch endpoint for all regions for tasks using …

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1876,31 +1876,32 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 		}
 	}
 
-	// We're currently relying on AWS SDK Go V1 to obtain/format the correct cloudwatch endpoint.
-	// This is will need to be updated once we upgrade to AWS SDK Go V2.
+	// This is a short term solution only for specific regions until AWS SDK Go is upgraded to V2
 	if hostConfig.LogConfig.Type == logDriverTypeAwslogs {
-		region := hostConfig.LogConfig.Config["awslogs-region"]
-		endpoint := ""
-		dnsSuffix := ""
-		partition, ok := ep.PartitionForRegion(ep.DefaultPartitions(), region)
-		if !ok {
-			logger.Warn("No partition resolved for region. Using AWS default", logger.Fields{
-				"region":           region,
-				"defaultDNSSuffix": ep.AwsPartition().DNSSuffix(),
-			})
-			dnsSuffix = ep.AwsPartition().DNSSuffix()
-		} else {
-			resolvedEndpoint, err := partition.EndpointFor("logs", region)
-			if err == nil {
-				endpoint = resolvedEndpoint.URL
+		region := engine.cfg.AWSRegion
+		if region == "eu-isoe-west-1" || region == "us-isof-south-1" || region == "us-isof-east-1" {
+			endpoint := ""
+			dnsSuffix := ""
+			partition, ok := ep.PartitionForRegion(ep.DefaultPartitions(), region)
+			if !ok {
+				logger.Warn("No partition resolved for region. Using AWS default", logger.Fields{
+					"region":           region,
+					"defaultDNSSuffix": ep.AwsPartition().DNSSuffix(),
+				})
+				dnsSuffix = ep.AwsPartition().DNSSuffix()
 			} else {
-				dnsSuffix = partition.DNSSuffix()
+				resolvedEndpoint, err := partition.EndpointFor("logs", region)
+				if err == nil {
+					endpoint = resolvedEndpoint.URL
+				} else {
+					dnsSuffix = partition.DNSSuffix()
+				}
 			}
+			if endpoint == "" {
+				endpoint = fmt.Sprintf("https://logs.%s.%s", region, dnsSuffix)
+			}
+			hostConfig.LogConfig.Config["awslogs-endpoint"] = endpoint
 		}
-		if endpoint == "" {
-			endpoint = fmt.Sprintf("https://logs.%s.%s", region, dnsSuffix)
-		}
-		hostConfig.LogConfig.Config["awslogs-endpoint"] = endpoint
 	}
 
 	//Apply the log driver secret into container's LogConfig and Env secrets to container.Environment

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -2955,17 +2955,7 @@ func TestCreateContainerAwslogsLogDriver(t *testing.T) {
 		{
 			name:                      "test container that uses awslogs log driver in IAD",
 			region:                    "us-east-1",
-			expectedLogConfigEndpoint: "https://logs.us-east-1.amazonaws.com",
-		},
-		{
-			name:                      "test container that uses awslogs log driver in BJS",
-			region:                    "cn-north-1",
-			expectedLogConfigEndpoint: "https://logs.cn-north-1.amazonaws.com.cn",
-		},
-		{
-			name:                      "test container that uses awslogs log driver in OSU",
-			region:                    "us-gov-east-1",
-			expectedLogConfigEndpoint: "https://logs.us-gov-east-1.amazonaws.com",
+			expectedLogConfigEndpoint: "",
 		},
 		{
 			name:                      "test container that uses awslogs log driver in NCL",
@@ -2994,10 +2984,8 @@ func TestCreateContainerAwslogsLogDriver(t *testing.T) {
 
 			rawHostConfigInput := dockercontainer.HostConfig{
 				LogConfig: dockercontainer.LogConfig{
-					Type: "awslogs",
-					Config: map[string]string{
-						"awslogs-region": tc.region,
-					},
+					Type:   "awslogs",
+					Config: map[string]string{},
 				},
 			}
 			rawHostConfig, err := json.Marshal(&rawHostConfigInput)


### PR DESCRIPTION
This reverts #4191 as this change is incompatible with old docker versions 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
