### PR TITLE
Implementing network blackhole port handler

### DIFF
--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -212,39 +212,39 @@ func registerFaultHandlers(
 	).Methods("PUT")
 	muxRouter.HandleFunc(
 		fault.FaultNetworkFaultPath(faulttype.BlackHolePortFaultType),
-		handler.StopBlackHolePort(),
+		handler.StopNetworkBlackHolePort(),
 	).Methods("DELETE")
 	muxRouter.HandleFunc(
 		fault.FaultNetworkFaultPath(faulttype.BlackHolePortFaultType),
-		handler.CheckBlackHolePortStatus(),
+		handler.CheckNetworkBlackHolePort(),
 	).Methods("GET")
 
 	// Setting up handler endpoints for network latency fault injections
 	muxRouter.HandleFunc(
 		fault.FaultNetworkFaultPath(faulttype.LatencyFaultType),
-		handler.StartLatency(),
+		handler.StartNetworkLatency(),
 	).Methods("PUT")
 	muxRouter.HandleFunc(
 		fault.FaultNetworkFaultPath(faulttype.LatencyFaultType),
-		handler.StopLatency(),
+		handler.StopNetworkLatency(),
 	).Methods("DELETE")
 	muxRouter.HandleFunc(
 		fault.FaultNetworkFaultPath(faulttype.LatencyFaultType),
-		handler.CheckLatencyStatus(),
+		handler.CheckNetworkLatency(),
 	).Methods("GET")
 
 	// Setting up handler endpoints for network packet loss fault injections
 	muxRouter.HandleFunc(
 		fault.FaultNetworkFaultPath(faulttype.PacketLossFaultType),
-		handler.StartPacketLoss(),
+		handler.StartNetworkPacketLoss(),
 	).Methods("PUT")
 	muxRouter.HandleFunc(
 		fault.FaultNetworkFaultPath(faulttype.PacketLossFaultType),
-		handler.StopPacketLoss(),
+		handler.StopNetworkPacketLoss(),
 	).Methods("DELETE")
 	muxRouter.HandleFunc(
 		fault.FaultNetworkFaultPath(faulttype.PacketLossFaultType),
-		handler.CheckPacketLossStatus(),
+		handler.CheckNetworkPacketLoss(),
 	).Methods("GET")
 
 	seelog.Debug("Successfully set up Fault TMDS handlers")

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
@@ -63,4 +63,6 @@ const (
 	Endpoint                = "endpoint"
 	TelemetryEndpoint       = "telemetryEndpoint"
 	ServiceConnectEndpoint  = "serviceConnectEndpoint"
+	Response                = "response"
+	Request                 = "request"
 )

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -14,13 +14,28 @@
 package handlers
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
 	v4 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4"
 	state "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state"
+
+	"github.com/gorilla/mux"
+)
+
+const (
+	startFaultRequestType       = "start %s"
+	stopFaultRequestType        = "stop %s"
+	checkStatusFaultRequestType = "check status %s"
 )
 
 type FaultHandler struct {
@@ -36,56 +51,278 @@ func FaultNetworkFaultPath(fault string) string {
 		utils.ConstructMuxVar(v4.EndpointContainerIDMuxName, utils.AnythingButSlashRegEx), fault)
 }
 
-// TODO
 func (h *FaultHandler) StartNetworkBlackholePort() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		var request types.NetworkBlackholePortRequest
