### PR TITLE
Add network-latency fault implementation

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -119,18 +119,19 @@ const (
 	hostNetworkNamespace       = "host"
 	defaultIfname              = "eth0"
 
-	port                           = 1234
-	protocol                       = "tcp"
-	trafficType                    = "ingress"
-	delayMilliseconds              = 123456789
-	jitterMilliseconds             = 4567
-	lossPercent                    = 6
-	invalidNetworkMode             = "invalid"
-	iptablesChainNotFoundError     = "iptables: Bad rule (does a matching rule exist in that chain?)."
-	iptablesChainAlreadyExistError = "iptables: Chain already exists."
-	tcLossFaultExistsCommandOutput = `[{"kind":"netem","handle":"10:","dev":"eth0","parent":"1:1","options":{"limit":1000,"loss-random":{"loss":0.06,"correlation":0},"ecn":false,"gap":0}}]`
-	tcCommandEmptyOutput           = `[]`
-	requestTimeoutDuration         = 5 * time.Second
+	port                              = 1234
+	protocol                          = "tcp"
+	trafficType                       = "ingress"
+	delayMilliseconds                 = 123456789
+	jitterMilliseconds                = 4567
+	lossPercent                       = 6
+	invalidNetworkMode                = "invalid"
+	iptablesChainNotFoundError        = "iptables: Bad rule (does a matching rule exist in that chain?)."
+	iptablesChainAlreadyExistError    = "iptables: Chain already exists."
+	tcLossFaultExistsCommandOutput    = `[{"kind":"netem","handle":"10:","dev":"eth0","parent":"1:1","options":{"limit":1000,"loss-random":{"loss":0.06,"correlation":0},"ecn":false,"gap":0}}]`
+	tcLatencyFaultExistsCommandOutput = `[{"kind":"netem","handle":"10:","parent":"1:1","options":{"limit":1000,"delay":{"delay":123456789,"jitter":4567,"correlation":0},"ecn":false,"gap":0}}]`
+	tcCommandEmptyOutput              = `[]`
+	requestTimeoutDuration            = 5 * time.Second
 )
 
 var (
@@ -3824,27 +3825,44 @@ func TestRegisterCheckBlackholePortFaultHandler(t *testing.T) {
 }
 
 func TestRegisterStartLatencyFaultHandler(t *testing.T) {
-	// TODO: Will need to set the correct os/exec exectation calls once this is implemented
 	setExecExpectations := func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+		mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+		gomock.InOrder(
+			exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+			exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
+		)
+		exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(4).Return(mockCMD)
+		mockCMD.EXPECT().CombinedOutput().Times(4).Return([]byte(tcCommandEmptyOutput), nil)
 	}
 	tcs := generateCommonNetworkFaultInjectionTestCases("start latency", "running", setExecExpectations, happyNetworkLatencyReqBody)
 	testRegisterFaultHandler(t, tcs, faulthandler.NetworkFaultPath(faulttype.LatencyFaultType, faulttype.StartNetworkFaultPostfix))
 }
 
 func TestRegisterStopLatencyFaultHandler(t *testing.T) {
-	// TODO: Will need to set the correct os/exec exectation calls once this is implemented
 	setExecExpectations := func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+		mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+		gomock.InOrder(
+			exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+			exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
+		)
 	}
 	tcs := generateCommonNetworkFaultInjectionTestCases("stop latency", "stopped", setExecExpectations, happyNetworkLatencyReqBody)
 	testRegisterFaultHandler(t, tcs, faulthandler.NetworkFaultPath(faulttype.LatencyFaultType, faulttype.StopNetworkFaultPostfix))
 }
 
 func TestRegisterCheckLatencyFaultHandler(t *testing.T) {
-	// TODO: Will need to set the correct os/exec exectation calls once this is implemented
 	setExecExpectations := func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+		mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+		gomock.InOrder(
+			exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+			exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLatencyFaultExistsCommandOutput), nil),
+		)
 	}
 	tcs := generateCommonNetworkFaultInjectionTestCases("check latency", "running", setExecExpectations, happyNetworkLatencyReqBody)
 	testRegisterFaultHandler(t, tcs, faulthandler.NetworkFaultPath(faulttype.LatencyFaultType, faulttype.CheckNetworkFaultPostfix))

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
@@ -67,4 +67,6 @@ const (
 	Request                 = "request"
 	RoleType                = "roleType"
 	RoleARN                 = "roleARN"
+	CommandString           = "commandString"
+	CommandOutput           = "commandOutput"
 )

--- a/ecs-agent/logger/field/constants.go
+++ b/ecs-agent/logger/field/constants.go
@@ -67,4 +67,6 @@ const (
 	Request                 = "request"
 	RoleType                = "roleType"
 	RoleARN                 = "roleARN"
+	CommandString           = "commandString"
+	CommandOutput           = "commandOutput"
 )


### PR DESCRIPTION
### Summary
Adding implementation for the 3 APIs for network-latency fault, including `StartNetworkLatency()`, `StopNetworkLatency()`, and `CheckNetworkLatency()`, as well as corresponding unit tests.

### Implementation details
The network-latency fault implementation is similar to that of the network-packet-loss fault.
The following Linux command will be called:
```
# Start
<nsenterPrefix> tc qdisc add dev <interfaceName> root handle 1: prio priomap 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
<nsenterPrefix> "tc qdisc add dev <interfaceName> parent 1:1 handle 10: netem delay <latency>ms <jitter>ms
# Stop
Share the same helper method as StopNetworkPacketLoss()
# Check
Share the same helper method as CheckNetworkPacketLoss()
```


