### PR TITLE
Add awslogs-endpoint for isolated regions when creating containers

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1876,10 +1876,10 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 		}
 	}
 
-	// This is a short term solution only for specific regions until AWS SDK Go is upgraded to V2
+	// This is a short term solution only for specific regions
 	if hostConfig.LogConfig.Type == logDriverTypeAwslogs {
 		region := engine.cfg.AWSRegion
-		if region == "eu-isoe-west-1" || region == "us-isof-south-1" || region == "us-isof-east-1" {
+		if region == "us-isob-east-1" || region == "us-iso-east-1" || region == "us-iso-west-1" || region == "eu-isoe-west-1" || region == "us-isof-south-1" || region == "us-isof-east-1" {
 			endpoint := ""
 			dnsSuffix := ""
 			partition, ok := ep.PartitionForRegion(ep.DefaultPartitions(), region)

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -2972,6 +2972,21 @@ func TestCreateContainerAwslogsLogDriver(t *testing.T) {
 			region:                    "us-isof-east-1",
 			expectedLogConfigEndpoint: "https://logs.us-isof-east-1.csp.hci.ic.gov",
 		},
+		{
+			name:                      "test container that uses awslogs log driver in LCK",
+			region:                    "us-isob-east-1",
+			expectedLogConfigEndpoint: "https://logs.us-isob-east-1.sc2s.sgov.gov",
+		},
+		{
+			name:                      "test container that uses awslogs log driver in DCA",
+			region:                    "us-iso-east-1",
+			expectedLogConfigEndpoint: "https://logs.us-iso-east-1.c2s.ic.gov",
+		},
+		{
+			name:                      "test container that uses awslogs log driver in APA",
+			region:                    "us-iso-west-1",
+			expectedLogConfigEndpoint: "https://logs.us-iso-west-1.c2s.ic.gov",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR makes agent add `awslogs-endpoint` for all isolated regions when `awslogs` driver is configured for the container.

### Implementation details
<!-- How are the changes implemented? -->
Add all current isolated regions to the current list of regions where agent configures `awslogs-endpoint` when creating containers

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Added unit tests for all regions

New tests cover the changes: <!-- yes|no -->
Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bugfix: Add awslogs-endpoint for isolated regions when creating containers 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