+		requestType := fmt.Sprintf(startFaultRequestType, types.BlackHolePortFaultType)
+
+		// Parse the fault request
+		err := decodeRequest(w, &request, requestType, r)
+		if err != nil {
+			return
+		}
+		// Validate the fault request
+		err = validateRequest(w, request, requestType)
+		if err != nil {
+			return
+		}
+		logger.Debug("Successfully parsed fault request payload", logger.Fields{
+			field.Request: request.ToString(),
+		})
+
+		// Obtain the task metadata via the endpoint container ID
+		// TODO: Will be using the returned task metadata in a future PR
+		_, err = getTaskMetadataForFault(w, h.AgentState, requestType, r)
+		if err != nil {
+			return
+		}
+
+		// TODO: Check status of current fault injection
+		// TODO: Invoke the start fault injection functionality if not running
+
+		responseBody := types.NewNetworkFaultInjectionSuccessResponse("running")
+		logger.Info("Successfully started fault", logger.Fields{
+			field.RequestType: requestType,
+			field.Request:     request.ToString(),
+			field.Response:    responseBody.ToString(),
+		})
+		utils.WriteJSONResponse(
+			w,
+			http.StatusOK,
+			responseBody,
+			requestType,
+		)
+	}
+}
+
+func (h *FaultHandler) StopNetworkBlackHolePort() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var request types.NetworkBlackholePortRequest
+		requestType := fmt.Sprintf(stopFaultRequestType, types.BlackHolePortFaultType)
+
+		// Parse the fault request
+		err := decodeRequest(w, &request, requestType, r)
+		if err != nil {
+			return
+		}
+		// Validate the fault request
+		err = validateRequest(w, request, requestType)
+		if err != nil {
+			return
+		}
+
+		logger.Debug("Successfully parsed fault request payload", logger.Fields{
+			field.Request: request.ToString(),
+		})
+
+		// Obtain the task metadata via the endpoint container ID
+		// TODO: Will be using the returned task metadata in a future PR
+		_, err = getTaskMetadataForFault(w, h.AgentState, requestType, r)
+		if err != nil {
+			return
+		}
+
+		// TODO: Check status of current fault injection
+		// TODO: Invoke the stop fault injection functionality if running
+
+		responseBody := types.NewNetworkFaultInjectionSuccessResponse("stopped")
+		logger.Info("Successfully stopped fault", logger.Fields{
+			field.RequestType: requestType,
+			field.Request:     request.ToString(),
+			field.Response:    responseBody.ToString(),
+		})
+		utils.WriteJSONResponse(
+			w,
+			http.StatusOK,
+			responseBody,
+			requestType,
+		)
+	}
+}
+
+func (h *FaultHandler) CheckNetworkBlackHolePort() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var request types.NetworkBlackholePortRequest
+		requestType := fmt.Sprintf(checkStatusFaultRequestType, types.BlackHolePortFaultType)
+
+		// Parse the fault request
+		err := decodeRequest(w, &request, requestType, r)
+		if err != nil {
+			return
+		}
+		// Validate the fault request
+		err = validateRequest(w, request, requestType)
+		if err != nil {
+			return
+		}
+
+		logger.Debug("Successfully parsed fault request payload", logger.Fields{
+			field.Request: request.ToString(),
+		})
+
+		// Obtain the task metadata via the endpoint container ID
+		// TODO: Will be using the returned task metadata in a future PR
+		_, err = getTaskMetadataForFault(w, h.AgentState, requestType, r)
+		if err != nil {
+			return
+		}
+
+		// Check status of current fault injection
+
+		// TODO: Return the correct status state
+		responseBody := types.NewNetworkFaultInjectionSuccessResponse("running")
+		logger.Info("Successfully checked status for fault", logger.Fields{
+			field.RequestType: requestType,
+			field.Request:     request.ToString(),
+			field.Response:    responseBody.ToString(),
+		})
+		utils.WriteJSONResponse(
+			w,
+			http.StatusOK,
+			responseBody,
+			requestType,
+		)
 	}
 }
 
 // TODO
-func (h *FaultHandler) StopBlackHolePort() func(http.ResponseWriter, *http.Request) {
+func (h *FaultHandler) StartNetworkLatency() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+	}
+}
+
+// TODO
+func (h *FaultHandler) StopNetworkLatency() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
 // TODO
