### PR TITLE
Add read/write lock in the fault handler

### DIFF
--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -196,10 +196,7 @@ func registerFaultHandlers(
 	agentState *v4.TMDSAgentState,
 	metricsFactory metrics.EntryFactory,
 ) {
-	handler := fault.FaultHandler{
-		AgentState:     agentState,
-		MetricsFactory: metricsFactory,
-	}
+	handler := fault.New(agentState, metricsFactory)
 
 	if muxRouter == nil {
 		return

--- a/agent/handlers/v4/tmdsstate.go
+++ b/agent/handlers/v4/tmdsstate.go
@@ -161,7 +161,6 @@ func (s *TMDSAgentState) getTaskMetadata(v3EndpointID string, includeTags bool) 
 					Path: task.GetNetworkNamespace(),
 					NetworkInterfaces: []*tmdsv4.NetworkInterface{
 						{
-							ENIID:      "eni-fake-id",
 							DeviceName: "ethx",
 						},
 					},

--- a/agent/handlers/v4/tmdsstate.go
+++ b/agent/handlers/v4/tmdsstate.go
@@ -161,7 +161,8 @@ func (s *TMDSAgentState) getTaskMetadata(v3EndpointID string, includeTags bool) 
 					Path: task.GetNetworkNamespace(),
 					NetworkInterfaces: []*tmdsv4.NetworkInterface{
 						{
-							DeviceName: "",
+							ENIID:      "eni-fake-id",
+							DeviceName: "ethx",
 						},
 					},
 				},

--- a/agent/handlers/v4/tmdsstate.go
+++ b/agent/handlers/v4/tmdsstate.go
@@ -161,7 +161,12 @@ func (s *TMDSAgentState) getTaskMetadata(v3EndpointID string, includeTags bool) 
 					Path: task.GetNetworkNamespace(),
 					NetworkInterfaces: []*tmdsv4.NetworkInterface{
 						{
-							DeviceName: "ethx",
+							// TODO: fetch the correct device name.
+							// We are exposing this information via AgentState to facilitate the fault injection
+							// handler to start/stop/check network faults.
+							// Use 'eth0'(a fake value) for existing fault injection related unit tests for now and
+							// it will be updated in the future.
+							DeviceName: "eth0",
 						},
 					},
 				},

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -44,8 +44,7 @@ const (
 
 type FaultHandler struct {
 	// mutexMap is used to avoid multiple clients to manipulate same resource at same
-	// time. The 'key' is the ENI ID or the network namespace path and 'value' is the
-	// RWMutex.
+	// time. The 'key' is the the network namespace path and 'value' is the RWMutex.
 	// Using concurrent map here because the handler is shared by all requests.
 	mutexMap       sync.Map
 	AgentState     state.AgentState
@@ -96,8 +95,7 @@ func (h *FaultHandler) StartNetworkBlackholePort() func(http.ResponseWriter, *ht
 			return
 		}
 
-		// the network blackhole port fault would be injected to given task network
-		// namespace.
+		// To avoid multiple requests to manipulate same network resource
 		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
 		rwMu := h.loadLock(networkNSPath)
 		rwMu.Lock()
@@ -148,6 +146,7 @@ func (h *FaultHandler) StopNetworkBlackHolePort() func(http.ResponseWriter, *htt
 			return
 		}
 
+		// To avoid multiple requests to manipulate same network resource
 		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
 		rwMu := h.loadLock(networkNSPath)
 		rwMu.Lock()
@@ -198,6 +197,7 @@ func (h *FaultHandler) CheckNetworkBlackHolePort() func(http.ResponseWriter, *ht
 			return
 		}
 
+		// To avoid multiple requests to manipulate same network resource
 		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
 		rwMu := h.loadLock(networkNSPath)
 		rwMu.RLock()
@@ -243,13 +243,9 @@ func (h *FaultHandler) StartNetworkLatency() func(http.ResponseWriter, *http.Req
 			return
 		}
 
-		// the network latency fault would be injected to given elastic network
-		// interface/ENI.
-		eniID := taskMetadata.TaskNetworkConfig.
-			NetworkNamespaces[0].
-			NetworkInterfaces[0].
-			ENIID
-		rwMu := h.loadLock(eniID)
+		// To avoid multiple requests to manipulate same network resource
+		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
+		rwMu := h.loadLock(networkNSPath)
 		rwMu.Lock()
 		defer rwMu.Unlock()
 
@@ -294,11 +290,9 @@ func (h *FaultHandler) StopNetworkLatency() func(http.ResponseWriter, *http.Requ
 			return
 		}
 
-		eniID := taskMetadata.TaskNetworkConfig.
-			NetworkNamespaces[0].
-			NetworkInterfaces[0].
-			ENIID
-		rwMu := h.loadLock(eniID)
+		// To avoid multiple requests to manipulate same network resource
+		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
+		rwMu := h.loadLock(networkNSPath)
 		rwMu.Lock()
 		defer rwMu.Unlock()
 
@@ -343,11 +337,9 @@ func (h *FaultHandler) CheckNetworkLatency() func(http.ResponseWriter, *http.Req
 			return
 		}
 
-		eniID := taskMetadata.TaskNetworkConfig.
-			NetworkNamespaces[0].
-			NetworkInterfaces[0].
-			ENIID
-		rwMu := h.loadLock(eniID)
+		// To avoid multiple requests to manipulate same network resource
+		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
+		rwMu := h.loadLock(networkNSPath)
 		rwMu.RLock()
 		defer rwMu.RUnlock()
 
@@ -391,13 +383,9 @@ func (h *FaultHandler) StartNetworkPacketLoss() func(http.ResponseWriter, *http.
 			return
 		}
 
-		// the network packet loss fault would be injected to given elastic network
-		// interface/ENI.
-		eniID := taskMetadata.TaskNetworkConfig.
-			NetworkNamespaces[0].
-			NetworkInterfaces[0].
-			ENIID
-		rwMu := h.loadLock(eniID)
+		// To avoid multiple requests to manipulate same network resource
+		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
+		rwMu := h.loadLock(networkNSPath)
 		rwMu.Lock()
 		defer rwMu.Unlock()
 
@@ -442,11 +430,9 @@ func (h *FaultHandler) StopNetworkPacketLoss() func(http.ResponseWriter, *http.R
 			return
 		}
 
-		eniID := taskMetadata.TaskNetworkConfig.
-			NetworkNamespaces[0].
-			NetworkInterfaces[0].
-			ENIID
-		rwMu := h.loadLock(eniID)
+		// To avoid multiple requests to manipulate same network resource
+		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
+		rwMu := h.loadLock(networkNSPath)
 		rwMu.Lock()
 		defer rwMu.Unlock()
 
@@ -492,11 +478,9 @@ func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.
 			return
 		}
 
-		eniID := taskMetadata.TaskNetworkConfig.
-			NetworkNamespaces[0].
-			NetworkInterfaces[0].
-			ENIID
-		rwMu := h.loadLock(eniID)
+		// To avoid multiple requests to manipulate same network resource
+		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
+		rwMu := h.loadLock(networkNSPath)
 		rwMu.RLock()
 		defer rwMu.RUnlock()
 
@@ -704,11 +688,6 @@ func validateTaskNetworkConfig(taskNetworkConfig *state.TaskNetworkConfig) error
 	// Device name is required to inject network faults to given ENI in the task.
 	if taskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces[0].DeviceName == "" {
 		return errors.New("no ENI device name in the network namespace within task network config")
-	}
-
-	// ENIID is required to avoid race condition where multiple requests are manunipuating same ENI.
-	if taskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces[0].ENIID == "" {
-		return errors.New("no ENI ID in the network namespace within task network config")
 	}
 
 	return nil

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
@@ -56,8 +56,6 @@ type NetworkNamespace struct {
 type NetworkInterface struct {
 	// DeviceName is the device name on the host.
 	DeviceName string
-	// ENIID is the id of eni.
-	ENIID string
 }
 
 // Instance's clock drift status

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -44,8 +44,7 @@ const (
 
 type FaultHandler struct {
 	// mutexMap is used to avoid multiple clients to manipulate same resource at same
-	// time. The 'key' is the ENI ID or the network namespace path and 'value' is the
-	// RWMutex.
+	// time. The 'key' is the the network namespace path and 'value' is the RWMutex.
 	// Using concurrent map here because the handler is shared by all requests.
 	mutexMap       sync.Map
 	AgentState     state.AgentState
@@ -96,8 +95,7 @@ func (h *FaultHandler) StartNetworkBlackholePort() func(http.ResponseWriter, *ht
 			return
 		}
 
-		// the network blackhole port fault would be injected to given task network
-		// namespace.
+		// To avoid multiple requests to manipulate same network resource
 		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
 		rwMu := h.loadLock(networkNSPath)
 		rwMu.Lock()
@@ -148,6 +146,7 @@ func (h *FaultHandler) StopNetworkBlackHolePort() func(http.ResponseWriter, *htt
 			return
 		}
 
+		// To avoid multiple requests to manipulate same network resource
 		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
 		rwMu := h.loadLock(networkNSPath)
 		rwMu.Lock()
@@ -198,6 +197,7 @@ func (h *FaultHandler) CheckNetworkBlackHolePort() func(http.ResponseWriter, *ht
 			return
 		}
 
+		// To avoid multiple requests to manipulate same network resource
 		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
 		rwMu := h.loadLock(networkNSPath)
 		rwMu.RLock()
@@ -243,13 +243,9 @@ func (h *FaultHandler) StartNetworkLatency() func(http.ResponseWriter, *http.Req
 			return
 		}
 
-		// the network latency fault would be injected to given elastic network
-		// interface/ENI.
-		eniID := taskMetadata.TaskNetworkConfig.
-			NetworkNamespaces[0].
-			NetworkInterfaces[0].
-			ENIID
-		rwMu := h.loadLock(eniID)
+		// To avoid multiple requests to manipulate same network resource
+		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
+		rwMu := h.loadLock(networkNSPath)
 		rwMu.Lock()
 		defer rwMu.Unlock()
 
@@ -294,11 +290,9 @@ func (h *FaultHandler) StopNetworkLatency() func(http.ResponseWriter, *http.Requ
 			return
 		}
 
-		eniID := taskMetadata.TaskNetworkConfig.
-			NetworkNamespaces[0].
-			NetworkInterfaces[0].
-			ENIID
-		rwMu := h.loadLock(eniID)
+		// To avoid multiple requests to manipulate same network resource
+		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
+		rwMu := h.loadLock(networkNSPath)
 		rwMu.Lock()
 		defer rwMu.Unlock()
 
@@ -343,11 +337,9 @@ func (h *FaultHandler) CheckNetworkLatency() func(http.ResponseWriter, *http.Req
 			return
 		}
 
-		eniID := taskMetadata.TaskNetworkConfig.
-			NetworkNamespaces[0].
-			NetworkInterfaces[0].
-			ENIID
-		rwMu := h.loadLock(eniID)
+		// To avoid multiple requests to manipulate same network resource
+		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
+		rwMu := h.loadLock(networkNSPath)
 		rwMu.RLock()
 		defer rwMu.RUnlock()
 
@@ -391,13 +383,9 @@ func (h *FaultHandler) StartNetworkPacketLoss() func(http.ResponseWriter, *http.
 			return
 		}
 
-		// the network packet loss fault would be injected to given elastic network
-		// interface/ENI.
-		eniID := taskMetadata.TaskNetworkConfig.
-			NetworkNamespaces[0].
-			NetworkInterfaces[0].
-			ENIID
-		rwMu := h.loadLock(eniID)
+		// To avoid multiple requests to manipulate same network resource
+		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
+		rwMu := h.loadLock(networkNSPath)
 		rwMu.Lock()
 		defer rwMu.Unlock()
 
@@ -442,11 +430,9 @@ func (h *FaultHandler) StopNetworkPacketLoss() func(http.ResponseWriter, *http.R
 			return
 		}
 
-		eniID := taskMetadata.TaskNetworkConfig.
-			NetworkNamespaces[0].
-			NetworkInterfaces[0].
-			ENIID
-		rwMu := h.loadLock(eniID)
+		// To avoid multiple requests to manipulate same network resource
+		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
+		rwMu := h.loadLock(networkNSPath)
 		rwMu.Lock()
 		defer rwMu.Unlock()
 
@@ -492,11 +478,9 @@ func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.
 			return
 		}
 
-		eniID := taskMetadata.TaskNetworkConfig.
-			NetworkNamespaces[0].
-			NetworkInterfaces[0].
-			ENIID
-		rwMu := h.loadLock(eniID)
+		// To avoid multiple requests to manipulate same network resource
+		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
+		rwMu := h.loadLock(networkNSPath)
 		rwMu.RLock()
 		defer rwMu.RUnlock()
 
@@ -704,11 +688,6 @@ func validateTaskNetworkConfig(taskNetworkConfig *state.TaskNetworkConfig) error
 	// Device name is required to inject network faults to given ENI in the task.
 	if taskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces[0].DeviceName == "" {
 		return errors.New("no ENI device name in the network namespace within task network config")
-	}
-
-	// ENIID is required to avoid race condition where multiple requests are manunipuating same ENI.
-	if taskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces[0].ENIID == "" {
-		return errors.New("no ENI ID in the network namespace within task network config")
 	}
 
 	return nil

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
@@ -50,18 +50,41 @@ const (
 	awsvpcNetworkMode  = "awsvpc"
 	deviceName         = "eth0"
 	invalidNetworkMode = "invalid"
+	eniID              = "eni-123"
 )
 
 var (
+	noDeviceNameInNetworkInterfaces = []*state.NetworkInterface{
+		{
+			DeviceName: "",
+			ENIID:      eniID,
+		},
+	}
+
+	noENIIDInNetworkInterfaces = []*state.NetworkInterface{
+		{
+			DeviceName: deviceName,
+			ENIID:      "",
+		},
+	}
+
 	happyNetworkInterfaces = []*state.NetworkInterface{
 		{
 			DeviceName: deviceName,
+			ENIID:      eniID,
 		},
 	}
 
 	happyNetworkNamespaces = []*state.NetworkNamespace{
 		{
 			Path:              "/some/path",
+			NetworkInterfaces: happyNetworkInterfaces,
+		},
+	}
+
+	noPathInNetworkNamespaces = []*state.NetworkNamespace{
+		{
+			Path:              "",
 			NetworkInterfaces: happyNetworkInterfaces,
 		},
 	}
@@ -114,7 +137,9 @@ func generateNetworkBlackHolePortTestCases(name string, expectedHappyResponseBod
 			requestBody:          happyBlackHolePortReqBody,
 			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse(expectedHappyResponseBody),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(happyTaskResponse, nil)
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(happyTaskResponse, nil).
+					Times(1)
 			},
 		},
 		{
@@ -128,7 +153,9 @@ func generateNetworkBlackHolePortTestCases(name string, expectedHappyResponseBod
 			},
 			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse(expectedHappyResponseBody),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(happyTaskResponse, nil)
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(happyTaskResponse, nil).
+					Times(1)
 			},
 		},
 		{
@@ -201,7 +228,9 @@ func generateNetworkBlackHolePortTestCases(name string, expectedHappyResponseBod
 			requestBody:          happyBlackHolePortReqBody,
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("unable to lookup container: %s", endpointId)),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, state.NewErrorLookupFailure("task lookup failed"))
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(state.TaskResponse{}, state.NewErrorLookupFailure("task lookup failed")).
+					Times(1)
 			},
 		},
 		{
@@ -211,7 +240,8 @@ func generateNetworkBlackHolePortTestCases(name string, expectedHappyResponseBod
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("unable to obtain container metadata for container: %s", endpointId)),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
 				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, state.NewErrorMetadataFetchFailure(
-					"Unable to generate metadata for task"))
+					"Unable to generate metadata for task")).
+					Times(1)
 			},
 		},
 		{
@@ -220,7 +250,9 @@ func generateNetworkBlackHolePortTestCases(name string, expectedHappyResponseBod
 			requestBody:          happyBlackHolePortReqBody,
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("failed to get task metadata due to internal server error for container: %s", endpointId)),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, errors.New("unknown error"))
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(state.TaskResponse{}, errors.New("unknown error")).
+					Times(1)
 			},
 		},
 		{
@@ -252,15 +284,94 @@ func generateNetworkBlackHolePortTestCases(name string, expectedHappyResponseBod
 			},
 		},
 		{
-			name:                 fmt.Sprintf("%s empty task network config", name),
-			expectedStatusCode:   500,
-			requestBody:          happyBlackHolePortReqBody,
-			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("failed to get task metadata due to internal server error for container: %s", endpointId)),
+			name:               fmt.Sprintf("%s empty task network config", name),
+			expectedStatusCode: 500,
+			requestBody:        happyBlackHolePortReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(
+				fmt.Sprintf("failed to get task metadata due to internal server error for container: %s", endpointId)),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
 				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{
 					TaskResponse:          &v2.TaskResponse{TaskARN: taskARN},
 					FaultInjectionEnabled: true,
 					TaskNetworkConfig:     nil,
+				}, nil)
+			},
+		},
+		{
+			name:               fmt.Sprintf("%s no task network namespace", name),
+			expectedStatusCode: 500,
+			requestBody:        happyBlackHolePortReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(
+				fmt.Sprintf("failed to get task metadata due to internal server error for container: %s", endpointId)),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{
+					TaskResponse:          &v2.TaskResponse{TaskARN: taskARN},
+					FaultInjectionEnabled: true,
+					TaskNetworkConfig: &state.TaskNetworkConfig{
+						NetworkMode:       awsvpcNetworkMode,
+						NetworkNamespaces: nil,
+					},
+				}, nil)
+			},
+		},
+		{
+			name:               fmt.Sprintf("%s no path in task network config", name),
+			expectedStatusCode: 500,
+			requestBody:        happyBlackHolePortReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(
+				fmt.Sprintf("failed to get task metadata due to internal server error for container: %s", endpointId)),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{
+					TaskResponse:          &v2.TaskResponse{TaskARN: taskARN},
+					FaultInjectionEnabled: true,
+					TaskNetworkConfig: &state.TaskNetworkConfig{
+						NetworkMode:       awsvpcNetworkMode,
+						NetworkNamespaces: noPathInNetworkNamespaces,
+					},
+				}, nil)
+			},
+		},
+		{
+			name:               fmt.Sprintf("%s no device name in task network config", name),
+			expectedStatusCode: 500,
+			requestBody:        happyBlackHolePortReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(
+				fmt.Sprintf("failed to get task metadata due to internal server error for container: %s", endpointId)),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{
+					TaskResponse:          &v2.TaskResponse{TaskARN: taskARN},
+					FaultInjectionEnabled: true,
+					TaskNetworkConfig: &state.TaskNetworkConfig{
+						NetworkMode: awsvpcNetworkMode,
+						NetworkNamespaces: []*state.NetworkNamespace{
+							&state.NetworkNamespace{
+								Path:              "/path",
+								NetworkInterfaces: noDeviceNameInNetworkInterfaces,
+							},
+						},
+					},
+				}, nil)
+			},
+		},
+		{
+			name:               fmt.Sprintf("%s no ENI ID in task network config", name),
+			expectedStatusCode: 500,
+			requestBody:        happyBlackHolePortReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(
+				fmt.Sprintf("failed to get task metadata due to internal server error for container: %s", endpointId)),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{
+					TaskResponse:          &v2.TaskResponse{TaskARN: taskARN},
+					FaultInjectionEnabled: true,
+					TaskNetworkConfig: &state.TaskNetworkConfig{
+						NetworkMode: awsvpcNetworkMode,
+						NetworkNamespaces: []*state.NetworkNamespace{
+							&state.NetworkNamespace{
+								Path:              "/path",
+								NetworkInterfaces: noENIIDInNetworkInterfaces,
+							},
+						},
+					},
 				}, nil)
 			},
 		},
