### PR TITLE
Expose FaultInjectionEnabled in Task Metadata Response

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -54,13 +54,13 @@ import (
 	tmdsv1 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v1"
 	v2 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v2"
 	v4 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state"
-	"github.com/gorilla/mux"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -533,6 +533,14 @@ func v4ContainerResponseFromV2(
 	}
 }
 
+// expectedV4TaskResponseWithFaultInjectionEnabled returns a standard v4 task response with
+// FaultInjection enabled.
+func expectedV4TaskResponseWithFaultInjectionEnabled() v4.TaskResponse {
+	taskResp := expectedV4TaskResponse()
+	taskResp.FaultInjectionEnabled = true
+	return taskResp
+}
+
 // Returns a standard v4 task response. This getter function protects against tests mutating
 // the response.
 func expectedV4TaskResponse() v4.TaskResponse {
@@ -561,6 +569,14 @@ func expectedV4TaskResponse() v4.TaskResponse {
 
 func expectedV4TaskNetworkConfig(faultInjectionEnabled bool, networkMode, path, deviceName string) *v4.TaskNetworkConfig {
 	return v4.NewTaskNetworkConfig(networkMode, path, deviceName)
+}
+
+// expectedV4TaskResponseHostModeWithFaultInjectionEnabled returns a standard v4 task response with
+// FaultInjection enabled.
+func expectedV4TaskResponseHostModeWithFaultInjectionEnabled() v4.TaskResponse {
+	taskResp := expectedV4TaskResponseHostMode()
+	taskResp.FaultInjectionEnabled = true
+	return taskResp
 }
 
 func expectedV4TaskResponseHostMode() v4.TaskResponse {
@@ -677,9 +693,10 @@ func v4TaskResponseFromV2(
 ) v4.TaskResponse {
 	v2TaskResponse.Containers = nil
 	return v4.TaskResponse{
-		TaskResponse: &v2TaskResponse,
-		Containers:   containers,
-		VPCID:        vpcID,
+		TaskResponse:          &v2TaskResponse,
+		Containers:            containers,
+		VPCID:                 vpcID,
+		FaultInjectionEnabled: false,
 	}
 }
 
@@ -2076,7 +2093,7 @@ func TestV4TaskMetadata(t *testing.T) {
 				)
 			},
 			expectedStatusCode:   http.StatusOK,
-			expectedResponseBody: expectedV4TaskResponse(),
+			expectedResponseBody: expectedV4TaskResponseWithFaultInjectionEnabled(),
 		})
 	})
 
@@ -2098,7 +2115,7 @@ func TestV4TaskMetadata(t *testing.T) {
 				)
 			},
 			expectedStatusCode:   http.StatusOK,
-			expectedResponseBody: expectedV4TaskResponseHostMode(),
+			expectedResponseBody: expectedV4TaskResponseHostModeWithFaultInjectionEnabled(),
 		})
 	})
 

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
@@ -38,7 +38,7 @@ type TaskResponse struct {
 	EphemeralStorageMetrics *EphemeralStorageMetrics `json:"EphemeralStorageMetrics,omitempty"`
 	CredentialsID           string                   `json:"-"`
 	TaskNetworkConfig       *TaskNetworkConfig       `json:"-"`
-	FaultInjectionEnabled   bool                     `json:"-"`
+	FaultInjectionEnabled   bool                     `json:"FaultInjectionEnabled,omitempty"`
 }
 
 // TaskNetworkConfig contains required network configurations for network faults injection.

