### PR TITLE
Return explicit error message when required request body is missing

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -3835,7 +3835,7 @@ func getNetworkBlackHolePortHandlerTestCases(name, fault string, expectedHappyRe
 			name:                  fmt.Sprintf("%s fault injection disabled", name),
 			expectedStatusCode:    400,
 			requestBody:           happyBlackHolePortReqBody,
-			expectedFaultResponse: faulttype.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("fault injection is not enabled for task: %s", taskARN)),
+			expectedFaultResponse: faulttype.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("enableFaultInjection is not enabled for task: %s", taskARN)),
 			setStateExpectations:  agentStateExpectations,
 			faultInjectionEnabled: false,
 			networkMode:           apitask.AWSVPCNetworkMode,

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -79,12 +79,12 @@ func (h *FaultHandler) StartNetworkBlackholePort() func(http.ResponseWriter, *ht
 		requestType := fmt.Sprintf(startFaultRequestType, types.BlackHolePortFaultType)
 
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -126,12 +126,12 @@ func (h *FaultHandler) StopNetworkBlackHolePort() func(http.ResponseWriter, *htt
 		requestType := fmt.Sprintf(stopFaultRequestType, types.BlackHolePortFaultType)
 
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -177,12 +177,12 @@ func (h *FaultHandler) CheckNetworkBlackHolePort() func(http.ResponseWriter, *ht
 		requestType := fmt.Sprintf(checkStatusFaultRequestType, types.BlackHolePortFaultType)
 
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -226,13 +226,13 @@ func (h *FaultHandler) StartNetworkLatency() func(http.ResponseWriter, *http.Req
 		var request types.NetworkLatencyRequest
 		requestType := fmt.Sprintf(startFaultRequestType, types.LatencyFaultType)
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -274,12 +274,12 @@ func (h *FaultHandler) StopNetworkLatency() func(http.ResponseWriter, *http.Requ
 		requestType := fmt.Sprintf(stopFaultRequestType, types.LatencyFaultType)
 
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -321,12 +321,12 @@ func (h *FaultHandler) CheckNetworkLatency() func(http.ResponseWriter, *http.Req
 		requestType := fmt.Sprintf(checkStatusFaultRequestType, types.LatencyFaultType)
 
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -366,13 +366,13 @@ func (h *FaultHandler) StartNetworkPacketLoss() func(http.ResponseWriter, *http.
 		var request types.NetworkPacketLossRequest
 		requestType := fmt.Sprintf(startFaultRequestType, types.PacketLossFaultType)
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -414,12 +414,12 @@ func (h *FaultHandler) StopNetworkPacketLoss() func(http.ResponseWriter, *http.R
 		requestType := fmt.Sprintf(startFaultRequestType, types.PacketLossFaultType)
 
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -461,12 +461,12 @@ func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.
 		requestType := fmt.Sprintf(startFaultRequestType, types.PacketLossFaultType)
 
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -502,15 +502,14 @@ func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.
 }
 
 // decodeRequest will log the request and then translate/unmarshal an incoming fault injection request into
-// one of the network fault structs if the request body is required.
-func decodeRequest(w http.ResponseWriter, request types.NetworkFaultRequest, requestType string,
-	r *http.Request, requiredRequestBody bool) error {
+// one of the network fault structs which requires the reqeust body to non-empty.
+func decodeRequest(w http.ResponseWriter, request types.NetworkFaultRequest, requestType string, r *http.Request) error {
 	logRequest(requestType, r)
 
 	jsonDecoder := json.NewDecoder(r.Body)
 	if err := jsonDecoder.Decode(request); err != nil {
-		// The request has empty body. Respond an explicit message if that's required.
-		if err == io.EOF && requiredRequestBody {
+		// The request has empty body and then respond an explicit message.
+		if err == io.EOF {
 			err = errors.New(types.MissingRequestBodyError)
 		}
 
@@ -533,13 +532,9 @@ func decodeRequest(w http.ResponseWriter, request types.NetworkFaultRequest, req
 	return nil
 }
 
-// validateRequest will validate that the incoming fault injection request will have the required fields.
-func validateRequest(w http.ResponseWriter, request types.NetworkFaultRequest, requestType string,
-	requiredRequestBody bool) error {
-	if !requiredRequestBody {
-		return nil
-	}
-
+// validateRequest will validate that the incoming fault injection request will have the required fields
+// in the request body.
+func validateRequest(w http.ResponseWriter, request types.NetworkFaultRequest, requestType string) error {
 	if err := request.ValidateRequest(); err != nil {
 		responseBody := types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("%v", err))
 		logger.Error("Error: missing required payload fields", logger.Fields{

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -27,6 +27,7 @@ const (
 	LatencyFaultType          = "network-latency"
 	PacketLossFaultType       = "network-packet-loss"
 	missingRequiredFieldError = "required parameter %s is missing"
+	MissingRequestBodyError   = "required request body is missing"
 	invalidValueError         = "invalid value %s for parameter %s"
 )
 

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -79,12 +79,12 @@ func (h *FaultHandler) StartNetworkBlackholePort() func(http.ResponseWriter, *ht
 		requestType := fmt.Sprintf(startFaultRequestType, types.BlackHolePortFaultType)
 
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -126,12 +126,12 @@ func (h *FaultHandler) StopNetworkBlackHolePort() func(http.ResponseWriter, *htt
 		requestType := fmt.Sprintf(stopFaultRequestType, types.BlackHolePortFaultType)
 
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -177,12 +177,12 @@ func (h *FaultHandler) CheckNetworkBlackHolePort() func(http.ResponseWriter, *ht
 		requestType := fmt.Sprintf(checkStatusFaultRequestType, types.BlackHolePortFaultType)
 
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -226,13 +226,13 @@ func (h *FaultHandler) StartNetworkLatency() func(http.ResponseWriter, *http.Req
 		var request types.NetworkLatencyRequest
 		requestType := fmt.Sprintf(startFaultRequestType, types.LatencyFaultType)
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -274,12 +274,12 @@ func (h *FaultHandler) StopNetworkLatency() func(http.ResponseWriter, *http.Requ
 		requestType := fmt.Sprintf(stopFaultRequestType, types.LatencyFaultType)
 
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -321,12 +321,12 @@ func (h *FaultHandler) CheckNetworkLatency() func(http.ResponseWriter, *http.Req
 		requestType := fmt.Sprintf(checkStatusFaultRequestType, types.LatencyFaultType)
 
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -366,13 +366,13 @@ func (h *FaultHandler) StartNetworkPacketLoss() func(http.ResponseWriter, *http.
 		var request types.NetworkPacketLossRequest
 		requestType := fmt.Sprintf(startFaultRequestType, types.PacketLossFaultType)
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -414,12 +414,12 @@ func (h *FaultHandler) StopNetworkPacketLoss() func(http.ResponseWriter, *http.R
 		requestType := fmt.Sprintf(startFaultRequestType, types.PacketLossFaultType)
 
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -461,12 +461,12 @@ func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.
 		requestType := fmt.Sprintf(startFaultRequestType, types.PacketLossFaultType)
 
 		// Parse the fault request
-		err := decodeRequest(w, &request, requestType, r, true)
+		err := decodeRequest(w, &request, requestType, r)
 		if err != nil {
 			return
 		}
 		// Validate the fault request
-		err = validateRequest(w, request, requestType, true)
+		err = validateRequest(w, request, requestType)
 		if err != nil {
 			return
 		}
@@ -502,15 +502,14 @@ func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.
 }
 
 // decodeRequest will log the request and then translate/unmarshal an incoming fault injection request into
-// one of the network fault structs if the request body is required.
-func decodeRequest(w http.ResponseWriter, request types.NetworkFaultRequest, requestType string,
-	r *http.Request, requiredRequestBody bool) error {
+// one of the network fault structs which requires the reqeust body to non-empty.
+func decodeRequest(w http.ResponseWriter, request types.NetworkFaultRequest, requestType string, r *http.Request) error {
 	logRequest(requestType, r)
 
 	jsonDecoder := json.NewDecoder(r.Body)
 	if err := jsonDecoder.Decode(request); err != nil {
-		// The request has empty body. Respond an explicit message if that's required.
-		if err == io.EOF && requiredRequestBody {
+		// The request has empty body and then respond an explicit message.
+		if err == io.EOF {
 			err = errors.New(types.MissingRequestBodyError)
 		}
 
@@ -533,13 +532,9 @@ func decodeRequest(w http.ResponseWriter, request types.NetworkFaultRequest, req
 	return nil
 }
 
-// validateRequest will validate that the incoming fault injection request will have the required fields.
-func validateRequest(w http.ResponseWriter, request types.NetworkFaultRequest, requestType string,
-	requiredRequestBody bool) error {
-	if !requiredRequestBody {
-		return nil
-	}
-
+// validateRequest will validate that the incoming fault injection request will have the required fields
+// in the request body.
+func validateRequest(w http.ResponseWriter, request types.NetworkFaultRequest, requestType string) error {
 	if err := request.ValidateRequest(); err != nil {
 		responseBody := types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf("%v", err))
 		logger.Error("Error: missing required payload fields", logger.Fields{

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
@@ -149,6 +149,15 @@ func generateNetworkBlackHolePortTestCases(name string, expectedHappyResponseBod
 			},
 		},
 		{
+			name:                 fmt.Sprintf("%s no request body", name),
+			expectedStatusCode:   400,
+			requestBody:          nil,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("required request body is missing"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
+			},
+		},
+		{
 			name:               fmt.Sprintf("%s malformed request body", name),
 			expectedStatusCode: 400,
 			requestBody: map[string]interface{}{
@@ -526,6 +535,15 @@ func generateNetworkLatencyTestCases(name, expectedHappyResponseBody string) []n
 				agentState.EXPECT().GetTaskMetadata(endpointId).
 					Return(happyTaskResponse, nil).
 					Times(1)
+			},
+		},
+		{
+			name:                 fmt.Sprintf("%s no request body", name),
+			expectedStatusCode:   400,
+			requestBody:          nil,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("required request body is missing"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
 			},
 		},
 		{
@@ -911,6 +929,15 @@ func generateNetworkPacketLossTestCases(name, expectedHappyResponseBody string) 
 			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse(expectedHappyResponseBody),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
 				agentState.EXPECT().GetTaskMetadata(endpointId).Return(happyTaskResponse, nil)
+			},
+		},
+		{
+			name:                 fmt.Sprintf("%s no request body", name),
+			expectedStatusCode:   400,
+			requestBody:          nil,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("required request body is missing"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState) {
+				agentState.EXPECT().GetTaskMetadata(endpointId).Return(state.TaskResponse{}, nil).Times(0)
 			},
 		},
 		{

--- a/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -27,6 +27,7 @@ const (
 	LatencyFaultType          = "network-latency"
 	PacketLossFaultType       = "network-packet-loss"
 	missingRequiredFieldError = "required parameter %s is missing"
+	MissingRequestBodyError   = "required request body is missing"
 	invalidValueError         = "invalid value %s for parameter %s"
 )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR is to return an explicit error message when the required request body is missing for a fault injection request.

### Implementation details
<!-- How are the changes implemented? -->
- Add one check before we decode it from the request (in `decodeRequest` [code ref](https://github.com/aws/amazon-ecs-agent/blob/dev/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go#L507))

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

- Added new unit test.
- Manual test to verify the new error message.
```
// before the PR
sh-5.2# curl -X GET $ECS_AGENT_URI/fault/v1/network-blackhole-port  -v
Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying 169.254.170.2:80...
* Connected to 169.254.170.2 (169.254.170.2) port 80
> GET /api/605a5eac95e4408fb27c87d43a135be0-3147973833/fault/v1/network-blackhole-port HTTP/1.1
> Host: 169.254.170.2
> User-Agent: curl/8.5.0
> Accept: */*
> 
< HTTP/1.1 400 Bad Request
< Content-Type: application/json
< X-Rate-Limit-Duration: 1
< X-Rate-Limit-Limit: 0.20
< X-Rate-Limit-Request-Forwarded-For: 
< X-Rate-Limit-Request-Remote-Addr: 169.254.172.2:46042
< Date: Mon, 16 Sep 2024 21:56:55 GMT
< Content-Length: 15
< 
* Connection #0 to host 169.254.170.2 left intact
{"Error":"EOF"}sh-5.2#


// after the PR
sh-5.2# curl -X GET $ECS_AGENT_URI/fault/v1/network-blackhole-port  -v
Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying 169.254.170.2:80...
* Connected to 169.254.170.2 (169.254.170.2) port 80
> GET /api/605a5eac95e4408fb27c87d43a135be0-3147973833/fault/v1/network-blackhole-port HTTP/1.1
> Host: 169.254.170.2
> User-Agent: curl/8.5.0
> Accept: */*
> 
< HTTP/1.1 400 Bad Request
< Content-Type: application/json
< X-Rate-Limit-Duration: 1
< X-Rate-Limit-Limit: 0.20
< X-Rate-Limit-Request-Forwarded-For: 
< X-Rate-Limit-Request-Remote-Addr: 169.254.172.2:33716
< Date: Mon, 16 Sep 2024 22:08:04 GMT
< Content-Length: 44
< 
* Connection #0 to host 169.254.170.2 left intact
{"Error":"required request body is missing"}sh-5.2#
```

New tests cover the changes: <!-- yes|no -->

Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

- Feature: Return an explicit error message when required request body is missing for fault injection requests.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
