### PR TITLE
Add fault injection SourcesToFilter field in the request payload

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -476,6 +476,8 @@ var (
 
 	ipSources = []string{"52.95.154.1", "52.95.154.2"}
 
+	ipSourcesToFilter = []string{"8.8.8.8"}
+
 	happyBlackHolePortReqBody = map[string]interface{}{
 		"Port":        port,
 		"Protocol":    protocol,
@@ -486,11 +488,13 @@ var (
 		"DelayMilliseconds":  delayMilliseconds,
 		"JitterMilliseconds": jitterMilliseconds,
 		"Sources":            ipSources,
+		"SourcesToFilter":    ipSourcesToFilter,
 	}
 
 	happyNetworkPacketLossReqBody = map[string]interface{}{
-		"LossPercent": lossPercent,
-		"Sources":     ipSources,
+		"LossPercent":     lossPercent,
+		"Sources":         ipSources,
+		"SourcesToFilter": ipSourcesToFilter,
 	}
 )
 

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -719,6 +719,7 @@ func (h *FaultHandler) CheckNetworkLatency() func(http.ResponseWriter, *http.Req
 			responseBody = types.NewNetworkFaultInjectionErrorResponse(err.Error())
 			httpStatusCode = http.StatusInternalServerError
 		} else {
+			stringToBeLogged = "Successfully checked fault status"
 			// If there already exists a fault in the task network namespace.
 			if latencyFaultExists {
 				responseBody = types.NewNetworkFaultInjectionSuccessResponse("running")
@@ -950,6 +951,7 @@ func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.
 			responseBody = types.NewNetworkFaultInjectionErrorResponse(err.Error())
 			httpStatusCode = http.StatusInternalServerError
 		} else {
+			stringToBeLogged = "Successfully checked fault status"
 			// If there already exists a fault in the task network namespace.
 			if packetLossFaultExists {
 				responseBody = types.NewNetworkFaultInjectionSuccessResponse("running")

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -94,6 +94,9 @@ type NetworkLatencyRequest struct {
 	JitterMilliseconds *uint64 `json:"JitterMilliseconds"`
 	// Sources is a list including IPv4 addresses or IPv4 CIDR blocks.
 	Sources []*string `json:"Sources"`
+	// SourcesToFilter is a list including IPv4 addresses or IPv4 CIDR blocks that will be excluded from the
+	// network latency fault.
+	SourcesToFilter []*string `json:"SourcesToFilter,omitempty"`
 }
 
 // ValidateRequest validates required fields are present and its value.
@@ -107,7 +110,15 @@ func (request NetworkLatencyRequest) ValidateRequest() error {
 	if request.Sources == nil || len(request.Sources) == 0 {
 		return fmt.Errorf(missingRequiredFieldError, "Sources")
 	}
-	return validateNetworkFaultRequestSources(request.Sources)
+	err := validateNetworkFaultRequestSources(request.Sources, "Sources")
+	if err != nil {
+		return err
+	}
+	err = validateNetworkFaultRequestSources(request.SourcesToFilter, "SourcesToFilter")
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (request NetworkLatencyRequest) ToString() string {
@@ -123,6 +134,9 @@ type NetworkPacketLossRequest struct {
 	LossPercent *uint64 `json:"LossPercent"`
 	// Sources is a list including IPv4 addresses or IPv4 CIDR blocks.
 	Sources []*string `json:"Sources"`
+	// SourcesToFilter is a list including IPv4 addresses or IPv4 CIDR blocks that will be excluded from the
+	// network packet loss fault.
+	SourcesToFilter []*string `json:"SourcesToFilter,omitempty"`
 }
 
 // ValidateRequest validates required fields are present and its value.
@@ -137,7 +151,15 @@ func (request NetworkPacketLossRequest) ValidateRequest() error {
 	if request.Sources == nil || len(request.Sources) == 0 {
 		return fmt.Errorf(missingRequiredFieldError, "Sources")
 	}
-	return validateNetworkFaultRequestSources(request.Sources)
+	err := validateNetworkFaultRequestSources(request.Sources, "Sources")
+	if err != nil {
+		return err
+	}
+	err = validateNetworkFaultRequestSources(request.SourcesToFilter, "SourcesToFilter")
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (request NetworkPacketLossRequest) ToString() string {
@@ -160,7 +182,7 @@ func NewNetworkFaultInjectionErrorResponse(err string) NetworkFaultInjectionResp
 	}
 }
 
-func validateNetworkFaultRequestSources(sources []*string) error {
+func validateNetworkFaultRequestSources(sources []*string, sourcesType string) error {
 	for _, element := range sources {
 		elementStr := aws.StringValue(element)
 		validIp := true
@@ -173,7 +195,7 @@ func validateNetworkFaultRequestSources(sources []*string) error {
 		}
 
 		if !validIpCIDRBlock && !validIp {
-			return fmt.Errorf(invalidValueError, elementStr, "Sources")
+			return fmt.Errorf(invalidValueError, elementStr, sourcesType)
 		}
 	}
 	return nil

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -719,6 +719,7 @@ func (h *FaultHandler) CheckNetworkLatency() func(http.ResponseWriter, *http.Req
 			responseBody = types.NewNetworkFaultInjectionErrorResponse(err.Error())
 			httpStatusCode = http.StatusInternalServerError
 		} else {
+			stringToBeLogged = "Successfully checked fault status"
 			// If there already exists a fault in the task network namespace.
 			if latencyFaultExists {
 				responseBody = types.NewNetworkFaultInjectionSuccessResponse("running")
@@ -950,6 +951,7 @@ func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.
 			responseBody = types.NewNetworkFaultInjectionErrorResponse(err.Error())
 			httpStatusCode = http.StatusInternalServerError
 		} else {
+			stringToBeLogged = "Successfully checked fault status"
 			// If there already exists a fault in the task network namespace.
 			if packetLossFaultExists {
 				responseBody = types.NewNetworkFaultInjectionSuccessResponse("running")

--- a/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -94,6 +94,9 @@ type NetworkLatencyRequest struct {
 	JitterMilliseconds *uint64 `json:"JitterMilliseconds"`
 	// Sources is a list including IPv4 addresses or IPv4 CIDR blocks.
 	Sources []*string `json:"Sources"`
+	// SourcesToFilter is a list including IPv4 addresses or IPv4 CIDR blocks that will be excluded from the
+	// network latency fault.
+	SourcesToFilter []*string `json:"SourcesToFilter,omitempty"`
 }
 
 // ValidateRequest validates required fields are present and its value.
@@ -107,7 +110,15 @@ func (request NetworkLatencyRequest) ValidateRequest() error {
 	if request.Sources == nil || len(request.Sources) == 0 {
 		return fmt.Errorf(missingRequiredFieldError, "Sources")
 	}
-	return validateNetworkFaultRequestSources(request.Sources)
+	err := validateNetworkFaultRequestSources(request.Sources, "Sources")
+	if err != nil {
+		return err
+	}
+	err = validateNetworkFaultRequestSources(request.SourcesToFilter, "SourcesToFilter")
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (request NetworkLatencyRequest) ToString() string {
@@ -123,6 +134,9 @@ type NetworkPacketLossRequest struct {
 	LossPercent *uint64 `json:"LossPercent"`
 	// Sources is a list including IPv4 addresses or IPv4 CIDR blocks.
 	Sources []*string `json:"Sources"`
+	// SourcesToFilter is a list including IPv4 addresses or IPv4 CIDR blocks that will be excluded from the
+	// network packet loss fault.
+	SourcesToFilter []*string `json:"SourcesToFilter,omitempty"`
 }
 
 // ValidateRequest validates required fields are present and its value.
@@ -137,7 +151,15 @@ func (request NetworkPacketLossRequest) ValidateRequest() error {
 	if request.Sources == nil || len(request.Sources) == 0 {
 		return fmt.Errorf(missingRequiredFieldError, "Sources")
 	}
-	return validateNetworkFaultRequestSources(request.Sources)
+	err := validateNetworkFaultRequestSources(request.Sources, "Sources")
+	if err != nil {
+		return err
+	}
+	err = validateNetworkFaultRequestSources(request.SourcesToFilter, "SourcesToFilter")
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (request NetworkPacketLossRequest) ToString() string {
@@ -160,7 +182,7 @@ func NewNetworkFaultInjectionErrorResponse(err string) NetworkFaultInjectionResp
 	}
 }
 
-func validateNetworkFaultRequestSources(sources []*string) error {
+func validateNetworkFaultRequestSources(sources []*string, sourcesType string) error {
 	for _, element := range sources {
 		elementStr := aws.StringValue(element)
 		validIp := true
@@ -173,7 +195,7 @@ func validateNetworkFaultRequestSources(sources []*string) error {
 		}
 
 		if !validIpCIDRBlock && !validIp {
-			return fmt.Errorf(invalidValueError, elementStr, "Sources")
+			return fmt.Errorf(invalidValueError, elementStr, sourcesType)
 		}
 	}
 	return nil


### PR DESCRIPTION
### Summary
Add fault injection SourcesToFilter field in the request payload.

Also incorporated the following comments from [PR-4363](https://github.com/aws/amazon-ecs-agent/pull/4363)
1. In the request times out unit tests, use `Do(func(){time.Sleep()})` instead of using -1 when creating context with timeout.
2. Add logging when check latency and check packet loss is successful
3. Add back the no-request-body test case for latency fault and packet loss fault

### Implementation details
A new omitempty field `SourcesToFilter` has been added to the network latency and network packet loss request type, allowing.

### Testing
All existing and newly added unit/integ tests passed.

New tests cover the changes: Unit tests have been modified to accommodate this new field. Added a new test case for when the IP address passed in for this field is invalid.

### Description for the changelog
Add fault injection SourcesToFilter field in the request payload

### Licensing
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
