### PR TITLE
Registering fault handlers on TMDS server start up

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -134,6 +134,7 @@ var (
 		attributePrefix + taskEIAWithOptimizedCPU,
 		attributePrefix + capabilityServiceConnect,
 		attributePrefix + capabilityEBSTaskAttach,
+		attributePrefix + capabilityFaultInjection,
 	}
 	// List of capabilities that are only supported on external capaciity. Currently only one but keep as a list
 	// for future proof and also align with externalUnsupportedCapabilities.

--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -96,9 +96,8 @@ func taskServerSetup(
 	agentAPIV1HandlersSetup(muxRouter, state, credentialsManager, cluster, tmdsAgentState,
 		taskProtectionClientFactory, metricsFactory)
 
-	// TODO: Future PR to pass in TMDS server router once all of the handlers have been implemented.
 	execWrapper := execwrapper.NewExec()
-	registerFaultHandlers(nil, tmdsAgentState, metricsFactory, execWrapper)
+	registerFaultHandlers(muxRouter, tmdsAgentState, metricsFactory, execWrapper)
 
 	return tmds.NewServer(auditLogger,
 		tmds.WithHandler(muxRouter),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will add/register the fault handlers into the TMDS server on start up. This also adds the fault injection capability to the list of unsupported capabilities for external launch type.

### Implementation details
* Modified the `registerFaultHandlers`call to now be passing the mux router object of the TMDS server instead of a nil object within `agent/handlers/task_server_setup.go`
* Adds `capabilityFaultInjection` to the `externalUnsupportedCapabilities` ( a list of unsupported capabilities for external launch types)

### Testing
Note: It is currently expected that all of the fault injection requests should return a 400 response code and stating that the task is not fault injection enabled.

Starting BHP fault:
```
level=debug time=2024-10-04T17:00:27Z msg="Handling http request" method="POST" from="169.254.172.2:45720"
level=info time=2024-10-04T17:00:27Z msg="Received new request for request type: start network-blackhole-port" tmdsEndpointContainerID="4cd9989a-73b4-491d-93e7-2940293497d2" request="{\"Protocol\":\"tcp\",\"TrafficType\":\"egress\",\"Port\":1234}" requestType="start network-blackhole-port"
level=error time=2024-10-04T17:00:27Z msg="Error: Task is not fault injection enabled." requestType="start network-blackhole-port" tmdsEndpointContainerID="4cd9989a-73b4-491d-93e7-2940293497d2" response="{\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/754c6a6f46b74a678bf47f2aab789d6c\"}" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/754c6a6f46b74a678bf47f2aab789d6c" error="enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/754c6a6f46b74a678bf47f2aab789d6c"
level=error time=2024-10-04T17:00:27Z msg="HTTP response status code is '400', request type is: start network-blackhole-port, and response in JSON is {\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/754c6a6f46b74a678bf47f2aab789d6c\"}" module=helpers.go
```

Checking status of BHP fault
```
level=debug time=2024-10-04T17:00:37Z msg="Handling http request" method="POST" from="169.254.172.2:43172"
level=info time=2024-10-04T17:00:37Z msg="Received new request for request type: check status network-blackhole-port" request="{\"Protocol\":\"tcp\",\"TrafficType\":\"egress\",\"Port\":1234}" requestType="check status network-blackhole-port" tmdsEndpointContainerID="4cd9989a-73b4-491d-93e7-2940293497d2"
level=debug time=2024-10-04T17:00:37Z msg="Successfully parsed fault request payload" request="{\"Port\":1234,\"Protocol\":\"tcp\",\"TrafficType\":\"egress\"}"
level=error time=2024-10-04T17:00:37Z msg="Error: Task is not fault injection enabled." tmdsEndpointContainerID="4cd9989a-73b4-491d-93e7-2940293497d2" response="{\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/754c6a6f46b74a678bf47f2aab789d6c\"}" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/754c6a6f46b74a678bf47f2aab789d6c" error="enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/754c6a6f46b74a678bf47f2aab789d6c" requestType="check status network-blackhole-port"
level=error time=2024-10-04T17:00:37Z msg="HTTP response status code is '400', request type is: check status network-blackhole-port, and response in JSON is {\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/754c6a6f46b74a678bf47f2aab789d6c\"}" module=helpers.go
```

Stopping BHP fault
```
level=debug time=2024-10-04T17:00:47Z msg="Handling http request" method="POST" from="169.254.172.2:40328"
level=info time=2024-10-04T17:00:47Z msg="Received new request for request type: stop network-blackhole-port" tmdsEndpointContainerID="4cd9989a-73b4-491d-93e7-2940293497d2" request="{\"Protocol\":\"tcp\",\"TrafficType\":\"egress\",\"Port\":1234}" requestType="stop network-blackhole-port"
level=debug time=2024-10-04T17:00:47Z msg="Successfully parsed fault request payload" request="{\"Port\":1234,\"Protocol\":\"tcp\",\"TrafficType\":\"egress\"}"
level=error time=2024-10-04T17:00:47Z msg="Error: Task is not fault injection enabled." requestType="stop network-blackhole-port" tmdsEndpointContainerID="4cd9989a-73b4-491d-93e7-2940293497d2" response="{\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/754c6a6f46b74a678bf47f2aab789d6c\"}" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/754c6a6f46b74a678bf47f2aab789d6c" error="enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/754c6a6f46b74a678bf47f2aab789d6c"
level=error time=2024-10-04T17:00:47Z msg="HTTP response status code is '400', request type is: stop network-blackhole-port, and response in JSON is {\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/754c6a6f46b74a678bf47f2aab789d6c\"}" module=helpers.go
```

Starting latency fault
```
level=debug time=2024-10-04T17:04:46Z msg="Handling http request" method="POST" from="172.31.27.242:54806"
level=info time=2024-10-04T17:04:46Z msg="Received new request for request type: start network-latency" tmdsEndpointContainerID="efb1454b-a336-4562-8e2a-5364adc16c81" request="{\"DelayMilliseconds\":100, \"JitterMilliseconds\":10, \"Sources\":[\"192.168.0.1\"]}" requestType="start network-latency"
level=debug time=2024-10-04T17:04:46Z msg="Found route" Route={Ifindex: 2 Dst: <nil> Src: <nil> Gw: 172.31.16.1 Flags: [] Table: 254 Realm: 0}
level=debug time=2024-10-04T17:04:46Z msg="Found the associated network interface by the index" LinkIndex=2 LinkName="eth0"
level=info time=2024-10-04T17:04:46Z msg="Obtained default network interface name on host" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0" defaultDeviceName="eth0"
level=error time=2024-10-04T17:04:46Z msg="Error: Task is not fault injection enabled." tmdsEndpointContainerID="efb1454b-a336-4562-8e2a-5364adc16c81" response="{\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0\"}" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0" error="enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0" requestType="start network-latency"
level=error time=2024-10-04T17:04:46Z msg="HTTP response status code is '400', request type is: start network-latency, and response in JSON is {\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0\"}" module=helpers.go
```

Checking status of latency fault
```
level=debug time=2024-10-04T17:04:56Z msg="Handling http request" method="POST" from="172.31.27.242:54534"
level=info time=2024-10-04T17:04:56Z msg="Received new request for request type: check status network-latency" request="{\"DelayMilliseconds\":100, \"JitterMilliseconds\":10, \"Sources\":[\"192.168.0.1\"]}" requestType="check status network-latency" tmdsEndpointContainerID="efb1454b-a336-4562-8e2a-5364adc16c81"
level=debug time=2024-10-04T17:04:56Z msg="Found route" Route={Ifindex: 2 Dst: <nil> Src: <nil> Gw: 172.31.16.1 Flags: [] Table: 254 Realm: 0}
level=debug time=2024-10-04T17:04:56Z msg="Found the associated network interface by the index" LinkName="eth0" LinkIndex=2
level=info time=2024-10-04T17:04:56Z msg="Obtained default network interface name on host" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0" defaultDeviceName="eth0"
level=error time=2024-10-04T17:04:56Z msg="Error: Task is not fault injection enabled." requestType="check status network-latency" tmdsEndpointContainerID="efb1454b-a336-4562-8e2a-5364adc16c81" response="{\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0\"}" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0" error="enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0"
level=error time=2024-10-04T17:04:56Z msg="HTTP response status code is '400', request type is: check status network-latency, and response in JSON is {\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0\"}" module=helpers.go
```

Stopping latency fault
```
level=debug time=2024-10-04T17:05:06Z msg="Handling http request" method="POST" from="172.31.27.242:58722"
level=info time=2024-10-04T17:05:06Z msg="Received new request for request type: stop network-latency" request="{\"DelayMilliseconds\":100, \"JitterMilliseconds\":10, \"Sources\":[\"192.168.0.1\"]}" requestType="stop network-latency" tmdsEndpointContainerID="efb1454b-a336-4562-8e2a-5364adc16c81"
level=debug time=2024-10-04T17:05:06Z msg="Found route" Route={Ifindex: 2 Dst: <nil> Src: <nil> Gw: 172.31.16.1 Flags: [] Table: 254 Realm: 0}
level=debug time=2024-10-04T17:05:06Z msg="Found the associated network interface by the index" LinkName="eth0" LinkIndex=2
level=info time=2024-10-04T17:05:06Z msg="Obtained default network interface name on host" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0" defaultDeviceName="eth0"
level=error time=2024-10-04T17:05:06Z msg="Error: Task is not fault injection enabled." requestType="stop network-latency" tmdsEndpointContainerID="efb1454b-a336-4562-8e2a-5364adc16c81" response="{\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0\"}" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0" error="enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0"
level=error time=2024-10-04T17:05:06Z msg="HTTP response status code is '400', request type is: stop network-latency, and response in JSON is {\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/2f196b427bdb4a23919ad21f375f37c0\"}" module=helpers.go
```

Starting packet loss fault
```
level=debug time=2024-10-04T17:08:25Z msg="Handling http request" from="172.31.27.242:33178" method="POST"
level=info time=2024-10-04T17:08:25Z msg="Received new request for request type: start network-packet-loss" tmdsEndpointContainerID="8e17daff-852d-468a-8299-bf5f94abb4b5" request="{\"LossPercent\":50, \"Sources\":[\"192.168.0.1\"]}" requestType="start network-packet-loss"
level=debug time=2024-10-04T17:08:25Z msg="Found route" Route={Ifindex: 2 Dst: <nil> Src: <nil> Gw: 172.31.16.1 Flags: [] Table: 254 Realm: 0}
level=debug time=2024-10-04T17:08:25Z msg="Found the associated network interface by the index" LinkName="eth0" LinkIndex=2
level=info time=2024-10-04T17:08:25Z msg="Obtained default network interface name on host" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63" defaultDeviceName="eth0"
level=error time=2024-10-04T17:08:25Z msg="Error: Task is not fault injection enabled." requestType="start network-packet-loss" tmdsEndpointContainerID="8e17daff-852d-468a-8299-bf5f94abb4b5" response="{\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63\"}" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63" error="enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63"
level=error time=2024-10-04T17:08:25Z msg="HTTP response status code is '400', request type is: start network-packet-loss, and response in JSON is {\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63\"}" module=helpers.go
```

Checking status for packet loss fault
```
level=debug time=2024-10-04T17:08:35Z msg="Handling http request" method="POST" from="172.31.27.242:50984"
level=info time=2024-10-04T17:08:35Z msg="Received new request for request type: check status network-packet-loss" request="{\"LossPercent\":50, \"Sources\":[\"192.168.0.1\"]}" requestType="check status network-packet-loss" tmdsEndpointContainerID="8e17daff-852d-468a-8299-bf5f94abb4b5"
level=debug time=2024-10-04T17:08:35Z msg="Found route" Route={Ifindex: 2 Dst: <nil> Src: <nil> Gw: 172.31.16.1 Flags: [] Table: 254 Realm: 0}
level=debug time=2024-10-04T17:08:35Z msg="Found the associated network interface by the index" LinkName="eth0" LinkIndex=2
level=info time=2024-10-04T17:08:35Z msg="Obtained default network interface name on host" defaultDeviceName="eth0" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63"
level=error time=2024-10-04T17:08:35Z msg="Error: Task is not fault injection enabled." requestType="check status network-packet-loss" tmdsEndpointContainerID="8e17daff-852d-468a-8299-bf5f94abb4b5" response="{\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63\"}" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63" error="enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63"
level=error time=2024-10-04T17:08:35Z msg="HTTP response status code is '400', request type is: check status network-packet-loss, and response in JSON is {\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63\"}" module=helpers.go
```

Stopping packet loss fault
```
level=debug time=2024-10-04T17:08:45Z msg="Handling http request" from="172.31.27.242:37372" method="POST"
level=info time=2024-10-04T17:08:45Z msg="Received new request for request type: stop network-packet-loss" request="{\"LossPercent\":50, \"Sources\":[\"192.168.0.1\"]}" requestType="stop network-packet-loss" tmdsEndpointContainerID="8e17daff-852d-468a-8299-bf5f94abb4b5"
level=debug time=2024-10-04T17:08:45Z msg="Found route" Route={Ifindex: 2 Dst: <nil> Src: <nil> Gw: 172.31.16.1 Flags: [] Table: 254 Realm: 0}
level=debug time=2024-10-04T17:08:45Z msg="Found the associated network interface by the index" LinkName="eth0" LinkIndex=2
level=info time=2024-10-04T17:08:45Z msg="Obtained default network interface name on host" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63" defaultDeviceName="eth0"
level=error time=2024-10-04T17:08:45Z msg="Error: Task is not fault injection enabled." requestType="stop network-packet-loss" tmdsEndpointContainerID="8e17daff-852d-468a-8299-bf5f94abb4b5" response="{\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63\"}" taskARN="arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63" error="enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63"
level=error time=2024-10-04T17:08:45Z msg="HTTP response status code is '400', request type is: stop network-packet-loss, and response in JSON is {\"Error\":\"enableFaultInjection is not enabled for task: arn:aws:ecs:us-west-2:113424923516:task/fis/198a870445554d8a8461a14067029d63\"}" module=helpers.go
```


New tests cover the changes: yes

### Description for the changelog
Feature: Registering fault handlers on TMDS server start up

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
