### PR TITLE
Create support for managed instances in netlib

### DIFF
--- a/ecs-agent/netlib/network_builder.go
+++ b/ecs-agent/netlib/network_builder.go
@@ -100,6 +100,8 @@ func (nb *networkBuilder) Start(
 	switch mode {
 	case ecs.NetworkModeAwsvpc:
 		err = nb.startAWSVPC(ctx, taskID, netNS)
+	case ecs.NetworkModeHost:
+		err = nb.platformAPI.HandleHostMode()
 	default:
 		err = errors.New("invalid network mode: " + mode)
 	}
@@ -128,6 +130,8 @@ func (nb *networkBuilder) Stop(ctx context.Context, mode string, taskID string, 
 	switch mode {
 	case ecs.NetworkModeAwsvpc:
 		err = nb.stopAWSVPC(ctx, netNS)
+	case ecs.NetworkModeHost:
+		err = nb.platformAPI.HandleHostMode()
 	default:
 		err = errors.New("invalid network mode: " + mode)
 	}

--- a/ecs-agent/netlib/platform/api.go
+++ b/ecs-agent/netlib/platform/api.go
@@ -33,6 +33,9 @@ type API interface {
 		taskID string,
 		taskPayload *ecsacs.Task) (*tasknetworkconfig.TaskNetworkConfig, error)
 
+	// HandleHostMode returns error if host mode is not enabled for the platform.
+	HandleHostMode() error
+
 	// CreateNetNS creates a network namespace with the specified path.
 	CreateNetNS(netNSPath string) error
 

--- a/ecs-agent/netlib/platform/common.go
+++ b/ecs-agent/netlib/platform/common.go
@@ -15,6 +15,7 @@ package platform
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/ecscni"
@@ -28,6 +29,8 @@ const (
 	FirecrackerDebugPlatform = "ec2-debug-firecracker"
 	WarmpoolPlatform         = "warmpool"
 	FirecrackerPlatform      = "firecracker"
+	ManagedPlatform          = "managed-instance"
+	ManagedDebugPlatform     = "ec2-debug-managed-instance"
 )
 
 // executeCNIPlugin executes CNI plugins with the given network configs and a timeout context.
@@ -83,4 +86,9 @@ func (c *common) interfacesMACToName() (map[string]string, error) {
 	}
 
 	return macToName, nil
+}
+
+// HandleHostMode by default we do not want to support host mode.
+func (c *common) HandleHostMode() error {
+	return errors.New("invalid platform for host mode")
 }

--- a/ecs-agent/netlib/platform/common_linux.go
+++ b/ecs-agent/netlib/platform/common_linux.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/model/ecs"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials/instancecreds"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	netlibdata "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/data"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
@@ -41,6 +42,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/volume"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 	cnitypes "github.com/containernetworking/cni/pkg/types/100"
 	cnins "github.com/containernetworking/plugins/pkg/ns"
 	"github.com/pkg/errors"
@@ -63,6 +66,8 @@ const (
 	// It is assigned 100 because it is an unrealistically high
 	// value for interface index.
 	indexHighValue = 100
+
+	metadataRetries = 5
 )
 
 // common will be embedded within every implementation of the platform API.
@@ -119,6 +124,14 @@ func NewPlatform(
 			firecraker: firecraker{
 				common: commonPlatform,
 			},
+		}, nil
+	case ManagedPlatform, ManagedDebugPlatform:
+		config := aws.NewConfig().WithMaxRetries(metadataRetries)
+		config.Credentials = instancecreds.GetCredentials(false)
+		ec2Client := ec2metadata.New(session.New(), config)
+		return &managedLinux{
+			common: commonPlatform,
+			client: ec2Client,
 		}, nil
 	}
 	return nil, errors.New("invalid platform: " + platformString)