### Testing
Unit tests for the TMDS package was run.
```
 % go test -tags unit -v -run TestStartNetworkLatency /workplace/tianzes/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers
...
--- PASS: TestStartNetworkLatency (0.00s)

 % go test -tags unit -v -run TestStopNetworkLatency /workplace/tianzes/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers
...
--- PASS: TestStopNetworkLatency (0.00s)

 % go test -tags unit -v -run TestCheckNetworkLatency /workplace/tianzes/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers
...
--- PASS: TestCheckNetworkLatency (0.00s)
```

New tests cover the changes: <!-- yes|no -->
Besides existing test cases for the handler, also added the following cases specifically for the start endpoint:
1. When there doesn't exist a fault on the instance
2. When there exists a packet loss fault
3. When there exists a latency fault
4. When the request contains an unknown field but the rest of the payload is proper.

### Manual Testing
```
# First curl the check latency endpoint. Since we haven't injected anything yet, response should be not running
 % curl -X GET ${ECS_AGENT_URI}/fault/v1/network-latency --data '{"DelayMilliseconds":100, "JitterMilliseconds":10, "Sources":["192.168.0.1"]}'
{"Status":"not-running"}

# Now curl the start endpoint
 % curl -X PUT ${ECS_AGENT_URI}/fault/v1/network-latency --data '{"DelayMilliseconds":100, "JitterMilliseconds":10, "Sources":["192.168.0.1"]}'
{"Status":"running"}

# Curl the check endpoint again to confirm that the fault was running. Note that the IP address in the check payload is different from the one in the start payload. This shouldn't matter because we won't use it. But if we agree that we won't need it we should take an AI to remove it from the check and stop payload.
 % curl -X GET ${ECS_AGENT_URI}/fault/v1/network-latency --data '{"DelayMilliseconds":100, "JitterMilliseconds":10, "Sources":["192.168.0.1"]}'
{"Status":"running"}

# Curl the start endpoint again. This time it should report that there's already a latency fault running.
 % curl -X PUT ${ECS_AGENT_URI}/fault/v1/network-latency --data '{"DelayMilliseconds":100, "JitterMilliseconds":10, "Sources":["192.168.0.1"]}'
{"Error":"There is already one network latency fault running"}

# Curl the stop endpoint with arbitrary IP address
 % curl -X DELETE ${ECS_AGENT_URI}/fault/v1/network-latency --data '{"DelayMilliseconds":100, "JitterMilliseconds":10, "Sources":["192.168.0.1"]}'
{"Status":"stopped"}

# Finally, curl the check endpoint again. The result should be not-running
 % curl -X GET ${ECS_AGENT_URI}/fault/v1/network-latency --data '{"DelayMilliseconds":100, "JitterMilliseconds":10, "Sources":["192.168.0.1"]}'
 {"Status":"not-running"}

# Additional check:
# First start a network packet loss fault
 % curl -X PUT ${ECS_AGENT_URI}/fault/v1/network-packet-loss --data '{"lossPercent":6, "Sources":["192.168.0.1", "10.1.1.1", "25.168.10.2"]}'
{"Status":"running"}
# Now attempt to start a latency fault. The conflict should be reported
 % curl -X PUT ${ECS_AGENT_URI}/fault/v1/network-latency --data '{"DelayMilliseconds":100, "JitterMilliseconds":10, "Sources":["192.168.0.1"]}'
{"Error":"There is already one network packet loss fault running"}

# Now confirm that the fault is working
# First start a latency fault with IP address 8.8.8.8, with 1000ms delay and 100ms jitter.
 % curl -X PUT ${ECS_AGENT_URI}/fault/v1/network-latency --data '{"DelayMilliseconds":1000, "JitterMilliseconds":100, "Sources":["8.8.8.8"]}'
{"Status":"running"}
# Now ping the ip address
 % ping 8.8.8.8 -D
PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
...
[1727218069.113409] 64 bytes from 8.8.8.8: icmp_seq=20 ttl=57 time=1101 ms
[1727218070.117507] 64 bytes from 8.8.8.8: icmp_seq=21 ttl=57 time=1075 ms
[1727218071.070307] 64 bytes from 8.8.8.8: icmp_seq=22 ttl=57 time=1027 ms
[1727218072.067608] 64 bytes from 8.8.8.8: icmp_seq=23 ttl=57 time=1023 ms
[1727218073.097244] 64 bytes from 8.8.8.8: icmp_seq=24 ttl=57 time=1051 ms
# Now remove the fault
 % curl -X DELETE ${ECS_AGENT_URI}/fault/v1/network-latency --data '{"DelayMilliseconds":100, "JitterMilliseconds":10, "Sources":["192.168.0.1"]}'
{"Status":"stopped"}
# And ping the ip address again
 % ping 8.8.8.8 -D
PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
...
[1727218138.572887] 64 bytes from 8.8.8.8: icmp_seq=4 ttl=57 time=9.29 ms
[1727218139.574341] 64 bytes from 8.8.8.8: icmp_seq=5 ttl=57 time=9.32 ms
[1727218140.575834] 64 bytes from 8.8.8.8: icmp_seq=6 ttl=57 time=9.35 ms
[1727218141.577308] 64 bytes from 8.8.8.8: icmp_seq=7 ttl=57 time=9.32 ms
[1727218142.578780] 64 bytes from 8.8.8.8: icmp_seq=8 ttl=57 time=9.31 ms
# Note the difference in time (~1000ms vs ~9ms)
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Add network latency fault implementation 

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
