### PR TITLE
Revert changes adding backup Go installation to pr-build-amzn

### DIFF
--- a/buildspecs/pr-build-amzn.yml
+++ b/buildspecs/pr-build-amzn.yml
@@ -53,29 +53,19 @@ phases:
 
       # Define the Go version to install
       - GOVERSION="$(cat GO_VERSION)"
-
+      
       # Install Go and define variables based on Amazon Linux version (2 or 2023)
       # Amazon Linux 2023 uses package manager DNF, while older versions use YUM
-      # First, try to install the specified Go version, if unable, install latest Go version available
+      # Set the appropriate AL23 version echo string to include in build log
       - |
         if [[ "$amzn_version" = "amzn2023" ]]; then
           sudo dnf --releasever="$AL23_VERSION" update -y
+          sudo dnf install -y golang-$GOVERSION
           echo "Amazon Linux 2023 Version: $AL23_VERSION" 2>&1 | tee -a $BUILD_LOG
-          if sudo dnf install -y golang-$GOVERSION; then
-            echo "Installed Go version: $GOVERSION" 2>&1 | tee -a $BUILD_LOG
-          else
-            echo "Specified Go version $GOVERSION not found, installing latest available version" 2>&1 | tee -a $BUILD_LOG
-            sudo dnf install -y golang
-          fi
-
+          
         elif [[ "$amzn_version" = "amzn2" ]]; then
-          if sudo yum install -y golang-$GOVERSION; then
-            echo "Installed Go version $GOVERSION" 2>&1 | tee -a $BUILD_LOG
-          else
-            echo "Specified Go version $GOVERSION not found, installing latest available version" 2>&1 | tee -a $BUILD_LOG
-            sudo yum install -y golang
-          fi
-
+          sudo yum install -y golang-$GOVERSION
+          
         else
           echo "Unsupported Amazon Linux version"
           exit 1
@@ -84,7 +74,7 @@ phases:
       # Define the log file with AL version (amzn2 or amzn23) and the architecture
       - BUILD_LOG="build_${amzn_version}_${architecture}.log"
 
-      # Print all environment variables to the log file
+      # Print all environment variables to the log file 
       - which go | tee -a $BUILD_LOG
       - go version | tee -a $BUILD_LOG
       
@@ -129,4 +119,3 @@ artifacts:
     - $AMZN_LINUX_RPM
     - $BUILD_LOG
   name: $CODEBUILD_RESOLVED_SOURCE_VERSION
-


### PR DESCRIPTION
### Summary
This reverts the changes to [PR#4253](https://github.com/aws/amazon-ecs-agent/pull/4253), which added backup logic to the `pr-build-amzn` buildspec file to install the latest available Go version if the version in our repo (GO_VERSION) is ahead of the available versions Amazon Linux platforms. 

### Implementation details
This fix was meant to ensure artifacts were being created even if there is a discrepancy between Agent's Go version and Amazon Linux's Go version. 

However, it is in the team's best interest to allow these failures to occur so the issue is brought to light rather than masked. In the future a catch/ticket may be helpful to debug this situation.

This buildspec is used by CodeBuild to create Amazon Linux 2/2023 ECS-Init artifacts. The artifacts will be used in integration testing, but will not be released.

### Testing
This buildspec was used in a separate account within a CodeBuild project's configurations. The CodeBuild job worked as expected and the appropriate artifacts were produced. 

Testing did not cover cases of Golang version discrepancy, as there is currently no way to replicate the original issue described in [PR#4253](https://github.com/aws/amazon-ecs-agent/pull/4253). For reference, the expectation in such an event is that the CodeBuild projects will not explicitly fail because a build log will successfully be found. However, the Amazon Linux 2 and Amazon Linux 2023 artifacts would not be found in the artifact bucket. This would lead to integration test failures on those platforms after full artifact migration. 

### Description for the changelog
Revert addition of backup Go installation in `pr-build-amzn`

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
