### PR TITLE
Fix netkitten memory leak from infinite deferred functions

### DIFF
--- a/misc/netkitten/netkitten.go
+++ b/misc/netkitten/netkitten.go
@@ -44,11 +44,6 @@ func main() {
 	for {
 		// If given a target, work with it first
 		var cconn net.Conn
-		defer func() {
-			if cconn != nil {
-				cconn.Close()
-			}
-		}()
 		if target != "" {
 			var err error
 			cconn, err = net.Dial("tcp", target)
@@ -82,6 +77,7 @@ func main() {
 			conn.Close()
 		} else if cconn != nil {
 			io.Copy(os.Stdout, cconn)
+			cconn.Close()
 		}
 
 		if !*loop {


### PR DESCRIPTION
### Summary
Fix `netkitten` memory leak from infinite deferred functions.

The `netkitten` Docker image is used by our [integration tests](https://github.com/aws/amazon-ecs-agent/blob/c41d8e1b4abad6ece0093bc7d2b42fe5a21c46f8/agent/engine/common_unix_integ_test.go#L27). Some of these tests need to keep the container alive longer, so they pass [`-loop=true`](https://github.com/aws/amazon-ecs-agent/blob/c41d8e1b4abad6ece0093bc7d2b42fe5a21c46f8/agent/engine/common_unix_integ_test.go#L35-L39). This prevents `netkitten` from exiting, but with each iteration of the `for` loop, another deferred function is pushed onto the heap. The container eventually runs out of memory and is killed.

This is problematic because an integration test may fail if a `netkitten` container is OOM-killed before the test can assert that the container is running. A test may also fail if it tries to stop a `netkitten` container that has already stopped because it was OOM-killed.

### Implementation details
Close the connection `cconn` after its data has been read, instead of deferring it to when the program exits.

### Testing
Without this patch, run
```
make netkitten
docker stats $(docker run -d amazon/amazon-ecs-netkitten:make -loop)
```
and monitor the memory usage of the container. It will increase over time until it exceeds the memory limit, at which point, Docker will kill the container.

With this patch, run
```
make netkitten
docker stats $(docker run -d amazon/amazon-ecs-netkitten:make -loop)
```
and monitor the memory usage of the container. It will not increase over time.

New tests cover the changes: no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
