### PR TITLE
Add fault injection allowlist IP implementation

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -3854,8 +3854,8 @@ func TestRegisterStartLatencyFaultHandler(t *testing.T) {
 			exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
 			mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
 		)
-		exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(4).Return(mockCMD)
-		mockCMD.EXPECT().CombinedOutput().Times(4).Return([]byte(tcCommandEmptyOutput), nil)
+		exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(5).Return(mockCMD)
+		mockCMD.EXPECT().CombinedOutput().Times(5).Return([]byte(tcCommandEmptyOutput), nil)
 	}
 	tcs := generateCommonNetworkFaultInjectionTestCases("start latency", "running", setExecExpectations, happyNetworkLatencyReqBody)
 	testRegisterFaultHandler(t, tcs, faulthandler.NetworkFaultPath(faulttype.LatencyFaultType, faulttype.StartNetworkFaultPostfix))
@@ -3898,8 +3898,8 @@ func TestRegisterStartPacketLossFaultHandler(t *testing.T) {
 			exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
 			mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
 		)
-		exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(4).Return(mockCMD)
-		mockCMD.EXPECT().CombinedOutput().Times(4).Return([]byte(tcCommandEmptyOutput), nil)
+		exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(5).Return(mockCMD)
+		mockCMD.EXPECT().CombinedOutput().Times(5).Return([]byte(tcCommandEmptyOutput), nil)
 	}
 	tcs := generateCommonNetworkFaultInjectionTestCases("start packet loss", "running", setExecExpectations, happyNetworkPacketLossReqBody)
 	testRegisterFaultHandler(t, tcs, faulthandler.NetworkFaultPath(faulttype.PacketLossFaultType, faulttype.StartNetworkFaultPostfix))

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -110,12 +110,10 @@ func (request NetworkLatencyRequest) ValidateRequest() error {
 	if request.Sources == nil || len(request.Sources) == 0 {
 		return fmt.Errorf(missingRequiredFieldError, "Sources")
 	}
-	err := validateNetworkFaultRequestSources(request.Sources, "Sources")
-	if err != nil {
+	if err := validateNetworkFaultRequestSources(request.Sources, "Sources"); err != nil {
 		return err
 	}
-	err = validateNetworkFaultRequestSources(request.SourcesToFilter, "SourcesToFilter")
-	if err != nil {
+	if err := validateNetworkFaultRequestSources(request.SourcesToFilter, "SourcesToFilter"); err != nil {
 		return err
 	}
 	return nil
@@ -151,12 +149,10 @@ func (request NetworkPacketLossRequest) ValidateRequest() error {
 	if request.Sources == nil || len(request.Sources) == 0 {
 		return fmt.Errorf(missingRequiredFieldError, "Sources")
 	}
-	err := validateNetworkFaultRequestSources(request.Sources, "Sources")
-	if err != nil {
+	if err := validateNetworkFaultRequestSources(request.Sources, "Sources"); err != nil {
 		return err
 	}
-	err = validateNetworkFaultRequestSources(request.SourcesToFilter, "SourcesToFilter")
-	if err != nil {
+	if err := validateNetworkFaultRequestSources(request.SourcesToFilter, "SourcesToFilter"); err != nil {
 		return err
 	}
 	return nil

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
@@ -1216,8 +1216,8 @@ func generateStartNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
 					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
 				)
-				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(4).Return(mockCMD)
-				mockCMD.EXPECT().CombinedOutput().Times(4).Return([]byte(tcCommandEmptyOutput), nil)
+				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(5).Return(mockCMD)
+				mockCMD.EXPECT().CombinedOutput().Times(5).Return([]byte(tcCommandEmptyOutput), nil)
 			},
 		},
 		{
@@ -1259,6 +1259,7 @@ func generateStartNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 				"DelayMilliseconds":  delayMilliseconds,
 				"JitterMilliseconds": jitterMilliseconds,
 				"Sources":            ipSources,
+				"SourcesToFilter":    []string{},
 				"Unknown":            "",
 			},
 			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
@@ -1318,8 +1319,8 @@ func generateStopNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
 					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLatencyFaultExistsCommandOutput), nil),
 				)