@@ -285,12 +396,7 @@ func TestStartNetworkBlackHolePort(t *testing.T) {
 			}
 
 			router := mux.NewRouter()
-
-			handler := FaultHandler{
-				AgentState:     agentState,
-				MetricsFactory: metricsFactory,
-			}
-
+			handler := New(agentState, metricsFactory)
 			router.HandleFunc(
 				NetworkFaultPath(types.BlackHolePortFaultType),
 				handler.StartNetworkBlackholePort(),
@@ -338,12 +444,7 @@ func TestStopNetworkBlackHolePort(t *testing.T) {
 			}
 
 			router := mux.NewRouter()
-
-			handler := FaultHandler{
-				AgentState:     agentState,
-				MetricsFactory: metricsFactory,
-			}
-
+			handler := New(agentState, metricsFactory)
 			router.HandleFunc(
 				NetworkFaultPath(types.BlackHolePortFaultType),
 				handler.StopNetworkBlackHolePort(),
@@ -388,11 +489,7 @@ func TestCheckNetworkBlackHolePort(t *testing.T) {
 			metricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
 
 			router := mux.NewRouter()
-
-			handler := FaultHandler{
-				AgentState:     agentState,
-				MetricsFactory: metricsFactory,
-			}
+			handler := New(agentState, metricsFactory)
 
 			if tc.setAgentStateExpectations != nil {
 				tc.setAgentStateExpectations(agentState)
@@ -442,7 +539,9 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 			requestBody:          happyNetworkLatencyReqBody,
 			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse(expectedHappyResponseBody),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(happyTaskResponse, nil)
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(happyTaskResponse, nil).
+					Times(1)
 			},
 		},
 		{
@@ -456,7 +555,9 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 			},
 			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse(expectedHappyResponseBody),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(happyTaskResponse, nil)
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(happyTaskResponse, nil).
+					Times(1)
 			},
 		},
 		{
@@ -469,7 +570,9 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 			},
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("json: cannot unmarshal string into Go struct field NetworkLatencyRequest.DelayMilliseconds of type uint64"),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(state.TaskResponse{}, nil).
+					Times(0)
 			},
 		},
 		{
@@ -482,7 +585,9 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 			},
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("json: cannot unmarshal string into Go struct field NetworkLatencyRequest.JitterMilliseconds of type uint64"),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(state.TaskResponse{}, nil).
+					Times(0)
 			},
 		},
 		{
@@ -495,7 +600,9 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 			},
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("json: cannot unmarshal string into Go struct field NetworkLatencyRequest.Sources of type []*string"),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(state.TaskResponse{}, nil).
+					Times(0)
 			},
 		},
 		{
@@ -508,7 +615,9 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 			},
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("required parameter Sources is missing"),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(state.TaskResponse{}, nil).
+					Times(0)
 			},
 		},
 		{
@@ -520,7 +629,9 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 			},
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("required parameter Sources is missing"),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(state.TaskResponse{}, nil).
+					Times(0)
 			},
 		},
 		{
@@ -532,7 +643,9 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 			},
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("required parameter JitterMilliseconds is missing"),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(state.TaskResponse{}, nil).
+					Times(0)
 			},
 		},
 		{
@@ -544,7 +657,9 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 			},
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("required parameter DelayMilliseconds is missing"),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(state.TaskResponse{}, nil).
+					Times(0)
 			},
 		},
 		{
@@ -557,7 +672,9 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 			},
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("invalid value 10.1.2.3.4 for parameter Sources"),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(state.TaskResponse{}, nil).
+					Times(0)
 			},
 		},
 		{
@@ -570,7 +687,9 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 			},
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("invalid value 52.95.154.0/33 for parameter Sources"),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(state.TaskResponse{}, nil).
+					Times(0)
 			},
 		},
 		{
@@ -579,7 +698,9 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 			requestBody:          happyNetworkLatencyReqBody,
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("unable to lookup container: %s", endpointId)),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, state.NewErrorLookupFailure("task lookup failed"))
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(state.TaskResponse{}, state.NewErrorLookupFailure("task lookup failed")).
+					Times(1)
 			},
 		},
 		{
@@ -588,8 +709,10 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 			requestBody:          happyNetworkLatencyReqBody,
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("unable to obtain container metadata for container: %s", endpointId)),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, state.NewErrorMetadataFetchFailure(
-					"Unable to generate metadata for task"))
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(state.TaskResponse{}, state.NewErrorMetadataFetchFailure(
+						"Unable to generate metadata for task")).
+					Times(1)
 			},
 		},
 		{
@@ -598,7 +721,9 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 			requestBody:          happyNetworkLatencyReqBody,
 			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("failed to get task metadata due to internal server error for container: %s", endpointId)),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, errors.New("unknown error"))
