### PR TITLE
Add start network packet loss implementation

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -51,8 +51,12 @@ const (
 )
 
 var (
-	iptablesChainExistCmd = "iptables -C %s -p %s --dport %s -j DROP"
-	nsenterCommandString  = "nsenter --net=%s"
+	iptablesChainExistCmd         = "iptables -C %s -p %s --dport %s -j DROP"
+	nsenterCommandString          = "nsenter --net=%s "
+	tcCheckInjectionCommandString = "tc -j q show dev %s parent 1:1"
+	tcAddQdiscRootCommandString   = "tc qdisc add dev %s root handle 1: prio priomap 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2"
+	tcAddQdiscLossCommandString   = "tc qdisc add dev %s parent 1:1 handle 10: netem loss %d%%"
+	tcAddFilterForIPCommandString = "tc filter add dev %s protocol ip parent 1:0 prio 1 u32 match ip dst %s flowid 1:1"
 )
 
 type FaultHandler struct {
@@ -475,18 +479,47 @@ func (h *FaultHandler) StartNetworkPacketLoss() func(http.ResponseWriter, *http.
 		rwMu.Lock()
 		defer rwMu.Unlock()
 
-		// TODO: Check status of current fault injection
-		// TODO: Invoke the start fault injection functionality if not running
-
-		responseBody := types.NewNetworkFaultInjectionSuccessResponse("running")
-		logger.Info("Successfully started fault", logger.Fields{
+		var responseBody types.NetworkFaultInjectionResponse
+		var httpStatusCode int
+		stringToBeLogged := "Failed to start fault"
+		// All command executions for the start network packet loss workflow all together should finish within 5 seconds.
+		// Thus, create the context here so that it can be shared by all os/exec calls.
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+		defer cancel()
+		// Check the status of current fault injection.
+		latencyFaultExists, packetLossFaultExists, err := h.checkTCFault(ctx, taskMetadata)
+		if err != nil {
+			responseBody = types.NewNetworkFaultInjectionErrorResponse(err.Error())
+			httpStatusCode = http.StatusInternalServerError
+		} else {
+			// If there already exists a fault in the task network namespace.
+			if latencyFaultExists {
+				responseBody = types.NewNetworkFaultInjectionErrorResponse("There is already one network latency fault running")
+				httpStatusCode = http.StatusConflict
+			} else if packetLossFaultExists {
+				responseBody = types.NewNetworkFaultInjectionErrorResponse("There is already one network packet loss fault running")
+				httpStatusCode = http.StatusConflict
+			} else {
+				// Invoke the start fault injection functionality if not running.
+				err := h.startNetworkPacketLossFault(ctx, taskMetadata, request)
+				if err != nil {
+					responseBody = types.NewNetworkFaultInjectionErrorResponse("Failed to inject network-packet-loss fault")
+					httpStatusCode = http.StatusInternalServerError
+				} else {
+					stringToBeLogged = "Successfully started fault"
+					responseBody = types.NewNetworkFaultInjectionSuccessResponse("running")
+					httpStatusCode = http.StatusOK
+				}
+			}
+		}
+		logger.Info(stringToBeLogged, logger.Fields{
 			field.RequestType: requestType,
 			field.Request:     request.ToString(),
 			field.Response:    responseBody.ToString(),
 		})
 		utils.WriteJSONResponse(
 			w,
-			http.StatusOK,
+			httpStatusCode,
 			responseBody,
 			requestType,
 		)
@@ -792,6 +825,128 @@ func validateTaskNetworkConfig(taskNetworkConfig *state.TaskNetworkConfig) error
 	}
 
 	return nil
+}
+
+// startNetworkPacketLossFault invokes the linux TC utility tool to start the network-packet-loss fault.
+func (h *FaultHandler) startNetworkPacketLossFault(ctx context.Context, taskMetadata *state.TaskResponse, request types.NetworkPacketLossRequest) error {
+	interfaceName := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces[0].DeviceName
+	networkMode := taskMetadata.TaskNetworkConfig.NetworkMode
+	// If task's network mode is awsvpc, we need to run nsenter to access the task's network namespace.
+	nsenterPrefix := ""
+	if networkMode == ecs.NetworkModeAwsvpc {
+		nsenterPrefix = fmt.Sprintf(nsenterCommandString, taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path)
+	}
+	lossPercent := aws.Uint64Value(request.LossPercent)
+
+	// Command to be executed:
+	// <nsenterPrefix> tc qdisc add dev <interfaceName> root handle 1: prio priomap 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
+	// <nsenterPrefix> "tc qdisc add dev <interfaceName> parent 1:1 handle 10: netem loss <lossPercentage>%"
+	tcAddQdiscRootCommandComposed := nsenterPrefix + fmt.Sprintf(tcAddQdiscRootCommandString, interfaceName)
+	cmdList := strings.Split(tcAddQdiscRootCommandComposed, " ")
+	cmdOutput, err := h.runExecCommand(ctx, cmdList)
+	if err != nil {
+		logger.Error(fmt.Sprintf("'%s' command failed with the following error: '%s'. std output: '%s'",
+			tcAddQdiscRootCommandComposed, err, string(cmdOutput[:])))
+		return err
+	}
+	logger.Info(fmt.Sprintf("'%s' command result: '%s'", tcAddQdiscRootCommandComposed, string(cmdOutput[:])))
+	tcAddQdiscLossCommandComposed := nsenterPrefix + fmt.Sprintf(tcAddQdiscLossCommandString, interfaceName, lossPercent)
+	cmdList = strings.Split(tcAddQdiscLossCommandComposed, " ")
+	cmdOutput, err = h.runExecCommand(ctx, cmdList)
+	if err != nil {
+		logger.Error(fmt.Sprintf("'%s' command failed with the following error: '%s'. std output: '%s'",
+			tcAddQdiscLossCommandComposed, err, string(cmdOutput[:])))
+		return err
+	}
+	logger.Info(fmt.Sprintf("'%s' command result: '%s'", tcAddQdiscLossCommandComposed, string(cmdOutput[:])))
+	// After creating the queueing discipline, create filters to associate the IPs in the request with the handle.
+	for _, ip := range request.Sources {
+		tcAddFilterForIPCommandComposed := nsenterPrefix + fmt.Sprintf(tcAddFilterForIPCommandString, interfaceName, *ip)
+		cmdList = strings.Split(tcAddFilterForIPCommandComposed, " ")
+		_, err = h.runExecCommand(ctx, cmdList)
+		if err != nil {
+			logger.Error(fmt.Sprintf("'%s' command failed with the following error: '%s'. std output: '%s'",
+				tcAddFilterForIPCommandComposed, err, string(cmdOutput[:])))
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkTCFault check if there's existing network-latency fault or network-packet-loss fault.
+func (h *FaultHandler) checkTCFault(ctx context.Context, taskMetadata *state.TaskResponse) (bool, bool, error) {
+	interfaceName := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces[0].DeviceName
+	networkMode := taskMetadata.TaskNetworkConfig.NetworkMode
+	// If task's network mode is awsvpc, we need to run nsenter to access the task's network namespace.
+	nsenterPrefix := ""
+	if networkMode == ecs.NetworkModeAwsvpc {
+		nsenterPrefix = fmt.Sprintf(nsenterCommandString, taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path)
+	}
+
+	// We will run the following Linux command to assess if there existing fault.
+	// "tc -j q show dev {INTERFACE} parent 1:1"
+	// The command above gives the output of "tc q show dev {INTERFACE} parent 1:1" in json format.
+	// We will then unmarshall the json string and evaluate the fields of it.
+	tcCheckInjectionCommandComposed := nsenterPrefix + fmt.Sprintf(tcCheckInjectionCommandString, interfaceName)
+	cmdList := strings.Split(tcCheckInjectionCommandComposed, " ")
+	cmdOutput, err := h.runExecCommand(ctx, cmdList)
+	if err != nil {
+		logger.Error(fmt.Sprintf("'%s' command failed with the following error: '%s'. std output: '%s'",
+			tcCheckInjectionCommandComposed, err, string(cmdOutput[:])))
+		return false, false, fmt.Errorf("failed to check existing network fault: '%s' command failed with the following error: '%s'. std output: '%s'",
+			tcCheckInjectionCommandComposed, err, string(cmdOutput[:]))
+	}
+	// Log the command output to better help us debug.
+	logger.Info(fmt.Sprintf("'%s' command result: '%s'", tcCheckInjectionCommandComposed, string(cmdOutput[:])))
+
+	// Check whether latency fault exists and whether packet loss fault exists separately.
+	var outputUnmarshalled []map[string]interface{}
+	err = json.Unmarshal(cmdOutput, &outputUnmarshalled)
+	if err != nil {
+		return false, false, errors.New("failed to check existing network fault: failed to unmarshal tc command output: " + err.Error())
+	}
+	latencyFaultExists, err := checkLatencyFault(outputUnmarshalled)
+	if err != nil {
+		return false, false, errors.New("failed to check existing network fault: " + err.Error())
+	}
+	packetLossFaultExists, err := checkPacketLossFault(outputUnmarshalled)
+	if err != nil {
+		return false, false, errors.New("failed to check existing network fault: " + err.Error())
+	}
+	return latencyFaultExists, packetLossFaultExists, nil
+}
+
+// checkLatencyFault parses the tc command output and checks if there's existing network-latency fault running.
+func checkLatencyFault(outputUnmarshalled []map[string]interface{}) (bool, error) {
+	for _, line := range outputUnmarshalled {
+		// Check if field "kind":"netem" exists.
+		if line["kind"] == "netem" {
+			// Now check if network packet loss fault exists.
+			if options := line["options"]; options != nil {
+				if delay := options.(map[string]interface{})["delay"]; delay != nil {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
+// checkPacketLossFault parses the tc command output and checks if there's existing network-packet-loss fault running.
+func checkPacketLossFault(outputUnmarshalled []map[string]interface{}) (bool, error) {
+	for _, line := range outputUnmarshalled {
+		// First check field "kind":"netem" exists.
+		if line["kind"] == "netem" {
+			// Now check if field "loss":"<loss percent>" exists, and if the percentage matches with the value in the request.
+			if options := line["options"]; options != nil {
+				if lossRandom := options.(map[string]interface{})["loss-random"]; lossRandom != nil {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
 }
 
 // runExecCommand wraps around the execwrapper, providing a convenient way of running any Linux command

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -51,8 +51,12 @@ const (
 )
 
 var (
-	iptablesChainExistCmd = "iptables -C %s -p %s --dport %s -j DROP"
-	nsenterCommandString  = "nsenter --net=%s"
+	iptablesChainExistCmd         = "iptables -C %s -p %s --dport %s -j DROP"
+	nsenterCommandString          = "nsenter --net=%s "
+	tcCheckInjectionCommandString = "tc -j q show dev %s parent 1:1"
+	tcAddQdiscRootCommandString   = "tc qdisc add dev %s root handle 1: prio priomap 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2"
+	tcAddQdiscLossCommandString   = "tc qdisc add dev %s parent 1:1 handle 10: netem loss %d%%"
+	tcAddFilterForIPCommandString = "tc filter add dev %s protocol ip parent 1:0 prio 1 u32 match ip dst %s flowid 1:1"
 )
 
 type FaultHandler struct {
@@ -475,18 +479,47 @@ func (h *FaultHandler) StartNetworkPacketLoss() func(http.ResponseWriter, *http.
 		rwMu.Lock()
 		defer rwMu.Unlock()
 
-		// TODO: Check status of current fault injection
-		// TODO: Invoke the start fault injection functionality if not running
-
-		responseBody := types.NewNetworkFaultInjectionSuccessResponse("running")
-		logger.Info("Successfully started fault", logger.Fields{
+		var responseBody types.NetworkFaultInjectionResponse
+		var httpStatusCode int
+		stringToBeLogged := "Failed to start fault"
+		// All command executions for the start network packet loss workflow all together should finish within 5 seconds.
+		// Thus, create the context here so that it can be shared by all os/exec calls.
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+		defer cancel()
+		// Check the status of current fault injection.
+		latencyFaultExists, packetLossFaultExists, err := h.checkTCFault(ctx, taskMetadata)
+		if err != nil {
+			responseBody = types.NewNetworkFaultInjectionErrorResponse(err.Error())
+			httpStatusCode = http.StatusInternalServerError
+		} else {
+			// If there already exists a fault in the task network namespace.
+			if latencyFaultExists {
+				responseBody = types.NewNetworkFaultInjectionErrorResponse("There is already one network latency fault running")
+				httpStatusCode = http.StatusConflict
+			} else if packetLossFaultExists {
+				responseBody = types.NewNetworkFaultInjectionErrorResponse("There is already one network packet loss fault running")
+				httpStatusCode = http.StatusConflict
+			} else {
+				// Invoke the start fault injection functionality if not running.
+				err := h.startNetworkPacketLossFault(ctx, taskMetadata, request)
+				if err != nil {
+					responseBody = types.NewNetworkFaultInjectionErrorResponse("Failed to inject network-packet-loss fault")
+					httpStatusCode = http.StatusInternalServerError
+				} else {
+					stringToBeLogged = "Successfully started fault"
+					responseBody = types.NewNetworkFaultInjectionSuccessResponse("running")
+					httpStatusCode = http.StatusOK
+				}
+			}
+		}
+		logger.Info(stringToBeLogged, logger.Fields{
 			field.RequestType: requestType,
 			field.Request:     request.ToString(),
 			field.Response:    responseBody.ToString(),
 		})
 		utils.WriteJSONResponse(
 			w,
-			http.StatusOK,
+			httpStatusCode,
 			responseBody,
 			requestType,
 		)
@@ -792,6 +825,128 @@ func validateTaskNetworkConfig(taskNetworkConfig *state.TaskNetworkConfig) error
 	}
 
 	return nil
+}
+
+// startNetworkPacketLossFault invokes the linux TC utility tool to start the network-packet-loss fault.
+func (h *FaultHandler) startNetworkPacketLossFault(ctx context.Context, taskMetadata *state.TaskResponse, request types.NetworkPacketLossRequest) error {
+	interfaceName := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces[0].DeviceName
+	networkMode := taskMetadata.TaskNetworkConfig.NetworkMode
+	// If task's network mode is awsvpc, we need to run nsenter to access the task's network namespace.
+	nsenterPrefix := ""
+	if networkMode == ecs.NetworkModeAwsvpc {
+		nsenterPrefix = fmt.Sprintf(nsenterCommandString, taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path)
+	}
+	lossPercent := aws.Uint64Value(request.LossPercent)
+
+	// Command to be executed:
+	// <nsenterPrefix> tc qdisc add dev <interfaceName> root handle 1: prio priomap 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
+	// <nsenterPrefix> "tc qdisc add dev <interfaceName> parent 1:1 handle 10: netem loss <lossPercentage>%"
+	tcAddQdiscRootCommandComposed := nsenterPrefix + fmt.Sprintf(tcAddQdiscRootCommandString, interfaceName)
+	cmdList := strings.Split(tcAddQdiscRootCommandComposed, " ")
+	cmdOutput, err := h.runExecCommand(ctx, cmdList)
+	if err != nil {
+		logger.Error(fmt.Sprintf("'%s' command failed with the following error: '%s'. std output: '%s'",
+			tcAddQdiscRootCommandComposed, err, string(cmdOutput[:])))
+		return err
+	}
+	logger.Info(fmt.Sprintf("'%s' command result: '%s'", tcAddQdiscRootCommandComposed, string(cmdOutput[:])))
+	tcAddQdiscLossCommandComposed := nsenterPrefix + fmt.Sprintf(tcAddQdiscLossCommandString, interfaceName, lossPercent)
+	cmdList = strings.Split(tcAddQdiscLossCommandComposed, " ")
+	cmdOutput, err = h.runExecCommand(ctx, cmdList)
+	if err != nil {
+		logger.Error(fmt.Sprintf("'%s' command failed with the following error: '%s'. std output: '%s'",
+			tcAddQdiscLossCommandComposed, err, string(cmdOutput[:])))
+		return err
+	}
+	logger.Info(fmt.Sprintf("'%s' command result: '%s'", tcAddQdiscLossCommandComposed, string(cmdOutput[:])))
+	// After creating the queueing discipline, create filters to associate the IPs in the request with the handle.
+	for _, ip := range request.Sources {
+		tcAddFilterForIPCommandComposed := nsenterPrefix + fmt.Sprintf(tcAddFilterForIPCommandString, interfaceName, *ip)
+		cmdList = strings.Split(tcAddFilterForIPCommandComposed, " ")
+		_, err = h.runExecCommand(ctx, cmdList)
+		if err != nil {
+			logger.Error(fmt.Sprintf("'%s' command failed with the following error: '%s'. std output: '%s'",
+				tcAddFilterForIPCommandComposed, err, string(cmdOutput[:])))
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkTCFault check if there's existing network-latency fault or network-packet-loss fault.
+func (h *FaultHandler) checkTCFault(ctx context.Context, taskMetadata *state.TaskResponse) (bool, bool, error) {
+	interfaceName := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces[0].DeviceName
+	networkMode := taskMetadata.TaskNetworkConfig.NetworkMode
+	// If task's network mode is awsvpc, we need to run nsenter to access the task's network namespace.
+	nsenterPrefix := ""
+	if networkMode == ecs.NetworkModeAwsvpc {
+		nsenterPrefix = fmt.Sprintf(nsenterCommandString, taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path)
+	}
+
+	// We will run the following Linux command to assess if there existing fault.
+	// "tc -j q show dev {INTERFACE} parent 1:1"
+	// The command above gives the output of "tc q show dev {INTERFACE} parent 1:1" in json format.
+	// We will then unmarshall the json string and evaluate the fields of it.
+	tcCheckInjectionCommandComposed := nsenterPrefix + fmt.Sprintf(tcCheckInjectionCommandString, interfaceName)
+	cmdList := strings.Split(tcCheckInjectionCommandComposed, " ")
+	cmdOutput, err := h.runExecCommand(ctx, cmdList)
+	if err != nil {
+		logger.Error(fmt.Sprintf("'%s' command failed with the following error: '%s'. std output: '%s'",
+			tcCheckInjectionCommandComposed, err, string(cmdOutput[:])))
+		return false, false, fmt.Errorf("failed to check existing network fault: '%s' command failed with the following error: '%s'. std output: '%s'",
+			tcCheckInjectionCommandComposed, err, string(cmdOutput[:]))
+	}
+	// Log the command output to better help us debug.
+	logger.Info(fmt.Sprintf("'%s' command result: '%s'", tcCheckInjectionCommandComposed, string(cmdOutput[:])))
+
+	// Check whether latency fault exists and whether packet loss fault exists separately.
+	var outputUnmarshalled []map[string]interface{}
+	err = json.Unmarshal(cmdOutput, &outputUnmarshalled)
+	if err != nil {
+		return false, false, errors.New("failed to check existing network fault: failed to unmarshal tc command output: " + err.Error())
+	}
+	latencyFaultExists, err := checkLatencyFault(outputUnmarshalled)
+	if err != nil {
+		return false, false, errors.New("failed to check existing network fault: " + err.Error())
+	}
+	packetLossFaultExists, err := checkPacketLossFault(outputUnmarshalled)
+	if err != nil {
+		return false, false, errors.New("failed to check existing network fault: " + err.Error())
+	}
+	return latencyFaultExists, packetLossFaultExists, nil
+}
+
+// checkLatencyFault parses the tc command output and checks if there's existing network-latency fault running.
+func checkLatencyFault(outputUnmarshalled []map[string]interface{}) (bool, error) {
+	for _, line := range outputUnmarshalled {
+		// Check if field "kind":"netem" exists.
+		if line["kind"] == "netem" {
+			// Now check if network packet loss fault exists.
+			if options := line["options"]; options != nil {
+				if delay := options.(map[string]interface{})["delay"]; delay != nil {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
+// checkPacketLossFault parses the tc command output and checks if there's existing network-packet-loss fault running.
+func checkPacketLossFault(outputUnmarshalled []map[string]interface{}) (bool, error) {
+	for _, line := range outputUnmarshalled {
+		// First check field "kind":"netem" exists.
+		if line["kind"] == "netem" {
+			// Now check if field "loss":"<loss percent>" exists, and if the percentage matches with the value in the request.
+			if options := line["options"]; options != nil {
+				if lossRandom := options.(map[string]interface{})["loss-random"]; lossRandom != nil {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
 }
 
 // runExecCommand wraps around the execwrapper, providing a convenient way of running any Linux command


### PR DESCRIPTION
### Summary
Adding implementation for `StartNetworkPacketLoss()` and corresponding unit tests. Also updating the `os/exec` wrapper to include 2 more helper methods to facilitate mocks in unit testing.

The unit test syntax is sampled from this pending PR: https://github.com/aws/amazon-ecs-agent/pull/4330/files.

### Implementation details
When the start network-packet-loss endpoint is invoked, we will first check to see if there already exists a latency/packet loss fault, if yes, return code 409 to indicate the conflict. Otherwise, the following command will be called to start the fault:
```
<nsenterPrefix> tc qdisc add dev <interfaceName> root handle 1: prio priomap 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
<nsenterPrefix> "tc qdisc add dev <interfaceName> parent 1:1 handle 10: netem loss <lossPercentage>%"
```

### Testing
Unit tests for the TMDS package was run.
```
 % go test -tags unit -v -run TestStartNetworkPacketLoss /workplace/tianzes/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers
...
--- PASS: TestStartNetworkPacketLoss (0.00s)
    --- PASS: TestStartNetworkPacketLoss/no-existing-fault (0.00s)
    --- PASS: TestStartNetworkPacketLoss/existing-network-latency-fault (0.00s)
    --- PASS: TestStartNetworkPacketLoss/existing-network-packet-loss-fault (0.00s)
    --- PASS: TestStartNetworkPacketLoss/unknown-request-body-no-existing-fault (0.00s)
    --- PASS: TestStartNetworkPacketLoss/failed-to-unmarshal-json (0.00s)
    --- PASS: TestStartNetworkPacketLoss/os/exec-times-out (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_malformed_request_body_1 (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_malformed_request_body_2 (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_incomplete_request_body_1 (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_incomplete_request_body_2 (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_incomplete_request_body_3 (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_invalid_LossPercent_in_the_request_body_1 (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_invalid_LossPercent_in_the_request_body_2 (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_invalid_LossPercent_in_the_request_body_3 (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_invalid_IP_value_in_the_request_body_1 (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_invalid_IP_CIDR_block_value_in_the_request_body_2 (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_task_lookup_fail (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_task_metadata_fetch_fail (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_task_metadata_unknown_fail (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_fault_injection_disabled (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_invalid_network_mode (0.00s)
    --- PASS: TestStartNetworkPacketLoss/start_network-packet-loss_empty_task_network_config (0.00s)
PASS
```

New tests cover the changes: <!-- yes|no -->
Besides existing test cases for the handler, also added the following cases specifically for the start endpoint:
1. When there doesn't exist a fault on the instance
2. When there exists a packet loss fault
3. When there exists a latency fault
4. When the json is malformed
5. When the 5 second context times out

### Manual Testing
Launched a Fargate Instance with the changes. Launched a task with ecs-exec enabled.
```
# Log into the instance as 'su', manually run the tc command to check if there's existing fault:
% nsenter --net=/var/run/netns/f51cb03b1b68477899424be2256218d4-02362b26ecd3 tc q show dev eth1 parent 1:1
result was empty

# Now ecs-exec into the container, curl the start endpoint with the following:
% curl -X PUT \
${ECS_AGENT_URI}/fault/v1/network-packet-loss \
--data '{"lossPercent":6, "Sources":["192.168.0.1"]}'

# And check from the instance again:
% nsenter --net=/var/run/netns/f51cb03b1b68477899424be2256218d4-02362b26ecd3 tc q show dev eth1 parent 1:1
qdisc netem 10: parent 1:1 limit 1000 loss 6%

# Now curl the endpoint again, an error should be returned since we've already injected a fault.
% curl -X PUT ${ECS_AGENT_URI}/fault/v1/network-packet-loss --data '{"lossPercent":6, "Sources":["192.168.1.1"]}'
{"Error":"There is already one network packet loss fault running"}

# Edge case: manually add a latency fault, and call the start packet loss endpoint. An error should be returned as well:
% nsenter --net=/var/run/netns/f51cb03b1b68477899424be2256218d4-02362b26ecd3 tc qdisc add dev eth1 parent 1:1 handle 10: netem delay 100ms 10ms

% curl -X PUT ${ECS_AGENT_URI}/fault/v1/network-packet-loss --data '{"lossPercent":6, "Sources":["192.168.1.1"]}'
{"Error":"There is already one network latency fault running"}
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add start network packet loss implementation 

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
