### PR TITLE
Improve logging around task execution credentials

### DIFF
--- a/agent/acs/session/payload_responder.go
+++ b/agent/acs/session/payload_responder.go
@@ -148,6 +148,13 @@ func (pmHandler *payloadMessageHandler) addPayloadTasks(payload *ecsacs.PayloadM
 				allTasksOK = false
 				continue
 			}
+			logger.Info("Found application credentials for task", logger.Fields{
+				loggerfield.TaskARN:       apiTask.Arn,
+				loggerfield.TaskVersion:   apiTask.Version,
+				loggerfield.RoleARN:       taskIAMRoleCredentials.RoleArn,
+				loggerfield.RoleType:      taskIAMRoleCredentials.RoleType,
+				loggerfield.CredentialsID: taskIAMRoleCredentials.CredentialsID,
+			})
 			apiTask.SetCredentialsID(taskIAMRoleCredentials.CredentialsID)
 		}
 
@@ -189,6 +196,13 @@ func (pmHandler *payloadMessageHandler) addPayloadTasks(payload *ecsacs.PayloadM
 				allTasksOK = false
 				continue
 			}
+			logger.Info("Found execution credentials for task", logger.Fields{
+				loggerfield.TaskARN:       apiTask.Arn,
+				loggerfield.TaskVersion:   apiTask.Version,
+				loggerfield.RoleARN:       taskExecutionIAMRoleCredentials.RoleArn,
+				loggerfield.RoleType:      taskExecutionIAMRoleCredentials.RoleType,
+				loggerfield.CredentialsID: taskExecutionIAMRoleCredentials.CredentialsID,
+			})
 			apiTask.SetExecutionRoleCredentialsID(taskExecutionIAMRoleCredentials.CredentialsID)
 		}
 

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1891,6 +1891,13 @@ func (task *Task) ApplyExecutionRoleLogsAuth(hostConfig *dockercontainer.HostCon
 	if hostConfig.LogConfig.Config == nil {
 		hostConfig.LogConfig.Config = map[string]string{}
 	}
+	logger.Info("Applying execution role credentials to container log auth", logger.Fields{
+		field.TaskARN:           executionRoleCredentials.ARN,
+		field.RoleType:          executionRoleCredentials.IAMRoleCredentials.RoleType,
+		field.RoleARN:           executionRoleCredentials.IAMRoleCredentials.RoleArn,
+		field.CredentialsID:     executionRoleCredentials.IAMRoleCredentials.CredentialsID,
+		awslogsCredsEndpointOpt: credentialsEndpointRelativeURI,
+	})
 	hostConfig.LogConfig.Config[awslogsCredsEndpointOpt] = credentialsEndpointRelativeURI
 	return nil
 }

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -1582,7 +1582,8 @@ func (mtask *managedTask) cleanupTask(taskStoppedDuration time.Duration) {
 	// Remove TaskExecutionCredentials from credentialsManager
 	if taskExecutionCredentialsID != "" {
 		logger.Info("Cleaning up task's execution credentials", logger.Fields{
-			field.TaskID: mtask.GetID(),
+			field.TaskID:        mtask.GetID(),
+			field.CredentialsID: taskExecutionCredentialsID,
 		})
 		mtask.credentialsManager.RemoveCredentials(taskExecutionCredentialsID)
 	}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
@@ -65,4 +65,6 @@ const (
 	ServiceConnectEndpoint  = "serviceConnectEndpoint"
 	Response                = "response"
 	Request                 = "request"
+	RoleType                = "roleType"
+	RoleARN                 = "roleARN"
 )

--- a/ecs-agent/logger/field/constants.go
+++ b/ecs-agent/logger/field/constants.go
@@ -65,4 +65,6 @@ const (
 	ServiceConnectEndpoint  = "serviceConnectEndpoint"
 	Response                = "response"
 	Request                 = "request"
+	RoleType                = "roleType"
+	RoleARN                 = "roleARN"
 )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Improves logging around Task application and Task Execution roles supplied by ECS backend, logging their ARNs and credentials IDs, and to which tasks they are applied (such as logs auth, ECR image pull).

For example, when starting a task with task iam and execution roles, one would see logs like this:

```
level=info time=2024-09-16T18:15:10Z msg="Found application credentials for task" taskVersion="3" roleARN="arn:aws:iam::NNN:role/ecsTaskExecutionRole" roleType="TaskApplication" credentialsID="XXXX5763-cc10-XXXX-957d-f3498b4aXXXX" taskARN="arn:aws:ecs:us-west-2:NNN:task/clster/NNN"

level=info time=2024-09-16T18:15:10Z msg="Found execution credentials for task" taskARN="arn:aws:ecs:us-west-2:NNN:task/clster/NNN" taskVersion="3" roleARN="arn:aws:iam::NNN:role/ecsTaskExecutionRole" roleType="TaskExecution" credentialsID="XXXX9ca1-6ffd-45b4-XXXX-593ce7c0XXXX"

level=info time=2024-09-16T18:15:10Z msg="Setting task execution credentials for image pull registry auth" task="NNN" container="main" image="NNN.dkr.ecr.us-west-2.amazonaws.com/foo:tag" roleType="TaskExecution" roleARN="arn:aws:iam::NNN:role/ecsTaskExecutionRole" credentialsID="XXXX9ca1-6ffd-45b4-XXXX-593ce7c0XXXX"

level=info time=2024-09-16T18:15:22Z msg="Applying execution role credentials to container log auth" awslogs-credentials-endpoint="/v2/credentials/XXXX9ca1-6ffd-45b4-XXXX-593ce7c0XXXX" taskARN="arn:aws:ecs:us-west-2:NNN:task/clster/NNN" roleType="TaskExecution" roleARN="arn:aws:iam::NNN:role/ecsTaskExecutionRole" credentialsID="XXXX9ca1-6ffd-45b4-XXXX-593ce7c0XXXX"

level=info time=2024-09-16T18:15:22Z msg="Setting task execution credentials for image pull registry auth" image="NNN.dkr.ecr.us-west-2.amazonaws.com/foo:tag" roleType="TaskExecution" roleARN="arn:aws:iam::NNN:role/ecsTaskExecutionRole" credentialsID="XXXX9ca1-6ffd-45b4-XXXX-593ce7c0XXXX" task="NNN" container="main"

level=info time=2024-09-16T19:43:43Z msg="Cleaning up task's execution credentials" task="NNN" credentialsID="XXXX9ca1-6ffd-45b4-XXXX-593ce7c0XXXX"
```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

Tested manually, verified log messages

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
