### PR TITLE
Fix flakey TestManifestPulledDoesNotDependOnContainerOrdering integration test

### DIFF
--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -620,7 +620,7 @@ func TestManifestPulledDoesNotDependOnContainerOrdering(t *testing.T) {
 			defer done()
 
 			first := createTestContainerWithImageAndName(testRegistryImage, "first")
-			first.Command = []string{"sh", "-c", "sleep 60"}
+			first.Command = GetLongRunningCommand()
 
 			second := createTestContainerWithImageAndName(testRegistryImage, "second")
 			second.SetDependsOn([]apicontainer.DependsOn{


### PR DESCRIPTION
### Summary
Fix flakey [`TestManifestPulledDoesNotDependOnContainerOrdering`](https://github.com/aws/amazon-ecs-agent/blob/6e5e459d30acf34268350f4c66fa9c1baea77d4c/agent/engine/engine_integ_test.go#L606-L669) integration test.

```
--- FAIL: TestManifestPulledDoesNotDependOnContainerOrdering (23.82s)
    --- FAIL: TestManifestPulledDoesNotDependOnContainerOrdering/0 (6.14s)
        engine_integ_test.go:650: 
            	Error Trace:	/opt/amazon-ecs-agent/go/src/github.com/aws/amazon-ecs-agent/agent/engine/engine_integ_test.go:650
            	Error:      	Not equal: 
            	            	expected: 4
            	            	actual  : 6
            	Test:       	TestManifestPulledDoesNotDependOnContainerOrdering/0
```

The test runs a task with two containers and asserts that the first container is in the `RUNNING` state. Occasionally, the first container exits and enters the `STOPPED` state before the assertion is made, so the test fails.

https://github.com/aws/amazon-ecs-agent/blob/6e5e459d30acf34268350f4c66fa9c1baea77d4c/agent/engine/engine_integ_test.go#L622-L623
The container appears to run for 60 seconds, but it actually dies almost immediately after starting because it's using our [`netkitten`](https://github.com/aws/amazon-ecs-agent/tree/dev/misc/netkitten) image, which does not accept `sh -c "sleep 60"` as its command.

Reproducing this locally yields
```
> make netkitten
> docker run amazon/amazon-ecs-netkitten:make sh -c "sleep 60"
2024/08/20 00:40:42 Error connecting to target: dial tcp: address sh: missing port in address
```

### Implementation details
Change the container command to `-loop=true`, which will keep the container running indefinitely until it's told to stop.
https://github.com/aws/amazon-ecs-agent/blob/6e5e459d30acf34268350f4c66fa9c1baea77d4c/agent/engine/common_unix_integ_testutil.go#L35-L39

### Testing
Ran the flakey test 50 times and it completed successfully.
```
go test -tags integration ./agent/engine -count 50 -v -run TestManifestPulledDoesNotDependOnContainerOrdering
```

New tests cover the changes: no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
