### PR TITLE
Adding EnableFaultInjection to task payload

### DIFF
--- a/agent/acs/session/payload_responder.go
+++ b/agent/acs/session/payload_responder.go
@@ -132,6 +132,12 @@ func (pmHandler *payloadMessageHandler) addPayloadTasks(payload *ecsacs.PayloadM
 			loggerfield.DesiredStatus: apiTask.GetDesiredStatus(),
 		})
 
+		if apiTask.IsFaultInjectionEnabled() {
+			logger.Info("Fault Injection Enabled for task", logger.Fields{
+				loggerfield.TaskARN: apiTask.Arn,
+			})
+		}
+
 		if task.RoleCredentials != nil {
 			// The payload from ACS for the task has credentials for the
 			// task. Add those to the credentials manager and set the

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -299,8 +299,7 @@ type Task struct {
 
 	NetworkNamespace string `json:"NetworkNamespace,omitempty"`
 
-	// TODO: Will need to initialize/set the value in a follow PR
-	FaultInjectionEnabled bool `json:"FaultInjectionEnabled,omitempty"`
+	EnableFaultInjection bool `json:"enableFaultInjection,omitempty"`
 
 	// DefaultIfname is used to reference the default network interface name on the task network namespace
 	// For AWSVPC mode, it can be eth0 which corresponds to the interface name on the task ENI
@@ -321,6 +320,9 @@ func TaskFromACS(acsTask *ecsacs.Task, envelope *ecsacs.PayloadMessage) (*Task, 
 	if err := json.Unmarshal(data, task); err != nil {
 		return nil, err
 	}
+
+	// Set the EnableFaultInjection field if present
+	task.EnableFaultInjection = aws.BoolValue(acsTask.EnableFaultInjection)
 
 	// Overrides the container command if it's set
 	for _, container := range task.Containers {
@@ -3771,7 +3773,7 @@ func (task *Task) IsFaultInjectionEnabled() bool {
 	task.lock.RLock()
 	defer task.lock.RUnlock()
 
-	return task.FaultInjectionEnabled
+	return task.EnableFaultInjection
 }
 
 func (task *Task) GetNetworkMode() string {

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -457,9 +457,9 @@ var (
 		}},
 	})
 
-	agentStateExpectations = func(state *mock_dockerstate.MockTaskEngineState, faultInjectionEnabled bool, networkMode string) {
+	agentStateExpectations = func(state *mock_dockerstate.MockTaskEngineState, enableFaultInjection bool, networkMode string) {
 		task := standardTask()
-		task.FaultInjectionEnabled = faultInjectionEnabled
+		task.EnableFaultInjection = enableFaultInjection
 		task.NetworkMode = networkMode
 		task.NetworkNamespace = networkNamespace
 		task.DefaultIfname = defaultIfname
@@ -590,7 +590,7 @@ func expectedV4TaskResponse() v4.TaskResponse {
 	)
 }
 
-func expectedV4TaskNetworkConfig(faultInjectionEnabled bool, networkMode, path, deviceName string) *v4.TaskNetworkConfig {
+func expectedV4TaskNetworkConfig(enableFaultInjection bool, networkMode, path, deviceName string) *v4.TaskNetworkConfig {
 	return v4.NewTaskNetworkConfig(networkMode, path, deviceName)
 }
 
@@ -2093,7 +2093,7 @@ func TestV4TaskMetadata(t *testing.T) {
 		testTMDSRequest(t, TMDSTestCase[v4.TaskResponse]{
 			path: v4BasePath + v3EndpointID + "/task",
 			setStateExpectations: func(state *mock_dockerstate.MockTaskEngineState) {
-				task.FaultInjectionEnabled = true
+				task.EnableFaultInjection = true
 				task.NetworkNamespace = networkNamespace
 				task.DefaultIfname = defaultIfname
 				gomock.InOrder(
@@ -2116,7 +2116,7 @@ func TestV4TaskMetadata(t *testing.T) {
 			path: v4BasePath + v3EndpointID + "/task",
 			setStateExpectations: func(state *mock_dockerstate.MockTaskEngineState) {
 				hostTask := standardHostTask()
-				hostTask.FaultInjectionEnabled = true
+				hostTask.EnableFaultInjection = true
 				hostTask.NetworkNamespace = networkNamespace
 				hostTask.DefaultIfname = defaultIfname
 				gomock.InOrder(
@@ -3733,9 +3733,9 @@ type networkFaultTestCase struct {
 	expectedStatusCode    int
 	requestBody           interface{}
 	expectedFaultResponse faulttype.NetworkFaultInjectionResponse
-	setStateExpectations  func(state *mock_dockerstate.MockTaskEngineState, faultInjectionEnabled bool, networkMode string)
+	setStateExpectations  func(state *mock_dockerstate.MockTaskEngineState, enableFaultInjection bool, networkMode string)
 	setExecExpectations   execExpectations
-	faultInjectionEnabled bool
+	enableFaultInjection  bool
 	networkMode           string
 }
 
@@ -3750,7 +3750,7 @@ func generateCommonNetworkFaultInjectionTestCases(requestType, successResponse s
 			expectedFaultResponse: faulttype.NewNetworkFaultInjectionSuccessResponse(successResponse),
 			setStateExpectations:  agentStateExpectations,
 			setExecExpectations:   exec,
-			faultInjectionEnabled: true,
+			enableFaultInjection:  true,
 			networkMode:           apitask.HostNetworkMode,
 		},
 		{
@@ -3760,7 +3760,7 @@ func generateCommonNetworkFaultInjectionTestCases(requestType, successResponse s
 			expectedFaultResponse: faulttype.NewNetworkFaultInjectionSuccessResponse(successResponse),
 			setStateExpectations:  agentStateExpectations,
 			setExecExpectations:   exec,
-			faultInjectionEnabled: true,
+			enableFaultInjection:  true,
 			networkMode:           apitask.AWSVPCNetworkMode,
 		},
 	}
@@ -3910,7 +3910,7 @@ func testRegisterFaultHandler(t *testing.T, tcs []networkFaultTestCase, tmdsEndp
 			execWrapper := mock_execwrapper.NewMockExec(ctrl)
 
 			if tc.setStateExpectations != nil {
-				tc.setStateExpectations(state, tc.faultInjectionEnabled, tc.networkMode)
+				tc.setStateExpectations(state, tc.enableFaultInjection, tc.networkMode)
 			}
 
 			if tc.setExecExpectations != nil {
@@ -3979,7 +3979,7 @@ func TestV4GetTaskMetadataWithTaskNetworkConfig(t *testing.T) {
 			name: "happy case with awsvpc mode",
 			setStateExpectations: func(state *mock_dockerstate.MockTaskEngineState) {
 				task := standardTask()
-				task.FaultInjectionEnabled = true
+				task.EnableFaultInjection = true
 				task.NetworkNamespace = networkNamespace
 				task.DefaultIfname = defaultIfname
 				gomock.InOrder(
@@ -3998,7 +3998,7 @@ func TestV4GetTaskMetadataWithTaskNetworkConfig(t *testing.T) {
 			name: "happy case with host mode",
 			setStateExpectations: func(state *mock_dockerstate.MockTaskEngineState) {
 				hostTask := standardHostTask()
-				hostTask.FaultInjectionEnabled = true
+				hostTask.EnableFaultInjection = true
 				hostTask.NetworkNamespace = networkNamespace
 				hostTask.DefaultIfname = defaultIfname
 				gomock.InOrder(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request adds `EnableFaultInjection` to the task payload.
### Implementation details
<!-- How are the changes implemented? -->
* Introducing `EnableFaultInjection` into the task struct.
* Sets the `EnableFaultInjection` field to true in the task struct when the corresponding AcsTask is not nil.
### Testing
<!-- How was this tested? -->
Ran the existing set of tests to verify the change to `EnableFaultInjection`
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->



### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Adding EnableFaultInjection to task payload
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