+				agentState.EXPECT().GetTaskMetadata(endpointId).
+					Return(state.TaskResponse{}, errors.New("unknown error")).
+					Times(1)
 			},
 		},
 		{
@@ -663,12 +788,7 @@ func TestStartNetworkLatency(t *testing.T) {
 			}
 
 			router := mux.NewRouter()
-
-			handler := FaultHandler{
-				AgentState:     agentState,
-				MetricsFactory: metricsFactory,
-			}
-
+			handler := New(agentState, metricsFactory)
 			router.HandleFunc(
 				NetworkFaultPath(types.LatencyFaultType),
 				handler.StartNetworkLatency(),
@@ -716,12 +836,7 @@ func TestStopNetworkLatency(t *testing.T) {
 			}
 
 			router := mux.NewRouter()
-
-			handler := FaultHandler{
-				AgentState:     agentState,
-				MetricsFactory: metricsFactory,
-			}
-
+			handler := New(agentState, metricsFactory)
 			router.HandleFunc(
 				NetworkFaultPath(types.LatencyFaultType),
 				handler.StopNetworkLatency(),
@@ -766,12 +881,7 @@ func TestCheckNetworkLatency(t *testing.T) {
 			metricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
 
 			router := mux.NewRouter()
-
-			handler := FaultHandler{
-				AgentState:     agentState,
-				MetricsFactory: metricsFactory,
-			}
-
+			handler := New(agentState, metricsFactory)
 			if tc.setAgentStateExpectations != nil {
 				tc.setAgentStateExpectations(agentState)
 			}
@@ -1043,12 +1153,7 @@ func TestStartNetworkPacketLoss(t *testing.T) {
 			}
 
 			router := mux.NewRouter()
-
-			handler := FaultHandler{
-				AgentState:     agentState,
-				MetricsFactory: metricsFactory,
-			}
-
+			handler := New(agentState, metricsFactory)
 			router.HandleFunc(
 				NetworkFaultPath(types.PacketLossFaultType),
 				handler.StartNetworkPacketLoss(),
@@ -1096,12 +1201,7 @@ func TestStopNetworkPacketLoss(t *testing.T) {
 			}
 
 			router := mux.NewRouter()
-
-			handler := FaultHandler{
-				AgentState:     agentState,
-				MetricsFactory: metricsFactory,
-			}
-
+			handler := New(agentState, metricsFactory)
 			router.HandleFunc(
 				NetworkFaultPath(types.PacketLossFaultType),
 				handler.StopNetworkPacketLoss(),
@@ -1146,12 +1246,7 @@ func TestCheckNetworkPacketLoss(t *testing.T) {
 			metricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
 
 			router := mux.NewRouter()
-
-			handler := FaultHandler{
-				AgentState:     agentState,
-				MetricsFactory: metricsFactory,
-			}
-
+			handler := New(agentState, metricsFactory)
 			if tc.setAgentStateExpectations != nil {
 				tc.setAgentStateExpectations(agentState)
 			}

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
@@ -50,28 +50,18 @@ const (
 	awsvpcNetworkMode  = "awsvpc"
 	deviceName         = "eth0"
 	invalidNetworkMode = "invalid"
-	eniID              = "eni-123"
 )
 
 var (
 	noDeviceNameInNetworkInterfaces = []*state.NetworkInterface{
 		{
 			DeviceName: "",
-			ENIID:      eniID,
-		},
-	}
-
-	noENIIDInNetworkInterfaces = []*state.NetworkInterface{
-		{
-			DeviceName: deviceName,
-			ENIID:      "",
 		},
 	}
 
 	happyNetworkInterfaces = []*state.NetworkInterface{
 		{
 			DeviceName: deviceName,
-			ENIID:      eniID,
 		},
 	}
 
@@ -264,7 +254,7 @@ func generateNetworkBlackHolePortTestCases(name string, expectedHappyResponseBod
 				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{
 					TaskResponse:          &v2.TaskResponse{TaskARN: taskARN},
 					FaultInjectionEnabled: false,
-				}, nil)
+				}, nil).Times(1)
 			},
 		},
 		{
@@ -280,7 +270,7 @@ func generateNetworkBlackHolePortTestCases(name string, expectedHappyResponseBod
 						NetworkMode:       invalidNetworkMode,
 						NetworkNamespaces: happyNetworkNamespaces,
 					},
-				}, nil)
+				}, nil).Times(1)
 			},
 		},
 		{
@@ -294,7 +284,7 @@ func generateNetworkBlackHolePortTestCases(name string, expectedHappyResponseBod
 					TaskResponse:          &v2.TaskResponse{TaskARN: taskARN},
 					FaultInjectionEnabled: true,
 					TaskNetworkConfig:     nil,
-				}, nil)
+				}, nil).Times(1)
 			},
 		},
 		{
@@ -311,7 +301,7 @@ func generateNetworkBlackHolePortTestCases(name string, expectedHappyResponseBod
 						NetworkMode:       awsvpcNetworkMode,
 						NetworkNamespaces: nil,
 					},
-				}, nil)
+				}, nil).Times(1)
 			},
 		},
 		{
@@ -328,7 +318,7 @@ func generateNetworkBlackHolePortTestCases(name string, expectedHappyResponseBod
 						NetworkMode:       awsvpcNetworkMode,
 						NetworkNamespaces: noPathInNetworkNamespaces,
 					},
-				}, nil)
+				}, nil).Times(1)
 			},
 		},
 		{
@@ -350,29 +340,7 @@ func generateNetworkBlackHolePortTestCases(name string, expectedHappyResponseBod
 							},
 						},
 					},
