### PR TITLE
fix: do not err on existing default netns directory

### DIFF
--- a/ecs-agent/netlib/model/ecscni/nsutil_linux.go
+++ b/ecs-agent/netlib/model/ecscni/nsutil_linux.go
@@ -74,7 +74,7 @@ func (*netnsutil) NewNetNS(nspath string) error {
 	if err != nil {
 		// Create the default network namespace directory path if not exists
 		if os.IsNotExist(err) {
-			err = os.Mkdir(NETNS_PATH_DEFAULT, NsFileMode)
+			err = os.MkdirAll(NETNS_PATH_DEFAULT, NsFileMode)
 		}
 		if err != nil {
 			return errors.Wrap(err, "unable to get status of default ns directory")


### PR DESCRIPTION
### Summary
When setting up multiple ENIs, each will try to create its own network namespace. Both will also hit the common code path of checking and creating the default netns root path `/var/run/netns`. This can cause a race condition where:

1. Netns 1 checks if default dir exists(it does not)
2. Netns 2 checks if default dir exists(it does not)
3. Netns 1 creates default dir
4. Netns 2 tries to create default dir (throws err)
Task launch fails since the ENI could not be configured


### Implementation details
Change `os.Mkdir` to `os.MkdirAll` which does not err on an existing directory.

### Testing
Added a test to verify I will not receive an err from trying to create the same network namespace twice.

New tests cover the changes: esy

### Description for the changelog
fix: do not err on duplicate netns creation

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
no

**Does this PR include the addition of new environment variables in the README?**
no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
