### PR TITLE
Streamline how tasks stopped per ECS Control Plane

### DIFF
--- a/agent/acs/session/task_stop_verification_ack_responder.go
+++ b/agent/acs/session/task_stop_verification_ack_responder.go
@@ -42,7 +42,7 @@ func (ts *taskStopper) StopTask(taskARN string) {
 		logger.Info("Stopping task from task stop verification ACK: %s", logger.Fields{
 			loggerfield.TaskARN: task.Arn,
 		})
-		// Only task ARN and desired status are required in the deep copy to signal to task engine that the task
+		// Only task ARN and desired status are required to signal to task engine that the task
 		// should be stopped via call to task engine `UpsertTask`.
 		taskWithDesiredStatusStopped := createTaskWithARNAndDesiredStatus(task.Arn, apitaskstatus.TaskStopped)
 		ts.taskEngine.UpsertTask(taskWithDesiredStatusStopped)

--- a/agent/acs/session/task_stop_verification_ack_responder.go
+++ b/agent/acs/session/task_stop_verification_ack_responder.go
@@ -42,11 +42,10 @@ func (ts *taskStopper) StopTask(taskARN string) {
 		logger.Info("Stopping task from task stop verification ACK: %s", logger.Fields{
 			loggerfield.TaskARN: task.Arn,
 		})
-		// Create a minimal deep copy of the task with its desired status set to STOPPED.
 		// Only task ARN and desired status are required in the deep copy to signal to task engine that the task
-		// should be stopped via call to task engine `UpdateTask`.
+		// should be stopped via call to task engine `UpsertTask`.
 		taskWithDesiredStatusStopped := createTaskWithARNAndDesiredStatus(task.Arn, apitaskstatus.TaskStopped)
-		ts.taskEngine.UpdateTask(taskWithDesiredStatusStopped)
+		ts.taskEngine.UpsertTask(taskWithDesiredStatusStopped)
 		if err := ts.dataClient.SaveTask(task); err != nil {
 			logger.Error("Failed to save data for task", logger.Fields{
 				loggerfield.TaskARN: task.Arn,

--- a/agent/acs/session/task_stop_verification_ack_responder_test.go
+++ b/agent/acs/session/task_stop_verification_ack_responder_test.go
@@ -192,12 +192,12 @@ func TestTaskStopVerificationAckResponderStopsAllTasks(t *testing.T) {
 	}
 }
 
-// mockTaskEngineExpectUpdateTaskWithArnAndDesiredStatus expects the mock task engine to call UpdateTask and asserts
+// mockTaskEngineExpectUpdateTaskWithArnAndDesiredStatus expects the mock task engine to call UpsertTask and asserts
 // that the task it takes as input has task ARN `taskARN` and desired status `desiredStatus` before setting and
 // updating the desired status of the task and its containers on the instance.
 func mockTaskEngineExpectUpdateTaskWithArnAndDesiredStatus(t *testing.T, tester *taskStopVerificationAckTestHelper,
 	tasksOnInstance map[string]*task.Task, taskARN string, desiredStatus apitaskstatus.TaskStatus) {
-	tester.taskEngine.EXPECT().UpdateTask(gomock.Any()).Do(func(addedTask *task.Task) {
+	tester.taskEngine.EXPECT().UpsertTask(gomock.Any()).Do(func(addedTask *task.Task) {
 		assert.Equal(t, taskARN, addedTask.Arn)
 		assert.Equal(t, desiredStatus, addedTask.GetDesiredStatus())
 		tasksOnInstance[taskARN].SetDesiredStatus(desiredStatus)

--- a/agent/engine/common_integ_testutil.go
+++ b/agent/engine/common_integ_testutil.go
@@ -52,11 +52,6 @@ var (
 	sdkClientFactory sdkclientfactory.Factory
 )
 
-const (
-	taskSteadyStatePollInterval       = 100 * time.Millisecond
-	taskSteadyStatePollIntervalJitter = 10 * time.Millisecond
-)
-
 func init() {
 	sdkClientFactory = sdkclientfactory.NewFactory(context.TODO(), dockerEndpoint)
 }
@@ -124,10 +119,6 @@ func setupGMSALinux(cfg *config.Config, state dockerstate.TaskEngineState, t *te
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, &hostResourceManager, state, metadataManager,
 		resourceFields, execcmd.NewManager(), engineserviceconnect.NewManager(), daemonManagers)
-	// Set the steady state poll interval to a low value so that tasks transition from their current state to their
-	// desired state faster. This prevents tests from appearing to hang while waiting for state change events.
-	taskEngine.taskSteadyStatePollInterval = taskSteadyStatePollInterval
-	taskEngine.taskSteadyStatePollIntervalJitter = taskSteadyStatePollIntervalJitter
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {
 		taskEngine.Shutdown()
@@ -269,10 +260,6 @@ func SetupIntegTestTaskEngine(cfg *config.Config, state dockerstate.TaskEngineSt
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, &hostResourceManager, state, metadataManager,
 		nil, execcmd.NewManager(), engineserviceconnect.NewManager(), daemonManagers)
-	// Set the steady state poll interval to a low value so that tasks transition from their current state to their
-	// desired state faster. This prevents tests from appearing to hang while waiting for state change events.
-	taskEngine.taskSteadyStatePollInterval = taskSteadyStatePollInterval
-	taskEngine.taskSteadyStatePollIntervalJitter = taskSteadyStatePollIntervalJitter
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {
 		taskEngine.Shutdown()

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1180,11 +1180,14 @@ func (engine *DockerTaskEngine) AddTask(task *apitask.Task) {
 			logger.Info("docker_task_engine: Added AppNet Relay task to engine")
 		}
 	}
-	engine.UpdateTask(task)
+	engine.UpsertTask(task)
 }
 
-// UpdateTask updates a task in the task engine.
-func (engine *DockerTaskEngine) UpdateTask(task *apitask.Task) {
+// UpsertTask upserts a task in the task engine. Upserting means:
+//   - if a task with the same ARN already exists in the task engine's state, then the existing task's desired
+//     status is updated to the desired status of the upserted task
+//   - else the upserted task is inserted into the task engine's state
+func (engine *DockerTaskEngine) UpsertTask(task *apitask.Task) {
 	engine.tasksLock.Lock()
 	defer engine.tasksLock.Unlock()
 
@@ -1210,7 +1213,7 @@ func (engine *DockerTaskEngine) UpdateTask(task *apitask.Task) {
 		}
 		return
 	}
-	engine.updateTaskUnsafe(existingTask, task.GetDesiredStatus())
+	engine.updateTaskDesiredStatusUnsafe(existingTask, task.GetDesiredStatus())
 }
 
 // ListTasks returns the tasks currently managed by the DockerTaskEngine
@@ -2667,10 +2670,11 @@ func (engine *DockerTaskEngine) removeContainer(task *apitask.Task, container *a
 	return engine.client.RemoveContainer(engine.ctx, dockerID, dockerclient.RemoveContainerTimeout)
 }
 
-// updateTaskUnsafe determines if a new transition needs to be applied to the
+// updateTaskDesiredStatusUnsafe determines if a new transition needs to be applied to the
 // referenced task, and if needed applies it. It should not be called anywhere
-// but from 'UpdateTask' and is protected by the tasksLock lock there.
-func (engine *DockerTaskEngine) updateTaskUnsafe(task *apitask.Task, updateDesiredStatus apitaskstatus.TaskStatus) {
+// but from 'UpsertTask' and is protected by the tasksLock lock there.
+func (engine *DockerTaskEngine) updateTaskDesiredStatusUnsafe(task *apitask.Task,
+	updateDesiredStatus apitaskstatus.TaskStatus) {
 	managedTask, ok := engine.managedTasks[task.Arn]
 	if !ok {
 		logger.Critical("ACS message for a task we thought we managed, but don't! Aborting.", logger.Fields{

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -560,10 +560,6 @@ func setupGMSA(cfg *config.Config, state dockerstate.TaskEngineState, t *testing
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, &hostResourceManager, state, metadataManager,
 		resourceFields, execcmd.NewManager(), engineserviceconnect.NewManager())
-	// Set the steady state poll interval to a low value so that tasks transition from their current state to their
-	// desired state faster. This prevents tests from appearing to hang while waiting for state change events.
-	taskEngine.taskSteadyStatePollInterval = taskSteadyStatePollInterval
-	taskEngine.taskSteadyStatePollIntervalJitter = taskSteadyStatePollIntervalJitter
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {
 		taskEngine.Shutdown()

--- a/agent/engine/interface.go
+++ b/agent/engine/interface.go
@@ -43,8 +43,11 @@ type TaskEngine interface {
 	// lifecycle. If it returns an error, the task was not added.
 	AddTask(*apitask.Task)
 
-	// UpdateTask updates a task in the task engine.
-	UpdateTask(*apitask.Task)
+	// UpsertTask upserts a task in the task engine. Upserting means:
+	//   - if a task with the same ARN already exists in the task engine's state, then the existing task's desired
+	//     status is updated to the desired status of the upserted task
+	//   - else the upserted task is inserted into the task engine's state
+	UpsertTask(*apitask.Task)
 
 	// ListTasks lists all the tasks being managed by the TaskEngine.
 	ListTasks() ([]*apitask.Task, error)

--- a/agent/engine/interface.go
+++ b/agent/engine/interface.go
@@ -43,6 +43,9 @@ type TaskEngine interface {
 	// lifecycle. If it returns an error, the task was not added.
 	AddTask(*apitask.Task)
 
+	// UpdateTask updates a task in the task engine.
+	UpdateTask(*apitask.Task)
+
 	// ListTasks lists all the tasks being managed by the TaskEngine.
 	ListTasks() ([]*apitask.Task, error)
 

--- a/agent/engine/mocks/engine_mocks.go
+++ b/agent/engine/mocks/engine_mocks.go
@@ -257,16 +257,16 @@ func (mr *MockTaskEngineMockRecorder) UnmarshalJSON(arg0 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmarshalJSON", reflect.TypeOf((*MockTaskEngine)(nil).UnmarshalJSON), arg0)
 }
 
-// UpdateTask mocks base method.
-func (m *MockTaskEngine) UpdateTask(arg0 *task.Task) {
+// UpsertTask mocks base method.
+func (m *MockTaskEngine) UpsertTask(arg0 *task.Task) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateTask", arg0)
+	m.ctrl.Call(m, "UpsertTask", arg0)
 }
 
-// UpdateTask indicates an expected call of UpdateTask.
-func (mr *MockTaskEngineMockRecorder) UpdateTask(arg0 interface{}) *gomock.Call {
+// UpsertTask indicates an expected call of UpsertTask.
+func (mr *MockTaskEngineMockRecorder) UpsertTask(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTask", reflect.TypeOf((*MockTaskEngine)(nil).UpdateTask), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertTask", reflect.TypeOf((*MockTaskEngine)(nil).UpsertTask), arg0)
 }
 
 // Version mocks base method.

--- a/agent/engine/mocks/engine_mocks.go
+++ b/agent/engine/mocks/engine_mocks.go
@@ -257,6 +257,18 @@ func (mr *MockTaskEngineMockRecorder) UnmarshalJSON(arg0 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmarshalJSON", reflect.TypeOf((*MockTaskEngine)(nil).UnmarshalJSON), arg0)
 }
 
+// UpdateTask mocks base method.
+func (m *MockTaskEngine) UpdateTask(arg0 *task.Task) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateTask", arg0)
+}
+
+// UpdateTask indicates an expected call of UpdateTask.
+func (mr *MockTaskEngineMockRecorder) UpdateTask(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTask", reflect.TypeOf((*MockTaskEngine)(nil).UpdateTask), arg0)
+}
+
 // Version mocks base method.
 func (m *MockTaskEngine) Version() (string, error) {
 	m.ctrl.T.Helper()

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -362,7 +362,7 @@ func (engine *MockTaskEngine) SetDataClient(data.Client) {
 func (engine *MockTaskEngine) AddTask(*apitask.Task) {
 }
 
-func (engine *MockTaskEngine) UpdateTask(*apitask.Task) {
+func (engine *MockTaskEngine) UpsertTask(*apitask.Task) {
 }
 
 func (engine *MockTaskEngine) ListTasks() ([]*apitask.Task, error) {

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -362,6 +362,9 @@ func (engine *MockTaskEngine) SetDataClient(data.Client) {
 func (engine *MockTaskEngine) AddTask(*apitask.Task) {
 }
 
+func (engine *MockTaskEngine) UpdateTask(*apitask.Task) {
+}
+
 func (engine *MockTaskEngine) ListTasks() ([]*apitask.Task, error) {
 	return nil, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Streamline how tasks are stopped when ECS Control Plane indicates that a task should be stopped.

Currently ECS Control Plane indicates to ECS Data Plane via Agent Communication Service (ACS) that a task should be stopped in 2 ways:
1. via a payload message
2. via a task stop verification ACK

However, currently the workflow invoked/set of actions taken to actually stop a task on ECS Data Plane side differs for these 2 cases. We should streamline this to allow for consistency and better maintainability of code (e.g., not having to make changes in multiple places in the future).

### Implementation details
<!-- How are the changes implemented? -->
- Task engine `AddTask` method is currently overloaded. Factor out updating task in task engine logic into a separate method `UpsertTask`
   - Update testing mocks to factor in new task engine `UpsertTask` method 
- Refactor task engine `updateTaskUnsafe` method to:
   - take in as its 2nd argument the desired status to update the task to, instead of an entire update task. Taking in an entire update task is unnecessary since only the desired status of the update task is used
   - be renamed to `updateTaskDesiredStatusUnsafe` to be more specific/clear
- When stopping a task in response to a task stop verification ACK received from ACS, replace logic to call task methods `SetDesiredStatus` and `UpdateDesiredStatus` on the task directly with calling task engine `UpsertTask` method instead
- Remove integration test overrides of task engine `taskSteadyStatePollInterval` and `taskSteadyStatePollIntervalJitter` values as they are no longer necessary. This is because using `UpsertTask` to stop the task ensures that the ACS transition to stop the task is emitted on the task's `acsMessages` channel, and thus these values no longer affect how long `TestTaskStopVerificationACKResponder*` integration tests take to run  (see discussion on [previous pull request comment thread here](https://github.com/aws/amazon-ecs-agent/pull/4282#discussion_r1718905492) for additional context)

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Automated pull request tests.

Manually test using a custom ECS Agent built with the changes in this pull request against the internal bug repro environment mentioned in https://github.com/aws/amazon-ecs-agent/pull/4240 to ensure that the bug addressed by that pull request is still addressed with the changes in this pull request. With this custom ECS Agent, the aforementioned bug is still not observed AND we observe that the transition to stop the task is put on the task's ACS messages channel and stopping the container happens immediately after the transition is applied.
<details>

<summary>Partial manual testing ECS Agent logs</summary>
{

"level": "debug",
  "time": "2024-08-20T17:06:44Z",
  "msg": "Received message of type: TaskStopVerificationAck"
}

{
  "level": "debug",
  "time": "2024-08-20T17:06:44Z",
  "msg": "ACS activity occurred"
}

{
  "level": "debug",
  "time": "2024-08-20T17:06:44Z",
  "msg": "Handling TaskStopVerificationACKMessage"
}

{
  "level": "info",
  "time": "2024-08-20T17:06:44Z",
  "msg": "Sending message to task stopper to stop task",
  "taskARN": "arn:aws:ecs:us-west-2:REDACTED:task/my-cluster/b176d749a3844107ab3823af0b34c18b"
}

{
  "level": "info",
  "time": "2024-08-20T17:06:44Z",
  "msg": "Stopping task from task stop verification ACK: %s",
  "taskARN": "arn:aws:ecs:us-west-2:REDACTED:task/my-cluster/b176d749a3844107ab3823af0b34c18b"
}

{
  "level": "debug",
  "time": "2024-08-20T17:06:44Z",
  "msg": "Putting update on the acs channel",
  "desiredStatus": "STOPPED",
  "task": "b176d749a3844107ab3823af0b34c18b"
}

{
  "level": "debug",
  "time": "2024-08-20T17:06:44Z",
  "msg": "Update taken off the acs channel",
  "desiredStatus": "STOPPED",
  "task": "b176d749a3844107ab3823af0b34c18b"
}

{
  "level": "info",
  "time": "2024-08-20T17:06:44Z",
  "msg": "Managed task got acs event",
  "desiredStatus": "STOPPED",
  "seqnum": 0,
  "task": "b176d749a3844107ab3823af0b34c18b"
}

{
  "level": "info",
  "time": "2024-08-20T17:06:44Z",
  "msg": "New acs transition",
  "desiredStatus": "STOPPED",
  "seqnum": 0,
  "task": "b176d749a3844107ab3823af0b34c18b"
}

{
  "level": "info",
  "time": "2024-08-20T17:06:44Z",
  "msg": "Sleeping 45 seconds before applying acs transition (THIS IS ONLY DONE FOR INTERNAL BUG REPRO ENIVRONMENT)"
}

...
{
  "level": "debug",
  "time": "2024-08-20T17:07:29Z",
  "msg": "Updating task's desired status",
  "nContainers": 1,
  "nENIs": 0,
  "taskArn": "arn:aws:ecs:us-west-2:REDACTED:task/my-cluster/b176d749a3844107ab3823af0b34c18b",
  "taskDesiredStatus": "STOPPED",
  "taskFamily": "test-sleep",
  "taskKnownStatus": "RUNNING",
  "taskVersion": "3"
}

...
{
  "level": "debug",
  "time": "2024-08-20T17:07:29Z",
  "msg": "Waiting for task event",
  "task": "b176d749a3844107ab3823af0b34c18b"
}

{
  "level": "info",
  "time": "2024-08-20T17:07:29Z",
  "msg": "Managed task got acs event",
  "desiredStatus": "STOPPED",
  "seqnum": 0,
  "task": "b176d749a3844107ab3823af0b34c18b"
}

{
  "level": "info",
  "time": "2024-08-20T17:07:29Z",
  "msg": "New acs transition",
  "desiredStatus": "STOPPED",
  "seqnum": 0,
  "task": "b176d749a3844107ab3823af0b34c18b"
}

...
{
  "level": "debug",
  "time": "2024-08-20T17:07:29Z",
  "msg": "Update taken off the acs channel",
  "desiredStatus": "STOPPED",
  "task": "b176d749a3844107ab3823af0b34c18b"
}

{
  "level": "info",
  "time": "2024-08-20T17:07:29Z",
  "msg": "Stopping container",
  "container": "sleepy300",
  "task": "b176d749a3844107ab3823af0b34c18b"
}
</details>

New tests cover the changes: existing unit and integration tests updated

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Streamline how tasks stopped per ECS Control Plane

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
