### PR TITLE
Add read lock to task string method

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -2916,6 +2916,9 @@ func (task *Task) GetExecutionStoppedAt() time.Time {
 
 // String returns a human-readable string representation of this object
 func (task *Task) String() string {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
 	return task.stringUnsafe()
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will add a read lock to the task object `String()` method. There seems to be a transient/inconsistent data race condition with this method which was found in our unit tests. For example, one case of this that has happened is in the following [run](https://github.com/aws/amazon-ecs-agent/actions/runs/10424056418/attempts/1?pr=4285) while running `TestTaskWithCircularDependency` test case.

Error log encountered:
```
WARNING: DATA RACE
Read at 0x00c000a86e38 by goroutine 11:
  github.com/aws/amazon-ecs-agent/agent/api/task.(*Task).stringUnsafe()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/api/task/task.go:2920 +0x184
  github.com/aws/amazon-ecs-agent/agent/api/task.(*Task).String()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/api/task/task.go:2913 +0x26
  fmt.(*pp).handleMethods()
      /opt/hostedtoolcache/go/1.22.5/x64/src/fmt/print.go:673 +0x6ea
  fmt.(*pp).printArg()
      /opt/hostedtoolcache/go/1.22.5/x64/src/fmt/print.go:756 +0xb4b
  fmt.(*pp).doPrintf()
      /opt/hostedtoolcache/go/1.22.5/x64/src/fmt/print.go:1075 +0x592
  fmt.Sprintf()
      /opt/hostedtoolcache/go/1.22.5/x64/src/fmt/print.go:239 +0x5c
  github.com/cihub/seelog.(*logFormattedMessage).String()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/vendor/github.com/cihub/seelog/logger.go:369 +0x75
  github.com/cihub/seelog.(*commonLogger).processLogMsg()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/vendor/github.com/cihub/seelog/logger.go:312 +0xca
  github.com/cihub/seelog.(*asyncLogger).processQueueElement()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/vendor/github.com/cihub/seelog/behavior_asynclogger.go:115 +0x199
  github.com/cihub/seelog.(*asyncLoopLogger).processItem()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/vendor/github.com/cihub/seelog/behavior_asynclooplogger.go:57 +0x1f3
  github.com/cihub/seelog.(*asyncLoopLogger).processQueue()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/vendor/github.com/cihub/seelog/behavior_asynclooplogger.go:63 +0x36
  github.com/cihub/seelog.NewAsyncLoopLogger.gowrap1()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/vendor/github.com/cihub/seelog/behavior_asynclooplogger.go:40 +0x33

Previous write at 0x00c000a86e38 by goroutine 2015:
  github.com/aws/amazon-ecs-agent/agent/api/task.(*Task).SetDesiredStatus()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/api/task/task.go:2785 +0xa4
  github.com/aws/amazon-ecs-agent/agent/engine.(*DockerTaskEngine).AddTask()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/engine/docker_task_engine.go:1203 +0xf04
  github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph.ValidDependencies()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph/graph.go:101 +0x344
  github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph.dependenciesCanBeResolved()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph/graph.go:130 +0x1b2
  github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph.ValidDependencies()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph/graph.go:101 +0x344
  github.com/aws/amazon-ecs-agent/agent/engine.(*DockerTaskEngine).AddTask()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/engine/docker_task_engine.go:1196 +0xd09
  github.com/aws/amazon-ecs-agent/agent/engine.TestTaskWithCircularDependency.gowrap2()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/engine/docker_task_engine_test.go:1367 +0x50

Goroutine 11 (running) created at:
  github.com/cihub/seelog.NewAsyncLoopLogger()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/vendor/github.com/cihub/seelog/behavior_asynclooplogger.go:40 +0x11c
  github.com/cihub/seelog.createLoggerFromFullConfig()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/vendor/github.com/cihub/seelog/log.go:73 +0x4b4
  github.com/cihub/seelog.LoggerFromConfigAsBytes()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/vendor/github.com/cihub/seelog/cfg_config.go:58 +0xf6
  github.com/cihub/seelog.init.3()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/vendor/github.com/cihub/seelog/log.go:55 +0xe4

Goroutine 2015 (running) created at:
  github.com/aws/amazon-ecs-agent/agent/engine.TestTaskWithCircularDependency()
      /home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent/agent/engine/docker_task_engine_test.go:1367 +0x344
  testing.tRunner()
      /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1742 +0x44
```

### Implementation details
<!-- How are the changes implemented? -->

### Testing
Ran the `TestTaskWithCircularDependency` 500 times and it no longer encountered the race condition issue.

[Commit](https://github.com/aws/amazon-ecs-agent/compare/67d8b1fec1ad6276d8a67bc1ce07655877abc5d5..8b53921f315782b5de8025c163b2f7d09fe7457e)
[Linux unit test run](https://github.com/aws/amazon-ecs-agent/actions/runs/10424720575/job/28874078941?pr=4288)

New tests cover the changes: No

### Description for the changelog
Bugfix: Add read lock to task object String method

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
