### PR TITLE
Update agentstate to include task network namespace and default interface name to populate task network config

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -297,11 +297,17 @@ type Task struct {
 
 	IsInternal bool `json:"IsInternal,omitempty"`
 
-	// TODO: Will need to initialize/set the value in a follow PR
 	NetworkNamespace string `json:"NetworkNamespace,omitempty"`
 
 	// TODO: Will need to initialize/set the value in a follow PR
 	FaultInjectionEnabled bool `json:"FaultInjectionEnabled,omitempty"`
+
+	// DefaultIfname is used to reference the default network interface name on the task network namespace
+	// For AWSVPC mode, it can be eth0 which corresponds to the interface name on the task ENI
+	// For Host mode, it can vary based on the hardware/network config on the host instance (e.g. eth0, ens5, etc.) and will need to be obtained on the host.
+	// For all other network modes (i.e. bridge, none, etc.), DefaultIfname is currently not being initialized/set. In order to use this task field for these
+	// network modes, changes will need to be made in the corresponding task provisioning workflows.
+	DefaultIfname string `json:"DefaultIfname,omitempty"`
 }
 
 // TaskFromACS translates ecsacs.Task to apitask.Task by first marshaling the received
@@ -3772,4 +3778,25 @@ func (task *Task) GetNetworkNamespace() string {
 	defer task.lock.RUnlock()
 
 	return task.NetworkNamespace
+}
+
+func (task *Task) SetNetworkNamespace(netNs string) {
+	task.lock.Lock()
+	defer task.lock.Unlock()
+
+	task.NetworkNamespace = netNs
+}
+
+func (task *Task) GetDefaultIfname() string {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	return task.DefaultIfname
+}
+
+func (task *Task) SetDefaultIfname(ifname string) {
+	task.lock.Lock()
+	defer task.lock.Unlock()
+
+	task.DefaultIfname = ifname
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -2358,6 +2358,12 @@ func (engine *DockerTaskEngine) provisionContainerResourcesAwsvpc(task *apitask.
 		field.TaskID: task.GetID(),
 		"ip":         taskIP,
 	})
