### PR TITLE
Consume updated TaskResponse in network fault injection handlers

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -296,6 +296,12 @@ type Task struct {
 	NetworkMode string `json:"NetworkMode,omitempty"`
 
 	IsInternal bool `json:"IsInternal,omitempty"`
+
+	// TODO: Will need to initialize/set the value in a follow PR
+	NetworkNamespace string `json:"NetworkNamespace,omitempty"`
+
+	// TODO: Will need to initialize/set the value in a follow PR
+	FaultInjectionEnabled bool `json:"FaultInjectionEnabled,omitempty"`
 }
 
 // TaskFromACS translates ecsacs.Task to apitask.Task by first marshaling the received
@@ -3742,4 +3748,25 @@ func (task *Task) HasAContainerWithResolvedDigest() bool {
 		}
 	}
 	return false
+}
+
+func (task *Task) IsFaultInjectionEnabled() bool {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	return task.FaultInjectionEnabled
+}
+
+func (task *Task) GetNetworkMode() string {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	return task.NetworkMode
+}
+
+func (task *Task) GetNetworkNamespace() string {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	return task.NetworkNamespace
 }

--- a/agent/handlers/v4/tmdsstate.go
+++ b/agent/handlers/v4/tmdsstate.go
@@ -151,6 +151,25 @@ func (s *TMDSAgentState) getTaskMetadata(v3EndpointID string, includeTags bool) 
 			NewPulledContainerResponse(dockerContainer, task.GetPrimaryENI()))
 	}
 
+	if task.IsFaultInjectionEnabled() {
+		// TODO: The correct values for the task network config will need to be set/initialized
+		taskResponse.FaultInjectionEnabled = task.IsFaultInjectionEnabled()
+		taskNetworkConfig := tmdsv4.TaskNetworkConfig{
+			NetworkMode: task.GetNetworkMode(),
+			NetworkNamespaces: []*tmdsv4.NetworkNamespace{
+				{
+					Path: task.GetNetworkNamespace(),
+					NetworkInterfaces: []*tmdsv4.NetworkInterface{
+						{
+							DeviceName: "",
+						},
+					},
+				},
+			},
+		}
+		taskResponse.TaskNetworkConfig = &taskNetworkConfig
+	}
+
 	return *taskResponse, nil
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will consume the `TaskResponse` changes that were introduced in https://github.com/aws/amazon-ecs-agent/pull/4285 and https://github.com/aws/amazon-ecs-agent/pull/4273 within the shared fault injection handlers. We will also be validating that the obtained task metadata for the corresponding incoming request for the following:
* Is the task `FaultInjectionEnabled` ?
* Using either `host` or `awsvpc` network mode
* Does not have any null/empty values

### Implementation details
* `ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go` 
  * Modified `getTaskMetadataForFault` to validate the obtained task metadata from `GetTaskMetadata` if it satisfy the 3 checks above
* `agent/api/task/task.go`
  * Added new fields `NetworkNamespace` and `FaultInjectionEnabled` with corresponding getter methods. (Note: There will be a follow up PR to initialize/set these fields)
* `agent/handlers/v4/tmdsstate.go`
  * Modified `getTaskMetadata` to initialize `FaultInjectionEnabled` and a `TaskNetworkConfig` for the `TaskResponse` object to be returned if the corresponding `FaultInjectionEnabled` field of the `Task` struct  is `true`

### Testing
* Added new test cases to `ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go` for all three network fault injection handlers if:
  * `FaultInjectionEnabled` of TaskResponse is set to false
  * `TaskNetworkConfig`of TaskResponse is empty
  * `NetworkMode` of TaskNetworkConfig is set to an invalid value
* Added new test cases to `agent/handlers/task_server_setup_test.go` for all three network fault injection if:
  * `FaultInjectionEnabled` of Task is set to false
  * `NetworkMode` of Task is set to an invalid value

New tests cover the changes: Yes

### Description for the changelog
* Feature: Consume updated TaskResponse changes to network fault injection handlers

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