-				}, nil)
-			},
-		},
-		{
-			name:               fmt.Sprintf("%s no ENI ID in task network config", name),
-			expectedStatusCode: 500,
-			requestBody:        happyBlackHolePortReqBody,
-			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(
-				fmt.Sprintf("failed to get task metadata due to internal server error for container: %s", endpointId)),
-			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
-				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{
-					TaskResponse:          &v2.TaskResponse{TaskARN: taskARN},
-					FaultInjectionEnabled: true,
-					TaskNetworkConfig: &state.TaskNetworkConfig{
-						NetworkMode: awsvpcNetworkMode,
-						NetworkNamespaces: []*state.NetworkNamespace{
-							&state.NetworkNamespace{
-								Path:              "/path",
-								NetworkInterfaces: noENIIDInNetworkInterfaces,
-							},
-						},
-					},
-				}, nil)
+				}, nil).Times(1)
 			},
 		},
 	}

--- a/ecs-agent/tmds/handlers/v4/handlers_test.go
+++ b/ecs-agent/tmds/handlers/v4/handlers_test.go
@@ -167,7 +167,6 @@ func taskResponse() *state.TaskResponse {
 					NetworkInterfaces: []*state.NetworkInterface{
 						&state.NetworkInterface{
 							DeviceName: "eth1",
-							ENIID:      "eni-013ff4ad5747a0f6a",
 						},
 					},
 				},

--- a/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/ecs-agent/tmds/handlers/v4/state/response.go
@@ -56,8 +56,6 @@ type NetworkNamespace struct {
 type NetworkInterface struct {
 	// DeviceName is the device name on the host.
 	DeviceName string
-	// ENIID is the id of eni.
-	ENIID string
 }
 
 // Instance's clock drift status


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR is to add a field / RWMutex in the fault handler which can help to avoid race condition where multiple clients would manipulate the same network resource at the same time.

### Implementation details
<!-- How are the changes implemented? -->
- Add the read/write lock in the [FaultHandler](https://github.com/aws/amazon-ecs-agent/blob/dev/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go#L41C6-L41C18)
- Add a new method to create the [handler](https://github.com/aws/amazon-ecs-agent/blob/dev/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go#L41C6-L41C18) for faults
- Add more validations in [validateTaskNetworkConfig](https://github.com/aws/amazon-ecs-agent/blob/5589a96639d216db755ddde6fb45764376889a84/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go#L704-L712) to make sure the required field has non-empty value.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
No. Existing unit test will cover this.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Feature: Add RWMutex in the fault handler.



### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