-func (h *FaultHandler) CheckBlackHolePortStatus() func(http.ResponseWriter, *http.Request) {
+func (h *FaultHandler) CheckNetworkLatency() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
 // TODO
-func (h *FaultHandler) StartLatency() func(http.ResponseWriter, *http.Request) {
+func (h *FaultHandler) StartNetworkPacketLoss() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
 // TODO
-func (h *FaultHandler) StopLatency() func(http.ResponseWriter, *http.Request) {
+func (h *FaultHandler) StopNetworkPacketLoss() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
 // TODO
-func (h *FaultHandler) CheckLatencyStatus() func(http.ResponseWriter, *http.Request) {
+func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// TODO
-func (h *FaultHandler) StartPacketLoss() func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
+func decodeRequest(w http.ResponseWriter, request types.NetworkFaultRequest, requestType string, r *http.Request) error {
+	logRequest(requestType, r)
+	jsonDecoder := json.NewDecoder(r.Body)
+	if err := jsonDecoder.Decode(request); err != nil {
+		responseBody := types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("%v", err))
+		logger.Error("Error: failed to decode request", logger.Fields{
+			field.Error:       err,
+			field.RequestType: requestType,
+			field.Request:     request.ToString(),
+			field.Response:    responseBody.ToString(),
+		})
+
+		utils.WriteJSONResponse(
+			w,
+			http.StatusBadRequest,
+			responseBody,
+			requestType,
+		)
+		return err
 	}
+	return nil
 }
 
-// TODO
-func (h *FaultHandler) StopPacketLoss() func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
+func validateRequest(w http.ResponseWriter, request types.NetworkFaultRequest, requestType string) error {
+	if err := request.ValidateRequest(); err != nil {
+		responseBody := types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("%v", err))
+		logger.Error("Error: missing required payload fields", logger.Fields{
+			field.Error:       err,
+			field.RequestType: requestType,
+			field.Request:     request.ToString(),
+			field.Response:    responseBody.ToString(),
+		})
+		utils.WriteJSONResponse(
+			w,
+			http.StatusBadRequest,
+			responseBody,
+			requestType,
+		)
+
+		return err
 	}
+	return nil
 }
 
-// TODO
-func (h *FaultHandler) CheckPacketLossStatus() func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
+func getTaskMetadataForFault(w http.ResponseWriter, agentState state.AgentState, requestType string, r *http.Request) (*state.TaskResponse, error) {
+	var taskMetadata state.TaskResponse
+	endpointContainerID := mux.Vars(r)[v4.EndpointContainerIDMuxName]
+	taskMetadata, err := agentState.GetTaskMetadata(endpointContainerID)
+	if err != nil {
+		code, errResponse := getTaskMetadataErrorResponse(endpointContainerID, requestType, err)
+		responseBody := types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("%v", errResponse))
+		logger.Error("Error: Unable to obtain task metadata", logger.Fields{
+			field.Error:       errResponse,
+			field.RequestType: requestType,
+			field.Response:    responseBody.ToString(),
+		})
+		utils.WriteJSONResponse(
+			w,
+			code,
+			responseBody,
+			requestType,
+		)
+		return nil, errResponse
 	}
+
+	// TODO: Check if task is FIS-enabled
+	// TODO: Check if task is using a valid network mode
+
+	return &taskMetadata, nil
+}
+
+func getTaskMetadataErrorResponse(endpointContainerID, requestType string, err error) (int, error) {
+	var errContainerLookupFailed *state.ErrorLookupFailure
+	if errors.As(err, &errContainerLookupFailed) {
+		return http.StatusNotFound, fmt.Errorf("unable to lookup container: %s", endpointContainerID)
+	}
+
+	var errFailedToGetContainerMetadata *state.ErrorMetadataFetchFailure
+	if errors.As(err, &errFailedToGetContainerMetadata) {
+		return http.StatusInternalServerError, fmt.Errorf("unable to obtain container metadata for container: %s", endpointContainerID)
+	}
+
+	logger.Error("Unknown error encountered when handling task metadata fetch failure", logger.Fields{
+		field.Error:       err,
+		field.RequestType: requestType,
+	})
+	return http.StatusInternalServerError, fmt.Errorf("failed to get task metadata due to internal server error for container: %s", endpointContainerID)
+}
+
+func logRequest(requestType string, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		logger.Error("Error: Unable to decode request body", logger.Fields{
+			field.RequestType: requestType,
+			field.Error:       err,
+		})
+		return
+	}
+	logger.Info(fmt.Sprintf("Received new request for request type: %s", requestType), logger.Fields{
+		field.Request:     string(body),
+		field.RequestType: requestType,
+	})
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -13,8 +13,81 @@
 
 package types
 
-const (
-	BlackHolePortFaultType = "network-blackhole-port"
-	LatencyFaultType       = "network-latency"
-	PacketLossFaultType    = "network-packet-loss"
+import (
+	"encoding/json"
+	"fmt"
 )
+
+const (
+	BlackHolePortFaultType    = "network-blackhole-port"
+	LatencyFaultType          = "network-latency"
+	PacketLossFaultType       = "network-packet-loss"
+	missingRequiredFieldError = "required parameter %s is missing"
+	invalidValueError         = "invalid value %s for parameter %s"
+)
+
+type NetworkFaultRequest interface {
+	ValidateRequest() error
+	ToString() string
+}
+
+type NetworkBlackholePortRequest struct {
+	Port        *uint16 `json:"Port"`
+	Protocol    *string `json:"Protocol"`
+	TrafficType *string `json:"TrafficType"`
+}
+
+type NetworkFaultInjectionResponse struct {
+	Status string `json:"Status,omitempty"`
+	Error  string `json:"Error,omitempty"`
+}
+
+func (request NetworkBlackholePortRequest) ValidateRequest() error {
+	if request.Port == nil {
+		return fmt.Errorf(missingRequiredFieldError, "Port")
+	}
+	if request.Protocol == nil || *request.Protocol == "" {
+		return fmt.Errorf(missingRequiredFieldError, "Protocol")
+	}
+	if request.TrafficType == nil || *request.TrafficType == "" {
+		return fmt.Errorf(missingRequiredFieldError, "TrafficType")
+	}
+
+	if *request.Protocol != "tcp" && *request.Protocol != "udp" {
+		return fmt.Errorf(invalidValueError, *request.Protocol, "Protocol")
+	}
+
+	if *request.TrafficType != "ingress" && *request.TrafficType != "egress" {
+		return fmt.Errorf(invalidValueError, *request.TrafficType, "TrafficType")
+	}
+
+	return nil
+}
+
+func (request NetworkBlackholePortRequest) ToString() string {
+	data, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Sprintf("Error: Unable to parse %s request with error %v.", BlackHolePortFaultType, err)
+	}
+	return string(data)
+}
+
+func (response NetworkFaultInjectionResponse) ToString() string {
+	data, err := json.Marshal(response)
+	if err != nil {
+		return fmt.Sprintf("Error: Unable to parse network fault injection response with error %v.", err)
+	}
+	return string(data)
+}
+
+func NewNetworkFaultInjectionSuccessResponse(status string) NetworkFaultInjectionResponse {
+	return NetworkFaultInjectionResponse{
+		Status: status,
+	}
+}
+
+func NewNetworkFaultInjectionErrorResponse(err string) NetworkFaultInjectionResponse {
+	return NetworkFaultInjectionResponse{
+		Error: err,
+	}
+}

--- a/ecs-agent/logger/field/constants.go
+++ b/ecs-agent/logger/field/constants.go
@@ -63,4 +63,6 @@ const (
 	Endpoint                = "endpoint"
 	TelemetryEndpoint       = "telemetryEndpoint"
 	ServiceConnectEndpoint  = "serviceConnectEndpoint"
+	Response                = "response"
+	Request                 = "request"
 )

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -14,13 +14,28 @@
 package handlers
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
 	v4 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4"
 	state "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state"
+
+	"github.com/gorilla/mux"
+)
+
+const (
+	startFaultRequestType       = "start %s"
+	stopFaultRequestType        = "stop %s"
+	checkStatusFaultRequestType = "check status %s"
 )
 
 type FaultHandler struct {
@@ -36,56 +51,278 @@ func FaultNetworkFaultPath(fault string) string {
 		utils.ConstructMuxVar(v4.EndpointContainerIDMuxName, utils.AnythingButSlashRegEx), fault)
 }
 
