### PR TITLE
[Don't review] Test amazon-ecs-cni-plugins on aws-sdk-go-v2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "amazon-ecs-cni-plugins"]
 	path = amazon-ecs-cni-plugins
-	url = https://github.com/aws/amazon-ecs-cni-plugins.git
+	url = https://github.com/tinnywang/amazon-ecs-cni-plugins.git
 [submodule "amazon-vpc-cni-plugins"]
 	path = amazon-vpc-cni-plugins
 	url = https://github.com/aws/amazon-vpc-cni-plugins.git

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -29,7 +29,7 @@ import (
 const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated.
 	currentECSCNIVersion = "2024.09.0"
-	currentECSCNIGitHash = "8d916250b8018eac44de6556020a00ec8aa15836"
+	currentECSCNIGitHash = "4e2f3f2938471a210040e44c25d5912ab830d9db"
 	currentVPCCNIGitHash = "be5214353252f8315a1341f4df9ffbd8cf69000c"
 )
 

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -29,7 +29,7 @@ import (
 const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated.
 	currentECSCNIVersion = "2024.09.0"
-	currentECSCNIGitHash = "7acff6d4f794fb969b64b0557797f52e255266f7"
+	currentECSCNIGitHash = "8d916250b8018eac44de6556020a00ec8aa15836"
 	currentVPCCNIGitHash = "be5214353252f8315a1341f4df9ffbd8cf69000c"
 )
 

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -28,8 +28,8 @@ import (
 
 const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated.
-	currentECSCNIVersion = "2020.09.0"
-	currentECSCNIGitHash = "53a8481891251e66e35847554d52a13fc7c4fd03"
+	currentECSCNIVersion = "2024.09.0"
+	currentECSCNIGitHash = "718d13afd8618e88b4aa2b7c78541b6d79f4db30"
 	currentVPCCNIGitHash = "be5214353252f8315a1341f4df9ffbd8cf69000c"
 )
 

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -29,7 +29,7 @@ import (
 const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated.
 	currentECSCNIVersion = "2024.09.0"
-	currentECSCNIGitHash = "718d13afd8618e88b4aa2b7c78541b6d79f4db30"
+	currentECSCNIGitHash = "7acff6d4f794fb969b64b0557797f52e255266f7"
 	currentVPCCNIGitHash = "be5214353252f8315a1341f4df9ffbd8cf69000c"
 )
 


### PR DESCRIPTION
Updates the submodule `amazon-ecs-cni-plugins` to https://github.com/tinnywang/amazon-ecs-cni-plugins/commit/8d916250b8018eac44de6556020a00ec8aa15836.