### PR TITLE
Require nsenter for fault-injection capability

### DIFF
--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -247,10 +247,12 @@ var lookPathFunc = exec.LookPath
 // checkFaultInjectionTooling checks for the required network packages like iptables, tc
 // to be available on the host before ecs.capability.fault-injection can be advertised
 func checkFaultInjectionTooling() bool {
-	tools := []string{"iptables", "tc"}
+	tools := []string{"iptables", "tc", "nsenter"}
 	for _, tool := range tools {
 		if _, err := lookPathFunc(tool); err != nil {
-			seelog.Warnf("Failed to find network tool %s: %v", tool, err)
+			seelog.Warnf(
+				"Failed to find network tool %s that is needed for fault-injection feature: %v",
+				tool, err)
 			return false
 		}
 	}

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -984,7 +984,9 @@ func TestCheckFaultInjectionTooling(t *testing.T) {
 		lookPathFunc = func(file string) (string, error) {
 			return "/usr/bin" + file, nil
 		}
-		assert.True(t, checkFaultInjectionTooling(), "Expected checkNetworkTooling to return true when all tools are available")
+		assert.True(t,
+			checkFaultInjectionTooling(),
+			"Expected checkFaultInjectionTooling to return true when all tools are available")
 	})
 
 	tools := []string{"iptables", "tc", "nsenter"}
@@ -996,7 +998,9 @@ func TestCheckFaultInjectionTooling(t *testing.T) {
 				}
 				return "/usr/bin" + file, nil
 			}
-			assert.False(t, checkFaultInjectionTooling(), "Expected checkNetworkTooling to return false when a tool is missing")
+			assert.False(t,
+				checkFaultInjectionTooling(),
+				"Expected checkFaultInjectionTooling to return false when a tool is missing")
 		})
 	}
 }

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -974,7 +974,7 @@ func TestAppendFSxWindowsFileServerCapabilities(t *testing.T) {
 	assert.EqualValues(t, capabilities, inputCapabilities)
 }
 
-func TestCheckNetworkTooling(t *testing.T) {
+func TestCheckFaultInjectionTooling(t *testing.T) {
 	originalLookPath := exec.LookPath
 	defer func() {
 		lookPathFunc = originalLookPath


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fault Injection feature requires `nsenter` to be available to Agent. Agent will use `nsenter` to make changes to task network namespaces. Updating the capability requirements to include `nsenter`.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Built and ran an Agent with the changes in this PR. "fault-injection" capability was not advertised with the below warning in the logs. This warning is expected since ecs-init does not currently bind mount `nsenter` from the host to Agent container. I called `ecs describe-container-instances` API and verified that the response did not include "fault-injection" capability.
```
level=warn time=2024-09-13T22:32:27Z msg="Failed to find network tool nsenter: exec: \"nsenter\": executable file not found in $PATH" module=agent_capability_unix.go
```

After this I made a change locally to ecs-init to mount `nsenter` from host to Agent container and re-ran Agent. This time there was no warning in Agent logs. I called `ecs describe-container-instances` API and verified that "ecs.capability.fault-injection" capability was returned in the response. 

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Require nsenter for fault-injection capability

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
