### PR TITLE
Add check network packet loss implementation

### DIFF
--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -74,6 +74,7 @@ github.com/aws/amazon-ecs-agent/ecs-agent/tmds/utils/mux
 github.com/aws/amazon-ecs-agent/ecs-agent/utils
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/arn
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/cipher
+github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/httpproxy
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry/mock

--- a/ecs-agent/utils/execwrapper/exec.go
+++ b/ecs-agent/utils/execwrapper/exec.go
@@ -51,6 +51,8 @@ type Cmd interface {
 	AppendExtraFiles(...*os.File)
 	Args() []string
 	SetIOStreams(io.Reader, io.Writer, io.Writer)
+	Output() ([]byte, error)
+	CombinedOutput() ([]byte, error)
 }
 
 type cmdWrapper struct {
@@ -101,4 +103,12 @@ func (c *cmdWrapper) SetIOStreams(stdin io.Reader, stdout io.Writer, stderr io.W
 	if stderr != nil {
 		c.Stderr = stderr
 	}
+}
+
+func (c *cmdWrapper) Output() ([]byte, error) {
+	return c.Cmd.Output()
+}
+
+func (c *cmdWrapper) CombinedOutput() ([]byte, error) {
+	return c.Cmd.CombinedOutput()
 }

--- a/ecs-agent/utils/execwrapper/mocks/execwrapper_mocks.go
+++ b/ecs-agent/utils/execwrapper/mocks/execwrapper_mocks.go
@@ -81,6 +81,21 @@ func (mr *MockCmdMockRecorder) Args() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Args", reflect.TypeOf((*MockCmd)(nil).Args))
 }
 
+// CombinedOutput mocks base method.
+func (m *MockCmd) CombinedOutput() ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CombinedOutput")
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CombinedOutput indicates an expected call of CombinedOutput.
+func (mr *MockCmdMockRecorder) CombinedOutput() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CombinedOutput", reflect.TypeOf((*MockCmd)(nil).CombinedOutput))
+}
+
 // KillProcess mocks base method.
 func (m *MockCmd) KillProcess() error {
 	m.ctrl.T.Helper()
@@ -93,6 +108,21 @@ func (m *MockCmd) KillProcess() error {
 func (mr *MockCmdMockRecorder) KillProcess() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KillProcess", reflect.TypeOf((*MockCmd)(nil).KillProcess))
+}
+
+// Output mocks base method.
+func (m *MockCmd) Output() ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Output")
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Output indicates an expected call of Output.
+func (mr *MockCmdMockRecorder) Output() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Output", reflect.TypeOf((*MockCmd)(nil).Output))
 }
 
 // Run mocks base method.


### PR DESCRIPTION
### Summary
Adding implementation for `CheckNetworkPacketLoss()` and corresponding unit tests. Also updating the `os/exec` wrapper to include 2 more helper methods to facilitate mocks in unit testing.

### Implementation details
After the TMDS server receives the request to check for network packet loss, the following Linux command will be executed:
```
tc -j q
```
The output format will be a byte array of a json string. The output will then be unmarshalled and we will check whether the following exists:
```
{
"kind":"netem"
...
}
```

### Testing
Unit tests for the TMDS package was run.
```
 % go test -tags unit -v -run TestCheckNetworkPacketLoss /workplace/tianzes/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers
...
--- PASS: TestCheckNetworkPacketLoss (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_success-running (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_success-not-running (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_unknown_request_body (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_failed_to_unmarshal_json (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_malformed_request_body_1 (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_malformed_request_body_2 (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_incomplete_request_body_1 (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_incomplete_request_body_2 (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_incomplete_request_body_3 (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_invalid_LossPercent_in_the_request_body_1 (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_invalid_LossPercent_in_the_request_body_2 (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_invalid_LossPercent_in_the_request_body_3 (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_invalid_IP_value_in_the_request_body_1 (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_invalid_IP_CIDR_block_value_in_the_request_body_2 (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_task_lookup_fail (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_task_metadata_fetch_fail (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_task_metadata_unknown_fail (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_fault_injection_disabled (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_invalid_network_mode (0.00s)
    --- PASS: TestCheckNetworkPacketLoss/check_network_packet_loss_empty_task_network_config (0.00s)
PASS
ok  	github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers	0.010s
```

New tests cover the changes: <!-- yes|no -->
2 unhappy test cases were added:
1. Call was successful but there's no fault running
2. Call was successful but got internal error when processing the Linux command

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add check network packet loss implementation 

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
