### PR TITLE
Update retry strategy for manifest pulls to help setups that depend on network pause container for repo calls

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -87,7 +87,7 @@ const (
 	// Retry settings for pulling manifests.
 	//
 	// First few retries are quick (starting with 10ms) but the backoff increases
-	// fast (with a multiplier of 4 capping at 5s). This is to help setups that depend on
+	// fast (with a multiplier of 3 capping at 5s). This is to help setups that depend on
 	// network pause container for communicating to image repositories which require the pause
 	// container to be initialized before it is ready to serve requests.
 	// A proper long term solution is for the pause container to have a health check and Agent to

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -84,6 +84,20 @@ const (
 	// output will be suppressed in debug mode
 	pullStatusSuppressDelay = 2 * time.Second
 
+	// Retry settings for pulling manifests.
+	//
+	// First few retries are quick (starting with 10ms) but the backoff increases
+	// fast (with a multiplier of 4 capping at 5s). This is to help setups that depend on
+	// network pause container for communicating to image repositories which require the pause
+	// container to be initialized before it is ready to serve requests.
+	// A proper long term solution is for the pause container to have a health check and Agent to
+	// wait for it to become healthy but until then we are relying on this retry strategy.
+	maximumManifestPullRetries        = 10
+	minimumManifestPullRetryDelay     = 10 * time.Millisecond
+	maximumManifestPullRetryDelay     = 5 * time.Second
+	manifestPullRetryDelayMultiplier  = 4
+	manifestPullRetryJitterMultiplier = 0.2
+
 	// retry settings for pulling images
 	maximumPullRetries        = 5
 	minimumPullRetryDelay     = 1100 * time.Millisecond
@@ -325,8 +339,8 @@ func NewDockerGoClient(sdkclientFactory sdkclientfactory.Factory,
 		context:          ctx,
 		imagePullBackoff: retry.NewExponentialBackoff(minimumPullRetryDelay, maximumPullRetryDelay,
 			pullRetryJitterMultiplier, pullRetryDelayMultiplier),
-		manifestPullBackoff: retry.NewExponentialBackoff(minimumPullRetryDelay, maximumPullRetryDelay,
-			pullRetryJitterMultiplier, pullRetryDelayMultiplier),
+		manifestPullBackoff: retry.NewExponentialBackoff(minimumManifestPullRetryDelay,
+			maximumManifestPullRetryDelay, manifestPullRetryJitterMultiplier, manifestPullRetryDelayMultiplier),
 		imageTagBackoff:          retry.NewConstantBackoff(tagImageRetryInterval),
 		inactivityTimeoutHandler: handleInactivityTimeout,
 	}, nil
@@ -372,7 +386,7 @@ func (dg *dockerGoClient) PullImageManifest(
 	// Call DistributionInspect API with retries
 	startTime := time.Now()
 	var distInspectPtr *registry.DistributionInspect
-	err = retry.RetryNWithBackoffCtx(ctx, dg.manifestPullBackoff, maximumPullRetries, func() error {
+	err = retry.RetryNWithBackoffCtx(ctx, dg.manifestPullBackoff, maximumManifestPullRetries, func() error {
 		distInspect, err := client.DistributionInspect(ctx, imageRef, encodedAuth)
 		if err != nil {
 			return err

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -95,7 +95,7 @@ const (
 	maximumManifestPullRetries        = 9
 	minimumManifestPullRetryDelay     = 10 * time.Millisecond
 	maximumManifestPullRetryDelay     = 5 * time.Second
-	manifestPullRetryDelayMultiplier  = 4
+	manifestPullRetryDelayMultiplier  = 3
 	manifestPullRetryJitterMultiplier = 0.2
 
 	// retry settings for pulling images

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -92,7 +92,7 @@ const (
 	// container to be initialized before it is ready to serve requests.
 	// A proper long term solution is for the pause container to have a health check and Agent to
 	// wait for it to become healthy but until then we are relying on this retry strategy.
-	maximumManifestPullRetries        = 10
+	maximumManifestPullRetries        = 8
 	minimumManifestPullRetryDelay     = 10 * time.Millisecond
 	maximumManifestPullRetryDelay     = 5 * time.Second
 	manifestPullRetryDelayMultiplier  = 4

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -92,7 +92,7 @@ const (
 	// container to be initialized before it is ready to serve requests.
 	// A proper long term solution is for the pause container to have a health check and Agent to
 	// wait for it to become healthy but until then we are relying on this retry strategy.
-	maximumManifestPullRetries        = 8
+	maximumManifestPullRetries        = 9
 	minimumManifestPullRetryDelay     = 10 * time.Millisecond
 	maximumManifestPullRetryDelay     = 5 * time.Second
 	manifestPullRetryDelayMultiplier  = 4

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -351,7 +351,7 @@ func TestPullImageManifest(t *testing.T) {
 				client.EXPECT().
 					DistributionInspect(
 						gomock.Any(), "image", base64.URLEncoding.EncodeToString([]byte("{}"))).
-					Times(maximumPullRetries).
+					Times(maximumManifestPullRetries).
 					Return(
 						registry.DistributionInspect{},
 						errors.New("Some error for https://prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com"))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
For certain setups, all image repository calls are routed through the task's network pause container. This requires the pause container to not only have started but have completed any initialization and be ready to accept requests. However, currently Agent does not have a great way to detect that the pause container is ready as it only depends on the container being started. On these setups we have observed that the pause container is not ready when Agent makes the first image repository call (that was an image pull call before manifest pull was introduced and is a manifest pull call now after its addition in https://github.com/aws/amazon-ecs-agent/pull/4177). 

Although Agent's retries of the calls are eventually able to succeed, this does add additional latency to task provisioning times. Since the manifest pull call is a relatively new and additional call that we introduced in https://github.com/aws/amazon-ecs-agent/pull/4177, the task provisioning latency has slightly increased exacerbating the existing latency on the above mentioned setups. To alleviate this, this change updates the retry backoff settings for manifest pull call so that the first few retries are quicker (starting from 10 ms) but the backoff increases faster (with a multiplier of 3) eventually capping at 5 seconds. The changes are summarized below. The overall backoff time before giving up is roughly the same as before.

| Setting | Before | After |
| ------- | ------- | ----- |
| minimum backoff | 1.1 seconds | 10 milliseconds |
| multiplier | 2 | 3 |
| maximum backoff | 5 seconds | 5 seconds |
| retry attempts | 5 |  9 |
| Total backoff | 0 + 1.1 + 2.2 + 4.4 + 5 = 12.7 seconds | 0 + 10 + 30 + 90 + 270 + 810 + 2430 + 5000 + 5000 = 13.6 seconds |

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
We tested the changes on an environment where image repository calls are routed through the network pause container and observed a satisfactory reduction in task provisioning latency.

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: Update manifest pull retry strategy so that first few retries are quicker to help setups on which image repository calls depend on network pause container being initialized

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