-// TODO
 func (h *FaultHandler) StartNetworkBlackholePort() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		var request types.NetworkBlackholePortRequest
+		requestType := fmt.Sprintf(startFaultRequestType, types.BlackHolePortFaultType)
+
+		// Parse the fault request
+		err := decodeRequest(w, &request, requestType, r)
+		if err != nil {
+			return
+		}
+		// Validate the fault request
+		err = validateRequest(w, request, requestType)
+		if err != nil {
+			return
+		}
+		logger.Debug("Successfully parsed fault request payload", logger.Fields{
+			field.Request: request.ToString(),
+		})
+
+		// Obtain the task metadata via the endpoint container ID
+		// TODO: Will be using the returned task metadata in a future PR
+		_, err = getTaskMetadataForFault(w, h.AgentState, requestType, r)
+		if err != nil {
+			return
+		}
+
+		// TODO: Check status of current fault injection
+		// TODO: Invoke the start fault injection functionality if not running
+
+		responseBody := types.NewNetworkFaultInjectionSuccessResponse("running")
+		logger.Info("Successfully started fault", logger.Fields{
+			field.RequestType: requestType,
+			field.Request:     request.ToString(),
+			field.Response:    responseBody.ToString(),
+		})
+		utils.WriteJSONResponse(
+			w,
+			http.StatusOK,
+			responseBody,
+			requestType,
+		)
+	}
+}
+
+func (h *FaultHandler) StopNetworkBlackHolePort() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var request types.NetworkBlackholePortRequest
+		requestType := fmt.Sprintf(stopFaultRequestType, types.BlackHolePortFaultType)
+
+		// Parse the fault request
+		err := decodeRequest(w, &request, requestType, r)
+		if err != nil {
+			return
+		}
+		// Validate the fault request
+		err = validateRequest(w, request, requestType)
+		if err != nil {
+			return
+		}
+
+		logger.Debug("Successfully parsed fault request payload", logger.Fields{
+			field.Request: request.ToString(),
+		})
+
+		// Obtain the task metadata via the endpoint container ID
+		// TODO: Will be using the returned task metadata in a future PR
+		_, err = getTaskMetadataForFault(w, h.AgentState, requestType, r)
+		if err != nil {
+			return
+		}
+
+		// TODO: Check status of current fault injection
+		// TODO: Invoke the stop fault injection functionality if running
+
+		responseBody := types.NewNetworkFaultInjectionSuccessResponse("stopped")
+		logger.Info("Successfully stopped fault", logger.Fields{
+			field.RequestType: requestType,
+			field.Request:     request.ToString(),
+			field.Response:    responseBody.ToString(),
+		})
+		utils.WriteJSONResponse(
+			w,
+			http.StatusOK,
+			responseBody,
+			requestType,
+		)
+	}
+}
+
+func (h *FaultHandler) CheckNetworkBlackHolePort() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var request types.NetworkBlackholePortRequest
+		requestType := fmt.Sprintf(checkStatusFaultRequestType, types.BlackHolePortFaultType)
+
+		// Parse the fault request
+		err := decodeRequest(w, &request, requestType, r)
+		if err != nil {
+			return
+		}
+		// Validate the fault request
+		err = validateRequest(w, request, requestType)
+		if err != nil {
+			return
+		}
+
+		logger.Debug("Successfully parsed fault request payload", logger.Fields{
+			field.Request: request.ToString(),
+		})
+
+		// Obtain the task metadata via the endpoint container ID
+		// TODO: Will be using the returned task metadata in a future PR
+		_, err = getTaskMetadataForFault(w, h.AgentState, requestType, r)
+		if err != nil {
+			return
+		}
+
+		// Check status of current fault injection
+
+		// TODO: Return the correct status state
+		responseBody := types.NewNetworkFaultInjectionSuccessResponse("running")
+		logger.Info("Successfully checked status for fault", logger.Fields{
+			field.RequestType: requestType,
+			field.Request:     request.ToString(),
+			field.Response:    responseBody.ToString(),
+		})
+		utils.WriteJSONResponse(
+			w,
+			http.StatusOK,
+			responseBody,
+			requestType,
+		)
 	}
 }
 
 // TODO
-func (h *FaultHandler) StopBlackHolePort() func(http.ResponseWriter, *http.Request) {
+func (h *FaultHandler) StartNetworkLatency() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+	}
+}
+
+// TODO
+func (h *FaultHandler) StopNetworkLatency() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
 // TODO
