### PR TITLE
Added the fixes for Windows detected during internal testing.

### DIFF
--- a/agent/stats/engine_linux.go
+++ b/agent/stats/engine_linux.go
@@ -1,0 +1,35 @@
+//go:build linux
+// +build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import "time"
+
+const (
+	// publishMetricsTimeout is the duration that we wait for metrics/health info to be
+	// pushed to the TCS channels. In theory, this timeout should never be hit since
+	// the TCS handler should be continually reading from the channels and pushing to
+	// TCS, but when we lose connection to TCS, these channels back up. In case this
+	// happens, we need to have a timeout to prevent statsEngine channels from blocking.
+	// The times on Linux and Windows vary from one another and that is why we have
+	// them separated out in their respective modules.
+	publishMetricsTimeout = 1 * time.Second
+
+	// getVolumeMetricsTimeout is the time that we want for the metrics to be fetched from
+	// the local disk. The times on Linux and Windows vary from one another and that is
+	// why we have them separated out in their respective modules.
+	getVolumeMetricsTimeout = 1 * time.Second
+)

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -51,7 +51,6 @@ const (
 	SCContainerName                              = "service-connect"
 	testTelemetryChannelDefaultBufferSize        = 10
 	testTelemetryChannelBufferSizeForChannelFull = 1
-	testPublishMetricsInterval                   = 5 * time.Second
 )
 
 func TestStatsEngineAddRemoveContainers(t *testing.T) {
@@ -367,16 +366,6 @@ func TestStartMetricsPublish(t *testing.T) {
 			serviceConnectEnabled:      false,
 			disableMetrics:             true,
 			channelSize:                testTelemetryChannelDefaultBufferSize,
-		},
-		{
-			name:                       "ChannelFull",
-			hasPublishTicker:           true,
-			expectedInstanceMessageNum: 1, // expecting discarding messages after channel is full
-			expectedHealthMessageNum:   1,
-			expectedNonEmptyMetricsMsg: true,
-			serviceConnectEnabled:      false,
-			disableMetrics:             false,
-			channelSize:                testTelemetryChannelBufferSizeForChannelFull,
 		},
 	}
 

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -27,8 +27,11 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
 	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -172,7 +175,11 @@ func TestServiceConnectWithDisabledMetrics(t *testing.T) {
 	assert.Len(t, engine.taskToServiceConnectStats, 1)
 }
 