--- a/ecs-agent/tmds/handlers/v4/handlers_test.go
+++ b/ecs-agent/tmds/handlers/v4/handlers_test.go
@@ -299,9 +299,8 @@ func TestTaskMetadata(t *testing.T) {
 	t.Run("happy case with FaultInjection enabled", func(t *testing.T) {
 		metadata := taskResponseWithFaultInjectionEnabled()
 		expectedTaskResponse := taskResponseWithFaultInjectionEnabled()
-		expectedTaskResponse.CredentialsID = ""            // credentials ID not expected
-		expectedTaskResponse.TaskNetworkConfig = nil       // TaskNetworkConfig is not expected and would be used internally
-		expectedTaskResponse.FaultInjectionEnabled = false // FaultInjectionEnabled is not expected and would be used internally
+		expectedTaskResponse.CredentialsID = ""      // credentials ID not expected
+		expectedTaskResponse.TaskNetworkConfig = nil // TaskNetworkConfig is not expected and would be used internally
 
 		handler, _, agentState, _ := setup(t)
 		agentState.EXPECT().

--- a/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/ecs-agent/tmds/handlers/v4/state/response.go
@@ -38,7 +38,7 @@ type TaskResponse struct {
 	EphemeralStorageMetrics *EphemeralStorageMetrics `json:"EphemeralStorageMetrics,omitempty"`
 	CredentialsID           string                   `json:"-"`
 	TaskNetworkConfig       *TaskNetworkConfig       `json:"-"`
-	FaultInjectionEnabled   bool                     `json:"-"`
+	FaultInjectionEnabled   bool                     `json:"FaultInjectionEnabled,omitempty"`
 }
 
 // TaskNetworkConfig contains required network configurations for network faults injection.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR is to expose a new field `FaultInjectionEnabled ` in the task metadata response (v4) so that any customer can check the status of the fault injection support in the task.

### Implementation details
<!-- How are the changes implemented? -->
- Add a new field in the [task metadata response](https://github.com/aws/amazon-ecs-agent/blob/master/ecs-agent/tmds/handlers/v4/state/response.go#L32).

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

```
// before the PR
sh-5.2# curl http://169.254.170.2/v4/metadata 
{
  "Cluster": "arn:aws:ecs:us-west-2:371230630865:cluster/tobedeletedsoon",
  "TaskARN": "arn:aws:ecs:us-west-2:371230630865:task/tobedeletedsoon/605a5eac95e4408fb27c87d43a135be0",
  "Family": "shim-logger-test",
  "Revision": "6",
  "DesiredStatus": "RUNNING",
  "KnownStatus": "RUNNING",
  "Limits": {
    "CPU": 0.5,
    "Memory": 1024
  },
  "PullStartedAt": "2024-09-11T22:54:26.129922562Z",
  "PullStoppedAt": "2024-09-11T22:54:36.472017538Z",
  "AvailabilityZone": "us-west-2a",
  "LaunchType": "FARGATE",
  "Containers": [
    {
      "DockerId": "605a5eac95e4408fb27c87d43a135be0-3147973833",
      "Name": "testing-1",
      "DockerName": "testing-1",
      "Image": "public.ecr.aws/amazonlinux/amazonlinux:2023",
      "ImageID": "sha256:46c62658e791da5e9ef5a88a8c2747aa2b7f548e9feae09ccb2fd2d66e380b53",
      "Labels": {
        "com.amazonaws.ecs.cluster": "arn:aws:ecs:us-west-2:371230630865:cluster/tobedeletedsoon",
        "com.amazonaws.ecs.container-name": "testing-1",
        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:371230630865:task/tobedeletedsoon/605a5eac95e4408fb27c87d43a135be0",
        "com.amazonaws.ecs.task-definition-family": "shim-logger-test",
        "com.amazonaws.ecs.task-definition-version": "6"
      },
      "DesiredStatus": "RUNNING",
      "KnownStatus": "RUNNING",
      "Limits": {
        "CPU": 2
      },
      "CreatedAt": "2024-09-11T22:54:45.981415263Z",
      "StartedAt": "2024-09-11T22:54:45.981415263Z",
      "Type": "NORMAL",
      "LogDriver": "awslogs",
      "LogOptions": {
        "awslogs-create-group": "true",
        "awslogs-group": "xing-testing-group",
        "awslogs-region": "us-west-2",
        "awslogs-stream": "xing-testing-prefix/testing-1/605a5eac95e4408fb27c87d43a135be0",
        "mode": "non-blocking"
      },
      "ContainerARN": "arn:aws:ecs:us-west-2:371230630865:container/tobedeletedsoon/605a5eac95e4408fb27c87d43a135be0/6982a4da-74e2-4d1b-9ca4-ee78672d2f81",
      "Networks": [
        {
          "NetworkMode": "awsvpc",
          "IPv4Addresses": [
            "10.194.20.79"
          ],
          "AttachmentIndex": 0,
          "MACAddress": "06:94:57:4a:c7:a9",
          "IPv4SubnetCIDRBlock": "10.194.20.0/24",
          "PrivateDNSName": "ip-10-194-20-79.us-west-2.compute.internal",
          "SubnetGatewayIpv4Address": "10.194.20.1/24"
        }
      ],
      "Snapshotter": "overlayfs"
    }
  ],
  "ClockDrift": {
    "ClockErrorBound": 0.21647300000000003,
    "ReferenceTimestamp": "2024-09-18T18:35:49Z",
    "ClockSynchronizationStatus": "SYNCHRONIZED"
  },
  "EphemeralStorageMetrics": {
    "Utilized": 205,
    "Reserved": 20496
  }
}
sh-5.2#

// after the PR
sh-5.2# curl http://169.254.170.2/v4/metadata 
{
  "Cluster": "arn:aws:ecs:us-west-2:371230630865:cluster/tobedeletedsoon",
  "TaskARN": "arn:aws:ecs:us-west-2:371230630865:task/tobedeletedsoon/605a5eac95e4408fb27c87d43a135be0",
  "Family": "shim-logger-test",
  "Revision": "6",
  "DesiredStatus": "RUNNING",
  "KnownStatus": "RUNNING",
  "Limits": {
    "CPU": 0.5,
    "Memory": 1024
  },
  "PullStartedAt": "2024-09-11T22:54:26.129922562Z",
  "PullStoppedAt": "2024-09-11T22:54:36.472017538Z",
  "AvailabilityZone": "us-west-2a",
  "LaunchType": "FARGATE",
  "Containers": [
    {
      "DockerId": "605a5eac95e4408fb27c87d43a135be0-3147973833",
      "Name": "testing-1",
      "DockerName": "testing-1",
      "Image": "public.ecr.aws/amazonlinux/amazonlinux:2023",
      "ImageID": "sha256:46c62658e791da5e9ef5a88a8c2747aa2b7f548e9feae09ccb2fd2d66e380b53",
      "Labels": {
        "com.amazonaws.ecs.cluster": "arn:aws:ecs:us-west-2:371230630865:cluster/tobedeletedsoon",
        "com.amazonaws.ecs.container-name": "testing-1",
        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:371230630865:task/tobedeletedsoon/605a5eac95e4408fb27c87d43a135be0",
        "com.amazonaws.ecs.task-definition-family": "shim-logger-test",
        "com.amazonaws.ecs.task-definition-version": "6"
      },
      "DesiredStatus": "RUNNING",
      "KnownStatus": "RUNNING",
      "Limits": {
        "CPU": 2
      },
      "CreatedAt": "2024-09-11T22:54:45.981415263Z",
      "StartedAt": "2024-09-11T22:54:45.981415263Z",
      "Type": "NORMAL",
      "LogDriver": "awslogs",
      "LogOptions": {
        "awslogs-create-group": "true",
        "awslogs-group": "xing-testing-group",
        "awslogs-region": "us-west-2",
        "awslogs-stream": "xing-testing-prefix/testing-1/605a5eac95e4408fb27c87d43a135be0",
        "mode": "non-blocking"
      },
      "ContainerARN": "arn:aws:ecs:us-west-2:371230630865:container/tobedeletedsoon/605a5eac95e4408fb27c87d43a135be0/6982a4da-74e2-4d1b-9ca4-ee78672d2f81",
      "Networks": [
        {
          "NetworkMode": "awsvpc",
          "IPv4Addresses": [
            "10.194.20.79"
          ],
          "AttachmentIndex": 0,
          "MACAddress": "06:94:57:4a:c7:a9",
          "IPv4SubnetCIDRBlock": "10.194.20.0/24",
          "PrivateDNSName": "ip-10-194-20-79.us-west-2.compute.internal",
          "SubnetGatewayIpv4Address": "10.194.20.1/24"
        }
      ],
      "Snapshotter": "overlayfs"
    }
  ],
  "ClockDrift": {
    "ClockErrorBound": 0.22018249999999998,
    "ReferenceTimestamp": "2024-09-18T18:38:31Z",
    "ClockSynchronizationStatus": "SYNCHRONIZED"
  },
  "EphemeralStorageMetrics": {
    "Utilized": 205,
    "Reserved": 20496
  },
  "FaultInjectionEnabled": true
}
sh-5.2#
```

New tests cover the changes: <!-- yes|no -->

Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