-func (h *FaultHandler) CheckBlackHolePortStatus() func(http.ResponseWriter, *http.Request) {
+func (h *FaultHandler) CheckNetworkLatency() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
 // TODO
-func (h *FaultHandler) StartLatency() func(http.ResponseWriter, *http.Request) {
+func (h *FaultHandler) StartNetworkPacketLoss() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
 // TODO
-func (h *FaultHandler) StopLatency() func(http.ResponseWriter, *http.Request) {
+func (h *FaultHandler) StopNetworkPacketLoss() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
 // TODO
-func (h *FaultHandler) CheckLatencyStatus() func(http.ResponseWriter, *http.Request) {
+func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// TODO
-func (h *FaultHandler) StartPacketLoss() func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
+func decodeRequest(w http.ResponseWriter, request types.NetworkFaultRequest, requestType string, r *http.Request) error {
+	logRequest(requestType, r)
+	jsonDecoder := json.NewDecoder(r.Body)
+	if err := jsonDecoder.Decode(request); err != nil {
+		responseBody := types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("%v", err))
+		logger.Error("Error: failed to decode request", logger.Fields{
+			field.Error:       err,
+			field.RequestType: requestType,
+			field.Request:     request.ToString(),
+			field.Response:    responseBody.ToString(),
+		})
+
+		utils.WriteJSONResponse(
+			w,
+			http.StatusBadRequest,
+			responseBody,
+			requestType,
+		)
+		return err
 	}
+	return nil
 }
 
-// TODO
-func (h *FaultHandler) StopPacketLoss() func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
+func validateRequest(w http.ResponseWriter, request types.NetworkFaultRequest, requestType string) error {
+	if err := request.ValidateRequest(); err != nil {
+		responseBody := types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("%v", err))
+		logger.Error("Error: missing required payload fields", logger.Fields{
+			field.Error:       err,
+			field.RequestType: requestType,
+			field.Request:     request.ToString(),
+			field.Response:    responseBody.ToString(),
+		})
+		utils.WriteJSONResponse(
+			w,
+			http.StatusBadRequest,
+			responseBody,
+			requestType,
+		)
+
+		return err
 	}
+	return nil
 }
 
-// TODO
-func (h *FaultHandler) CheckPacketLossStatus() func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
+func getTaskMetadataForFault(w http.ResponseWriter, agentState state.AgentState, requestType string, r *http.Request) (*state.TaskResponse, error) {
+	var taskMetadata state.TaskResponse
+	endpointContainerID := mux.Vars(r)[v4.EndpointContainerIDMuxName]
+	taskMetadata, err := agentState.GetTaskMetadata(endpointContainerID)
+	if err != nil {
+		code, errResponse := getTaskMetadataErrorResponse(endpointContainerID, requestType, err)
+		responseBody := types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("%v", errResponse))
+		logger.Error("Error: Unable to obtain task metadata", logger.Fields{
+			field.Error:       errResponse,
+			field.RequestType: requestType,
+			field.Response:    responseBody.ToString(),
+		})
+		utils.WriteJSONResponse(
+			w,
+			code,
+			responseBody,
+			requestType,
+		)
+		return nil, errResponse
 	}
+
+	// TODO: Check if task is FIS-enabled
+	// TODO: Check if task is using a valid network mode
+
+	return &taskMetadata, nil
+}
+
+func getTaskMetadataErrorResponse(endpointContainerID, requestType string, err error) (int, error) {
+	var errContainerLookupFailed *state.ErrorLookupFailure
+	if errors.As(err, &errContainerLookupFailed) {
+		return http.StatusNotFound, fmt.Errorf("unable to lookup container: %s", endpointContainerID)
+	}
+
+	var errFailedToGetContainerMetadata *state.ErrorMetadataFetchFailure
+	if errors.As(err, &errFailedToGetContainerMetadata) {
+		return http.StatusInternalServerError, fmt.Errorf("unable to obtain container metadata for container: %s", endpointContainerID)
+	}
+
+	logger.Error("Unknown error encountered when handling task metadata fetch failure", logger.Fields{
+		field.Error:       err,
+		field.RequestType: requestType,
+	})
+	return http.StatusInternalServerError, fmt.Errorf("failed to get task metadata due to internal server error for container: %s", endpointContainerID)
+}
+
+func logRequest(requestType string, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		logger.Error("Error: Unable to decode request body", logger.Fields{
+			field.RequestType: requestType,
+			field.Error:       err,
+		})
+		return
+	}
+	logger.Info(fmt.Sprintf("Received new request for request type: %s", requestType), logger.Fields{
+		field.Request:     string(body),
+		field.RequestType: requestType,
+	})
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
 }

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
@@ -17,15 +17,31 @@
 package handlers
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	mock_metrics "github.com/aws/amazon-ecs-agent/ecs-agent/metrics/mocks"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types"
+	state "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state"
+	mock_state "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/mocks"
 
+	"github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
-	endpointId = "endpointId"
+	endpointId  = "endpointId"
+	port        = 1234
+	protocol    = "tcp"
+	trafficType = "ingress"
 )
 
 // Tests the path for Fault Network Faults API
