### PR TITLE
Clean up unit test and add a wait duration for iptables commands and fix response for default network interface name not found error

### DIFF
--- a/agent/handlers/task_server_setup_linux_test.go
+++ b/agent/handlers/task_server_setup_linux_test.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	internalError                           = "internal error"
-	defaultNetworkInterfaceNameErrorMessage = "failed to obtain default network interface name: unable to obtain default network interface name on host from v3 endpoint ID: %s"
+	defaultNetworkInterfaceNameErrorMessage = "failed to obtain default network interface name: unable to obtain default network interface name on host from endpoint ID: %s"
 )
 
 func TestV4GetTaskMetadataWithTaskNetworkConfig(t *testing.T) {

--- a/agent/handlers/v4/tmdsstate_linux.go
+++ b/agent/handlers/v4/tmdsstate_linux.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	defaultNetworkInterfaceNameNotFoundError = "unable to obtain default network interface name on host from v3 endpoint ID: %s"
+	defaultNetworkInterfaceNameNotFoundError = "unable to obtain default network interface name on host from endpoint ID: %s"
 )
 
 // Returns task metadata including the task network configuration in v4 format for the

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -53,7 +53,7 @@ const (
 	requestTimedOutError       = "%s: request timed out"
 	// This is our initial assumption of how much time it would take for the Linux commands used to inject faults
 	// to finish. This will be confirmed/updated after more testing.
-	requestTimeoutDuration = 5
+	requestTimeoutSeconds = 5
 	// Commands that will be used to start/stop/check fault.
 	iptablesNewChainCmd              = "iptables -w %d -N %s"
 	iptablesAppendChainRuleCmd       = "iptables -w %d -A %s -p %s --dport %s -j DROP"
@@ -135,7 +135,7 @@ func (h *FaultHandler) StartNetworkBlackholePort() func(http.ResponseWriter, *ht
 		defer rwMu.Unlock()
 
 		ctx := context.Background()
-		ctxWithTimeout, cancel := h.osExecWrapper.NewExecContextWithTimeout(ctx, requestTimeoutDuration*time.Second)
+		ctxWithTimeout, cancel := h.osExecWrapper.NewExecContextWithTimeout(ctx, requestTimeoutSeconds*time.Second)
 		defer cancel()
 
 		var responseBody types.NetworkFaultInjectionResponse
@@ -202,7 +202,7 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 		}
 
 		// Creating a new chain
-		newChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesNewChainCmd, requestTimeoutDuration, chain)
+		newChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesNewChainCmd, requestTimeoutSeconds, chain)
 		cmdOutput, err := h.runExecCommand(ctx, strings.Split(newChainCmdString, " "))
 		if err != nil {
 			logger.Error("Unable to create new chain", logger.Fields{
@@ -216,7 +216,7 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 		}
 
 		// Appending a new rule based on the protocol and port number from the request body
-		appendRuleCmdString := nsenterPrefix + fmt.Sprintf(iptablesAppendChainRuleCmd, requestTimeoutDuration, chain, protocol, port)
+		appendRuleCmdString := nsenterPrefix + fmt.Sprintf(iptablesAppendChainRuleCmd, requestTimeoutSeconds, chain, protocol, port)
 		cmdOutput, err = h.runExecCommand(ctx, strings.Split(appendRuleCmdString, " "))
 		if err != nil {
 			logger.Error("Unable to append rule to chain", logger.Fields{
@@ -230,7 +230,7 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 		}
 
 		// Inserting the chain into the built-in INPUT/OUTPUT table
-		insertChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesInsertChainCmd, requestTimeoutDuration, insertTable, chain)
+		insertChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesInsertChainCmd, requestTimeoutSeconds, insertTable, chain)
 		cmdOutput, err = h.runExecCommand(ctx, strings.Split(insertChainCmdString, " "))
 		if err != nil {
 			logger.Error("Unable to insert chain to table", logger.Fields{
@@ -281,7 +281,7 @@ func (h *FaultHandler) StopNetworkBlackHolePort() func(http.ResponseWriter, *htt
 		defer rwMu.Unlock()
 
 		ctx := context.Background()
-		ctxWithTimeout, cancel := h.osExecWrapper.NewExecContextWithTimeout(ctx, requestTimeoutDuration*time.Second)
+		ctxWithTimeout, cancel := h.osExecWrapper.NewExecContextWithTimeout(ctx, requestTimeoutSeconds*time.Second)
 		defer cancel()
 
 		var responseBody types.NetworkFaultInjectionResponse
@@ -349,7 +349,7 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 		}
 
 		// Clearing the appended rules that's associated to the chain
-		clearChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesClearChainCmd, requestTimeoutDuration, chain)
+		clearChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesClearChainCmd, requestTimeoutSeconds, chain)
 		cmdOutput, err := h.runExecCommand(ctx, strings.Split(clearChainCmdString, " "))
 		if err != nil {
 			logger.Error("Unable to clear chain", logger.Fields{
@@ -363,7 +363,7 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 		}
 
 		// Removing the chain from either the built-in INPUT/OUTPUT table
-		deleteFromTableCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteFromTableCmd, requestTimeoutDuration, insertTable, chain)
+		deleteFromTableCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteFromTableCmd, requestTimeoutSeconds, insertTable, chain)
 		cmdOutput, err = h.runExecCommand(ctx, strings.Split(deleteFromTableCmdString, " "))
 		if err != nil {
 			logger.Error("Unable to delete chain from table", logger.Fields{
@@ -378,7 +378,7 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 		}
 
 		// Deleting the chain
-		deleteChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteChainCmd, requestTimeoutDuration, chain)
+		deleteChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteChainCmd, requestTimeoutSeconds, chain)
 		cmdOutput, err = h.runExecCommand(ctx, strings.Split(deleteChainCmdString, " "))
 		if err != nil {
 			logger.Error("Unable to delete chain", logger.Fields{
@@ -429,7 +429,7 @@ func (h *FaultHandler) CheckNetworkBlackHolePort() func(http.ResponseWriter, *ht
 		defer rwMu.RUnlock()
 
 		ctx := context.Background()
-		ctxWithTimeout, cancel := h.osExecWrapper.NewExecContextWithTimeout(ctx, requestTimeoutDuration*time.Second)
+		ctxWithTimeout, cancel := h.osExecWrapper.NewExecContextWithTimeout(ctx, requestTimeoutSeconds*time.Second)
 		defer cancel()
 
 		var responseBody types.NetworkFaultInjectionResponse
@@ -481,7 +481,7 @@ func (h *FaultHandler) checkNetworkBlackHolePort(ctx context.Context, protocol, 
 		nsenterPrefix = fmt.Sprintf(nsenterCommandString, netNs)
 	}
 
-	cmdString := nsenterPrefix + fmt.Sprintf(iptablesChainExistCmd, requestTimeoutDuration, chain, protocol, port)
+	cmdString := nsenterPrefix + fmt.Sprintf(iptablesChainExistCmd, requestTimeoutSeconds, chain, protocol, port)
 	cmdList := strings.Split(cmdString, " ")
 
 	cmdOutput, err := h.runExecCommand(ctx, cmdList)
@@ -548,7 +548,7 @@ func (h *FaultHandler) StartNetworkLatency() func(http.ResponseWriter, *http.Req
 		stringToBeLogged := "Failed to start fault"
 		// All command executions for the start network latency workflow all together should finish within 5 seconds.
 		// Thus, create the context here so that it can be shared by all os/exec calls.
-		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutDuration*time.Second)
+		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutSeconds*time.Second)
 		defer cancel()
 		// Check the status of current fault injection.
 		latencyFaultExists, packetLossFaultExists, err := h.checkTCFault(ctx, taskMetadata)
@@ -620,7 +620,7 @@ func (h *FaultHandler) StopNetworkLatency() func(http.ResponseWriter, *http.Requ
 		stringToBeLogged := "Failed to stop fault"
 		// All command executions for the stop network latency workflow all together should finish within 5 seconds.
 		// Thus, create the context here so that it can be shared by all os/exec calls.
-		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutDuration*time.Second)
+		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutSeconds*time.Second)
 		defer cancel()
 		// Check the status of current fault injection.
 		latencyFaultExists, _, err := h.checkTCFault(ctx, taskMetadata)
@@ -691,7 +691,7 @@ func (h *FaultHandler) CheckNetworkLatency() func(http.ResponseWriter, *http.Req
 		stringToBeLogged := "Failed to check status for fault"
 		// All command executions for the check network latency workflow all together should finish within 5 seconds.
 		// Thus, create the context here so that it can be shared by all os/exec calls.
-		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutDuration*time.Second)
+		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutSeconds*time.Second)
 		defer cancel()
 		// Check the status of current fault injection.
 		latencyFaultExists, _, err := h.checkTCFault(ctx, taskMetadata)
@@ -761,7 +761,7 @@ func (h *FaultHandler) StartNetworkPacketLoss() func(http.ResponseWriter, *http.
 		stringToBeLogged := "Failed to start fault"
 		// All command executions for the start network packet loss workflow all together should finish within 5 seconds.
 		// Thus, create the context here so that it can be shared by all os/exec calls.
-		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutDuration*time.Second)
+		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutSeconds*time.Second)
 		defer cancel()
 		// Check the status of current fault injection.
 		latencyFaultExists, packetLossFaultExists, err := h.checkTCFault(ctx, taskMetadata)
@@ -833,7 +833,7 @@ func (h *FaultHandler) StopNetworkPacketLoss() func(http.ResponseWriter, *http.R
 		stringToBeLogged := "Failed to stop fault"
 		// All command executions for the stop network packet loss workflow all together should finish within 5 seconds.
 		// Thus, create the context here so that it can be shared by all os/exec calls.
-		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutDuration*time.Second)
+		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutSeconds*time.Second)
 		defer cancel()
 		// Check the status of current fault injection.
 		_, packetLossFaultExists, err := h.checkTCFault(ctx, taskMetadata)
@@ -904,7 +904,7 @@ func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.
 		stringToBeLogged := "Failed to check status for fault"
 		// All command executions for the check network packet loss workflow all together should finish within 5 seconds.
 		// Thus, create the context here so that it can be shared by all os/exec calls.
-		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutDuration*time.Second)
+		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutSeconds*time.Second)
 		defer cancel()
 		// Check the status of current fault injection.
 		_, packetLossFaultExists, err := h.checkTCFault(ctx, taskMetadata)

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -53,7 +53,7 @@ const (
 	requestTimedOutError       = "%s: request timed out"
 	// This is our initial assumption of how much time it would take for the Linux commands used to inject faults
 	// to finish. This will be confirmed/updated after more testing.
-	requestTimeoutDuration = 5
+	requestTimeoutSeconds = 5
 	// Commands that will be used to start/stop/check fault.
 	iptablesNewChainCmd              = "iptables -w %d -N %s"
 	iptablesAppendChainRuleCmd       = "iptables -w %d -A %s -p %s --dport %s -j DROP"
@@ -135,7 +135,7 @@ func (h *FaultHandler) StartNetworkBlackholePort() func(http.ResponseWriter, *ht
 		defer rwMu.Unlock()
 
 		ctx := context.Background()
-		ctxWithTimeout, cancel := h.osExecWrapper.NewExecContextWithTimeout(ctx, requestTimeoutDuration*time.Second)
+		ctxWithTimeout, cancel := h.osExecWrapper.NewExecContextWithTimeout(ctx, requestTimeoutSeconds*time.Second)
 		defer cancel()
 
 		var responseBody types.NetworkFaultInjectionResponse
@@ -202,7 +202,7 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 		}
 
 		// Creating a new chain
-		newChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesNewChainCmd, requestTimeoutDuration, chain)
+		newChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesNewChainCmd, requestTimeoutSeconds, chain)
 		cmdOutput, err := h.runExecCommand(ctx, strings.Split(newChainCmdString, " "))
 		if err != nil {
 			logger.Error("Unable to create new chain", logger.Fields{
@@ -216,7 +216,7 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 		}
 
 		// Appending a new rule based on the protocol and port number from the request body
-		appendRuleCmdString := nsenterPrefix + fmt.Sprintf(iptablesAppendChainRuleCmd, requestTimeoutDuration, chain, protocol, port)
+		appendRuleCmdString := nsenterPrefix + fmt.Sprintf(iptablesAppendChainRuleCmd, requestTimeoutSeconds, chain, protocol, port)
 		cmdOutput, err = h.runExecCommand(ctx, strings.Split(appendRuleCmdString, " "))
 		if err != nil {
 			logger.Error("Unable to append rule to chain", logger.Fields{
@@ -230,7 +230,7 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 		}
 
 		// Inserting the chain into the built-in INPUT/OUTPUT table
-		insertChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesInsertChainCmd, requestTimeoutDuration, insertTable, chain)
+		insertChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesInsertChainCmd, requestTimeoutSeconds, insertTable, chain)
 		cmdOutput, err = h.runExecCommand(ctx, strings.Split(insertChainCmdString, " "))
 		if err != nil {
 			logger.Error("Unable to insert chain to table", logger.Fields{
@@ -281,7 +281,7 @@ func (h *FaultHandler) StopNetworkBlackHolePort() func(http.ResponseWriter, *htt
 		defer rwMu.Unlock()
 
 		ctx := context.Background()
-		ctxWithTimeout, cancel := h.osExecWrapper.NewExecContextWithTimeout(ctx, requestTimeoutDuration*time.Second)
+		ctxWithTimeout, cancel := h.osExecWrapper.NewExecContextWithTimeout(ctx, requestTimeoutSeconds*time.Second)
 		defer cancel()
 
 		var responseBody types.NetworkFaultInjectionResponse
@@ -349,7 +349,7 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 		}
 
 		// Clearing the appended rules that's associated to the chain
-		clearChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesClearChainCmd, requestTimeoutDuration, chain)
+		clearChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesClearChainCmd, requestTimeoutSeconds, chain)
 		cmdOutput, err := h.runExecCommand(ctx, strings.Split(clearChainCmdString, " "))
 		if err != nil {
 			logger.Error("Unable to clear chain", logger.Fields{
@@ -363,7 +363,7 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 		}
 
 		// Removing the chain from either the built-in INPUT/OUTPUT table
-		deleteFromTableCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteFromTableCmd, requestTimeoutDuration, insertTable, chain)
+		deleteFromTableCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteFromTableCmd, requestTimeoutSeconds, insertTable, chain)
 		cmdOutput, err = h.runExecCommand(ctx, strings.Split(deleteFromTableCmdString, " "))
 		if err != nil {
 			logger.Error("Unable to delete chain from table", logger.Fields{
@@ -378,7 +378,7 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 		}
 
 		// Deleting the chain
-		deleteChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteChainCmd, requestTimeoutDuration, chain)
+		deleteChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteChainCmd, requestTimeoutSeconds, chain)
 		cmdOutput, err = h.runExecCommand(ctx, strings.Split(deleteChainCmdString, " "))
 		if err != nil {
 			logger.Error("Unable to delete chain", logger.Fields{
@@ -429,7 +429,7 @@ func (h *FaultHandler) CheckNetworkBlackHolePort() func(http.ResponseWriter, *ht
 		defer rwMu.RUnlock()
 
 		ctx := context.Background()
-		ctxWithTimeout, cancel := h.osExecWrapper.NewExecContextWithTimeout(ctx, requestTimeoutDuration*time.Second)
+		ctxWithTimeout, cancel := h.osExecWrapper.NewExecContextWithTimeout(ctx, requestTimeoutSeconds*time.Second)
 		defer cancel()
 
 		var responseBody types.NetworkFaultInjectionResponse
@@ -481,7 +481,7 @@ func (h *FaultHandler) checkNetworkBlackHolePort(ctx context.Context, protocol, 
 		nsenterPrefix = fmt.Sprintf(nsenterCommandString, netNs)
 	}
 
-	cmdString := nsenterPrefix + fmt.Sprintf(iptablesChainExistCmd, requestTimeoutDuration, chain, protocol, port)
+	cmdString := nsenterPrefix + fmt.Sprintf(iptablesChainExistCmd, requestTimeoutSeconds, chain, protocol, port)
 	cmdList := strings.Split(cmdString, " ")
 
 	cmdOutput, err := h.runExecCommand(ctx, cmdList)
@@ -548,7 +548,7 @@ func (h *FaultHandler) StartNetworkLatency() func(http.ResponseWriter, *http.Req
 		stringToBeLogged := "Failed to start fault"
 		// All command executions for the start network latency workflow all together should finish within 5 seconds.
 		// Thus, create the context here so that it can be shared by all os/exec calls.
-		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutDuration*time.Second)
+		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutSeconds*time.Second)
 		defer cancel()
 		// Check the status of current fault injection.
 		latencyFaultExists, packetLossFaultExists, err := h.checkTCFault(ctx, taskMetadata)
@@ -620,7 +620,7 @@ func (h *FaultHandler) StopNetworkLatency() func(http.ResponseWriter, *http.Requ
 		stringToBeLogged := "Failed to stop fault"
 		// All command executions for the stop network latency workflow all together should finish within 5 seconds.
 		// Thus, create the context here so that it can be shared by all os/exec calls.
-		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutDuration*time.Second)
+		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutSeconds*time.Second)
 		defer cancel()
 		// Check the status of current fault injection.
 		latencyFaultExists, _, err := h.checkTCFault(ctx, taskMetadata)
@@ -691,7 +691,7 @@ func (h *FaultHandler) CheckNetworkLatency() func(http.ResponseWriter, *http.Req
 		stringToBeLogged := "Failed to check status for fault"
 		// All command executions for the check network latency workflow all together should finish within 5 seconds.
 		// Thus, create the context here so that it can be shared by all os/exec calls.
-		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutDuration*time.Second)
+		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutSeconds*time.Second)
 		defer cancel()
 		// Check the status of current fault injection.
 		latencyFaultExists, _, err := h.checkTCFault(ctx, taskMetadata)
@@ -761,7 +761,7 @@ func (h *FaultHandler) StartNetworkPacketLoss() func(http.ResponseWriter, *http.
 		stringToBeLogged := "Failed to start fault"
 		// All command executions for the start network packet loss workflow all together should finish within 5 seconds.
 		// Thus, create the context here so that it can be shared by all os/exec calls.
-		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutDuration*time.Second)
+		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutSeconds*time.Second)
 		defer cancel()
 		// Check the status of current fault injection.
 		latencyFaultExists, packetLossFaultExists, err := h.checkTCFault(ctx, taskMetadata)
@@ -833,7 +833,7 @@ func (h *FaultHandler) StopNetworkPacketLoss() func(http.ResponseWriter, *http.R
 		stringToBeLogged := "Failed to stop fault"
 		// All command executions for the stop network packet loss workflow all together should finish within 5 seconds.
 		// Thus, create the context here so that it can be shared by all os/exec calls.
-		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutDuration*time.Second)
+		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutSeconds*time.Second)
 		defer cancel()
 		// Check the status of current fault injection.
 		_, packetLossFaultExists, err := h.checkTCFault(ctx, taskMetadata)
@@ -904,7 +904,7 @@ func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.
 		stringToBeLogged := "Failed to check status for fault"
 		// All command executions for the check network packet loss workflow all together should finish within 5 seconds.
 		// Thus, create the context here so that it can be shared by all os/exec calls.
-		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutDuration*time.Second)
+		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(context.Background(), requestTimeoutSeconds*time.Second)
 		defer cancel()
 		// Check the status of current fault injection.
 		_, packetLossFaultExists, err := h.checkTCFault(ctx, taskMetadata)

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
@@ -130,6 +130,8 @@ var (
 	startNetworkPacketLossTestPrefix    = fmt.Sprintf(startFaultRequestType, types.PacketLossFaultType)
 	stopNetworkPacketLossTestPrefix     = fmt.Sprintf(stopFaultRequestType, types.PacketLossFaultType)
 	checkNetworkPacketLossTestPrefix    = fmt.Sprintf(checkStatusFaultRequestType, types.PacketLossFaultType)
+
+	ctxTimeoutDuration = requestTimeoutDuration * time.Second
 )
 
 type networkFaultInjectionTestCase struct {
@@ -505,7 +507,7 @@ func generateStartBlackHolePortFaultTestCases() []networkFaultInjectionTestCase 
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -538,7 +540,7 @@ func generateStartBlackHolePortFaultTestCases() []networkFaultInjectionTestCase 
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -566,7 +568,7 @@ func generateStartBlackHolePortFaultTestCases() []networkFaultInjectionTestCase 
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -586,7 +588,7 @@ func generateStartBlackHolePortFaultTestCases() []networkFaultInjectionTestCase 
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -612,7 +614,7 @@ func generateStartBlackHolePortFaultTestCases() []networkFaultInjectionTestCase 
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -648,7 +650,7 @@ func generateStopBlackHolePortFaultTestCases() []networkFaultInjectionTestCase {
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -679,7 +681,7 @@ func generateStopBlackHolePortFaultTestCases() []networkFaultInjectionTestCase {
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -705,7 +707,7 @@ func generateStopBlackHolePortFaultTestCases() []networkFaultInjectionTestCase {
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -727,7 +729,7 @@ func generateStopBlackHolePortFaultTestCases() []networkFaultInjectionTestCase {
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -749,7 +751,7 @@ func generateStopBlackHolePortFaultTestCases() []networkFaultInjectionTestCase {
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -773,7 +775,7 @@ func generateStopBlackHolePortFaultTestCases() []networkFaultInjectionTestCase {
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -806,7 +808,7 @@ func generateCheckBlackHolePortFaultStatusTestCases() []networkFaultInjectionTes
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -831,7 +833,7 @@ func generateCheckBlackHolePortFaultStatusTestCases() []networkFaultInjectionTes
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -851,7 +853,7 @@ func generateCheckBlackHolePortFaultStatusTestCases() []networkFaultInjectionTes
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -873,7 +875,7 @@ func generateCheckBlackHolePortFaultStatusTestCases() []networkFaultInjectionTes
 					Times(1)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -988,7 +990,7 @@ func generateCommonNetworkLatencyTestCases(name string) []networkFaultInjectionT
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel)
 				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD)
@@ -1004,13 +1006,13 @@ func generateCommonNetworkLatencyTestCases(name string) []networkFaultInjectionT
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Do(func(_, _ interface{}) {
-						// Sleep for requestTimeoutDuration plus 1 second, to make sure the
+						// Sleep for ctxTimeoutDuration plus 1 second, to make sure the
 						// ctx that we passed to the os/exec execution times out.
-						time.Sleep(requestTimeoutDuration + 1*time.Second)
+						time.Sleep(ctxTimeoutDuration + 1*time.Second)
 					}).Times(1).Return(ctx, cancel),
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
 					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
@@ -1043,7 +1045,7 @@ func generateStartNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1063,7 +1065,7 @@ func generateStartNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel)
 				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD)
@@ -1079,7 +1081,7 @@ func generateStartNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel)
 				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD)
@@ -1101,7 +1103,7 @@ func generateStartNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1289,7 +1291,7 @@ func generateStopNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1307,7 +1309,7 @@ func generateStopNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1327,7 +1329,7 @@ func generateStopNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel)
 				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD)