--- a/ecs-agent/netlib/platform/managed_linux.go
+++ b/ecs-agent/netlib/platform/managed_linux.go
@@ -1,0 +1,147 @@
+package platform
+
+import (
+	"context"
+	goErr "errors"
+	"fmt"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/model/ecs"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	loggerfield "github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	netlibdata "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/data"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/serviceconnect"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/status"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/tasknetworkconfig"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/pkg/errors"
+)
+
+const (
+	MacResource         = "mac"
+	SubNetCidrBlock     = "network/interfaces/macs/%s/subnet-ipv4-cidr-block"
+	PrivateIPv4Resource = "local-ipv4"
+	InstanceIDResource  = "instance-id"
+	DefaultArg          = "default"
+)
+
+type managedLinux struct {
+	common
+	client ec2.HttpClient
+}
+
+// BuildTaskNetworkConfiguration translates network data in task payload sent by ACS
+// into the task network configuration data structure internal to the agent.
+func (m *managedLinux) BuildTaskNetworkConfiguration(
+	taskID string,
+	taskPayload *ecsacs.Task,
+) (*tasknetworkconfig.TaskNetworkConfig, error) {
+	mode := aws.StringValue(taskPayload.NetworkMode)
+	var netNSs []*tasknetworkconfig.NetworkNamespace
+	var err error
+	switch mode {
+	case ecs.NetworkModeAwsvpc:
+		netNSs, err = m.common.buildAWSVPCNetworkNamespaces(taskID, taskPayload, false, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to translate network configuration")
+		}
+	case ecs.NetworkModeHost:
+		netNSs, err = m.buildDefaultNetworkNamespace(taskID)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create network namespace with host eni")
+		}
+	default:
+		return nil, errors.New("invalid network mode: " + mode)
+	}
+	return &tasknetworkconfig.TaskNetworkConfig{
+		NetworkNamespaces: netNSs,
+		NetworkMode:       mode,
+	}, nil
+}
+
+func (m *managedLinux) CreateDNSConfig(taskID string,
+	netNS *tasknetworkconfig.NetworkNamespace) error {
+	return m.common.createDNSConfig(taskID, false, netNS)
+}
+
+func (m *managedLinux) ConfigureInterface(
+	ctx context.Context,
+	netNSPath string,
+	iface *networkinterface.NetworkInterface,
+	netDAO netlibdata.NetworkDataClient,
+) error {
+	return m.common.configureInterface(ctx, netNSPath, iface, netDAO)
+}
+
+func (m *managedLinux) ConfigureAppMesh(ctx context.Context,
+	netNSPath string,
+	cfg *appmesh.AppMesh) error {
+	return m.common.configureAppMesh(ctx, netNSPath, cfg)
+}
+
+func (m *managedLinux) ConfigureServiceConnect(
+	ctx context.Context,
+	netNSPath string,
+	primaryIf *networkinterface.NetworkInterface,
+	scConfig *serviceconnect.ServiceConnectConfig,
+) error {
+	return m.common.configureServiceConnect(ctx, netNSPath, primaryIf, scConfig)
+}
+
+// buildDefaultNetworkNamespace return default network namespace of host ENI for host mode.
+func (m *managedLinux) buildDefaultNetworkNamespace(taskID string) ([]*tasknetworkconfig.NetworkNamespace, error) {
+	privateIpv4, err1 := m.client.GetMetadata(PrivateIPv4Resource)
+	macAddress, err2 := m.client.GetMetadata(MacResource)
+	ec2ID, err3 := m.client.GetMetadata(InstanceIDResource)
+	subNet, err4 := m.client.GetMetadata(fmt.Sprintf(SubNetCidrBlock, macAddress))
+	macToNames, err5 := m.common.interfacesMACToName()
+	if err := goErr.Join(err1, err2, err3, err4, err5); err != nil {
+		logger.Error("Error fetching fields for default ENI", logger.Fields{
+			loggerfield.Error: err,
+		})
+		return nil, err
+	}
+
+	hostENI := &ecsacs.ElasticNetworkInterface{
+		AttachmentArn: aws.String("arn"),
+		Ec2Id:         aws.String(ec2ID),
+		Ipv4Addresses: []*ecsacs.IPv4AddressAssignment{
+			{
+				Primary:        aws.Bool(true),
+				PrivateAddress: aws.String(privateIpv4),
+			},
+		},
+		SubnetGatewayIpv4Address:     aws.String(subNet),
+		MacAddress:                   aws.String(macAddress),
+		DomainNameServers:            []*string{},
+		DomainName:                   []*string{},
+		PrivateDnsName:               aws.String(DefaultArg),
+		InterfaceAssociationProtocol: aws.String(DefaultArg),
+		Index:                        aws.Int64(64),
+	}
+
+	netNSName := networkinterface.NetNSName(taskID, DefaultArg)
+	netInt, _ := networkinterface.New(hostENI, DefaultArg, nil, macToNames)
+	netInt.Default = true
+	netInt.DesiredStatus = status.NetworkReady
+	netInt.KnownStatus = status.NetworkReady
+	defaultNameSpace, err := tasknetworkconfig.NewNetworkNamespace(netNSName, "", 0, nil, netInt)
+	if err != nil {
+		logger.Error("Error building default network namespace for host mode", logger.Fields{
+			loggerfield.Error: err,
+		})
+		return nil, err
+	}
+	defaultNameSpace.KnownState = status.NetworkReady
+	defaultNameSpace.DesiredState = status.NetworkReady
+	return []*tasknetworkconfig.NetworkNamespace{defaultNameSpace}, nil
+}
+
+// HandleHostMode is a no op because Host Mode does not require network interface configuration. No need to invoke CNI plugins.
+func (m *managedLinux) HandleHostMode() error {
+	return nil
+}

--- a/ecs-agent/netlib/platform/mocks/platform_mocks.go
+++ b/ecs-agent/netlib/platform/mocks/platform_mocks.go
@@ -180,3 +180,17 @@ func (mr *MockAPIMockRecorder) GetNetNSPath(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetNSPath", reflect.TypeOf((*MockAPI)(nil).GetNetNSPath), arg0)
 }
+
+// HandleHostMode mocks base method.
+func (m *MockAPI) HandleHostMode() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleHostMode")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HandleHostMode indicates an expected call of HandleHostMode.
+func (mr *MockAPIMockRecorder) HandleHostMode() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleHostMode", reflect.TypeOf((*MockAPI)(nil).HandleHostMode))
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add support for managed instances and host mode networking

### Implementation details
<!-- How are the changes implemented? -->
We added a new platform type in netlib for managed instances. Since the host ENI is not added in the ACS payload we need to fetch all information about the host ENI and create a network interface object to return to the caller.
### Testing
<!-- How was this tested? -->
Manually tested on a developer owned machine changing the dependency of the ecs agent to use the most up to date commit sha.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
no
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Feature - Add support for managed instances

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
