### PR TITLE
Modify Windows EBS tar and source directories

### DIFF
--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -2351,7 +2352,7 @@ func TestUnstageVolumes(t *testing.T) {
 				resourceStateChangeEvent: make(chan resourceStateChange),
 			}
 			mockCsiClient := mock_csiclient.NewMockCSIClient(mockCtrl)
-			mockCsiClient.EXPECT().NodeUnstageVolume(gomock.Any(), "vol-12345", "/mnt/ecs/ebs/taskarn_vol-12345").Return(tc.err).MinTimes(1).MaxTimes(5)
+			mockCsiClient.EXPECT().NodeUnstageVolume(gomock.Any(), "vol-12345", filepath.Join(taskresourcevolume.EBSSourcePrefix, "taskarn_vol-12345")).Return(tc.err).MinTimes(1).MaxTimes(5)
 
 			errors := mtask.UnstageVolumes(mockCsiClient)
 			assert.Len(t, errors, tc.numErrors)

--- a/agent/taskresource/volume/dockervolume.go
+++ b/agent/taskresource/volume/dockervolume.go
@@ -44,7 +44,6 @@ const (
 	DockerVolumeType          = "docker"
 	FSHostVolumeType          = "fshost"
 	netNSFormat               = "/proc/%s/ns/net"
-	EBSSourcePrefix           = "/mnt/ecs/ebs/"
 )
 
 // VolumeResource represents volume resource

--- a/agent/taskresource/volume/dockervolume_linux.go
+++ b/agent/taskresource/volume/dockervolume_linux.go
@@ -1,5 +1,5 @@
-//go:build windows && unit
-// +build windows,unit
+//go:build linux
+// +build linux
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
@@ -14,14 +14,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package manageddaemon
+package volume
 
 const (
-	TestImageName                         = "TestDaemon"
-	TestImageTag                          = "testTag"
-	TestImagePath                         = "C:\\ProgramData\\Amazon\\ECS\\images\\"
-	TestAgentPath                         = "C:\\Program Files\\Amazon\\ECS\\"
-	TestMountPointVolume                  = "testVolume"
-	ExpectedAgentCommunicationMountFormat = "C:\\ProgramData\\Amazon\\ECS\\%s\\"
-	ExpectedApplicationLogMountFormat     = "C:\\ProgramData\\Amazon\\ECS\\log\\%s\\"
+	EBSSourcePrefix = "/mnt/ecs/ebs/"
 )

--- a/agent/taskresource/volume/dockervolume_windows.go
+++ b/agent/taskresource/volume/dockervolume_windows.go
@@ -1,5 +1,5 @@
-//go:build windows && unit
-// +build windows,unit
+//go:build windows
+// +build windows
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
@@ -14,14 +14,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package manageddaemon
+package volume
 
 const (
-	TestImageName                         = "TestDaemon"
-	TestImageTag                          = "testTag"
-	TestImagePath                         = "C:\\ProgramData\\Amazon\\ECS\\images\\"
-	TestAgentPath                         = "C:\\Program Files\\Amazon\\ECS\\"
-	TestMountPointVolume                  = "testVolume"
-	ExpectedAgentCommunicationMountFormat = "C:\\ProgramData\\Amazon\\ECS\\%s\\"
-	ExpectedApplicationLogMountFormat     = "C:\\ProgramData\\Amazon\\ECS\\log\\%s\\"
+	EBSSourcePrefix = "C:\\ProgramData\\Amazon\\ECS\\ebs\\"
 )

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon/managed_daemon_windows.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon/managed_daemon_windows.go
@@ -57,7 +57,7 @@ var (
 	CsiDriverContainerWorkingPath    = "C:\\csi-driver\\"
 	CsiDriverSocketCommunicationPath = "C:\\ebs-csi-driver\\"
 	// This is the path to where the CSIDriver ManagedDaemon image tar file is
-	imageTarPath = filepath.Join(AmazonECSProgramData, "data")
+	imageTarPath = filepath.Join(AmazonECSProgramData, "images")
 
 	// The following two paths are used for agent communication and log paths to be shared with the ManagedDaemon
 	defaultAgentCommunicationPathHostRoot = AmazonECSProgramData

--- a/ecs-agent/manageddaemon/managed_daemon_windows.go
+++ b/ecs-agent/manageddaemon/managed_daemon_windows.go
@@ -57,7 +57,7 @@ var (
 	CsiDriverContainerWorkingPath    = "C:\\csi-driver\\"
 	CsiDriverSocketCommunicationPath = "C:\\ebs-csi-driver\\"
 	// This is the path to where the CSIDriver ManagedDaemon image tar file is
-	imageTarPath = filepath.Join(AmazonECSProgramData, "data")
+	imageTarPath = filepath.Join(AmazonECSProgramData, "images")
 
 	// The following two paths are used for agent communication and log paths to be shared with the ManagedDaemon
 	defaultAgentCommunicationPathHostRoot = AmazonECSProgramData


### PR DESCRIPTION
### Summary
This PR normalizes some paths related to Windows EBS TA. The `ebs-csi-driver.tar` file will be moved from `C:\ProgramData\Amazon\ECS\data\ebs-csi-driver` to `C:\ProgramData\Amazon\ECS\images\ebs-csi-driver` as `C:\ProgramData\Amazon\ECS\data` is frequently deleted and modified by customers. 

Additionally, added Windows implementation for `EBSSourcePrefix`. Previously, after EBS volume attachment, ECS task would try to specify the host source volume mount directory as the Linux path, causing Docker daemon to throw an error for Windows.

### Implementation details
Modified `imageTarPath` for Windows managed daemon. Took out `EBSSourcePrefix` const and added them to respective `dockervolume_windows.go` and `dockervolume_linux.go` files.

### Testing
Updated UTs to reflect new paths. Also ran integration test by uploading this commit's Agent executable to a Windows instance and launching a task with EBS Task Attach. Saw that the managed daemon image was loaded from the proper directory, and task was able to bind mount to the correct directory on the new volume.

New tests cover the changes: Yes

### Description for the changelog

Add support EBS-TaskAttach for Windows.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