-				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(3).Return(mockCMD)
-				mockCMD.EXPECT().CombinedOutput().Times(3).Return([]byte(""), nil)
+				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(mockCMD)
+				mockCMD.EXPECT().CombinedOutput().Times(2).Return([]byte(""), nil)
 			},
 		},
 		{
@@ -1423,7 +1424,7 @@ func generateCheckNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 			},
 		},
 		{
-			name:               "unknown-request-body-no-existing-fault",
+			name:               "unknown-request-body-no-existing-fault-no-allowlist-filter",
 			expectedStatusCode: 200,
 			requestBody: map[string]interface{}{
 				"DelayMilliseconds":  delayMilliseconds,
@@ -1764,8 +1765,8 @@ func generateStartNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
 					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
 				)
-				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(4).Return(mockCMD)
-				mockCMD.EXPECT().CombinedOutput().Times(4).Return([]byte(tcCommandEmptyOutput), nil)
+				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(5).Return(mockCMD)
+				mockCMD.EXPECT().CombinedOutput().Times(5).Return([]byte(tcCommandEmptyOutput), nil)
 			},
 		},
 		{
@@ -1801,12 +1802,13 @@ func generateStartNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 			},
 		},
 		{
-			name:               "unknown-request-body-no-existing-fault",
+			name:               "unknown-request-body-no-existing-fault-no-allowlist-filter",
 			expectedStatusCode: 200,
 			requestBody: map[string]interface{}{
-				"LossPercent": lossPercent,
-				"Sources":     ipSources,
-				"Unknown":     "",
+				"LossPercent":     lossPercent,
+				"Sources":         ipSources,
+				"SourcesToFilter": []string{},
+				"Unknown":         "",
 			},
 			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
 			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
@@ -1881,8 +1883,8 @@ func generateStopNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
 					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLossFaultExistsCommandOutput), nil),
 				)