@@ -39,4 +55,299 @@ func TestFaultLatencyFaultPath(t *testing.T) {
 
 func TestFaultPacketLossFaultPath(t *testing.T) {
 	assert.Equal(t, "/api/{endpointContainerIDMuxName:[^/]*}/fault/v1/network-packet-loss", FaultNetworkFaultPath(types.PacketLossFaultType))
+}
+
+type networkBlackHolePortTestCase struct {
+	name                      string
+	expectedStatusCode        int
+	requestBody               interface{}
+	expectedResponseBody      types.NetworkFaultInjectionResponse
+	setAgentStateExpectations func(agentState *mock_state.MockAgentState)
+}
+
+func getNetworkBlackHolePortTestCases(name string, expectedHappyResponseBody string) []networkBlackHolePortTestCase {
+	happyBlackHolePortReqBody := map[string]interface{}{
+		"Port":        port,
+		"Protocol":    protocol,
+		"TrafficType": trafficType,
+	}
+	tcs := []networkBlackHolePortTestCase{
+		{
+			name:                 fmt.Sprintf("%s success", name),
+			expectedStatusCode:   200,
+			requestBody:          happyBlackHolePortReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse(expectedHappyResponseBody),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil)
+			},
+		},
+		{
+			name:               fmt.Sprintf("%s unknown request body", name),
+			expectedStatusCode: 200,
+			requestBody: map[string]interface{}{
+				"Port":        port,
+				"Protocol":    protocol,
+				"TrafficType": trafficType,
+				"Unknown":     "",
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse(expectedHappyResponseBody),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil)
+			},
+		},
+		{
+			name:               fmt.Sprintf("%s malformed request body", name),
+			expectedStatusCode: 400,
+			requestBody: map[string]interface{}{
+				"Port":        "incorrect typing",
+				"Protocol":    protocol,
+				"TrafficType": trafficType,
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("json: cannot unmarshal string into Go struct field NetworkBlackholePortRequest.Port of type uint16"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+			},
+		},
+		{
+			name:               fmt.Sprintf("%s incomplete request body", name),
+			expectedStatusCode: 400,
+			requestBody: map[string]interface{}{
+				"Port":     port,
+				"Protocol": protocol,
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("required parameter TrafficType is missing"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+			},
+		},
+		{
+			name:               fmt.Sprintf("%s empty value request body", name),
+			expectedStatusCode: 400,
+			requestBody: map[string]interface{}{
+				"Port":        port,
+				"Protocol":    protocol,
+				"TrafficType": "",
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("required parameter TrafficType is missing"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+			},
+		},
+		{
+			name:               fmt.Sprintf("%s invalid port value request body", name),
+			expectedStatusCode: 400,
+			requestBody: map[string]interface{}{
+				"Port":        port,
+				"Protocol":    "invalid",
+				"TrafficType": trafficType,
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("invalid value invalid for parameter Protocol"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+			},
+		},
+		{
+			name:               fmt.Sprintf("%s invalid traffic type value request body", name),
+			expectedStatusCode: 400,
+			requestBody: map[string]interface{}{
+				"Port":        port,
+				"Protocol":    protocol,
+				"TrafficType": "invalid",
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("invalid value invalid for parameter TrafficType"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+			},
+		},
+		{
+			name:                 fmt.Sprintf("%s task lookup fail", name),
+			expectedStatusCode:   404,
+			requestBody:          happyBlackHolePortReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("unable to lookup container: %s", endpointId)),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, state.NewErrorLookupFailure("task lookup failed"))
+			},
+		},
+		{
+			name:                 fmt.Sprintf("%s task metadata fetch fail", name),
+			expectedStatusCode:   500,
+			requestBody:          happyBlackHolePortReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("unable to obtain container metadata for container: %s", endpointId)),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, state.NewErrorMetadataFetchFailure(
+					"Unable to generate metadata for task"))
+			},
+		},
+		{
+			name:                 fmt.Sprintf("%s task metadata unknown fail", name),
+			expectedStatusCode:   500,
+			requestBody:          happyBlackHolePortReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("failed to get task metadata due to internal server error for container: %s", endpointId)),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, errors.New("unknown error"))
+			},
+		},
+	}
+	return tcs
+}
+
+func TestStartNetworkBlackHolePort(t *testing.T) {
+	tcs := getNetworkBlackHolePortTestCases("start blackhole port", "running")
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mocks
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			agentState := mock_state.NewMockAgentState(ctrl)
+			metricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+			if tc.setAgentStateExpectations != nil {
+				tc.setAgentStateExpectations(agentState)
+			}
+
+			router := mux.NewRouter()
+
+			handler := FaultHandler{
+				AgentState:     agentState,
+				MetricsFactory: metricsFactory,
+			}
+
+			router.HandleFunc(
+				FaultNetworkFaultPath(types.BlackHolePortFaultType),
+				handler.StartNetworkBlackholePort(),
+			).Methods("PUT")
+
+			method := "PUT"
+			var requestBody io.Reader
+			if tc.requestBody != nil {
+				reqBodyBytes, err := json.Marshal(tc.requestBody)
+				require.NoError(t, err)
+				requestBody = bytes.NewReader(reqBodyBytes)
+			}
+			req, err := http.NewRequest(method, fmt.Sprintf("/api/%s/fault/v1/network-blackhole-port", endpointId),
+				requestBody)
+			require.NoError(t, err)
+
+			// Send the request and record the response
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			var actualResponseBody types.NetworkFaultInjectionResponse
+			err = json.Unmarshal(recorder.Body.Bytes(), &actualResponseBody)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedStatusCode, recorder.Code)
+			assert.Equal(t, tc.expectedResponseBody, actualResponseBody)
+
+		})
+	}
+}
+
+func TestStopNetworkBlackHolePort(t *testing.T) {
+	tcs := getNetworkBlackHolePortTestCases("stop blackhole port", "stopped")
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mocks
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			agentState := mock_state.NewMockAgentState(ctrl)
+			metricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+			if tc.setAgentStateExpectations != nil {
+				tc.setAgentStateExpectations(agentState)
+			}
+
+			router := mux.NewRouter()
+
+			handler := FaultHandler{
+				AgentState:     agentState,
+				MetricsFactory: metricsFactory,
+			}
+
+			router.HandleFunc(
+				FaultNetworkFaultPath(types.BlackHolePortFaultType),
+				handler.StopNetworkBlackHolePort(),
+			).Methods("DELETE")
+
+			method := "DELETE"
+			var requestBody io.Reader
+			if tc.requestBody != nil {
+				reqBodyBytes, err := json.Marshal(tc.requestBody)
+				require.NoError(t, err)
+				requestBody = bytes.NewReader(reqBodyBytes)
+			}
+			req, err := http.NewRequest(method, fmt.Sprintf("/api/%s/fault/v1/network-blackhole-port", endpointId),
+				requestBody)
+			require.NoError(t, err)
+
+			// Send the request and record the response
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			var actualResponseBody types.NetworkFaultInjectionResponse
+			err = json.Unmarshal(recorder.Body.Bytes(), &actualResponseBody)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedStatusCode, recorder.Code)
+			assert.Equal(t, tc.expectedResponseBody, actualResponseBody)
+
+		})
+	}
+}
+
+func TestCheckNetworkBlackHolePort(t *testing.T) {
+	tcs := getNetworkBlackHolePortTestCases("check blackhole port", "running")
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mocks
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			agentState := mock_state.NewMockAgentState(ctrl)
+			metricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+			router := mux.NewRouter()
+
+			handler := FaultHandler{
+				AgentState:     agentState,
+				MetricsFactory: metricsFactory,
+			}
+
+			if tc.setAgentStateExpectations != nil {
+				tc.setAgentStateExpectations(agentState)
+			}
+
+			router.HandleFunc(
+				FaultNetworkFaultPath(types.BlackHolePortFaultType),
+				handler.StartNetworkBlackholePort(),
+			).Methods("GET")
+
+			method := "GET"
+			var requestBody io.Reader
+			if tc.requestBody != nil {
+				reqBodyBytes, err := json.Marshal(tc.requestBody)
+				require.NoError(t, err)
+				requestBody = bytes.NewReader(reqBodyBytes)
+			}
+			req, err := http.NewRequest(method, fmt.Sprintf("/api/%s/fault/v1/network-blackhole-port", endpointId),
+				requestBody)
+			require.NoError(t, err)
+
+			// Send the request and record the response
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			var actualResponseBody types.NetworkFaultInjectionResponse
+			err = json.Unmarshal(recorder.Body.Bytes(), &actualResponseBody)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedStatusCode, recorder.Code)
+			assert.Equal(t, tc.expectedResponseBody, actualResponseBody)
+
+		})
+	}
 }