@@ -1347,7 +1349,7 @@ func generateStopNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1372,7 +1374,7 @@ func generateCheckNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1390,7 +1392,7 @@ func generateCheckNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1408,7 +1410,7 @@ func generateCheckNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1430,7 +1432,7 @@ func generateCheckNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1543,7 +1545,7 @@ func generateCommonNetworkPacketLossTestCases(name string) []networkFaultInjecti
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel)
 				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD)
@@ -1559,13 +1561,13 @@ func generateCommonNetworkPacketLossTestCases(name string) []networkFaultInjecti
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Do(func(_, _ interface{}) {
-						// Sleep for requestTimeoutDuration plus 1 second, to make sure the
+						// Sleep for ctxTimeoutDuration plus 1 second, to make sure the
 						// ctx that we passed to the os/exec execution times out.
-						time.Sleep(requestTimeoutDuration + 1*time.Second)
+						time.Sleep(ctxTimeoutDuration + 1*time.Second)
 					}).Times(1).Return(ctx, cancel),
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
 					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
@@ -1598,7 +1600,7 @@ func generateStartNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1618,7 +1620,7 @@ func generateStartNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel)
 				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD)
@@ -1634,7 +1636,7 @@ func generateStartNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel)
 				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD)
@@ -1655,7 +1657,7 @@ func generateStartNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1845,7 +1847,7 @@ func generateStopNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1863,7 +1865,7 @@ func generateStopNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel)
 				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD)
