### PR TITLE
use getters in *_equal testutils

### DIFF
--- a/agent/api/testutils/container_equal.go
+++ b/agent/api/testutils/container_equal.go
@@ -76,7 +76,7 @@ func ContainersEqual(lhs, rhs *apicontainer.Container) bool {
 	if !ContainerOverridesEqual(lhs.Overrides, rhs.Overrides) {
 		return false
 	}
-	if lhs.DesiredStatusUnsafe != rhs.DesiredStatusUnsafe || lhs.KnownStatusUnsafe != rhs.KnownStatusUnsafe {
+	if lhs.GetDesiredStatus() != rhs.GetDesiredStatus() || lhs.GetKnownStatus() != rhs.GetKnownStatus() {
 		return false
 	}
 	if lhs.AppliedStatus != rhs.AppliedStatus {

--- a/agent/api/testutils/task_equal.go
+++ b/agent/api/testutils/task_equal.go
@@ -41,7 +41,7 @@ func TasksEqual(lhs, rhs *apitask.Task) bool {
 		}
 	}
 
-	if lhs.DesiredStatusUnsafe != rhs.DesiredStatusUnsafe {
+	if lhs.GetDesiredStatus() != rhs.GetDesiredStatus() {
 		return false
 	}
 	if lhs.GetKnownStatus() != rhs.GetKnownStatus() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR modifies the container_equal and task_equal testutils methods to use getters when querying a container/task's desired status. These modified methods are only used in tests.

### Implementation details
<!-- How are the changes implemented? -->

Use task.GetDesiredStatus() and task.GetKnownStatus() instead of accessing task.DesiredStatusUnsafe and task.KnownStatusUnsafe.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

N/A

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->   no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
