### PR TITLE
Container Restart Policy feature

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -24,6 +24,7 @@ import (
 
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	referenceutil "github.com/aws/amazon-ecs-agent/agent/utils/reference"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
@@ -335,6 +336,13 @@ type Container struct {
 	ContainerPortSet map[int]struct{}
 	// ContainerPortRangeMap is a map of containerPortRange to its associated hostPortRange
 	ContainerPortRangeMap map[string]string
+
+	// RestartPolicy is an object representing the restart policy of the container
+	RestartPolicy *restart.RestartPolicy `json:"restartPolicy,omitempty"`
+	// RestartTracker tracks this container's restart policy metadata, such
+	// as restart count and last restart time. This is only initialized if the container
+	// has a restart policy defined and enabled.
+	RestartTracker *restart.RestartTracker `json:"restartTracker,omitempty"`
 }
 
 type DependsOn struct {
@@ -626,6 +634,16 @@ func (c *Container) IsEssential() bool {
 	defer c.lock.RUnlock()
 
 	return c.Essential
+}
+
+// RestartPolicyEnabled returns whether the restart policy is defined and enabled
+func (c *Container) RestartPolicyEnabled() bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if c.RestartPolicy == nil {
+		return false
+	}
+	return c.RestartPolicy.Enabled
 }
 
 // AWSLogAuthExecutionRole returns true if the auth is by execution role

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -25,6 +25,7 @@ import (
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
+	"github.com/docker/docker/api/types"
 
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	dockercontainer "github.com/docker/docker/api/types/container"
@@ -1401,6 +1402,51 @@ func TestRestartPolicy(t *testing.T) {
 			require.Equal(t, tc.restartCount, tc.container.RestartTracker.GetRestartCount())
 		}
 	}
+}
+
+func TestGetAndSetStartedAt(t *testing.T) {
+	testTime := time.Date(1969, 12, 31, 23, 59, 59, 0, time.UTC)
+	c := &Container{}
+
+	// Test getting started at time when it has never been set is the zero value of time.
+	require.True(t, c.GetStartedAt().IsZero())
+
+	// Test setting started at time sets the started at time.
+	c.SetStartedAt(testTime)
+	require.Equal(t, testTime, c.GetStartedAt())
+
+	// Test setting started at time after it has already been set does not change the originally set started at time.
+	c.SetStartedAt(time.Now())
+	require.Equal(t, testTime, c.GetStartedAt())
+}
+
+func TestGetAndSetRestartAggregationDataForStats(t *testing.T) {
+	testTime := time.Date(1969, 12, 31, 23, 59, 59, 0, time.UTC)
+	testStatsJSON := types.StatsJSON{
+		Stats: types.Stats{
+			CPUStats: types.CPUStats{
+				CPUUsage: types.CPUUsage{
+					TotalUsage: 100,
+				},
+			},
+			MemoryStats: types.MemoryStats{
+				MaxUsage: 200,
+			},
+		},
+	}
+	testRestartAggregationDataForStats := ContainerRestartAggregationDataForStats{
+		LastRestartDetectedAt:     testTime,
+		LastStatBeforeLastRestart: testStatsJSON,
+	}
+	c := &Container{}
+
+	// Test getting restart aggregation data for stats when it has never been set is the zero value of the
+	// ContainerRestartAggregationDataForStats struct.
+	require.Equal(t, ContainerRestartAggregationDataForStats{}, c.GetRestartAggregationDataForStats())
+
+	// Test setting restart aggregation data for stats sets the restart aggregation data for stats.
+	c.SetRestartAggregationDataForStats(testRestartAggregationDataForStats)
+	require.Equal(t, testRestartAggregationDataForStats, c.GetRestartAggregationDataForStats())
 }
 
 func getContainer(hostConfig string, credentialSpecs []string) *Container {

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -918,7 +918,7 @@ func (agent *ecsAgent) startAsyncRoutines(
 	telemetryMessages := make(chan ecstcs.TelemetryMessage, telemetryChannelDefaultBufferSize)
 	healthMessages := make(chan ecstcs.HealthMessage, telemetryChannelDefaultBufferSize)
 
-	statsEngine := stats.NewDockerStatsEngine(agent.cfg, agent.dockerClient, containerChangeEventStream, telemetryMessages, healthMessages)
+	statsEngine := stats.NewDockerStatsEngine(agent.cfg, agent.dockerClient, containerChangeEventStream, telemetryMessages, healthMessages, agent.dataClient)
 
 	// Start serving the endpoint to fetch IAM Role credentials and other task metadata
 	if agent.cfg.TaskMetadataAZDisabled {

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -81,6 +81,7 @@ const (
 	capabilityServiceConnect                               = "service-connect-v1"
 	capabilityGpuDriverVersion                             = "gpu-driver-version"
 	capabilityEBSTaskAttach                                = "storage.ebs-task-volume-attach"
+	capabilityContainerRestartPolicy                       = "container-restart-policy"
 
 	// network capabilities, going forward, please append "network." prefix to any new networking capability we introduce
 	networkCapabilityPrefix      = "network."
@@ -110,6 +111,8 @@ var (
 		capabilityEnvFilesS3,
 		// support container port range in container definition - port mapping field
 		capabilityContainerPortRange,
+		// support container restart policy
+		capabilityContainerRestartPolicy,
 	}
 	// use empty struct as value type to simulate set
 	capabilityExecInvalidSsmVersions = map[string]struct{}{}
@@ -194,6 +197,7 @@ var (
 //	ecs.capability.external
 //	ecs.capability.service-connect-v1
 //	ecs.capability.network.container-port-range
+//	ecs.capability.container-restart-policy
 func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	var capabilities []*ecs.Attribute
 

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -143,6 +143,7 @@ func TestCapabilities(t *testing.T) {
 		attributePrefix + capabilityExec,
 		attributePrefix + capabilityServiceConnect,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilityContainerRestartPolicy,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -1314,6 +1315,7 @@ func TestCapabilitiesNoServiceConnect(t *testing.T) {
 		attributePrefix + taskENIBlockInstanceMetadataAttributeSuffix,
 		attributePrefix + capabilityExec,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilityContainerRestartPolicy,
 	}
 
 	var expectedCapabilities []*ecs.Attribute

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -530,6 +530,7 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesUnix(t *testing.T) {
 		attributePrefix + capabilityEnvFilesS3,
 		attributePrefix + capabiltyPIDAndIPCNamespaceSharing,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilityContainerRestartPolicy,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -681,6 +682,7 @@ func TestAppMeshCapabilitiesUnix(t *testing.T) {
 		attributePrefix + capabiltyPIDAndIPCNamespaceSharing,
 		attributePrefix + appMeshAttributeSuffix,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilityContainerRestartPolicy,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -879,6 +881,7 @@ func TestCapabilitiesUnix(t *testing.T) {
 		attributePrefix + capabilityFirelensLoggingDriver + capabilityFireLensLoggingDriverConfigBufferLimitSuffix,
 		attributePrefix + capabilityEnvFilesS3,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilityContainerRestartPolicy,
 	}
 
 	var expectedCapabilities []*ecs.Attribute

--- a/agent/app/agent_capability_windows_test.go
+++ b/agent/app/agent_capability_windows_test.go
@@ -184,6 +184,7 @@ func TestSupportedCapabilitiesWindows(t *testing.T) {
 		attributePrefix + capabilityEnvFilesS3,
 		attributePrefix + taskENIBlockInstanceMetadataAttributeSuffix,
 		attributePrefix + capabilityContainerPortRange,
+		attributePrefix + capabilityContainerRestartPolicy,
 	}
 
 	var expectedCapabilities []*ecs.Attribute

--- a/agent/engine/testdata/test_tasks/sleep5RestartPolicy.json
+++ b/agent/engine/testdata/test_tasks/sleep5RestartPolicy.json
@@ -1,0 +1,42 @@
+{
+    "Arn":"arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1",
+    "Family":"sleep5RestartPolicy",
+    "Version":"2",
+    "Containers":
+    [
+      {
+        "Name":"sleep5",
+        "RuntimeID": "12345678-ctrr-cdef-ctrr-56780abcdef1",
+        "Image":"busybox",
+        "Command":["sleep","5"],
+        "Cpu":10,
+        "Memory":10,
+        "Links":null,
+        "volumesFrom":[],
+        "mountPoints":[],
+        "portMappings":[],
+        "Essential":true,
+        "EntryPoint":null,
+        "environment":{},
+        "overrides":{"command":null},
+        "desiredStatus":"NONE",
+        "KnownStatus":"NONE",
+        "RunDependencies":null,
+        "IsInternal":false,
+        "AppliedStatus":"NONE",
+        "ApplyingError":null,
+        "SentStatus":"NONE",
+        "KnownExitCode":null,
+        "KnownPortBindingsUnsafe":null,
+        "StatusLock":{},
+        "RestartPolicy": {
+            "Enabled":true
+        }
+      }
+    ],
+    "volumes":[],
+    "DesiredStatus":"RUNNING",
+    "KnownStatus":"NONE",
+    "KnownTime":"0001-01-01T00:00:00Z",
+    "SentStatus":"NONE"
+  }

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/rootless-containers/rootlesskit v1.1.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -230,6 +230,8 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -1381,7 +1381,7 @@ func testTMDSRequest[R TMDSResponse](t *testing.T, tc TMDSTestCase[R]) {
 	// Parse the response body
 	var actualResponseBody R
 	err = json.Unmarshal(recorder.Body.Bytes(), &actualResponseBody)
-	require.NoError(t, err)
+	require.NoError(t, err, recorder.Body.String())
 
 	// Assert status code and body
 	assert.Equal(t, tc.expectedStatusCode, recorder.Code)
@@ -1801,8 +1801,9 @@ func TestV4ContainerMetadata(t *testing.T) {
 			setStateExpectations: func(state *mock_dockerstate.MockTaskEngineState) {
 				gomock.InOrder(
 					state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
-					state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true),
+					state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 					state.EXPECT().TaskByID(containerID).Return(task, true).Times(2),
+					state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 				)
 			},
 			expectedStatusCode:   http.StatusOK,
@@ -1817,7 +1818,7 @@ func TestV4ContainerMetadata(t *testing.T) {
 					state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
 					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true),
 					state.EXPECT().TaskByID(containerID).Return(bridgeTask, true),
-					state.EXPECT().ContainerByID(containerID).Return(nil, false),
+					state.EXPECT().ContainerByID(containerID).Return(nil, false).AnyTimes(),
 				)
 			},
 			expectedStatusCode:   http.StatusInternalServerError,
@@ -1832,7 +1833,7 @@ func TestV4ContainerMetadata(t *testing.T) {
 					state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
 					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true),
 					state.EXPECT().TaskByID(containerID).Return(bridgeTask, true),
-					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true).AnyTimes(),
 				)
 			},
 			expectedStatusCode: http.StatusInternalServerError,
@@ -1846,9 +1847,9 @@ func TestV4ContainerMetadata(t *testing.T) {
 			setStateExpectations: func(state *mock_dockerstate.MockTaskEngineState) {
 				gomock.InOrder(
 					state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
-					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true).AnyTimes(),
 					state.EXPECT().TaskByID(containerID).Return(bridgeTask, true),
-					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true).AnyTimes(),
 				)
 			},
 			expectedStatusCode:   http.StatusOK,
@@ -1939,8 +1940,10 @@ func TestV4TaskMetadata(t *testing.T) {
 				gomock.InOrder(
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(task, true).Times(2),
+					state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 					state.EXPECT().TaskByArn(taskARN).Return(task, true),
+					state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
 				)
 			},
@@ -1955,8 +1958,10 @@ func TestV4TaskMetadata(t *testing.T) {
 				gomock.InOrder(
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(pulledTask, true).Times(2),
+					state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 					state.EXPECT().TaskByArn(taskARN).Return(pulledTask, true),
+					state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(pulledContainerNameToDockerContainer, true),
 				)
 			},
@@ -1972,8 +1977,9 @@ func TestV4TaskMetadata(t *testing.T) {
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true).Times(2),
 					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
-					state.EXPECT().ContainerByID(containerID).Return(nil, false),
+					state.EXPECT().ContainerByID(containerID).Return(nil, false).AnyTimes(),
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
+					state.EXPECT().ContainerByID(containerID).Return(nil, false).AnyTimes(),
 				)
 			},
 			expectedStatusCode:   http.StatusOK,
@@ -1988,8 +1994,9 @@ func TestV4TaskMetadata(t *testing.T) {
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true).Times(2),
 					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
-					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true).AnyTimes(),
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true).AnyTimes(),
 				)
 			},
 			expectedStatusCode:   http.StatusOK,