-				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(3).Return(mockCMD)
-				mockCMD.EXPECT().CombinedOutput().Times(3).Return([]byte(""), nil)
+				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(mockCMD)
+				mockCMD.EXPECT().CombinedOutput().Times(2).Return([]byte(""), nil)
 			},
 		},
 		{

--- a/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -110,12 +110,10 @@ func (request NetworkLatencyRequest) ValidateRequest() error {
 	if request.Sources == nil || len(request.Sources) == 0 {
 		return fmt.Errorf(missingRequiredFieldError, "Sources")
 	}
-	err := validateNetworkFaultRequestSources(request.Sources, "Sources")
-	if err != nil {
+	if err := validateNetworkFaultRequestSources(request.Sources, "Sources"); err != nil {
 		return err
 	}
-	err = validateNetworkFaultRequestSources(request.SourcesToFilter, "SourcesToFilter")
-	if err != nil {
+	if err := validateNetworkFaultRequestSources(request.SourcesToFilter, "SourcesToFilter"); err != nil {
 		return err
 	}
 	return nil
@@ -151,12 +149,10 @@ func (request NetworkPacketLossRequest) ValidateRequest() error {
 	if request.Sources == nil || len(request.Sources) == 0 {
 		return fmt.Errorf(missingRequiredFieldError, "Sources")
 	}
-	err := validateNetworkFaultRequestSources(request.Sources, "Sources")
-	if err != nil {
+	if err := validateNetworkFaultRequestSources(request.Sources, "Sources"); err != nil {
 		return err
 	}
-	err = validateNetworkFaultRequestSources(request.SourcesToFilter, "SourcesToFilter")
-	if err != nil {
+	if err := validateNetworkFaultRequestSources(request.SourcesToFilter, "SourcesToFilter"); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
### Summary
Add fault injection allowlist IP implementation.

### Implementation details
Now the request payload for network packet loss fault and network latency fault takes in 2 arrays, with the newly added array as an allowlist. IP addresses added to the allowlist will not first be added to a separate filter to ensure that they won't be impacted by the loss/latency filter.

### Testing
Manual testing:
```
# Launch a task with ecs-exec enabled, and connect to the container in the task
# Inject a latency fault with 2 ip addresses, with one of the 2 added to the allowlist list
% curl -X POST ${ECS_AGENT_URI}/fault/v1/network-packet-loss/start --data '{"lossPercent":50, "Sources":["3.5.76.1", "3.5.76.4"], "SourcesToFilter": ["3.5.76.1"]}'
{"Status":"running"}
# Ping the one that's allowlisted
% ping -D 3.5.76.1
PING 3.5.76.1 (3.5.76.1) 56(84) bytes of data.
...
--- 3.5.76.1 ping statistics ---
59 packets transmitted, 59 received, 0% packet loss, time 59305ms
rtt min/avg/max/mdev = 0.468/0.559/1.766/0.181 ms
# We can see that this IP is not impacted by the loss filter
# Ping the one that's not allowlisted
% ping -D 3.5.76.4
PING 3.5.76.4 (3.5.76.4) 56(84) bytes of data.
...
--- 3.5.76.4 ping statistics ---
37 packets transmitted, 20 received, 45.9459% packet loss, time 36781ms
rtt min/avg/max/mdev = 0.382/0.682/3.834/0.840 ms
# We can see that the loss percent is close to 50% (the one we added in the filter)

# Now stop the fault
% curl -X POST ${ECS_AGENT_URI}/fault/v1/network-packet-loss/stop --data '{"lossPercent":50, "Sources":["3.5.76.1", "3.5.76.4"], "SourcesToFilter": ["3.5.76.1"]}'
{"Status":"stopped"}

# Curl the check endpoint
% curl -X POST ${ECS_AGENT_URI}/fault/v1/network-packet-loss/status --data '{"lossPercent":50, "Sources":["3.5.76.1", "3.5.76.4"], "SourcesToFilter": ["3.5.76.1"]}'
{"Status":"not-running"}


# Repeat the same for latency fault:
% curl -X POST ${ECS_AGENT_URI}/fault/v1/network-latency/start --data '{"DelayMilliseconds":1000, "JitterMilliseconds":100, "Sources":["3.5.76.1", "3.5.76.4"], "SourcesToFilter": ["3.5.76.1"]}'
{"Status":"running"}
# Ping the one that's allowlisted
% ping -D 3.5.76.1
PING 3.5.76.1 (3.5.76.1) 56(84) bytes of data.
[1727806969.961276] 64 bytes from 3.5.76.1: icmp_seq=1 ttl=63 time=2.31 ms
[1727806970.960944] 64 bytes from 3.5.76.1: icmp_seq=2 ttl=63 time=0.574 ms
[1727806971.977215] 64 bytes from 3.5.76.1: icmp_seq=3 ttl=63 time=0.513 ms
# Ping the one that's not allowlisted
% ping -D 3.5.76.4
PING 3.5.76.4 (3.5.76.4) 56(84) bytes of data.
[1727806982.874885] 64 bytes from 3.5.76.4: icmp_seq=1 ttl=63 time=967 ms
[1727806983.970733] 64 bytes from 3.5.76.4: icmp_seq=2 ttl=63 time=1063 ms
[1727806984.927355] 64 bytes from 3.5.76.4: icmp_seq=3 ttl=63 time=1015 ms
# We can see the difference in time.

# Now stop the fault
% curl -X POST ${ECS_AGENT_URI}/fault/v1/network-latency/stop --data '{"DelayMilliseconds":1000, "JitterMilliseconds":100, "Sources":["3.5.76.1", "3.5.76.4"], "SourcesToFilter": ["3.5.76.1"]}'
{"Status":"stopped"}

# Curl the check endpoint
% curl -X POST ${ECS_AGENT_URI}/fault/v1/network-latency/status --data '{"DelayMilliseconds":1000, "JitterMilliseconds":100, "Sources":["3.5.76.1", "3.5.76.4"], "SourcesToFilter": ["3.5.76.1"]}'
{"Status":"not-running"}
```

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
Add fault injection allowlist IP implementation.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
