### PR TITLE
Check if nsenter is available and bind mount it on Agent container

### DIFF
--- a/ecs-init/docker/docker_config.go
+++ b/ecs-init/docker/docker_config.go
@@ -47,7 +47,7 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 		iptablesLegacyDir+":"+iptablesLegacyDir+readOnly,
 		"/usr/bin/lsblk:/usr/bin/lsblk",
 	)
-	binds = bindNsenterIfAvailable(binds, os.Stat)
+	binds = append(binds, getNsenterBinds(os.Stat)...)
 
 	logConfig := config.AgentDockerLogDriverConfiguration()
 
@@ -84,9 +84,10 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 	return hostConfig
 }
 
-// Appends nsenter to provided binds slice if it is found on the host and returns it.
-// Returns the input slice otherwise.
-func bindNsenterIfAvailable(binds []string, statFn func(string) (os.FileInfo, error)) []string {
+// Returns nsenter bind as a slice if nsenter is available on the host.
+// Returns an empty slice otherwise.
+func getNsenterBinds(statFn func(string) (os.FileInfo, error)) []string {
+	binds := []string{}
 	const nsenterPath = "/usr/bin/nsenter"
 	if _, err := statFn(nsenterPath); err == nil {
 		binds = append(binds, nsenterPath+":"+nsenterPath)

--- a/ecs-init/docker/docker_config.go
+++ b/ecs-init/docker/docker_config.go
@@ -15,8 +15,10 @@ package docker
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/aws/amazon-ecs-agent/ecs-init/config"
+	"github.com/cihub/seelog"
 	ctrdapparmor "github.com/containerd/containerd/pkg/apparmor"
 	godocker "github.com/fsouza/go-dockerclient"
 )
@@ -45,6 +47,13 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 		iptablesLegacyDir+":"+iptablesLegacyDir+readOnly,
 		"/usr/bin/lsblk:/usr/bin/lsblk",
 	)
+
+	const nsenterPath = "/usr/bin/nsenter"
+	if _, err := os.Stat(nsenterPath); err == nil {
+		binds = append(binds, nsenterPath+":"+nsenterPath)
+	} else {
+		seelog.Warnf("nsenter not found at %s, skip binding it to Agent container", nsenterPath)
+	}
 
 	logConfig := config.AgentDockerLogDriverConfiguration()
 

--- a/ecs-init/docker/docker_config_test.go
+++ b/ecs-init/docker/docker_config_test.go
@@ -22,17 +22,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBindNsenterIfAvailable(t *testing.T) {
+func TestGetNsenterBinds(t *testing.T) {
 	t.Run("nsenter not found", func(t *testing.T) {
-		binds := bindNsenterIfAvailable(
-			[]string{},
+		binds := getNsenterBinds(
 			func(s string) (os.FileInfo, error) { return nil, errors.New("not found") })
 		assert.Empty(t, binds)
 	})
 
 	t.Run("nsenter is found", func(t *testing.T) {
-		binds := bindNsenterIfAvailable(
-			[]string{},
+		binds := getNsenterBinds(
 			func(s string) (os.FileInfo, error) { return nil, nil })
 		require.Len(t, binds, 1)
 		assert.Equal(t, "/usr/bin/nsenter:/usr/bin/nsenter", binds[0])

--- a/ecs-init/docker/docker_config_test.go
+++ b/ecs-init/docker/docker_config_test.go
@@ -1,0 +1,40 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package docker
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindNsenterIfAvailable(t *testing.T) {
+	t.Run("nsenter not found", func(t *testing.T) {
+		binds := bindNsenterIfAvailable(
+			[]string{},
+			func(s string) (os.FileInfo, error) { return nil, errors.New("not found") })
+		assert.Empty(t, binds)
+	})
+
+	t.Run("nsenter is found", func(t *testing.T) {
+		binds := bindNsenterIfAvailable(
+			[]string{},
+			func(s string) (os.FileInfo, error) { return nil, nil })
+		require.Len(t, binds, 1)
+		assert.Equal(t, "/usr/bin/nsenter:/usr/bin/nsenter", binds[0])
+	})
+}

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -32,7 +32,7 @@ import (
 // Note: Change this value every time when a new bind mount is added to
 // agent for the tests to pass
 const (
-	defaultExpectedAgentBinds = 20
+	defaultExpectedAgentBinds = 21
 )
 
 func TestIsAgentImageLoadedListFailure(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR make ecs-init look for `/usr/bin/nsenter` on the container instance and creates a bind mount for it on Agent container if found. This tool is used by fault-injection feature. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Tested with and without `/usr/bin/nsenter` on the host. 

When it was not available then it was not bind mounted on the container and the following warning is seen. 

```
level=warn time=2024-09-17T02:29:06Z msg="nsenter not found at /usr/bin/nsenter, skip binding it to Agent container: stat /usr/bin/nsenter: no such file or directory"
```

When it was available then it was bind mounted on the Agent container.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Check if nsenter is available and bind mount it on Agent container for fault injection.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