@@ -2004,8 +2011,9 @@ func TestV4TaskMetadata(t *testing.T) {
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true).Times(2),
 					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
-					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true).AnyTimes(),
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true).AnyTimes(),
 				)
 			},
 			expectedStatusCode:   http.StatusOK,
@@ -2340,8 +2348,10 @@ func TestV4TaskMetadataWithTags(t *testing.T) {
 		gomock.InOrder(
 			state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 			state.EXPECT().TaskByArn(taskARN).Return(task, true).AnyTimes(),
+			state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true).AnyTimes(),
 			state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 			state.EXPECT().TaskByArn(taskARN).Return(task, true).AnyTimes(),
+			state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true).AnyTimes(),
 			state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
 		)
 	}
@@ -2495,8 +2505,9 @@ func TestV4TaskMetadataWithTags(t *testing.T) {
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true).Times(2),
 					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
-					state.EXPECT().ContainerByID(containerID).Return(nil, false),
+					state.EXPECT().ContainerByID(containerID).Return(nil, false).AnyTimes(),
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
+					state.EXPECT().ContainerByID(containerID).Return(nil, false).AnyTimes(),
 				)
 			},
 			setECSClientExpectations: happyECSClientExpectations,
@@ -2515,8 +2526,9 @@ func TestV4TaskMetadataWithTags(t *testing.T) {
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true).Times(2),
 					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
-					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true).AnyTimes(),
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
+					state.EXPECT().ContainerByID(containerID).Return(bridgeContainerNoNetwork, true).AnyTimes(),
 				)
 			},
 			setECSClientExpectations: happyECSClientExpectations,
@@ -3002,6 +3014,7 @@ func TestGetTaskProtection(t *testing.T) {
 			state.EXPECT().TaskByArn(taskARN).Return(task, true).Times(2),
 			state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 			state.EXPECT().TaskByArn(taskARN).Return(task, true),
+			state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 			state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
 		)
 	}
@@ -3273,6 +3286,7 @@ func TestUpdateTaskProtection(t *testing.T) {
 			state.EXPECT().TaskByArn(taskARN).Return(task, true).Times(2),
 			state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 			state.EXPECT().TaskByArn(taskARN).Return(task, true),
+			state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes(),
 			state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
 		)
 	}

--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -48,16 +48,17 @@ type TasksResponse struct {
 
 // ContainerResponse is the schema for the container response JSON object
 type ContainerResponse struct {
-	DockerID   string                        `json:"DockerId"`
-	DockerName string                        `json:"DockerName"`
-	Name       string                        `json:"Name"`
-	Image      string                        `json:"Image"`
-	ImageID    string                        `json:"ImageID"`
-	CreatedAt  *time.Time                    `json:"CreatedAt,omitempty"`
-	StartedAt  *time.Time                    `json:"StartedAt,omitempty"`
-	Ports      []tmdsresponse.PortResponse   `json:"Ports,omitempty"`
-	Networks   []tmdsresponse.Network        `json:"Networks,omitempty"`
-	Volumes    []tmdsresponse.VolumeResponse `json:"Volumes,omitempty"`
+	DockerID     string                        `json:"DockerId"`
+	DockerName   string                        `json:"DockerName"`
+	Name         string                        `json:"Name"`
+	Image        string                        `json:"Image"`
+	ImageID      string                        `json:"ImageID"`
+	CreatedAt    *time.Time                    `json:"CreatedAt,omitempty"`
+	StartedAt    *time.Time                    `json:"StartedAt,omitempty"`
+	Ports        []tmdsresponse.PortResponse   `json:"Ports,omitempty"`
+	Networks     []tmdsresponse.Network        `json:"Networks,omitempty"`
+	Volumes      []tmdsresponse.VolumeResponse `json:"Volumes,omitempty"`
+	RestartCount *int                          `json:"RestartCount,omitempty"`
 }
 
 // NewTaskResponse creates a TaskResponse for a task.
@@ -120,6 +121,10 @@ func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *ni
 	if startedAt := container.GetStartedAt(); !startedAt.IsZero() {
 		startedAt = startedAt.UTC()
 		resp.StartedAt = &startedAt
+	}
+	if container.RestartPolicyEnabled() {
+		restartCount := container.RestartTracker.GetRestartCount()
+		resp.RestartCount = &restartCount
 	}
 	return resp
 }

--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -19,6 +19,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
@@ -28,7 +30,7 @@ import (
 )
 
 // NewTaskResponse creates a new v4 response object for the task. It augments v2 task response
-// with additional network interface fields.
+// with additional fields for the v4 response.
 func NewTaskResponse(
 	taskARN string,
 	state dockerstate.TaskEngineState,
@@ -55,10 +57,12 @@ func NewTaskResponse(
 		if err != nil {
 			return nil, err
 		}
-		containers = append(containers, tmdsv4.ContainerResponse{
+		v4Response := &tmdsv4.ContainerResponse{
 			ContainerResponse: &v2Resp.Containers[i],
 			Networks:          networks,
-		})
+		}
+		v4Response = augmentContainerResponse(container.ID, state, v4Response)
+		containers = append(containers, *v4Response)
 	}
 
 	return &tmdsv4.TaskResponse{
@@ -69,8 +73,8 @@ func NewTaskResponse(
 	}, nil
 }
 
-// NewContainerResponse creates a new v4 container response based on container id.  It augments
-// v4 container response with additional network interface fields.
+// NewContainerResponse creates a new v4 container response based on container id. It augments
+// v2 container response with additional fields for v4.
 func NewContainerResponse(
 	containerID string,
 	state dockerstate.TaskEngineState,
@@ -87,10 +91,11 @@ func NewContainerResponse(
 	if err != nil {
 		return nil, err
 	}
-	return &tmdsv4.ContainerResponse{
+	v4Response := tmdsv4.ContainerResponse{
 		ContainerResponse: container,
 		Networks:          networks,
-	}, nil
+	}
+	return augmentContainerResponse(containerID, state, &v4Response), nil
 }
 
 // toV4NetworkResponse converts v2 network response to v4. Additional fields are only
@@ -119,6 +124,30 @@ func toV4NetworkResponse(
 	}
 
 	return resp, nil
+}
+
+// augmentContainerResponse augments the container response with additional fields.
+func augmentContainerResponse(
+	containerID string,
+	state dockerstate.TaskEngineState,
+	v4Response *tmdsv4.ContainerResponse,
+) *tmdsv4.ContainerResponse {
+	dockerContainer, ok := state.ContainerByID(containerID)
+	if !ok {
+		// did not find container, continue on and try next container(s)
+		// we don't return error here to avoid disrupting all of a TMDS response
+		// on a single missing container.
+		logger.Warn("V4 container response: unable to find container in internal state",
+			logger.Fields{
+				field.RuntimeID: containerID,
+			})
+		return v4Response
+	}
+	if dockerContainer.Container.RestartPolicyEnabled() {
+		restartCount := dockerContainer.Container.RestartTracker.GetRestartCount()
+		v4Response.RestartCount = &restartCount
+	}
+	return v4Response
 }
 
 // newNetworkInterfaceProperties creates the NetworkInterfaceProperties object for a given

--- a/agent/handlers/v4/response_test.go
+++ b/agent/handlers/v4/response_test.go
@@ -132,11 +132,10 @@ func TestNewTaskContainerResponses(t *testing.T) {
 	containerNameToDockerContainer := map[string]*apicontainer.DockerContainer{
 		taskARN: dockerContainer,
 	}
-	gomock.InOrder(
-		state.EXPECT().TaskByArn(taskARN).Return(task, true),
-		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
-		state.EXPECT().TaskByArn(taskARN).Return(task, true),
-	)
+	state.EXPECT().TaskByArn(taskARN).Return(task, true)
+	state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes()
+	state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true)
+	state.EXPECT().TaskByArn(taskARN).Return(task, true)
 
 	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster,
 		availabilityZone, vpcID, containerInstanceArn, task.ServiceName, false)
