### PR TITLE
Removing omitempty for fault injection task metadata field

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
@@ -38,7 +38,7 @@ type TaskResponse struct {
 	EphemeralStorageMetrics *EphemeralStorageMetrics `json:"EphemeralStorageMetrics,omitempty"`
 	CredentialsID           string                   `json:"-"`
 	TaskNetworkConfig       *TaskNetworkConfig       `json:"-"`
-	FaultInjectionEnabled   bool                     `json:"FaultInjectionEnabled,omitempty"`
+	FaultInjectionEnabled   bool                     `json:"FaultInjectionEnabled"`
 }
 
 // TaskNetworkConfig contains required network configurations for network faults injection.

--- a/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/ecs-agent/tmds/handlers/v4/state/response.go
@@ -38,7 +38,7 @@ type TaskResponse struct {
 	EphemeralStorageMetrics *EphemeralStorageMetrics `json:"EphemeralStorageMetrics,omitempty"`
 	CredentialsID           string                   `json:"-"`
 	TaskNetworkConfig       *TaskNetworkConfig       `json:"-"`
-	FaultInjectionEnabled   bool                     `json:"FaultInjectionEnabled,omitempty"`
+	FaultInjectionEnabled   bool                     `json:"FaultInjectionEnabled"`
 }
 
 // TaskNetworkConfig contains required network configurations for network faults injection.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR removes the `omitempty` from the fault injection task metadata field. 