-func TestStartMetricsPublish(t *testing.T) {
+// This test has been moved to be run Linux only. For Windows, the publish metrics timeout has been set to be 5 seconds
+// for the reason that Windows takes a bit more time to fetch the volume metrics. This test results in a race condition
+// for Windows. Specifically, the discard message condition cannot be replicated in Windows because of the higher
+// timeout.
+func TestStartMetricsPublishForChannelFull(t *testing.T) {
 	testcases := []struct {
 		name                       string
 		hasPublishTicker           bool

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -19,6 +19,7 @@ package stats
 import (
 	"context"
 	"testing"
+	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
@@ -31,6 +32,10 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testPublishMetricsInterval = 5 * time.Second
 )
 
 func TestLinuxTaskNetworkStatsSet(t *testing.T) {
@@ -165,4 +170,165 @@ func TestServiceConnectWithDisabledMetrics(t *testing.T) {
 	assert.Len(t, engine.tasksToContainers, 0, "No containers should be tracked if metrics is disabled")
 	assert.Len(t, engine.tasksToHealthCheckContainers, 1)
 	assert.Len(t, engine.taskToServiceConnectStats, 1)
+}
+
+func TestStartMetricsPublish(t *testing.T) {
+	testcases := []struct {
+		name                       string
+		hasPublishTicker           bool
+		expectedInstanceMessageNum int
+		expectedHealthMessageNum   int
+		expectedNonEmptyMetricsMsg bool
+		serviceConnectEnabled      bool
+		disableMetrics             bool
+		channelSize                int
+	}{
+		{
+			name:                       "ChannelFull",
+			hasPublishTicker:           true,
+			expectedInstanceMessageNum: 1, // expecting discarding messages after channel is full
+			expectedHealthMessageNum:   1,
+			expectedNonEmptyMetricsMsg: true,
+			serviceConnectEnabled:      false,
+			disableMetrics:             false,
+			channelSize:                testTelemetryChannelBufferSizeForChannelFull,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			publishMetricsCfg := cfg
+			if tc.disableMetrics {
+				publishMetricsCfg.DisableMetrics = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
+			}
+
+			containerID := "c1"
+			t1 := &apitask.Task{
+				Arn:               "t1",
+				Family:            "f1",
+				KnownStatusUnsafe: apitaskstatus.TaskRunning,
+				Containers: []*apicontainer.Container{
+					{Name: containerID},
+				},
+			}
+
+			mockDockerClient := mock_dockerapi.NewMockDockerClient(mockCtrl)
+			resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
+
+			mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			mockDockerClient.EXPECT().InspectContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(&types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					ID:    containerID,
+					State: &types.ContainerState{Pid: 23},
+				},
+			}, nil).AnyTimes()
+
+			resolver.EXPECT().ResolveTask(containerID).AnyTimes().Return(t1, nil)
+			resolver.EXPECT().ResolveTaskByARN(gomock.Any()).Return(t1, nil).AnyTimes()
+			resolver.EXPECT().ResolveContainer(containerID).Return(&apicontainer.DockerContainer{
+				DockerID: containerID,
+				Container: &apicontainer.Container{
+					KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
+					HealthCheckType:   "docker",
+					Health: apicontainer.HealthStatus{
+						Status: apicontainerstatus.ContainerHealthy,
+						Since:  aws.Time(time.Now()),
+					},
+				},
+			}, nil).AnyTimes()
+
+			telemetryMessages := make(chan ecstcs.TelemetryMessage, tc.channelSize)
+			healthMessages := make(chan ecstcs.HealthMessage, tc.channelSize)
+
+			engine := NewDockerStatsEngine(&publishMetricsCfg, nil, eventStream("TestStartMetricsPublish"), telemetryMessages, healthMessages)
+			ctx, cancel := context.WithCancel(context.TODO())
+			engine.ctx = ctx
+			engine.resolver = resolver
+			engine.cluster = defaultCluster
+			engine.containerInstanceArn = defaultContainerInstance
+			engine.client = mockDockerClient
+			ticker := time.NewTicker(testPublishMetricsInterval)
+			if !tc.hasPublishTicker {
+				ticker = nil
+			}
+			engine.publishMetricsTicker = ticker
+
+			engine.addAndStartStatsContainer(containerID)
+			ts1 := parseNanoTime("2015-02-12T21:22:05.131117533Z")
+
+			containerStats := createFakeContainerStats()
+			dockerStats := []*types.StatsJSON{{}, {}}
+			dockerStats[0].Read = ts1
+			containers, _ := engine.tasksToContainers["t1"]
+
+			// Two docker stats sample can be one CW stats.
+			for _, statsContainer := range containers {
+				for i := 0; i < 2; i++ {
+					statsContainer.statsQueue.add(containerStats[i])
+					statsContainer.statsQueue.setLastStat(dockerStats[i])
+				}
+			}
+
+			go engine.StartMetricsPublish()
+
+			// wait 1s for first set of metrics sent (immediately), and then add a second set of stats
+			time.Sleep(time.Second)
+			for _, statsContainer := range containers {
+				for i := 0; i < 2; i++ {
+					statsContainer.statsQueue.add(containerStats[i])
+					statsContainer.statsQueue.setLastStat(dockerStats[i])
+				}
+			}
+
+			time.Sleep(testPublishMetricsInterval + time.Second)
+
+			assert.Len(t, telemetryMessages, tc.expectedInstanceMessageNum)
+			assert.Len(t, healthMessages, tc.expectedHealthMessageNum)
+
+			if tc.expectedInstanceMessageNum > 0 {
+				telemetryMessage := <-telemetryMessages
+				if tc.expectedNonEmptyMetricsMsg {
+					assert.NotEmpty(t, telemetryMessage.TaskMetrics)
+					assert.NotZero(t, *telemetryMessage.TaskMetrics[0].ContainerMetrics[0].StorageStatsSet.ReadSizeBytes.Sum)
+				} else {
+					assert.Empty(t, telemetryMessage.TaskMetrics)
+				}
+			}
+			if tc.expectedHealthMessageNum > 0 {
+				healthMessage := <-healthMessages
+				assert.NotEmpty(t, healthMessage.HealthMetrics)
+			}
+
+			// verify full channel behavior: the message is dropped
+			if tc.channelSize == testTelemetryChannelBufferSizeForChannelFull {
+
+				// add a third set of metrics. This time, change storageReadBytes to 0 to verify that the 2nd set of metrics
+				// are dropped as expected.
+				containerStats[0].storageReadBytes = uint64(0)
+				containerStats[1].storageReadBytes = uint64(0)
+				for _, statsContainer := range containers {
+					for i := 0; i < 2; i++ {
+						statsContainer.statsQueue.add(containerStats[i])
+						statsContainer.statsQueue.setLastStat(dockerStats[i])
+					}
+				}
+
+				telemetryMessage := <-telemetryMessages
+				healthMessage := <-healthMessages
+				assert.NotEmpty(t, telemetryMessage.TaskMetrics)
+				assert.NotEmpty(t, healthMessage.HealthMetrics)
+				assert.Zero(t, *telemetryMessage.TaskMetrics[0].ContainerMetrics[0].StorageStatsSet.ReadSizeBytes.Sum)
+			}
+
+			cancel()
+			if ticker != nil {
+				ticker.Stop()
+			}
+			close(telemetryMessages)
+			close(healthMessages)
+		})
+	}
 }

--- a/agent/stats/engine_windows.go
+++ b/agent/stats/engine_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import "time"
+
+const (
+	// publishMetricsTimeout is the duration that we wait for metrics/health info to be
+	// pushed to the TCS channels. In theory, this timeout should never be hit since
+	// the TCS handler should be continually reading from the channels and pushing to
+	// TCS, but when we lose connection to TCS, these channels back up. In case this
+	// happens, we need to have a timeout to prevent statsEngine channels from blocking.
+	// The times on Linux and Windows vary from one another and that is why we have
+	// them separated out in their respective modules.
+	publishMetricsTimeout = 6 * time.Second
+
+	// getVolumeMetricsTimeout is the time that we want for the metrics to be fetched from
+	// the local disk. The times on Linux and Windows vary from one another and that is
+	// why we have them separated out in their respective modules.
+	getVolumeMetricsTimeout = 5 * time.Second
+)

--- a/agent/stats/engine_windows_test.go
+++ b/agent/stats/engine_windows_test.go
@@ -1,0 +1,23 @@
+//go:build windows && unit
+// +build windows,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import "time"
+
+const (
+	testPublishMetricsInterval = 5 * time.Second
+)

--- a/ecs-agent/daemonimages/csidriver/driver/node.go
+++ b/ecs-agent/daemonimages/csidriver/driver/node.go
@@ -335,7 +335,7 @@ func (d *nodeService) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 	}
 
 	if isBlock {
-		bcap, blockErr := d.getBlockSizeBytes(req.VolumePath)
+		bcap, blockErr := d.getBlockSizeBytes(req.VolumePath, req.VolumeId)
 		if blockErr != nil {
 			return nil, status.Errorf(codes.Internal, "failed to get block capacity on path %s: %v", req.VolumePath, err)
 		}

--- a/ecs-agent/daemonimages/csidriver/driver/node_linux.go
+++ b/ecs-agent/daemonimages/csidriver/driver/node_linux.go
@@ -169,7 +169,7 @@ func (d *nodeService) IsBlockDevice(fullPath string) (bool, error) {
 	return (st.Mode & unix.S_IFMT) == unix.S_IFBLK, nil
 }
 
-func (d *nodeService) getBlockSizeBytes(devicePath string) (int64, error) {
+func (d *nodeService) getBlockSizeBytes(devicePath string, _ string) (int64, error) {
 	cmd := d.mounter.(*NodeMounter).Exec.Command("blockdev", "--getsize64", devicePath)
 	output, err := cmd.Output()
 	if err != nil {

--- a/ecs-agent/daemonimages/csidriver/driver/node_windows.go
+++ b/ecs-agent/daemonimages/csidriver/driver/node_windows.go
@@ -31,13 +31,19 @@ import (
 )
 
 // getBlockSizeBytes gets the size of the disk in bytes
-func (d *nodeService) getBlockSizeBytes(devicePath string) (int64, error) {
+func (d *nodeService) getBlockSizeBytes(devicePath string, volumeId string) (int64, error) {
+	// We need to fetch the device ID based on the devicePath and volumeId. This is needed
+	// for fetching disk metrics.
+	deviceId, err := d.findDevicePath(devicePath, volumeId, "")
+	if err != nil {
+		return -1, fmt.Errorf("error listing disk ids while getting the block size: %q", err)
+	}
 	proxyMounter, ok := (d.mounter.(*NodeMounter)).SafeFormatAndMount.Interface.(*mounter.CSIProxyMounter)
 	if !ok {
 		return -1, fmt.Errorf("failed to cast mounter to csi proxy mounter")
 	}
 
-	sizeInBytes, err := proxyMounter.GetDeviceSize(devicePath)
+	sizeInBytes, err := proxyMounter.GetDeviceSize(deviceId)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
### Summary
This PR adds the fixes to the volume metrics fetcher in the agent flows and in the CSI Driver for Windows.

### Implementation details

- We changed the path that was used by the CSIDriver to fetch the metrics.
- We use a different timeout for Windows when fetching the metrics. The default timeout of 1 second for Linux is not sufficient for Windows.

### Testing
We ran the integration in a Windows environment and validated the working of the metrics fetch.

New tests cover the changes: No. The existing tests were used to test this.

### Description for the changelog
Added the fixes for Windows detected during internal testing.

### Additional Information

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