@@ -150,10 +149,8 @@ func TestNewTaskContainerResponses(t *testing.T) {
 	assert.Equal(t, subnetGatewayIPV4Address, taskResponse.Containers[0].Networks[0].SubnetGatewayIPV4Address)
 	assert.Equal(t, serviceName, taskResponse.ServiceName)
 
-	gomock.InOrder(
-		state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true),
-		state.EXPECT().TaskByID(containerID).Return(task, true).Times(2),
-	)
+	state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true).AnyTimes()
+	state.EXPECT().TaskByID(containerID).Return(task, true).Times(2)
 	containerResponse, err := NewContainerResponse(containerID, state)
 	require.NoError(t, err)
 	_, err = json.Marshal(containerResponse)

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -60,6 +60,9 @@ const (
 	taskDefinitionVersion       = "1"
 	containerName               = "gremlin-container"
 	serviceConnectContainerName = "service-connect-container"
+
+	testNetworkNameA = "eth0"
+	testNetworkNameB = "eth1"
 )
 
 var (

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -317,8 +317,22 @@ func createFakeContainerStats() []*ContainerStats {
 		TxPackets: 60,
 	}
 	return []*ContainerStats{
-		{22400432, 1839104, uint64(100), uint64(200), netStats, parseNanoTime("2015-02-12T21:22:05.131117533Z")},
-		{116499979, 3649536, uint64(300), uint64(400), netStats, parseNanoTime("2015-02-12T21:22:05.232291187Z")},
+		{
+			cpuUsage:          22400432,
+			memoryUsage:       1839104,
+			storageReadBytes:  uint64(100),
+			storageWriteBytes: uint64(200),
+			networkStats:      netStats,
+			timestamp:         parseNanoTime("2015-02-12T21:22:05.131117533Z"),
+		},
+		{
+			cpuUsage:          116499979,
+			memoryUsage:       3649536,
+			storageReadBytes:  uint64(300),
+			storageWriteBytes: uint64(400),
+			networkStats:      netStats,
+			timestamp:         parseNanoTime("2015-02-12T21:22:05.232291187Z"),
+		},
 	}
 }
 

--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -15,22 +15,23 @@ package stats
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/stats/resolver"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	loggerfield "github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 	"github.com/cihub/seelog"
+	"github.com/pkg/errors"
 )
 
-func newStatsContainer(dockerID string, client dockerapi.DockerClient, resolver resolver.ContainerMetadataResolver,
-	cfg *config.Config) (*StatsContainer, error) {
+func newStatsContainer(dockerID string, client dockerapi.DockerClient, resolver resolver.ContainerMetadataResolver, cfg *config.Config, dataClient data.Client) (*StatsContainer, error) {
 	dockerContainer, err := resolver.ResolveContainer(dockerID)
 	if err != nil {
 		return nil, err
@@ -43,11 +44,13 @@ func newStatsContainer(dockerID string, client dockerapi.DockerClient, resolver 
 			NetworkMode: dockerContainer.Container.GetNetworkMode(),
 			StartedAt:   dockerContainer.Container.GetStartedAt(),
 		},
-		ctx:      ctx,
-		cancel:   cancel,
-		client:   client,
-		resolver: resolver,
-		config:   cfg,
+		ctx:                    ctx,
+		cancel:                 cancel,
+		client:                 client,
+		resolver:               resolver,
+		config:                 cfg,
+		restartAggregationData: dockerContainer.Container.GetRestartAggregationDataForStats(),
+		dataClient:             dataClient,
 	}, nil
 }
 
@@ -169,8 +172,23 @@ func (container *StatsContainer) processStatsStream() error {
 				return err
 			}
 
-			if err := container.statsQueue.Add(rawStat, getNonDockerContainerStats(apiContainer)); err != nil {
+			isFirstStatAfterContainerRestart := apiContainer != nil && apiContainer.RestartPolicyEnabled() &&
+				container.syncContainerRestartAggregationData()
+			err = container.statsQueue.AddContainerStat(rawStat, getNonDockerContainerStats(apiContainer),
+				&container.restartAggregationData.LastStatBeforeLastRestart, container.hasRestartedBefore())
+			if err != nil {
 				seelog.Warnf("Container [%s]: error converting stats for container: %v", dockerID, err)
+				continue
+			}
+			if isFirstStatAfterContainerRestart {
+				err = container.saveRestartAggregationData(apiContainer)
+				if err != nil {
+					logger.Error("Failed to update container's stats restart aggregation data in database",
+						logger.Fields{
+							loggerfield.DockerId: dockerID,
+							loggerfield.Error:    err,
+						})
+				}
 			}
 		}
 	}
@@ -182,4 +200,45 @@ func (container *StatsContainer) terminal() (bool, error) {
 		return false, err
 	}
 	return dockerContainer.Container.KnownTerminal(), nil
+}
+
+// syncContainerRestartAggregationData updates a container's restart aggregation data if a container restart has been
+// detected. This method returns true if a restart was detected and returns false otherwise.
+func (container *StatsContainer) syncContainerRestartAggregationData() bool {
+	_, dockerContainerData := container.client.DescribeContainer(container.ctx, container.containerMetadata.DockerID)
+	restartDetected := dockerContainerData.StartedAt.Sub(container.containerMetadata.StartedAt) > 0
+	if container.hasRestartedBefore() {
+		restartDetected = dockerContainerData.StartedAt.Sub(container.restartAggregationData.LastRestartDetectedAt) > 0
+	}
+
+	if restartDetected {
+		container.restartAggregationData.LastRestartDetectedAt = time.Now()
+
+		logger.Debug("Received first stat for container after a container restart", logger.Fields{
+			loggerfield.DockerId: container.containerMetadata.DockerID,
+		})
+
+		lastStat := container.statsQueue.GetLastStat()
+		if lastStat != nil {
+			container.restartAggregationData.LastStatBeforeLastRestart = *lastStat
+		}
+	}
+
+	return restartDetected
+}
+
+// saveRestartAggregationData is used to save a container's restart aggregation data in Agent's local state database.
+func (container *StatsContainer) saveRestartAggregationData(apiContainer *apicontainer.Container) error {
+	apiContainer.SetRestartAggregationDataForStats(container.restartAggregationData)
+	err := container.dataClient.SaveContainer(apiContainer)
+	if err != nil {
+		return errors.Wrap(err, "failed to save data for container")
+	}
+
+	return nil
+}
+
+// hasRestartedBefore determines if a container has ever restarted before.
+func (container *StatsContainer) hasRestartedBefore() bool {
+	return !container.restartAggregationData.LastRestartDetectedAt.IsZero()
 }

--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -119,14 +119,14 @@ func (container *StatsContainer) getApiContainer(dockerID string) (*apicontainer
 	return dockerContainer.Container, nil
 }
 
