### PR TITLE
Fix flakey TaskStopVerificationACKResponder integration test

### DIFF
--- a/agent/engine/common_integ_testutil.go
+++ b/agent/engine/common_integ_testutil.go
@@ -355,10 +355,10 @@ func InitTestEventCollection(taskEngine TaskEngine) *TestEvents {
 
 // This method queries the TestEvents struct to check a Task Status.
 // This method will block if there are no more stateChangeEvents from the DockerTaskEngine but is expected
-func VerifyTaskStatus(status apitaskstatus.TaskStatus, taskARN string, testEvents *TestEvents, t *testing.T) error {
+func VerifyTaskStatus(status apitaskstatus.TaskStatus, taskARN string, testEvents *TestEvents, t *testing.T) {
 	for {
 		if _, found := testEvents.RecordedEvents[statechange.TaskEvent][status.String()][taskARN]; found {
-			return nil
+			return
 		}
 		event := <-testEvents.StateChangeEvents
 		RecordTestEvent(testEvents, event)
@@ -367,10 +367,10 @@ func VerifyTaskStatus(status apitaskstatus.TaskStatus, taskARN string, testEvent
 
 // This method queries the TestEvents struct to check a Task Status.
 // This method will block if there are no more stateChangeEvents from the DockerTaskEngine but is expected
-func VerifyContainerStatus(status apicontainerstatus.ContainerStatus, ARNcontName string, testEvents *TestEvents, t *testing.T) error {
+func VerifyContainerStatus(status apicontainerstatus.ContainerStatus, ARNcontName string, testEvents *TestEvents, t *testing.T) {
 	for {
 		if _, found := testEvents.RecordedEvents[statechange.ContainerEvent][status.String()][ARNcontName]; found {
-			return nil
+			return
 		}
 		event := <-testEvents.StateChangeEvents
 		RecordTestEvent(testEvents, event)

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -228,28 +228,22 @@ func TestFirelensFluentbit(t *testing.T) {
 	testEvents := InitTestEventCollection(taskEngine)
 
 	//Verify logsender container is running
-	err = VerifyContainerStatus(apicontainerstatus.ContainerRunning, testTask.Arn+":logsender", testEvents, t)
-	assert.NoError(t, err, "Verify logsender container is running")
+	VerifyContainerStatus(apicontainerstatus.ContainerRunning, testTask.Arn+":logsender", testEvents, t)
 
 	//Verify firelens container is running
-	err = VerifyContainerStatus(apicontainerstatus.ContainerRunning, testTask.Arn+":firelens", testEvents, t)
-	assert.NoError(t, err, "Verify firelens container is running")
+	VerifyContainerStatus(apicontainerstatus.ContainerRunning, testTask.Arn+":firelens", testEvents, t)
 
 	//Verify task is in running state
-	err = VerifyTaskStatus(apitaskstatus.TaskRunning, testTask.Arn, testEvents, t)
-	assert.NoError(t, err, "Not verified task running")
+	VerifyTaskStatus(apitaskstatus.TaskRunning, testTask.Arn, testEvents, t)
 
 	//Verify logsender container is stopped
-	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTask.Arn+":logsender", testEvents, t)
-	assert.NoError(t, err)
+	VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTask.Arn+":logsender", testEvents, t)
 
 	//Verify firelens container is stopped
-	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTask.Arn+":firelens", testEvents, t)
-	assert.NoError(t, err)
+	VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTask.Arn+":firelens", testEvents, t)
 
 	//Verify the task itself has stopped
-	err = VerifyTaskStatus(apitaskstatus.TaskStopped, testTask.Arn, testEvents, t)
-	assert.NoError(t, err)
+	VerifyTaskStatus(apitaskstatus.TaskStopped, testTask.Arn, testEvents, t)
 
 	taskID := testTask.GetID()
 


### PR DESCRIPTION
### Summary
Fix a flakey `TaskStopVerificationACKResponder` integration test that is expecting task and container state changes from two different tasks to appear in a particular order. The order isn't guaranteed because state change events from two different tasks can be interwoven. When this happens, the test fails because it's expecting a container state change event but receives a task state change event, or vice versa.

```
--- FAIL: TestTaskStopVerificationACKResponder_StopsSpecificTasks (1.52s)
panic: interface conversion: statechange.Event is api.ContainerStateChange, not api.TaskStateChange [recovered]
	panic: interface conversion: statechange.Event is api.ContainerStateChange, not api.TaskStateChange

goroutine 323 [running]:
testing.tRunner.func1.2({0x1c73f80, 0xc00091faa0})
	/usr/local/go/src/testing/testing.go:1631 +0x3f7
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1634 +0x6b6
panic({0x1c73f80?, 0xc00091faa0?})
	/usr/local/go/src/runtime/panic.go:770 +0x132
github.com/aws/amazon-ecs-agent/agent/engine.VerifyTaskStoppedStateChange(0xc0005c9040, {0x3675430, 0xc000b566c8})
	/opt/amazon-ecs-agent/go/src/github.com/aws/amazon-ecs-agent/agent/engine/common_integ_testutil.go:243 +0x125
github.com/aws/amazon-ecs-agent/agent/acs/session_test.TestTaskStopVerificationACKResponder_StopsSpecificTasks(0xc0005c9040)
	/opt/amazon-ecs-agent/go/src/github.com/aws/amazon-ecs-agent/agent/acs/session/task_stop_verification_ack_responder_integ_test.go:118 +0xf59
testing.tRunner(0xc0005c9040, 0x1f0ba90)
	/usr/local/go/src/testing/testing.go:1689 +0x21f
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:1742 +0x826
```

### Implementation details
Update the integration test to use the [`TestEvent` collector and status verification helper functions](https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/common_integ_testutil.go#L328-L388). https://github.com/aws/amazon-ecs-agent/blob/e37d2c0bb910177c9136bc1c20a5370088dd388b/agent/engine/common_integ_testutil.go#L342-L364
The helper functions don't do type conversions on events. They collect events indefinitely until one that matches the assertion criteria is found. If no such event ever occurs, the test won't stop.

### Testing
Ran the flakey test 50 times and it completed successfully.
```
go test -tags integration ./agent/acs/session -count 50 -v -run TestTaskStopVerificationACKResponder_StopsSpecificTasks 
```

New tests cover the changes: no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