--- a/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -13,8 +13,81 @@
 
 package types
 
-const (
-	BlackHolePortFaultType = "network-blackhole-port"
-	LatencyFaultType       = "network-latency"
-	PacketLossFaultType    = "network-packet-loss"
+import (
+	"encoding/json"
+	"fmt"
 )
+
+const (
+	BlackHolePortFaultType    = "network-blackhole-port"
+	LatencyFaultType          = "network-latency"
+	PacketLossFaultType       = "network-packet-loss"
+	missingRequiredFieldError = "required parameter %s is missing"
+	invalidValueError         = "invalid value %s for parameter %s"
+)
+
+type NetworkFaultRequest interface {
+	ValidateRequest() error
+	ToString() string
+}
+
+type NetworkBlackholePortRequest struct {
+	Port        *uint16 `json:"Port"`
+	Protocol    *string `json:"Protocol"`
+	TrafficType *string `json:"TrafficType"`
+}
+
+type NetworkFaultInjectionResponse struct {
+	Status string `json:"Status,omitempty"`
+	Error  string `json:"Error,omitempty"`
+}
+
+func (request NetworkBlackholePortRequest) ValidateRequest() error {
+	if request.Port == nil {
+		return fmt.Errorf(missingRequiredFieldError, "Port")
+	}
+	if request.Protocol == nil || *request.Protocol == "" {
+		return fmt.Errorf(missingRequiredFieldError, "Protocol")
+	}
+	if request.TrafficType == nil || *request.TrafficType == "" {
+		return fmt.Errorf(missingRequiredFieldError, "TrafficType")
+	}
+
+	if *request.Protocol != "tcp" && *request.Protocol != "udp" {
+		return fmt.Errorf(invalidValueError, *request.Protocol, "Protocol")
+	}
+
+	if *request.TrafficType != "ingress" && *request.TrafficType != "egress" {
+		return fmt.Errorf(invalidValueError, *request.TrafficType, "TrafficType")
+	}
+
+	return nil
+}
+
+func (request NetworkBlackholePortRequest) ToString() string {
+	data, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Sprintf("Error: Unable to parse %s request with error %v.", BlackHolePortFaultType, err)
+	}
+	return string(data)
+}
+
+func (response NetworkFaultInjectionResponse) ToString() string {
+	data, err := json.Marshal(response)
+	if err != nil {
+		return fmt.Sprintf("Error: Unable to parse network fault injection response with error %v.", err)
+	}
+	return string(data)
+}
+
+func NewNetworkFaultInjectionSuccessResponse(status string) NetworkFaultInjectionResponse {
+	return NetworkFaultInjectionResponse{
+		Status: status,
+	}
+}
+
+func NewNetworkFaultInjectionErrorResponse(err string) NetworkFaultInjectionResponse {
+	return NetworkFaultInjectionResponse{
+		Error: err,
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will implement the each of the three new TMDS endpoint handlers for network black hole port that was introduced in the following: https://github.com/aws/amazon-ecs-agent/pull/4267 which will be for black hole port faults. 

### Implementation details
* `agent/handlers/task_server_setup.go`
  * Minor changes such as renaming the functions
* `ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go`
  * Modified `StartNetworkBlackholePort`: This function will be responsible for handling incoming requests for starting a black hole port fault. It will first parse(`decodeRequest`) + validate(`validateRequest`) the body of the requests and if there's any errors we will respond back the requests with a `400` status code. Then, it will try to obtain the task metadata which will contain necessary metadata in order to start the fault and if this fails it either returns a 404 or 500 status code. If all of the validation steps has passed, it will respond back to the request with 200 status code.
  * Modified `StopNetworkBlackHolePort`: This function will be responsible for handling incoming requests for stopping a black hole port fault. It will first parse(`decodeRequest`) + validate(`validateRequest`) the body of the requests and if there's any errors we will respond back the requests with a `400` status code. Then, it will try to obtain the task metadata which will contain necessary metadata in order to start the fault and if this fails it either returns a 404 or 500 status code. If all of the validation steps has passed, it will respond back to the request with 200 status code.
  * Modified `CheckNetworkBlackHolePort`: This function will be responsible for handling incoming requests for checking the status a black hole port fault. It will call `decodeRequest` and `validateRequest` to parse and validate the incoming request. Then, it will try to obtain the task metadata which will contain necessary metadata in order to start the fault and if this fails it either returns a 404 or 500 status code. If all of the validation steps has passed, it will respond back to the request with 200 status code.
  * Added new function `decodeRequest`: This function is used as a helper function where it'll take in a request and decode/parse it into a given fault request struct (defined as `NetworkFISRequest` so that it will take in future fault request structs).
  * Added new function `validateRequest`: This function is used as a helper function where it will call the corresponding fault struct `ValidateRequest` function.
  * Added new function `getTaskMetadataForFault`: This function is used as a helper function where it will call `getTaskMetadata` to get the corresponding task of the container that made the TMDS request. There will be a near future PR to actually use the returned task metadata in each of the fault handler functions.
  * Added new function `getTaskMetadataErrorResponse`: This function is used as a helper function to identify the correct error type when trying to get the task metadata via `getTaskMetadata`. It is called in `getTaskMetadataForFault`.
  * Minor cleanup like renaming functions
* `ecs-agent/tmds/handlers/fault/v1/types/types.go`
  * New interface `NetworkFISRequest`: This interface will be used to for all of the fault request structs to implement. Each fault request structs will have a `ValidateRequest` function which will check if all of the required payload fields are present and valid + a `ToString` function.
  * New struct `NetworkBlackholePortRequest`: This struct will be used to decode/store the body of an incoming request to the black hole port endpoints. The following fields are required: `Port`, `Protocol`, and `TrafficType`. It also implements `NetworkFISRequest`
  * New struct `NetworkFaultInjectionResponse`: This struct will be used as the response body to respond back to the TMDS request for each fault endpoint. This struct will container the status of the fault and any errors that were encountered when handling a request.

### Testing
* `agent/handlers/task_server_setup_test.go`
  * Removed the generic `TestRegisterHandler` test cases
  * Added new test cases for starting(`PUT`), stopping(`DELETE`), and checking the status(`GET`) of the black hole port handler after calling `registerFaultHandlers`
* `ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go`
  * Added new test cases for each of the black hole port handler functions (StartNetworkBlackholePort, StopNetworkBlackHolePort, and CheckNetworkBlackHolePort)

New tests cover the changes: Yes

### Description for the changelog
Feature: Implementing network black hole port handler

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
