### PR TITLE
Add full task and EBS volume context to EBS debug log messages

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3482,11 +3482,17 @@ func (task *Task) IsEBSTaskAttachEnabled() bool {
 }
 
 func (task *Task) isEBSTaskAttachEnabledUnsafe() bool {
-	logger.Debug("Checking if there are any ebs volume configs")
+	taskFields := task.fieldsUnsafe()
+	logger.Debug("Checking if there are any ebs volume configs", taskFields)
 	for _, tv := range task.Volumes {
 		switch tv.Volume.(type) {
 		case *taskresourcevolume.EBSTaskVolumeConfig:
-			logger.Debug("found ebs volume config")
+			logger.Debug("Found ebs volume config", taskFields, logger.Fields{
+				"volumeName":   tv.Volume.GetVolumeName(),
+				"volumeId":     tv.Volume.GetVolumeId(),
+				"volumeType":   tv.Volume.GetType(),
+				"volumeSource": tv.Volume.Source(),
+			})
 			return true
 		default:
 			continue


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This adds task context to two EBS debug log messages. Without this context, the log messages are not very helpful since they just indicate that some task has EBS volumes. This change will allow us to narrow down the messages to particular tasks and EBS volume IDs.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement: EBS volume logging improvement

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