@@ -1879,7 +1881,7 @@ func generateStopNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1903,7 +1905,7 @@ func generateStopNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1928,7 +1930,7 @@ func generateCheckNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1946,7 +1948,7 @@ func generateCheckNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1964,7 +1966,7 @@ func generateCheckNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
@@ -1986,7 +1988,7 @@ func generateCheckNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
 			},
 			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
-				ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
 				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
 				gomock.InOrder(
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
@@ -131,7 +131,7 @@ var (
 	stopNetworkPacketLossTestPrefix     = fmt.Sprintf(stopFaultRequestType, types.PacketLossFaultType)
 	checkNetworkPacketLossTestPrefix    = fmt.Sprintf(checkStatusFaultRequestType, types.PacketLossFaultType)
 
-	ctxTimeoutDuration = requestTimeoutDuration * time.Second
+	ctxTimeoutDuration = requestTimeoutSeconds * time.Second
 )
 
 type networkFaultInjectionTestCase struct {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will include the following changes:
* Remove an unnecessary unit test case. Basically, there shouldn't be a case where we try to create a duplicate Iptable chain if it already exists. Instead, it should be responding back with a 200 and with "running" as the body.
* Add a wait timeout duration for all of the iptables commands
* Remove `v3` from the response message for default network interface name not found error

### Implementation details
* Removed `fail duplicate chain` from the list of test cases within `generateStartBlackHolePortFaultTestCases()` 
* Added the `-w` flag within all of the iptables commands within `ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go`. The value is in seconds and it is set to the request timeout duration of 5 seconds.
* Removed `v3` from being mentioned in the `defaultNetworkInterfaceNameNotFoundError` response message

### Testing
Before adding a wait duration within the iptables, we get the following error pretty often when we launch multiple AWSVPC tasks that tries to start up a BHP fault injection
```
level=info time=2024-10-04T18:02:56Z msg="Failed to start fault" requestType="start network-blackhole-port" request="{\"Port\":1234,\"Protocol\":\"tcp\",\"TrafficType\":\"egress\"}" response="{\"Error\":\"Another app is currently holding the xtables lock. Perhaps you want to use the -w option?\\n\"}"
```

After adding a wait duration, we no longer encounter this issue
```
level=debug time=2024-10-04T19:15:52Z msg="Handling http request" method="POST" from="169.254.172.2:38578"
level=info time=2024-10-04T19:15:52Z msg="Received new request for request type: start network-blackhole-port" request="{\"Protocol\":\"tcp\",\"TrafficType\":\"egress\",\"Port\":1234}" requestType="start network-blackhole-port" tmdsEndpointContainerID="2909e899-509d-4b11-a5e0-cb89fa237c2a"
level=debug time=2024-10-04T19:15:52Z msg="Handling http request" method="POST" from="169.254.172.3:59796"
level=info time=2024-10-04T19:15:52Z msg="Received new request for request type: start network-blackhole-port" request="{\"Protocol\":\"tcp\",\"TrafficType\":\"egress\",\"Port\":1234}" requestType="start network-blackhole-port" tmdsEndpointContainerID="e8f4d4f4-dd7f-4981-a07b-b8a72f3124b4"
level=info time=2024-10-04T19:15:52Z msg="[INFO] Black hole port fault is not running" command="nsenter --net=/host/proc/10362/ns/net iptables -w 5 -C egress-tcp-1234 -p tcp --dport 1234 -j DROP" output="iptables: Bad rule (does a matching rule exist in that chain?).\n" taskArn="arn:aws:ecs:us-west-2:113424923516:task/fis/27c85dee5b604c508bfea8a813df19ed" exitCode=1 netns="/host/proc/10362/ns/net"
level=info time=2024-10-04T19:15:52Z msg="[INFO] Attempting to start network black hole port fault" netns="/host/proc/10362/ns/net" chain="egress-tcp-1234" taskArn="arn:aws:ecs:us-west-2:113424923516:task/fis/27c85dee5b604c508bfea8a813df19ed"
level=info time=2024-10-04T19:15:52Z msg="Successfully started fault" requestType="start network-blackhole-port" request="{\"Port\":1234,\"Protocol\":\"tcp\",\"TrafficType\":\"egress\"}" response="{\"Status\":\"running\"}"
level=info time=2024-10-04T19:15:53Z msg="[INFO] Black hole port fault is not running" command="nsenter --net=/host/proc/10393/ns/net iptables -w 5 -C egress-tcp-1234 -p tcp --dport 1234 -j DROP" output="iptables: Bad rule (does a matching rule exist in that chain?).\n" taskArn="arn:aws:ecs:us-west-2:113424923516:task/fis/85ac6d44cbd84ca4b95d19a46b27aad7" exitCode=1 netns="/host/proc/10393/ns/net"
level=info time=2024-10-04T19:15:53Z msg="[INFO] Attempting to start network black hole port fault" netns="/host/proc/10393/ns/net" chain="egress-tcp-1234" taskArn="arn:aws:ecs:us-west-2:113424923516:task/fis/85ac6d44cbd84ca4b95d19a46b27aad7"
level=info time=2024-10-04T19:15:53Z msg="Successfully started fault" request="{\"Port\":1234,\"Protocol\":\"tcp\",\"TrafficType\":\"egress\"}" response="{\"Status\":\"running\"}" requestType="start network-blackhole-port"
```

New tests cover the changes: Yes

### Description for the changelog
Enhancement: Clean up unit test and add a wait duration for iptables commands and fix response for default network interface name not found error

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