### Implementation details
<!-- How are the changes implemented? -->
* Remove `omitempty` from `FaultInjectionEnabled` in `type TaskResponse struct`
### Testing
<!-- How was this tested? -->
* Before removing `omitempty`
```
{
  "Cluster": "harishxr-ecs",
  "TaskARN": "arn:aws:ecs:us-west-2:xxyyzz:task/harishxr-ecs/8ec46eb80d6e42a49a669ad9321076a2",
  "Family": "fis-omniempty",
  "Revision": "1",
  "DesiredStatus": "RUNNING",
  "KnownStatus": "RUNNING",
  "Limits": {
    "CPU": 1,
    "Memory": 3072
  },
  "PullStartedAt": "2024-10-01T22:03:05.264367788Z",
  "PullStoppedAt": "2024-10-01T22:03:05.343280945Z",
  "AvailabilityZone": "us-west-2c",
  "LaunchType": "EC2",
  "Containers": [
    {
      "DockerId": "c7c3a97cc6b22695746d477997b55b952153dcb9c938e86aecefa15593f0132e",
      "Name": "~internal~ecs~pause",
      "DockerName": "ecs-fis-omniempty-1-internalecspause-c89ddcec89bec8825400",
      "Image": "amazon/amazon-ecs-pause:0.1.0",
      "ImageID": "",
      "Labels": {
        "com.amazonaws.ecs.cluster": "harishxr-ecs",
        "com.amazonaws.ecs.container-name": "~internal~ecs~pause",
        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:xxyyzz:task/harishxr-ecs/8ec46eb80d6e42a49a669ad9321076a2",
        "com.amazonaws.ecs.task-definition-family": "fis-omniempty",
        "com.amazonaws.ecs.task-definition-version": "1"
      },
      "DesiredStatus": "RESOURCES_PROVISIONED",
      "KnownStatus": "RESOURCES_PROVISIONED",
      "Limits": {
        "CPU": 2,
        "Memory": 0
      },
      "CreatedAt": "2024-10-01T22:03:04.229888206Z",
      "StartedAt": "2024-10-01T22:03:04.496784854Z",
      "Type": "CNI_PAUSE",
      "Networks": [
        {
          "NetworkMode": "awsvpc",
          "IPv4Addresses": [
            "172.31.156.252"
          ],
          "AttachmentIndex": 0,
          "MACAddress": "0a:3f:eb:8b:26:d7",
          "IPv4SubnetCIDRBlock": "172.31.128.0/17",
          "PrivateDNSName": "ip-172-31-156-252.us-west-2.compute.internal",
          "SubnetGatewayIpv4Address": "172.31.128.1/17"
        }
      ]
    },
    {
      "DockerId": "b997bbea697331c37e6b078635c1df4abff8bc3f840891901e55d03691eaae9b",
      "Name": "fis-omni",
      "DockerName": "ecs-fis-omniempty-1-fis-omni-c6ac88cd8082a1a92300",
      "Image": "public.ecr.aws/nginx/nginx:stable-perl",
      "ImageID": "sha256:988616769ca20aeb4b850f98a0b6e37256b5179e3b0c0a443c41daa3691a43a5",
      "Labels": {
        "com.amazonaws.ecs.cluster": "harishxr-ecs",
        "com.amazonaws.ecs.container-name": "fis-omni",
        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:xxyyzz:task/harishxr-ecs/8ec46eb80d6e42a49a669ad9321076a2",
        "com.amazonaws.ecs.task-definition-family": "fis-omniempty",
        "com.amazonaws.ecs.task-definition-version": "1"
      },
      "DesiredStatus": "RUNNING",
      "KnownStatus": "RUNNING",
      "Limits": {
        "CPU": 2,
        "Memory": 0
      },
      "CreatedAt": "2024-10-01T22:03:05.356372903Z",
      "StartedAt": "2024-10-01T22:03:05.613742123Z",
      "Type": "NORMAL",
      "LogDriver": "awslogs",
      "LogOptions": {
        "awslogs-create-group": "true",
        "awslogs-group": "/ecs/fis-omniempty",
        "awslogs-region": "us-west-2",
        "awslogs-stream": "ecs/fis-omni/8ec46eb80d6e42a49a669ad9321076a2",
        "max-buffer-size": "25m",
        "mode": "non-blocking"
      },
      "ContainerARN": "arn:aws:ecs:us-west-2:xxyyzz:container/harishxr-ecs/8ec46eb80d6e42a49a669ad9321076a2/daad66df-bad0-4cb4-bcc5-9d34958070e4",
      "Networks": [
        {
          "NetworkMode": "awsvpc",
          "IPv4Addresses": [
            "172.31.156.252"
          ],
          "AttachmentIndex": 0,
          "MACAddress": "0a:3f:eb:8b:26:d7",
          "IPv4SubnetCIDRBlock": "172.31.128.0/17",
          "PrivateDNSName": "ip-172-31-156-252.us-west-2.compute.internal",
          "SubnetGatewayIpv4Address": "172.31.128.1/17"
        }
      ]
    }
  ],
  "VPCID": "vpc-0eca12de1619e3962"
}
```
* After removing `omitempty`
```
# curl ${ECS_CONTAINER_METADATA_URI_V4}/task
{
  "Cluster": "harishxr-ecs",
  "TaskARN": "arn:aws:ecs:us-west-2:xxyyzz:task/harishxr-ecs/0fdcc5ebf7df41ab927c4ee8b6214306",
  "Family": "fis-omniempty",
  "Revision": "1",
  "DesiredStatus": "RUNNING",
  "KnownStatus": "RUNNING",
  "Limits": {
    "CPU": 1,
    "Memory": 3072
  },
  "PullStartedAt": "2024-10-01T20:54:24.850558404Z",
  "PullStoppedAt": "2024-10-01T20:54:24.930660769Z",
  "AvailabilityZone": "us-west-2c",
  "LaunchType": "EC2",
  "Containers": [
    {
      "DockerId": "339df43dd3fcd9156f862ba73b632b85178a1d2d993e99db35a9a16e886cbf98",
      "Name": "~internal~ecs~pause",
      "DockerName": "ecs-fis-omniempty-1-internalecspause-9ae2fac2bff5ebc94b00",
      "Image": "amazon/amazon-ecs-pause:0.1.0",
      "ImageID": "",
      "Labels": {
        "com.amazonaws.ecs.cluster": "harishxr-ecs",
        "com.amazonaws.ecs.container-name": "~internal~ecs~pause",
        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:xxyyzz:task/harishxr-ecs/0fdcc5ebf7df41ab927c4ee8b6214306",
        "com.amazonaws.ecs.task-definition-family": "fis-omniempty",
        "com.amazonaws.ecs.task-definition-version": "1"
      },
      "DesiredStatus": "RESOURCES_PROVISIONED",
      "KnownStatus": "RESOURCES_PROVISIONED",
      "Limits": {
        "CPU": 2,
        "Memory": 0
      },
      "CreatedAt": "2024-10-01T20:54:23.941243117Z",
      "StartedAt": "2024-10-01T20:54:24.19547403Z",
      "Type": "CNI_PAUSE",
      "Networks": [
        {
          "NetworkMode": "awsvpc",
          "IPv4Addresses": [
            "172.31.250.169"
          ],
          "AttachmentIndex": 0,
          "MACAddress": "0a:d0:1c:f0:45:19",
          "IPv4SubnetCIDRBlock": "172.31.128.0/17",
          "PrivateDNSName": "ip-172-31-250-169.us-west-2.compute.internal",
          "SubnetGatewayIpv4Address": "172.31.128.1/17"
        }
      ]
    },
    {
      "DockerId": "ae3c936816e089ddf90c2a5b3e8f5ab96f1264e8860035166870f4974702a943",
      "Name": "fis-omni",
      "DockerName": "ecs-fis-omniempty-1-fis-omni-8e9aa98dc0c3dbcc2a00",
      "Image": "public.ecr.aws/nginx/nginx:stable-perl",
      "ImageID": "sha256:988616769ca20aeb4b850f98a0b6e37256b5179e3b0c0a443c41daa3691a43a5",
      "Labels": {
        "com.amazonaws.ecs.cluster": "harishxr-ecs",
        "com.amazonaws.ecs.container-name": "fis-omni",
        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:xxyyzz:task/harishxr-ecs/0fdcc5ebf7df41ab927c4ee8b6214306",
        "com.amazonaws.ecs.task-definition-family": "fis-omniempty",
        "com.amazonaws.ecs.task-definition-version": "1"
      },
      "DesiredStatus": "RUNNING",
      "KnownStatus": "RUNNING",
      "Limits": {
        "CPU": 2,
        "Memory": 0
      },
      "CreatedAt": "2024-10-01T20:54:24.943565746Z",
      "StartedAt": "2024-10-01T20:54:25.164074976Z",
      "Type": "NORMAL",
      "LogDriver": "awslogs",
      "LogOptions": {
        "awslogs-create-group": "true",
        "awslogs-group": "/ecs/fis-omniempty",
        "awslogs-region": "us-west-2",
        "awslogs-stream": "ecs/fis-omni/0fdcc5ebf7df41ab927c4ee8b6214306",
        "max-buffer-size": "25m",
        "mode": "non-blocking"
      },
      "ContainerARN": "arn:aws:ecs:us-west-2:xxyyzz:container/harishxr-ecs/0fdcc5ebf7df41ab927c4ee8b6214306/13d9e096-c7b7-4b30-9bbe-e1186ab3c300",
      "Networks": [
        {
          "NetworkMode": "awsvpc",
          "IPv4Addresses": [
            "172.31.250.169"
          ],
          "AttachmentIndex": 0,
          "MACAddress": "0a:d0:1c:f0:45:19",
          "IPv4SubnetCIDRBlock": "172.31.128.0/17",
          "PrivateDNSName": "ip-172-31-250-169.us-west-2.compute.internal",
          "SubnetGatewayIpv4Address": "172.31.128.1/17"
        }
      ]
    }
  ],
  "VPCID": "vpc-0eca12de1619e3962",
  "FaultInjectionEnabled": false
}
```
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