+	task.SetNetworkNamespace(cniConfig.ContainerNetNS)
+	// Note: By default, the interface name is set to eth0 within the CNI configs. We can also always assume that the first entry of the CNI network config to be
+	// the task ENI. Otherwise this means that there weren't any task ENIs passed down to agent from the task payload.
+	if len(cniConfig.NetworkConfigs) > 0 {
+		task.SetDefaultIfname(cniConfig.NetworkConfigs[0].IfName)
+	}
 	engine.state.AddTaskIPAddress(taskIP, task.Arn)
 	task.SetLocalIPAddress(taskIP)
 	engine.saveTaskData(task)

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -73,10 +73,11 @@ import (
 )
 
 const (
-	cgroupMountPath    = "/sys/fs/cgroup"
-	testTaskDefFamily  = "testFamily"
-	testTaskDefVersion = "1"
-	containerNetNS     = "none"
+	cgroupMountPath          = "/sys/fs/cgroup"
+	testTaskDefFamily        = "testFamily"
+	testTaskDefVersion       = "1"
+	containerNetNS           = "none"
+	ExpectedNetworkNamespace = "/host/proc/123/ns/net"
 )
 
 func init() {

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -114,6 +114,7 @@ const (
 	containerNetworkMode        = "none"
 	serviceConnectContainerName = "service-connect"
 	mediaTypeManifestV2         = "application/vnd.docker.distribution.manifest.v2+json"
+	defaultIfname               = "eth0"
 )
 
 var (
@@ -1098,6 +1099,8 @@ func TestProvisionContainerResourcesAwsvpcSetPausePIDInVolumeResources(t *testin
 	require.Nil(t, taskEngine.(*DockerTaskEngine).provisionContainerResources(testTask, pauseContainer).Error)
 	assert.Equal(t, strconv.Itoa(containerPid), volRes.GetPauseContainerPID())
 	assert.Equal(t, taskIP, testTask.GetLocalIPAddress())
+	assert.Equal(t, defaultIfname, testTask.GetDefaultIfname())
+	assert.Equal(t, ExpectedNetworkNamespace, testTask.GetNetworkNamespace())
 	savedTasks, err := dataClient.GetTasks()
 	require.NoError(t, err)
 	assert.Len(t, savedTasks, 1)

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -53,7 +53,8 @@ import (
 )
 
 const (
-	containerNetNS = "container:abcd"
+	containerNetNS           = "container:abcd"
+	ExpectedNetworkNamespace = "none"
 )
 
 func TestDeleteTask(t *testing.T) {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
@@ -47,6 +47,22 @@ type TaskNetworkConfig struct {
 	NetworkNamespaces []*NetworkNamespace
 }
 
+func NewTaskNetworkConfig(networkMode, path, deviceName string) *TaskNetworkConfig {
+	return &TaskNetworkConfig{
+		NetworkMode: networkMode,
+		NetworkNamespaces: []*NetworkNamespace{
+			{
+				Path: path,
+				NetworkInterfaces: []*NetworkInterface{
+					{
+						DeviceName: deviceName,
+					},
+				},
+			},
+		},
+	}
+}
+
 type NetworkNamespace struct {
 	Path              string
 	NetworkInterfaces []*NetworkInterface

--- a/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/ecs-agent/tmds/handlers/v4/state/response.go
@@ -47,6 +47,22 @@ type TaskNetworkConfig struct {
 	NetworkNamespaces []*NetworkNamespace
 }
 
+func NewTaskNetworkConfig(networkMode, path, deviceName string) *TaskNetworkConfig {
+	return &TaskNetworkConfig{
+		NetworkMode: networkMode,
+		NetworkNamespaces: []*NetworkNamespace{
+			{
+				Path: path,
+				NetworkInterfaces: []*NetworkInterface{
+					{
+						DeviceName: deviceName,
+					},
+				},
+			},
+		},
+	}
+}
+
 type NetworkNamespace struct {
 	Path              string
 	NetworkInterfaces []*NetworkInterface


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will update the agent state so that it keeps track of the task network namespace path and default interface name of the corresponding task namespace. This is a follow up to the following PRs:
* https://github.com/aws/amazon-ecs-agent/pull/4285
* https://github.com/aws/amazon-ecs-agent/pull/4273

where we will be populating the new `TaskNetworkConfig` struct and its fields for the `TaskResponse` .

Note: There will be a follow up PR to actually obtain and populate the `DefaultIfname` on host mode.

### Implementation details
* `agent/api/task/task.go`
  * Added new `DefaultIfname` field to the `Task` struct to keep track of the default interface name of the task
  * Added new Getters and Setters for `NetworkNamespace` and `DefaultIfname` 
* `agent/engine/docker_task_engine.go`
  * Obtaining the task network namespace from the CNI config that we get from `buildCNIConfigFromTaskContainerAwsvpc` and then setting it as the value for the task `NetworkNamespace`
  * Obtaining the default interface name from the `NetworkConfigs` of the CNI config that we get from `buildCNIConfigFromTaskContainerAwsvpc`. By default on linux, the interface name is `eth0` and the first entry within the `NetworkConfigs` list should correspond to the task ENI that was passed in from the task payload. Otherwise, this would mean we're trying to start a task in AWSVPC without a corresponding task ENI
* `agent/handlers/v4/tmdsstate.go`
 * Now setting the values of `FaultInjectionEnabled` and `TaskNetworkConfig` for the `TaskResponse` based on the agent state (before, it was empty)
 * No longer restricting these values based on whether the task is `FaultInjectionEnabled` or not for future proofing
 * If the task is running on host mode, we will always set the task network namespace path to be `host` so that it can be used in the concurrent map introduced in https://github.com/aws/amazon-ecs-agent/pull/4309 for the fault handlers It won't be used in the actual fault injection implementation
* `ecs-agent/tmds/handlers/v4/state/response.go`
  * New function to create a new `NewTaskNetworkConfig` pointer object based on the passed in `networkMode`, `networkNamespacePath`, and `interfaceName`. This is called in `agent/handlers/v4/tmdsstate.go`

### Testing
* Added new tests `TestV4GetTaskMetadataWithTaskNetworkConfig` in `agent/handlers/task_server_setup_test.go` to test whether or not we can create/populate the `TaskNetworkConfig` of the `TaskResponse` based on the corresponding task
* Modified `TestProvisionContainerResourcesAwsvpcSetPausePIDInVolumeResources` in  `agent/engine/docker_task_engine_test.go` so that it can also check that the `DefaultIfname` and `NetworkNamespace` of the task is being set properly

Manual Testing
Tested whether or not the `DefaultIfname` and `NetworkNamespace` can be loaded back after an agent restart by first launching a task in AWSVPC mode that will call the TMDS endpoint to get the task metadata. 

Note: Additional logging statements were added but not pushed as part of the changes in order to better see the expected behavior/results.

Results:

Task start up
```
vel=debug time=2024-09-05T19:13:00Z msg="Handling http request" method="GET" from="169.254.172.2:42614"
level=info time=2024-09-05T19:13:00Z msg="Writing response for v4 task metadata" tmdsEndpointContainerID="d1105a10-be0b-4f8a-82c7-56a19a9ee517" taskARN="arn:aws:ecs:us-west-2:113424923516:task/default/35467b7441554e759180b43f13b6e3eb"
level=info time=2024-09-05T19:13:00Z msg="[DEBUG] Task Network config from task metadata request" networkMode="awsvpc" networkNamespace="/host/proc/12141/ns/net" defaultInterfaceName="eth0"
level=debug time=2024-09-05T19:13:00Z msg="Received non-transition events" task="35467b7441554e759180b43f13b6e3eb"
level=debug time=2024-09-05T19:13:00Z msg="Updating task's known status" task="35467b7441554e759180b43f13b6e3eb"
level=debug time=2024-09-05T19:13:00Z msg="Found container with earliest known status" container="test" knownStatus=RUNNING desiredStatus=RUNNING task="35467b7441554e759180b43f13b6e3eb"
level=debug time=2024-09-05T19:13:00Z msg="Updating task's desired status" taskKnownStatus="RUNNING" taskDesiredStatus="RUNNING" nContainers=2 nENIs=1 taskFamily="tmds-test" taskVersion="4" taskArn="arn:aws:ecs:us-west-2:113424923516:task/default/35467b7441554e759180b43f13b6e3eb"
```

After restart agent
```
level=info time=2024-09-05T19:15:08Z msg="Event stream ContainerChange start listening..." module=eventstream.go
level=info time=2024-09-05T19:15:08Z msg="[DEBUG] Loaded task from local state. Task default interface name: eth0, Task default network namespace: /host/proc/12141/ns/net, Task network mode: awsvpc" module=data.go
level=debug time=2024-09-05T19:15:08Z msg="Setting cluster to default; none configured" module=agent.go
level=info time=2024-09-05T19:15:08Z msg="Cluster was successfully restored" cluster="default"
level=debug time=2024-09-05T19:15:08Z msg="Loading pause container tarball:" image="/images/amazon-ecs-pause.tar"
level=debug time=2024-09-05T19:15:08Z msg="Inspecting container image: " image="amazon/amazon-ecs-pause:0.1.0"
level=debug time=2024-09-05T19:15:08Z msg="Setting up ENI Watcher" module=agent_unix.go
level=info time=2024-09-05T19:15:08Z msg="eni watcher has been initialized" module=watcher_linux.go
level=debug time=2024-09-05T19:15:15Z msg="Handling http request" method="GET" from="169.254.172.2:57386"
level=info time=2024-09-05T19:15:15Z msg="Writing response for v4 task metadata" tmdsEndpointContainerID="d1105a10-be0b-4f8a-82c7-56a19a9ee517" taskARN="arn:aws:ecs:us-west-2:113424923516:task/default/35467b7441554e759180b43f13b6e3eb"
level=info time=2024-09-05T19:15:15Z msg="[DEBUG] Task Network config from task metadata request" networkNamespace="/host/proc/12141/ns/net" defaultInterfaceName="eth0" networkMode="awsvpc"
```

Host Mode
```
level=debug time=2024-09-05T19:18:09Z msg="Handling http request" method="GET" from="172.31.47.213:40596"
level=info time=2024-09-05T19:18:09Z msg="Writing response for v4 task metadata" tmdsEndpointContainerID="d70285f4-d6a1-4538-81b4-c91f92cb9174" taskARN="arn:aws:ecs:us-west-2:113424923516:task/default/1c4a5f45c75c4638a7da1b5133a840b0"
level=info time=2024-09-05T19:18:09Z msg="[DEBUG] Task Network config from task metadata request" networkMode="host" networkNamespace="host" defaultInterfaceName=""
```

After restart
```
level=info time=2024-09-05T19:19:03Z msg="[DEBUG] Loaded task from local state. Task default interface name: , Task default network namespace: , Task network mode: host" module=data.go
level=debug time=2024-09-05T19:19:03Z msg="Setting cluster to default; none configured" module=agent.go
level=info time=2024-09-05T19:19:03Z msg="Cluster was successfully restored" cluster="default"
level=debug time=2024-09-05T19:19:03Z msg="Loading pause container tarball:" image="/images/amazon-ecs-pause.tar"
level=debug time=2024-09-05T19:19:09Z msg="Handling http request" method="GET" from="172.31.47.213:57346"
level=info time=2024-09-05T19:19:09Z msg="Writing response for v4 task metadata" tmdsEndpointContainerID="d70285f4-d6a1-4538-81b4-c91f92cb9174" taskARN="arn:aws:ecs:us-west-2:113424923516:task/default/1c4a5f45c75c4638a7da1b5133a840b0"
level=info time=2024-09-05T19:19:09Z msg="[DEBUG] Task Network config from task metadata request" networkMode="host" networkNamespace="host" defaultInterfaceName=""
```

New tests cover the changes: Yes

### Description for the changelog
Feature: Update agent state to initialize and populate task default interface name and network namespace

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