-func getNonDockerContainerStats(apiContainer *apicontainer.Container) *NonDockerContainerStats {
+func getNonDockerContainerStats(apiContainer *apicontainer.Container) NonDockerContainerStats {
+	nonDockerStats := NonDockerContainerStats{}
 	if apiContainer == nil {
-		return nil
+		return nonDockerStats
 	}
-	var nonDockerStats *NonDockerContainerStats
 	if apiContainer.RestartPolicyEnabled() {
-		nonDockerStats = &NonDockerContainerStats{}
-		nonDockerStats.restartCount = int64(apiContainer.RestartTracker.GetRestartCount())
+		restartCount := int64(apiContainer.RestartTracker.GetRestartCount())
+		nonDockerStats.restartCount = &restartCount
 	}
 	return nonDockerStats
 }

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -878,6 +878,19 @@ func (engine *DockerStatsEngine) taskContainerMetricsUnsafe(taskArn string) ([]*
 			containerMetric.StorageStatsSet = storageStatsSet
 		}
 
+		restartStatsSet, err := container.statsQueue.GetRestartStatsSet()
+		if err != nil && age > gracePeriod {
+			// we expect to get an error here if there are no restart metrics,
+			// which would be common as it just means there is no restart policy on
+			// the container, so just log a debug message here.
+			logger.Debug("Unable to get restart stats for container", logger.Fields{
+				field.Container: dockerID,
+				field.Error:     err,
+			})
+		} else {
+			containerMetric.RestartStatsSet = restartStatsSet
+		}
+
 		task, err := engine.resolver.ResolveTask(dockerID)
 		if err != nil {
 			logger.Warn("Task not found for container", logger.Fields{

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -63,7 +63,7 @@ func createRunningTask(networkMode string) *apitask.Task {
 
 func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithExistingContainersWithoutHealth"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithExistingContainersWithoutHealth"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -131,7 +131,7 @@ func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 
 func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"), nil, nil, nil)
 	defer engine.removeAll()
 
 	// Assign ContainerStop timeout to addressable variable
@@ -206,7 +206,7 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 
 func TestStatsEngineWithExistingContainers(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithExistingContainers"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithExistingContainers"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -280,7 +280,7 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 
 func TestStatsEngineWithNewContainers(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"), nil, nil, nil)
 	defer engine.removeAll()
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -365,7 +365,7 @@ func TestStatsEngineWithNewContainersWithPolling(t *testing.T) {
 	// Create a new docker client with new config
 	dockerClientForNewContainersWithPolling, _ := dockerapi.NewDockerGoClient(sdkClientFactory, &cfg, ctx)
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClientForNewContainersWithPolling, eventStream("TestStatsEngineWithNewContainers"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClientForNewContainersWithPolling, eventStream("TestStatsEngineWithNewContainers"), nil, nil, nil)
 	defer engine.removeAll()
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -475,7 +475,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 		testTask)
 
 	// Create a new docker stats engine
-	statsEngine := NewDockerStatsEngine(&cfg, dockerClient, containerChangeEventStream, nil, nil)
+	statsEngine := NewDockerStatsEngine(&cfg, dockerClient, containerChangeEventStream, nil, nil, nil)
 	err = statsEngine.MustInit(ctx, taskEngine, defaultCluster, defaultContainerInstance)
 	require.NoError(t, err, "initializing stats engine failed")
 	defer statsEngine.removeAll()
@@ -561,7 +561,7 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 		testTask)
 
 	// Create a new docker stats engine
-	statsEngine := NewDockerStatsEngine(&cfg, dockerClient, containerChangeEventStream, nil, nil)
+	statsEngine := NewDockerStatsEngine(&cfg, dockerClient, containerChangeEventStream, nil, nil, nil)
 	err = statsEngine.MustInit(ctx, taskEngine, defaultCluster, defaultContainerInstance)
 	require.NoError(t, err, "initializing stats engine failed")
 	defer statsEngine.removeAll()
@@ -607,7 +607,7 @@ func TestStatsEngineWithNetworkStatsDefaultMode(t *testing.T) {
 
 func testNetworkModeStatsInteg(t *testing.T, networkMode string, statsEmpty bool) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNetworkStats"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNetworkStats"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -691,7 +691,7 @@ func testNetworkModeStatsInteg(t *testing.T, networkMode string, statsEmpty bool
 
 func TestStorageStats(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithStorageStats"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithStorageStats"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -78,7 +78,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	mockStatsChannel := make(chan *types.StatsJSON)
 	defer close(mockStatsChannel)
 	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStatsChannel, nil).AnyTimes()
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineAddRemoveContainers"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineAddRemoveContainers"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -229,7 +229,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	resolver.EXPECT().ResolveTaskByARN(gomock.Any()).Return(t1, nil).AnyTimes()
 
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineMetadataInStatsSets"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineMetadataInStatsSets"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -279,7 +279,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 }
 
 func TestStatsEngineInvalidTaskEngine(t *testing.T) {
-	statsEngine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineInvalidTaskEngine"), nil, nil)
+	statsEngine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineInvalidTaskEngine"), nil, nil, nil)
 	taskEngine := &MockTaskEngine{}
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -290,7 +290,7 @@ func TestStatsEngineInvalidTaskEngine(t *testing.T) {
 }
 
 func TestStatsEngineUninitialized(t *testing.T) {
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineUninitialized"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineUninitialized"), nil, nil, nil)
 	defer engine.removeAll()
 
 	engine.resolver = &DockerContainerMetadataResolver{}
@@ -309,7 +309,7 @@ func TestStatsEngineTerminalTask(t *testing.T) {
 		KnownStatusUnsafe: apitaskstatus.TaskStopped,
 		Family:            "f1",
 	}, nil)
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineTerminalTask"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineTerminalTask"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -426,7 +426,7 @@ func TestStartMetricsPublish(t *testing.T) {
 			telemetryMessages := make(chan ecstcs.TelemetryMessage, tc.channelSize)
 			healthMessages := make(chan ecstcs.HealthMessage, tc.channelSize)
 
-			engine := NewDockerStatsEngine(&publishMetricsCfg, nil, eventStream("TestStartMetricsPublish"), telemetryMessages, healthMessages)
+			engine := NewDockerStatsEngine(&publishMetricsCfg, nil, eventStream("TestStartMetricsPublish"), telemetryMessages, healthMessages, nil)
 			ctx, cancel := context.WithCancel(context.TODO())
 			engine.ctx = ctx
 			engine.resolver = resolver
@@ -521,7 +521,7 @@ func TestGetInstanceMetricsNonIdleEmptyError(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetInstanceMetrics"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetInstanceMetrics"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -558,7 +558,7 @@ func TestGetTaskHealthMetrics(t *testing.T) {
 		},
 	}, nil).Times(3)
 
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -566,7 +566,7 @@ func TestGetTaskHealthMetrics(t *testing.T) {
 
 	containerToStats := make(map[string]*StatsContainer)
 	var err error
-	containerToStats[containerID], err = newStatsContainer(containerID, nil, resolver, nil)
+	containerToStats[containerID], err = newStatsContainer(containerID, nil, resolver, nil, nil)
 	assert.NoError(t, err)
 	engine.tasksToHealthCheckContainers["t1"] = containerToStats
 	engine.tasksToDefinitions["t1"] = &taskDefinition{
@@ -602,7 +602,7 @@ func TestGetTaskHealthMetricsStoppedContainer(t *testing.T) {
 		},
 	}, nil).Times(2)
 
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -610,7 +610,7 @@ func TestGetTaskHealthMetricsStoppedContainer(t *testing.T) {
 
 	containerToStats := make(map[string]*StatsContainer)
 	var err error
-	containerToStats[containerID], err = newStatsContainer(containerID, nil, resolver, nil)
+	containerToStats[containerID], err = newStatsContainer(containerID, nil, resolver, nil, nil)
 	assert.NoError(t, err)
 	engine.tasksToHealthCheckContainers["t1"] = containerToStats
 	engine.tasksToDefinitions["t1"] = &taskDefinition{
@@ -628,7 +628,7 @@ func TestGetTaskHealthMetricsEmptyError(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -669,7 +669,7 @@ func TestMetricsDisabled(t *testing.T) {
 		},
 	}, nil).Times(2)
 
-	engine := NewDockerStatsEngine(&disableMetricsConfig, nil, eventStream("TestMetricsDisabled"), nil, nil)
+	engine := NewDockerStatsEngine(&disableMetricsConfig, nil, eventStream("TestMetricsDisabled"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -690,7 +690,7 @@ func TestSynchronizeOnRestart(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	resolver := mock_resolver.NewMockContainerMetadataResolver(ctrl)
 
-	engine := NewDockerStatsEngine(&cfg, client, eventStream("TestSynchronizeOnRestart"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, client, eventStream("TestSynchronizeOnRestart"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -789,7 +789,7 @@ func testNetworkModeStats(t *testing.T, netMode string, enis []*ni.NetworkInterf
 			State: &types.ContainerState{Pid: 23},
 		},
 	}, nil).AnyTimes()
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestTaskNetworkStatsSet"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestTaskNetworkStatsSet"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -324,6 +324,7 @@ func TestStatsEngineTerminalTask(t *testing.T) {
 }
 
 func TestStartMetricsPublish(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name                       string
 		hasPublishTicker           bool
@@ -378,6 +379,7 @@ func TestStartMetricsPublish(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 
@@ -714,7 +716,7 @@ func TestSynchronizeOnRestart(t *testing.T) {
 		Container: &apicontainer.Container{
 			HealthCheckType: "docker",
 		},
-	}, nil).Times(3)
+	}, nil).AnyTimes()
 	err := engine.synchronizeState()
 	assert.NoError(t, err)
 

--- a/agent/stats/engine_unix_integ_test.go
+++ b/agent/stats/engine_unix_integ_test.go
@@ -90,7 +90,7 @@ func TestStatsEngineWithServiceConnectMetrics(t *testing.T) {
 			}
 
 			// Create a new docker stats engine
-			engine := NewDockerStatsEngine(&testConfig, dockerClient, eventStream("TestStatsEngineWithServiceConnectMetrics"), nil, nil)
+			engine := NewDockerStatsEngine(&testConfig, dockerClient, eventStream("TestStatsEngineWithServiceConnectMetrics"), nil, nil, nil)
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
 

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -90,7 +90,7 @@ func TestNetworkModeStatsAWSVPCMode(t *testing.T) {
 			State: &types.ContainerState{Pid: 23},
 		},
 	}, nil).AnyTimes()
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestTaskNetworkStatsSet"), nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestTaskNetworkStatsSet"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -148,7 +148,7 @@ func TestServiceConnectWithDisabledMetrics(t *testing.T) {
 		Container: &container,
 	}, nil).Times(2)
 
-	engine := NewDockerStatsEngine(&disableMetricsConfig, nil, eventStream("TestServiceConnectWithDisabledMetrics"), nil, nil)
+	engine := NewDockerStatsEngine(&disableMetricsConfig, nil, eventStream("TestServiceConnectWithDisabledMetrics"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -234,7 +234,7 @@ func TestFetchEBSVolumeMetrics(t *testing.T) {
 					},
 				},
 			}
-			engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestFetchEBSVolumeMetrics"), nil, nil)
+			engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestFetchEBSVolumeMetrics"), nil, nil, nil)
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
 			engine.ctx = ctx

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -29,7 +29,6 @@ import (
 	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	apiresource "github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment/resource"
-	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/csiclient"
 	mock_csiclient "github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/mocks"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
@@ -75,17 +74,7 @@ func TestNetworkModeStatsAWSVPCMode(t *testing.T) {
 		},
 	}
 
-	t1 := &apitask.Task{
-		Arn:               "t1",
-		Family:            "f1",
-		ENIs:              []*ni.NetworkInterface{{ID: "ec2Id"}},
-		NetworkMode:       apitask.AWSVPCNetworkMode,
-		KnownStatusUnsafe: apitaskstatus.TaskRunning,
-		Containers: []*apicontainer.Container{
-			{Name: "test"},
-			{Name: "test1"},
-		},
-	}
+	t1 := getTestTask()
 
 	resolver.EXPECT().ResolveTask("c1").AnyTimes().Return(t1, nil)
 	resolver.EXPECT().ResolveTask("c2").AnyTimes().Return(t1, nil)
@@ -148,15 +137,12 @@ func TestServiceConnectWithDisabledMetrics(t *testing.T) {
 		HealthCheckType: "docker",
 	}
 	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
-	resolver.EXPECT().ResolveTask(containerID).Return(&apitask.Task{
-		Arn:               "t1",
-		KnownStatusUnsafe: apitaskstatus.TaskRunning,
-		Family:            "f1",
-		ServiceConnectConfig: &serviceconnect.Config{
-			ContainerName: "service-connect",
-		},
-		Containers: []*apicontainer.Container{&container},
-	}, nil)
+	t1 := getTestTask()
+	t1.ServiceConnectConfig = &serviceconnect.Config{
+		ContainerName: "service-connect",
+	}
+	t1.Containers = []*apicontainer.Container{&container}
+	resolver.EXPECT().ResolveTask(containerID).Return(t1, nil)
 	resolver.EXPECT().ResolveContainer(containerID).Return(&apicontainer.DockerContainer{
 		DockerID:  containerID,
 		Container: &container,
@@ -233,20 +219,18 @@ func TestFetchEBSVolumeMetrics(t *testing.T) {
 			defer mockCtrl.Finish()
 			resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
 			mockDockerClient := mock_dockerapi.NewMockDockerClient(mockCtrl)
-			t1 := &apitask.Task{
-				Arn: "t1",
-				Volumes: []apitask.TaskVolume{
-					{
-						Name: "1",
-						Type: apiresource.EBSTaskAttach,
-						Volume: &taskresourcevolume.EBSTaskVolumeConfig{
-							VolumeId:             "vol-12345",
-							VolumeName:           "test-volume",
-							VolumeSizeGib:        "10",
-							SourceVolumeHostPath: "taskarn_vol-12345",
-							DeviceName:           "/dev/nvme1n1",
-							FileSystem:           "ext4",
-						},
+			t1 := getTestTask()
+			t1.Volumes = []apitask.TaskVolume{
+				{
+					Name: "1",
+					Type: apiresource.EBSTaskAttach,
+					Volume: &taskresourcevolume.EBSTaskVolumeConfig{
+						VolumeId:             "vol-12345",
+						VolumeName:           "test-volume",
+						VolumeSizeGib:        "10",
+						SourceVolumeHostPath: "taskarn_vol-12345",
+						DeviceName:           "/dev/nvme1n1",
+						FileSystem:           "ext4",
 					},
 				},
 			}

--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -61,14 +61,14 @@ func (queue *Queue) Reset() {
 }
 
 // Add adds a new set of container stats to the queue.
-func (queue *Queue) Add(dockerStat *types.StatsJSON, nonDockerStats *NonDockerContainerStats) error {
+func (queue *Queue) Add(dockerStat *types.StatsJSON, nonDockerStats NonDockerContainerStats) error {
 	queue.setLastStat(dockerStat)
 	stat, err := dockerStatsToContainerStats(dockerStat)
 	if err != nil {
 		return err
 	}
-	if nonDockerStats != nil {
-		stat.restartCount = &nonDockerStats.restartCount
+	if nonDockerStats.restartCount != nil {
+		stat.restartCount = nonDockerStats.restartCount
 	}
 	queue.add(stat)
 	return nil

--- a/agent/stats/queue_unix.go
+++ b/agent/stats/queue_unix.go
@@ -1,0 +1,146 @@
+//go:build linux
+// +build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
+	"github.com/docker/docker/api/types"
+)
+
+type BlockStatKey struct {
+	Major uint64
+	Minor uint64
+	Op    string
+}
+
+type BlockStatValue struct {
+	HasBeenRetrieved bool
+	Value            uint64
+}
+
+// aggregateOSDependentStats aggregates stats that are measured cumulatively against container start time and
+// populated only for Linux OS.
+func aggregateOSDependentStats(dockerStat, lastStatBeforeLastRestart *types.StatsJSON) *types.StatsJSON {
+	// CPU stats.
+	aggregateUsagePerCore(&dockerStat.CPUStats.CPUUsage.PercpuUsage,
+		lastStatBeforeLastRestart.CPUStats.CPUUsage.PercpuUsage)
+	dockerStat.CPUStats.ThrottlingData.Periods += lastStatBeforeLastRestart.CPUStats.ThrottlingData.Periods
+	dockerStat.CPUStats.ThrottlingData.ThrottledPeriods +=
+		lastStatBeforeLastRestart.CPUStats.ThrottlingData.ThrottledPeriods
+	dockerStat.CPUStats.ThrottlingData.ThrottledTime += lastStatBeforeLastRestart.CPUStats.ThrottlingData.ThrottledTime
+
+	// Memory stats.
+	dockerStat.MemoryStats.MaxUsage = utils.MaxNum(dockerStat.MemoryStats.MaxUsage,
+		lastStatBeforeLastRestart.MemoryStats.MaxUsage)
+	dockerStat.MemoryStats.Failcnt += lastStatBeforeLastRestart.MemoryStats.Failcnt
+
+	// Block I/O stats.
+	aggregateBlockStat(&dockerStat.BlkioStats.IoServiceBytesRecursive,
+		lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive)
+	aggregateBlockStat(&dockerStat.BlkioStats.IoServicedRecursive,
+		lastStatBeforeLastRestart.BlkioStats.IoServicedRecursive)
+	aggregateBlockStat(&dockerStat.BlkioStats.IoServiceTimeRecursive,
+		lastStatBeforeLastRestart.BlkioStats.IoServiceTimeRecursive)
+	aggregateBlockStat(&dockerStat.BlkioStats.IoWaitTimeRecursive,
+		lastStatBeforeLastRestart.BlkioStats.IoWaitTimeRecursive)
+	aggregateBlockStat(&dockerStat.BlkioStats.IoMergedRecursive, lastStatBeforeLastRestart.BlkioStats.IoMergedRecursive)
+	aggregateBlockStat(&dockerStat.BlkioStats.IoTimeRecursive, lastStatBeforeLastRestart.BlkioStats.IoTimeRecursive)
+	aggregateBlockStat(&dockerStat.BlkioStats.SectorsRecursive, lastStatBeforeLastRestart.BlkioStats.SectorsRecursive)
+
+	// Network stats.
+	for key, dockerStatNetwork := range dockerStat.Networks {
+		lastStatBeforeLastRestartNetwork, ok := lastStatBeforeLastRestart.Networks[key]
+		if ok {
+			dockerStatNetwork.RxErrors += lastStatBeforeLastRestartNetwork.RxErrors
+			dockerStatNetwork.TxErrors += lastStatBeforeLastRestartNetwork.TxErrors
+		}
+		dockerStat.Networks[key] = dockerStatNetwork
+	}
+
+	return dockerStat
+}
+
+// aggregateUsagePerCore aggregates the total CPU time consumed per core.
+func aggregateUsagePerCore(dockerStatUsageSlice *[]uint64, lastStatBeforeLastRestartStatUsageSlice []uint64) {
+	if len(*dockerStatUsageSlice) == 0 && len(lastStatBeforeLastRestartStatUsageSlice) == 0 {
+		return
+	}
+
+	var aggregatedUsageSlice []uint64
+	peakNumCores := utils.MaxNum(len(*dockerStatUsageSlice), len(lastStatBeforeLastRestartStatUsageSlice))
+	for i := 0; i < peakNumCores; i++ {
+		coreUsage := uint64(0)
+		if i < len(lastStatBeforeLastRestartStatUsageSlice) {
+			coreUsage += lastStatBeforeLastRestartStatUsageSlice[i]
+		}
+		if i < len(*dockerStatUsageSlice) {
+			coreUsage += (*dockerStatUsageSlice)[i]
+		}
+		aggregatedUsageSlice = append(aggregatedUsageSlice, coreUsage)
+	}
+	*dockerStatUsageSlice = aggregatedUsageSlice
+}
+
+// aggregateBlockStat aggregates block I/O stats for the specified I/O service stat.
+func aggregateBlockStat(dockerStatBlockStatSlice *[]types.BlkioStatEntry,
+	lastStatBeforeLastRestartStatBlockStatSlice []types.BlkioStatEntry) {
+	if len(*dockerStatBlockStatSlice) == 0 && len(lastStatBeforeLastRestartStatBlockStatSlice) == 0 {
+		return
+	}
+
+	var aggregatedBlockStatSlice []types.BlkioStatEntry
+	blockStatsMap := make(map[BlockStatKey]BlockStatValue)
+
+	// Add block stat entries from stats to map (merging duplicates).
+	addBlockStatEntriesFromSliceToMap(lastStatBeforeLastRestartStatBlockStatSlice, blockStatsMap)
+	addBlockStatEntriesFromSliceToMap(*dockerStatBlockStatSlice, blockStatsMap)
+
+	// Get entries from map and add them to the result slice in the same order they were originally encountered.
+	addCorrespondingMapEntriesOfSliceToAggregatedSlice(blockStatsMap,
+		lastStatBeforeLastRestartStatBlockStatSlice, &aggregatedBlockStatSlice)
+	addCorrespondingMapEntriesOfSliceToAggregatedSlice(blockStatsMap,
+		*dockerStatBlockStatSlice, &aggregatedBlockStatSlice)
+
+	*dockerStatBlockStatSlice = aggregatedBlockStatSlice
+}
+
+func addBlockStatEntriesFromSliceToMap(statSlice []types.BlkioStatEntry, statMap map[BlockStatKey]BlockStatValue) {
+	for _, blockStat := range statSlice {
+		blkStatKey := BlockStatKey{blockStat.Major, blockStat.Minor, blockStat.Op}
+		blkStatVal, ok := statMap[blkStatKey]
+		if ok {
+			blkStatVal.Value += blockStat.Value
+		} else {
+			blkStatVal = BlockStatValue{false, blockStat.Value}
+		}
+		statMap[blkStatKey] = blkStatVal
+	}
+}
+
+func addCorrespondingMapEntriesOfSliceToAggregatedSlice(statMap map[BlockStatKey]BlockStatValue,
+	statSlice []types.BlkioStatEntry, aggregatedSlice *[]types.BlkioStatEntry) {
+	for _, blockStat := range statSlice {
+		blkStatKey := BlockStatKey{blockStat.Major, blockStat.Minor, blockStat.Op}
+		blkStatVal, ok := statMap[blkStatKey]
+		if ok && !blkStatVal.HasBeenRetrieved {
+			*aggregatedSlice = append(*aggregatedSlice, types.BlkioStatEntry{
+				Major: blockStat.Major, Minor: blockStat.Minor, Op: blockStat.Op, Value: blkStatVal.Value})
+			blkStatVal.HasBeenRetrieved = true
+			statMap[blkStatKey] = blkStatVal
+		}
+	}
+}

--- a/agent/stats/queue_unix_test.go
+++ b/agent/stats/queue_unix_test.go
@@ -1,0 +1,184 @@
+//go:build linux && unit
+// +build linux,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
+	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregateOSDependentStats(t *testing.T) {
+	dockerStat := getTestStatsJSONForOSDependentStats(1, 2, 3, 4, 5, 6, 7, 8, 9,
+		[]types.BlkioStatEntry{
+			{
+				Major: 202,
+				Minor: 192,
+				Op:    "Read",
+				Value: 1,
+			},
+			{
+				Major: 202,
+				Minor: 192,
+				Op:    "Write",
+				Value: 2,
+			},
+			{
+				Major: 253,
+				Minor: 1,
+				Op:    "Read",
+				Value: 3,
+			},
+			{
+				Major: 253,
+				Minor: 1,
+				Op:    "Write",
+				Value: 4,
+			},
+		})
+	lastStatBeforeLastRestart := getTestStatsJSONForOSDependentStats(1, 2, 3, 4, 5, 6, 7, 8, 9,
+		[]types.BlkioStatEntry{
+			{
+				Major: 253,
+				Minor: 1,
+				Op:    "Read",
+				Value: 1234,
+			},
+			{
+				Major: 253,
+				Minor: 1,
+				Op:    "Write",
+				Value: 5678,
+			},
+		})
+
+	// Sanity length checks/enforcement.
+	require.Equal(t, 2, len(dockerStat.CPUStats.CPUUsage.PercpuUsage))
+	require.Equal(t, 2, len(lastStatBeforeLastRestart.CPUStats.CPUUsage.PercpuUsage))
+	require.Equal(t, 4, len(dockerStat.BlkioStats.IoServiceBytesRecursive))
+	require.Equal(t, 2, len(lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive))
+
+	expectedAggregatedStat := types.StatsJSON{
+		Stats: types.Stats{
+			CPUStats: types.CPUStats{
+				CPUUsage: types.CPUUsage{
+					PercpuUsage: []uint64{
+						dockerStat.Stats.CPUStats.CPUUsage.PercpuUsage[0] +
+							lastStatBeforeLastRestart.Stats.CPUStats.CPUUsage.PercpuUsage[0],
+						dockerStat.Stats.CPUStats.CPUUsage.PercpuUsage[1] +
+							lastStatBeforeLastRestart.Stats.CPUStats.CPUUsage.PercpuUsage[1]},
+				},
+				ThrottlingData: types.ThrottlingData{
+					Periods: dockerStat.Stats.CPUStats.ThrottlingData.Periods +
+						lastStatBeforeLastRestart.Stats.CPUStats.ThrottlingData.Periods,
+					ThrottledPeriods: dockerStat.Stats.CPUStats.ThrottlingData.ThrottledPeriods +
+						lastStatBeforeLastRestart.Stats.CPUStats.ThrottlingData.ThrottledPeriods,
+					ThrottledTime: dockerStat.Stats.CPUStats.ThrottlingData.ThrottledTime +
+						lastStatBeforeLastRestart.Stats.CPUStats.ThrottlingData.ThrottledTime,
+				},
+			},
+			MemoryStats: types.MemoryStats{
+				MaxUsage: utils.MaxNum(dockerStat.MemoryStats.MaxUsage, lastStatBeforeLastRestart.MemoryStats.MaxUsage),
+				Failcnt:  dockerStat.MemoryStats.Failcnt + lastStatBeforeLastRestart.MemoryStats.Failcnt,
+			},
+			BlkioStats: types.BlkioStats{
+				IoServiceBytesRecursive: []types.BlkioStatEntry{
+					{
+						Major: lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[0].Major,
+						Minor: lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[0].Minor,
+						Op:    lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[0].Op,
+						Value: lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[0].Value +
+							dockerStat.BlkioStats.IoServiceBytesRecursive[2].Value,
+					},
+					{
+						Major: lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[1].Major,
+						Minor: lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[1].Minor,
+						Op:    lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[1].Op,
+						Value: lastStatBeforeLastRestart.BlkioStats.IoServiceBytesRecursive[1].Value +
+							dockerStat.BlkioStats.IoServiceBytesRecursive[3].Value,
+					},
+					{
+						Major: dockerStat.BlkioStats.IoServiceBytesRecursive[0].Major,
+						Minor: dockerStat.BlkioStats.IoServiceBytesRecursive[0].Minor,
+						Op:    dockerStat.BlkioStats.IoServiceBytesRecursive[0].Op,
+						Value: dockerStat.BlkioStats.IoServiceBytesRecursive[0].Value,
+					},
+					{
+						Major: dockerStat.BlkioStats.IoServiceBytesRecursive[1].Major,
+						Minor: dockerStat.BlkioStats.IoServiceBytesRecursive[1].Minor,
+						Op:    dockerStat.BlkioStats.IoServiceBytesRecursive[1].Op,
+						Value: dockerStat.BlkioStats.IoServiceBytesRecursive[1].Value,
+					},
+				},
+			},
+		},
+		Networks: map[string]types.NetworkStats{
+			testNetworkNameA: {
+				RxErrors: dockerStat.Networks[testNetworkNameA].RxErrors +
+					lastStatBeforeLastRestart.Networks[testNetworkNameA].RxErrors,
+				TxErrors: dockerStat.Networks[testNetworkNameA].TxErrors +
+					lastStatBeforeLastRestart.Networks[testNetworkNameA].TxErrors,
+			},
+			testNetworkNameB: {
+				RxErrors: dockerStat.Networks[testNetworkNameB].RxErrors +
+					lastStatBeforeLastRestart.Networks[testNetworkNameB].RxErrors,
+				TxErrors: dockerStat.Networks[testNetworkNameB].TxErrors +
+					lastStatBeforeLastRestart.Networks[testNetworkNameB].TxErrors,
+			},
+		},
+	}
+
+	dockerStat = aggregateOSDependentStats(dockerStat, lastStatBeforeLastRestart)
+	require.Equal(t, *dockerStat, expectedAggregatedStat)
+}
+
+func getTestStatsJSONForOSDependentStats(usageCoreA, usageCoreB, periods, throttledPeriods, throttledTime, maxUsage,
+	failCnt, rxErrors, txErrors uint64, ioServiceBytesRecursive []types.BlkioStatEntry) *types.StatsJSON {
+	return &types.StatsJSON{
+		Stats: types.Stats{
+			CPUStats: types.CPUStats{
+				CPUUsage: types.CPUUsage{
+					PercpuUsage: []uint64{usageCoreA, usageCoreB},
+				},
+				ThrottlingData: types.ThrottlingData{
+					Periods:          periods,
+					ThrottledPeriods: throttledPeriods,
+					ThrottledTime:    throttledTime,
+				},
+			},
+			MemoryStats: types.MemoryStats{
+				MaxUsage: maxUsage,
+				Failcnt:  failCnt,
+			},
+			BlkioStats: types.BlkioStats{
+				IoServiceBytesRecursive: ioServiceBytesRecursive,
+			},
+		},
+		Networks: map[string]types.NetworkStats{
+			testNetworkNameA: {
+				RxErrors: rxErrors,
+				TxErrors: txErrors,
+			},
+			testNetworkNameB: {
+				RxErrors: rxErrors + 1,
+				TxErrors: txErrors + 1,
+			},
+		},
+	}
+}

--- a/agent/stats/queue_unix_test.go
+++ b/agent/stats/queue_unix_test.go
@@ -145,7 +145,7 @@ func TestAggregateOSDependentStats(t *testing.T) {
 	}
 
 	dockerStat = aggregateOSDependentStats(dockerStat, lastStatBeforeLastRestart)
-	require.Equal(t, *dockerStat, expectedAggregatedStat)
+	require.Equal(t, expectedAggregatedStat, *dockerStat)
 }
 
 func getTestStatsJSONForOSDependentStats(usageCoreA, usageCoreB, periods, throttledPeriods, throttledTime, maxUsage,

--- a/agent/stats/queue_windows.go
+++ b/agent/stats/queue_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
+	"github.com/docker/docker/api/types"
+)
+
+// aggregateOSDependentStats aggregates stats that are measured cumulatively against container start time and
+// populated only for Windows OS.
+func aggregateOSDependentStats(dockerStat, lastStatBeforeLastRestart *types.StatsJSON) *types.StatsJSON {
+	// Memory stats.
+	dockerStat.MemoryStats.CommitPeak = utils.MaxNum(dockerStat.MemoryStats.CommitPeak,
+		lastStatBeforeLastRestart.MemoryStats.CommitPeak)
+
+	// Disk I/O stats.
+	dockerStat.StorageStats.ReadCountNormalized += lastStatBeforeLastRestart.StorageStats.ReadCountNormalized
+	dockerStat.StorageStats.ReadSizeBytes += lastStatBeforeLastRestart.StorageStats.ReadSizeBytes
+	dockerStat.StorageStats.WriteCountNormalized += lastStatBeforeLastRestart.StorageStats.WriteCountNormalized
+	dockerStat.StorageStats.WriteSizeBytes += lastStatBeforeLastRestart.StorageStats.WriteSizeBytes
+
+	return dockerStat
+}

--- a/agent/stats/queue_windows_test.go
+++ b/agent/stats/queue_windows_test.go
@@ -47,7 +47,7 @@ func TestAggregateOSDependentStats(t *testing.T) {
 	}
 
 	dockerStat = aggregateOSDependentStats(dockerStat, lastStatBeforeLastRestart)
-	require.Equal(t, *dockerStat, expectedAggregatedStat)
+	require.Equal(t, expectedAggregatedStat, *dockerStat)
 }
 
 func getTestStatsJSONForOSDependentStats(commitPeak, readCountNormalized, readSizeBytes, writeCountNormalized,

--- a/agent/stats/queue_windows_test.go
+++ b/agent/stats/queue_windows_test.go
@@ -1,0 +1,68 @@
+//go:build windows && unit
+// +build windows,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
+	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregateOSDependentStats(t *testing.T) {
+	dockerStat := getTestStatsJSONForOSDependentStats(1, 2, 3, 4, 5)
+	lastStatBeforeLastRestart := getTestStatsJSONForOSDependentStats(5, 4, 3, 2, 1)
+	expectedAggregatedStat := types.StatsJSON{
+		Stats: types.Stats{
+			MemoryStats: types.MemoryStats{
+				CommitPeak: utils.MaxNum(dockerStat.MemoryStats.CommitPeak,
+					lastStatBeforeLastRestart.MemoryStats.CommitPeak),
+			},
+			StorageStats: types.StorageStats{
+				ReadCountNormalized: dockerStat.StorageStats.ReadCountNormalized +
+					lastStatBeforeLastRestart.StorageStats.ReadCountNormalized,
+				ReadSizeBytes: dockerStat.StorageStats.ReadSizeBytes +
+					lastStatBeforeLastRestart.StorageStats.ReadSizeBytes,
+				WriteCountNormalized: dockerStat.StorageStats.WriteCountNormalized +
+					lastStatBeforeLastRestart.StorageStats.WriteCountNormalized,
+				WriteSizeBytes: dockerStat.StorageStats.WriteSizeBytes +
+					lastStatBeforeLastRestart.StorageStats.WriteSizeBytes,
+			},
+		},
+	}
+
+	dockerStat = aggregateOSDependentStats(dockerStat, lastStatBeforeLastRestart)
+	require.Equal(t, *dockerStat, expectedAggregatedStat)
+}
+
+func getTestStatsJSONForOSDependentStats(commitPeak, readCountNormalized, readSizeBytes, writeCountNormalized,
+	writeSizeBytes uint64) *types.StatsJSON {
+	return &types.StatsJSON{
+		Stats: types.Stats{
+			MemoryStats: types.MemoryStats{
+				CommitPeak: commitPeak,
+			},
+			StorageStats: types.StorageStats{
+				ReadCountNormalized:  readCountNormalized,
+				ReadSizeBytes:        readSizeBytes,
+				WriteCountNormalized: writeCountNormalized,
+				WriteSizeBytes:       writeSizeBytes,
+			},
+		},
+	}
+}

--- a/agent/stats/task.go
+++ b/agent/stats/task.go
@@ -121,7 +121,7 @@ func (taskStat *StatsTask) processStatsStream() error {
 				}
 				return nil
 			}
-			if err := taskStat.StatsQueue.Add(rawStat); err != nil {
+			if err := taskStat.StatsQueue.Add(rawStat, nil); err != nil {
 				logger.Warn("Error converting task stats", logger.Fields{
 					field.TaskID: taskId,
 					field.Error:  err,

--- a/agent/stats/task.go
+++ b/agent/stats/task.go
@@ -121,7 +121,7 @@ func (taskStat *StatsTask) processStatsStream() error {
 				}
 				return nil
 			}
-			if err := taskStat.StatsQueue.Add(rawStat, nil); err != nil {
+			if err := taskStat.StatsQueue.Add(rawStat, NonDockerContainerStats{}); err != nil {
 				logger.Warn("Error converting task stats", logger.Fields{
 					field.TaskID: taskId,
 					field.Error:  err,

--- a/agent/stats/task_linux_test.go
+++ b/agent/stats/task_linux_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 func TestTaskStatsCollection(t *testing.T) {
+	t.Parallel()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	resolver := mock_resolver.NewMockContainerMetadataResolver(ctrl)
@@ -97,6 +98,7 @@ func TestTaskStatsCollection(t *testing.T) {
 }
 
 func TestTaskStatsCollectionError(t *testing.T) {
+	t.Parallel()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	resolver := mock_resolver.NewMockContainerMetadataResolver(ctrl)

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -38,7 +38,7 @@ type ContainerStats struct {
 // These are amended to the docker stats and added to the stats queue if they are
 // available.
 type NonDockerContainerStats struct {
-	restartCount int64
+	restartCount *int64
 }
 
 // NetworkStats contains the network stats information for a container

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -14,11 +14,12 @@
 package stats
 
 import (
+	"context"
 	"time"
 
-	"context"
-
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/stats/resolver"
 )
@@ -89,13 +90,15 @@ type TaskMetadata struct {
 
 // StatsContainer abstracts methods to gather and aggregate utilization data for a container.
 type StatsContainer struct {
-	containerMetadata *ContainerMetadata
-	ctx               context.Context
-	cancel            context.CancelFunc
-	client            dockerapi.DockerClient
-	statsQueue        *Queue
-	resolver          resolver.ContainerMetadataResolver
-	config            *config.Config
+	containerMetadata      *ContainerMetadata
+	ctx                    context.Context
+	cancel                 context.CancelFunc
+	client                 dockerapi.DockerClient
+	statsQueue             *Queue
+	resolver               resolver.ContainerMetadataResolver
+	config                 *config.Config
+	restartAggregationData apicontainer.ContainerRestartAggregationDataForStats
+	dataClient             data.Client
 }
 
 // taskDefinition encapsulates family and version strings for a task definition

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -29,8 +29,16 @@ type ContainerStats struct {
 	memoryUsage       uint64
 	storageReadBytes  uint64
 	storageWriteBytes uint64
+	restartCount      *int64
 	networkStats      *NetworkStats
 	timestamp         time.Time
+}
+
+// NonDockerContainerStats contains stats for a container that are not gotten from docker.
+// These are amended to the docker stats and added to the stats queue if they are
+// available.
+type NonDockerContainerStats struct {
+	restartCount int64
 }
 
 // NetworkStats contains the network stats information for a container
@@ -54,6 +62,7 @@ type UsageStats struct {
 	StorageReadBytes  uint64        `json:"storageReadBytes"`
 	StorageWriteBytes uint64        `json:"storageWriteBytes"`
 	NetworkStats      *NetworkStats `json:"networkStats"`
+	RestartCount      *int64        `json:"restartCount"`
 	Timestamp         time.Time     `json:"timestamp"`
 	cpuUsage          uint64
 	// sent indicates if the stat has been sent to TACS already.

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart/restart_tracker.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart/restart_tracker.go
@@ -92,7 +92,7 @@ func (rt *RestartTracker) ShouldRestart(exitCode *int, startedAt time.Time,
 	if !rt.LastRestartAt.IsZero() {
 		startTime = rt.LastRestartAt
 	}
-	if time.Since(startTime) < time.Duration(rt.RestartPolicy.RestartAttemptPeriod)*time.Second {
+	if time.Since(startTime).Seconds() < float64(rt.RestartPolicy.RestartAttemptPeriod) {
 		return false, "attempt reset period has not elapsed"
 	}
 	return true, ""

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart/restart_tracker.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart/restart_tracker.go
@@ -31,9 +31,9 @@ type RestartTracker struct {
 // RestartPolicy represents a policy that contains key information considered when
 // deciding whether or not a container should be restarted after it has exited.
 type RestartPolicy struct {
-	Enabled              bool          `json:"enabled"`
-	IgnoredExitCodes     []int         `json:"ignoredExitCodes"`
-	RestartAttemptPeriod time.Duration `json:"restartAttemptPeriod"`
+	Enabled              bool  `json:"enabled"`
+	IgnoredExitCodes     []int `json:"ignoredExitCodes"`
+	RestartAttemptPeriod int   `json:"restartAttemptPeriod"`
 }
 
 func NewRestartTracker(restartPolicy RestartPolicy) *RestartTracker {
@@ -92,7 +92,7 @@ func (rt *RestartTracker) ShouldRestart(exitCode *int, startedAt time.Time,
 	if !rt.LastRestartAt.IsZero() {
 		startTime = rt.LastRestartAt
 	}
-	if time.Since(startTime) < rt.RestartPolicy.RestartAttemptPeriod {
+	if time.Since(startTime) < time.Duration(rt.RestartPolicy.RestartAttemptPeriod)*time.Second {
 		return false, "attempt reset period has not elapsed"
 	}
 	return true, ""

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart/restart_tracker.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart/restart_tracker.go
@@ -22,9 +22,9 @@ import (
 )
 
 type RestartTracker struct {
-	RestartCount  int       `json:"restartCount,omitempty"`
-	LastRestartAt time.Time `json:"lastRestartAt,omitempty"`
-	restartPolicy RestartPolicy
+	RestartCount  int           `json:"restartCount,omitempty"`
+	LastRestartAt time.Time     `json:"lastRestartAt,omitempty"`
+	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty"`
 	lock          sync.RWMutex
 }
 
@@ -38,7 +38,7 @@ type RestartPolicy struct {
 
 func NewRestartTracker(restartPolicy RestartPolicy) *RestartTracker {
 	return &RestartTracker{
-		restartPolicy: restartPolicy,
+		RestartPolicy: restartPolicy,
 	}
 }
 
@@ -73,7 +73,7 @@ func (rt *RestartTracker) ShouldRestart(exitCode *int, startedAt time.Time,
 	rt.lock.RLock()
 	defer rt.lock.RUnlock()
 
-	if !rt.restartPolicy.Enabled {
+	if !rt.RestartPolicy.Enabled {
 		return false, "restart policy is not enabled"
 	}
 	if desiredStatus == apicontainerstatus.ContainerStopped {
@@ -82,7 +82,7 @@ func (rt *RestartTracker) ShouldRestart(exitCode *int, startedAt time.Time,
 	if exitCode == nil {
 		return false, "exit code is nil"
 	}
-	for _, ignoredCode := range rt.restartPolicy.IgnoredExitCodes {
+	for _, ignoredCode := range rt.RestartPolicy.IgnoredExitCodes {
 		if ignoredCode == *exitCode {
 			return false, fmt.Sprintf("exit code %d should be ignored", *exitCode)
 		}
@@ -92,7 +92,7 @@ func (rt *RestartTracker) ShouldRestart(exitCode *int, startedAt time.Time,
 	if !rt.LastRestartAt.IsZero() {
 		startTime = rt.LastRestartAt
 	}
-	if time.Since(startTime) < rt.restartPolicy.RestartAttemptPeriod {
+	if time.Since(startTime) < rt.RestartPolicy.RestartAttemptPeriod {
 		return false, "attempt reset period has not elapsed"
 	}
 	return true, ""

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart/restart_tracker.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart/restart_tracker.go
@@ -1,0 +1,99 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package restart
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
+)
+
+type RestartTracker struct {
+	RestartCount  int       `json:"restartCount,omitempty"`
+	LastRestartAt time.Time `json:"lastRestartAt,omitempty"`
+	restartPolicy RestartPolicy
+	lock          sync.RWMutex
+}
+
+// RestartPolicy represents a policy that contains key information considered when
+// deciding whether or not a container should be restarted after it has exited.
+type RestartPolicy struct {
+	Enabled              bool          `json:"enabled"`
+	IgnoredExitCodes     []int         `json:"ignoredExitCodes"`
+	RestartAttemptPeriod time.Duration `json:"restartAttemptPeriod"`
+}
+
+func NewRestartTracker(restartPolicy RestartPolicy) *RestartTracker {
+	return &RestartTracker{
+		restartPolicy: restartPolicy,
+	}
+}
+
+func (rt *RestartTracker) GetLastRestartAt() time.Time {
+	rt.lock.RLock()
+	defer rt.lock.RUnlock()
+	return rt.LastRestartAt
+}
+
+func (rt *RestartTracker) GetRestartCount() int {
+	rt.lock.RLock()
+	defer rt.lock.RUnlock()
+	return rt.RestartCount
+}
+
+// RecordRestart updates the restart tracker's metadata after a restart has occurred.
+// This metadata is used to calculate when restarts should occur and track how many
+// have occurred. It is not the job of this method to determine if a restart should
+// occur or restart the container.
+func (rt *RestartTracker) RecordRestart() {
+	rt.lock.Lock()
+	defer rt.lock.Unlock()
+	rt.RestartCount++
+	rt.LastRestartAt = time.Now()
+}
+
+// ShouldRestart returns whether the container should restart and a reason string
+// explaining why not. The reset attempt period will be calculated first
+// with LastRestart at, using the passed in startedAt if it does not exist.
+func (rt *RestartTracker) ShouldRestart(exitCode *int, startedAt time.Time,
+	desiredStatus apicontainerstatus.ContainerStatus) (bool, string) {
+	rt.lock.RLock()
+	defer rt.lock.RUnlock()
+
+	if !rt.restartPolicy.Enabled {
+		return false, "restart policy is not enabled"
+	}
+	if desiredStatus == apicontainerstatus.ContainerStopped {
+		return false, "container's desired status is stopped"
+	}
+	if exitCode == nil {
+		return false, "exit code is nil"
+	}
+	for _, ignoredCode := range rt.restartPolicy.IgnoredExitCodes {
+		if ignoredCode == *exitCode {
+			return false, fmt.Sprintf("exit code %d should be ignored", *exitCode)
+		}
+	}
+
+	startTime := startedAt
+	if !rt.LastRestartAt.IsZero() {
+		startTime = rt.LastRestartAt
+	}
+	if time.Since(startTime) < rt.restartPolicy.RestartAttemptPeriod {
+		return false, "attempt reset period has not elapsed"
+	}
+	return true, ""
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"golang.org/x/exp/constraints"
 )
 
 func ZeroOrNil(obj interface{}) bool {
@@ -58,4 +59,12 @@ func Int64PtrToIntPtr(int64ptr *int64) *int {
 		return nil
 	}
 	return aws.Int(int(aws.Int64Value(int64ptr)))
+}
+
+// MaxNum returns the maximum value between two numbers.
+func MaxNum[T constraints.Integer | constraints.Float](a, b T) T {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/agent/vendor/golang.org/x/exp/LICENSE
+++ b/agent/vendor/golang.org/x/exp/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/agent/vendor/golang.org/x/exp/PATENTS
+++ b/agent/vendor/golang.org/x/exp/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/agent/vendor/golang.org/x/exp/constraints/constraints.go
+++ b/agent/vendor/golang.org/x/exp/constraints/constraints.go
@@ -1,0 +1,50 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package constraints defines a set of useful constraints to be used
+// with type parameters.
+package constraints
+
+// Signed is a constraint that permits any signed integer type.
+// If future releases of Go add new predeclared signed integer types,
+// this constraint will be modified to include them.
+type Signed interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+// Unsigned is a constraint that permits any unsigned integer type.
+// If future releases of Go add new predeclared unsigned integer types,
+// this constraint will be modified to include them.
+type Unsigned interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+// Integer is a constraint that permits any integer type.
+// If future releases of Go add new predeclared integer types,
+// this constraint will be modified to include them.
+type Integer interface {
+	Signed | Unsigned
+}
+
+// Float is a constraint that permits any floating-point type.
+// If future releases of Go add new predeclared floating-point types,
+// this constraint will be modified to include them.
+type Float interface {
+	~float32 | ~float64
+}
+
+// Complex is a constraint that permits any complex numeric type.
+// If future releases of Go add new predeclared complex numeric types,
+// this constraint will be modified to include them.
+type Complex interface {
+	~complex64 | ~complex128
+}
+
+// Ordered is a constraint that permits any ordered type: any type
+// that supports the operators < <= >= >.
+// If future releases of Go add new ordered types,
+// this constraint will be modified to include them.
+type Ordered interface {
+	Integer | Float | ~string
+}

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -355,6 +355,9 @@ github.com/vishvananda/netns
 # go.etcd.io/bbolt v1.3.9
 ## explicit; go 1.17
 go.etcd.io/bbolt
+# golang.org/x/exp v0.0.0-20231006140011-7918f672742d
+## explicit; go 1.20
+golang.org/x/exp/constraints
 # golang.org/x/mod v0.14.0
 ## explicit; go 1.18
 golang.org/x/mod/internal/lazyregexp

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -16,6 +16,7 @@ github.com/aws/amazon-ecs-agent/ecs-agent/api/appnet/mocks
 github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment
 github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment/resource
 github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment/resource/mocks
+github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart
 github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status
 github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs
 github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client

--- a/ecs-agent/go.mod
+++ b/ecs-agent/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	go.etcd.io/bbolt v1.3.9
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/net v0.23.0
 	golang.org/x/sys v0.18.0
 	golang.org/x/tools v0.17.0

--- a/ecs-agent/go.sum
+++ b/ecs-agent/go.sum
@@ -236,6 +236,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/ecs-agent/utils/utils.go
+++ b/ecs-agent/utils/utils.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"golang.org/x/exp/constraints"
 )
 
 func ZeroOrNil(obj interface{}) bool {
@@ -58,4 +59,12 @@ func Int64PtrToIntPtr(int64ptr *int64) *int {
 		return nil
 	}
 	return aws.Int(int(aws.Int64Value(int64ptr)))
+}
+
+// MaxNum returns the maximum value between two numbers.
+func MaxNum[T constraints.Integer | constraints.Float](a, b T) T {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/ecs-agent/utils/utils_test.go
+++ b/ecs-agent/utils/utils_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type dummyStruct struct {
@@ -106,4 +107,25 @@ func TestInt64PtrToIntPtr(t *testing.T) {
 			assert.Equal(t, tc.expectedOutput, Int64PtrToIntPtr(tc.input))
 		})
 	}
+}
+
+func TestMaxNum(t *testing.T) {
+	testMaxNumInt(t)
+	testMaxNumFloat(t)
+}
+
+func testMaxNumInt(t *testing.T) {
+	smallerVal := 8
+	largerVal := 88
+
+	require.Equal(t, largerVal, MaxNum(smallerVal, largerVal))
+	require.Equal(t, largerVal, MaxNum(largerVal, largerVal))
+}
+
+func testMaxNumFloat(t *testing.T) {
+	smallerVal := 2.718283
+	largerVal := 3.14159
+
+	require.Equal(t, largerVal, MaxNum(largerVal, smallerVal))
+	require.Equal(t, largerVal, MaxNum(largerVal, largerVal))
 }

--- a/ecs-agent/vendor/golang.org/x/exp/LICENSE
+++ b/ecs-agent/vendor/golang.org/x/exp/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ecs-agent/vendor/golang.org/x/exp/PATENTS
+++ b/ecs-agent/vendor/golang.org/x/exp/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/ecs-agent/vendor/golang.org/x/exp/constraints/constraints.go
+++ b/ecs-agent/vendor/golang.org/x/exp/constraints/constraints.go
@@ -1,0 +1,50 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package constraints defines a set of useful constraints to be used
+// with type parameters.
+package constraints
+
+// Signed is a constraint that permits any signed integer type.
+// If future releases of Go add new predeclared signed integer types,
+// this constraint will be modified to include them.
+type Signed interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+// Unsigned is a constraint that permits any unsigned integer type.
+// If future releases of Go add new predeclared unsigned integer types,
+// this constraint will be modified to include them.
+type Unsigned interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+// Integer is a constraint that permits any integer type.
+// If future releases of Go add new predeclared integer types,
+// this constraint will be modified to include them.
+type Integer interface {
+	Signed | Unsigned
+}
+
+// Float is a constraint that permits any floating-point type.
+// If future releases of Go add new predeclared floating-point types,
+// this constraint will be modified to include them.
+type Float interface {
+	~float32 | ~float64
+}
+
+// Complex is a constraint that permits any complex numeric type.
+// If future releases of Go add new predeclared complex numeric types,
+// this constraint will be modified to include them.
+type Complex interface {
+	~complex64 | ~complex128
+}
+
+// Ordered is a constraint that permits any ordered type: any type
+// that supports the operators < <= >= >.
+// If future releases of Go add new ordered types,
+// this constraint will be modified to include them.
+type Ordered interface {
+	Integer | Float | ~string
+}

--- a/ecs-agent/vendor/modules.txt
+++ b/ecs-agent/vendor/modules.txt
@@ -249,6 +249,9 @@ go.opencensus.io/internal
 go.opencensus.io/trace
 go.opencensus.io/trace/internal
 go.opencensus.io/trace/tracestate
+# golang.org/x/exp v0.0.0-20231006140011-7918f672742d
+## explicit; go 1.20
+golang.org/x/exp/constraints
 # golang.org/x/mod v0.14.0
 ## explicit; go 1.18
 golang.org/x/mod/internal/lazyregexp


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR merges the feature/crp feature branch to the dev branch.

This feature will support a container restart policy feature in the ECS task definition through a new container definition parameter. More details on this new feature will be forthcoming.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

New unit tests, integ tests, functional tests to test feature.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Feature: Container Restart Policy

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
