### PR TITLE
Add more validation of stats received from Docker

### DIFF
--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -584,12 +584,15 @@ func getAggregatedDockerStatAcrossRestarts(dockerStat, lastStatBeforeLastRestart
 	dockerStat = aggregateOSIndependentStats(dockerStat, lastStatBeforeLastRestart)
 	dockerStat = aggregateOSDependentStats(dockerStat, lastStatBeforeLastRestart)
 
-	// PreCPU stats.
+	// Stats relevant to PreCPU.
 	preCPUStats := types.CPUStats{}
+	preRead := time.Time{}
 	if lastStatInStatsQueue != nil {
 		preCPUStats = lastStatInStatsQueue.CPUStats
+		preRead = lastStatInStatsQueue.Read
 	}
 	dockerStat.PreCPUStats = preCPUStats
+	dockerStat.PreRead = preRead
 
 	logger.Debug("Aggregated Docker stat across restart(s)", logger.Fields{
 		loggerfield.DockerId: dockerStat.ID,

--- a/agent/stats/unix_test_stats.json
+++ b/agent/stats/unix_test_stats.json
@@ -1,4 +1,5 @@
 {
+    "read": "1969-12-31T23:59:59.99999999Z",
     "blkio_stats": {
         "io_service_bytes_recursive": [
             {

--- a/agent/stats/utils.go
+++ b/agent/stats/utils.go
@@ -20,6 +20,10 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
+const (
+	invalidStatZeroValueReadTimeMsg = "read time of stat is 0001-01-01T00:00:00Z"
+)
+
 var numCores = uint64(eautils.GetNumCPU())
 
 // nan32 returns a 32bit NaN.

--- a/agent/stats/utils_unix.go
+++ b/agent/stats/utils_unix.go
@@ -55,7 +55,12 @@ func getMemUsage(mem types.MemoryStats) uint64 {
 	return mem.Usage
 }
 
-func validateDockerStats(dockerStats *types.StatsJSON) error {
+func validateDockerStats(dockerStats *types.StatsJSON, containerEnabledRestartPolicy bool) error {
+	if containerEnabledRestartPolicy && dockerStats.Read.IsZero() {
+		return fmt.Errorf("invalid container statistics reported for container with restart policy enabled, %s",
+			invalidStatZeroValueReadTimeMsg)
+	}
+
 	if config.CgroupV2 {
 		// PercpuUsage is not available in cgroupv2
 		if numCores == uint64(0) {

--- a/agent/stats/utils_windows.go
+++ b/agent/stats/utils_windows.go
@@ -39,7 +39,12 @@ func dockerStatsToContainerStats(dockerStats *types.StatsJSON) (*ContainerStats,
 	}, nil
 }
 
-func validateDockerStats(dockerStats *types.StatsJSON) error {
+func validateDockerStats(dockerStats *types.StatsJSON, containerEnabledRestartPolicy bool) error {
+	if containerEnabledRestartPolicy && dockerStats.Read.IsZero() {
+		return fmt.Errorf("invalid container statistics reported for container with restart policy enabled, %s",
+			invalidStatZeroValueReadTimeMsg)
+	}
+
 	if numCores == uint64(0) {
 		return fmt.Errorf("invalid container statistics reported, no cpu core usage reported")
 	}

--- a/agent/stats/windows_test_stats.json
+++ b/agent/stats/windows_test_stats.json
@@ -1,4 +1,5 @@
 {
+    "read": "1969-12-31T23:59:59.99999999Z",
     "blkio_stats": {
         "io_service_bytes_recursive": null,
         "io_serviced_recursive": null,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add additional validation of container stats received from Docker such that they are considered invalid if they have a `read` time of `0001-01-01T00:00:00Z` (i.e., zero value of type `time.Time`) the associated container has a container restart policy is enabled.

This is so that if Docker does send ECS Agent a stat with a `read` time of `0001-01-01T00:00:00Z` for a container with a container restart policy enabled, then ECS Agent drops/filters it out.  

### Implementation details
<!-- How are the changes implemented? -->
- Update existing `validateDockerStats` function to consider stats with `read` time of `0001-01-01T00:00:00Z` as invalid for containers with a container restart policy enabled
- Update `getAggregatedDockerStatAcrossRestarts` function to set an aggregated stat's `preread` time to be the read time of the last stat stored in the stats queue, in case ECS Agent does receive from Docker a stat with a `read` time of `0001-01-01T00:00:00Z` directly prior to the current stat being processed
- Enhance logging to indicate what error was encountered (if any) during container stats collection (this allows visibility into specifically what errors ECS Agent could face, including receiving an invalid stat from Docker)

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Automated PR tests.

Also test via internal functional test that container metadata aggregation across restarts logic from https://github.com/aws/amazon-ecs-agent/pull/4206 works as expected even when invalid stats from Docker are received on the latest AL2 AMD64 and AL2023 AMD64 ECS-Optimized AMIs.

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add more validation of stats received from Docker

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No

**Does this PR include the addition of new environment variables in the README?**
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
