### PR TITLE
Add additional logging for Black Hole Port fault

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -134,6 +134,7 @@ var (
 		attributePrefix + taskEIAWithOptimizedCPU,
 		attributePrefix + capabilityServiceConnect,
 		attributePrefix + capabilityEBSTaskAttach,
+		attributePrefix + capabilityFaultInjection,
 	}
 	// List of capabilities that are only supported on external capaciity. Currently only one but keep as a list
 	// for future proof and also align with externalUnsupportedCapabilities.

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -314,8 +314,7 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 		capabilities = removeAttributesByNames(capabilities, externalUnsupportedCapabilities)
 	}
 
-	// TODO add fault-injection capabilities if applicable
-	// capabilities = agent.appendFaultInjectionCapabilities(capabilities)
+	capabilities = agent.appendFaultInjectionCapabilities(capabilities)
 
 	return capabilities, nil
 }
@@ -543,9 +542,6 @@ func (agent *ecsAgent) appendEBSTaskAttachCapabilities(capabilities []*ecs.Attri
 	return capabilities
 }
 
-// TODO Remove linter directive below when the function becomes used
-//
-//lint:ignore U1000 as this method will be used in the future.
 func (agent *ecsAgent) appendFaultInjectionCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 
 	// Check if the agent is running in EXTERNAL launch type

--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -96,9 +96,8 @@ func taskServerSetup(
 	agentAPIV1HandlersSetup(muxRouter, state, credentialsManager, cluster, tmdsAgentState,
 		taskProtectionClientFactory, metricsFactory)
 
-	// TODO: Future PR to pass in TMDS server router once all of the handlers have been implemented.
 	execWrapper := execwrapper.NewExec()
-	registerFaultHandlers(nil, tmdsAgentState, metricsFactory, execWrapper)
+	registerFaultHandlers(muxRouter, tmdsAgentState, metricsFactory, execWrapper)
 
 	return tmds.NewServer(auditLogger,
 		tmds.WithHandler(muxRouter),

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -214,6 +214,12 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("[INFO] Successfully created new chain", logger.Fields{
+			"command": newChainCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+			"error":   err,
+		})
 
 		// Appending a new rule based on the protocol and port number from the request body
 		appendRuleCmdString := nsenterPrefix + fmt.Sprintf(iptablesAppendChainRuleCmd, requestTimeoutSeconds, chain, protocol, port)
@@ -228,6 +234,12 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("[INFO] Successfully appended new rule to iptable chain", logger.Fields{
+			"command": appendRuleCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+			"error":   err,
+		})
 
 		// Inserting the chain into the built-in INPUT/OUTPUT table
 		insertChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesInsertChainCmd, requestTimeoutSeconds, insertTable, chain)
@@ -243,6 +255,13 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("[INFO] Successfully inserted chain into built-in iptable", logger.Fields{
+			"insertTable": insertTable,
+			"taskArn":     taskArn,
+			"error":       err,
+			"command":     insertChainCmdString,
+			"output":      string(cmdOutput),
+		})
 	}
 	return "", nil
 }
@@ -361,6 +380,11 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("[INFO] Successfully cleared iptable chain", logger.Fields{
+			"command": clearChainCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+		})
 
 		// Removing the chain from either the built-in INPUT/OUTPUT table
 		deleteFromTableCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteFromTableCmd, requestTimeoutSeconds, insertTable, chain)
@@ -376,6 +400,12 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("[INFO] Successfully deleted chain from table", logger.Fields{
+			"command":     deleteFromTableCmdString,
+			"output":      string(cmdOutput),
+			"insertTable": insertTable,
+			"taskArn":     taskArn,
+		})
 
 		// Deleting the chain
 		deleteChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteChainCmd, requestTimeoutSeconds, chain)
@@ -391,6 +421,11 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("[INFO] Successfully deleted chain", logger.Fields{
+			"command": deleteChainCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+		})
 	}
 	return "", nil
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
@@ -38,7 +38,7 @@ type TaskResponse struct {
 	EphemeralStorageMetrics *EphemeralStorageMetrics `json:"EphemeralStorageMetrics,omitempty"`
 	CredentialsID           string                   `json:"-"`
 	TaskNetworkConfig       *TaskNetworkConfig       `json:"-"`
-	FaultInjectionEnabled   bool                     `json:"FaultInjectionEnabled,omitempty"`
+	FaultInjectionEnabled   bool                     `json:"FaultInjectionEnabled"`
 }
 
 // TaskNetworkConfig contains required network configurations for network faults injection.

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -214,6 +214,12 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("[INFO] Successfully created new chain", logger.Fields{
+			"command": newChainCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+			"error":   err,
+		})
 
 		// Appending a new rule based on the protocol and port number from the request body
 		appendRuleCmdString := nsenterPrefix + fmt.Sprintf(iptablesAppendChainRuleCmd, requestTimeoutSeconds, chain, protocol, port)
@@ -228,6 +234,12 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("[INFO] Successfully appended new rule to iptable chain", logger.Fields{
+			"command": appendRuleCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+			"error":   err,
+		})
 
 		// Inserting the chain into the built-in INPUT/OUTPUT table
 		insertChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesInsertChainCmd, requestTimeoutSeconds, insertTable, chain)
@@ -243,6 +255,13 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("[INFO] Successfully inserted chain into built-in iptable", logger.Fields{
+			"insertTable": insertTable,
+			"taskArn":     taskArn,
+			"error":       err,
+			"command":     insertChainCmdString,
+			"output":      string(cmdOutput),
+		})
 	}
 	return "", nil
 }
@@ -361,6 +380,11 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("[INFO] Successfully cleared iptable chain", logger.Fields{
+			"command": clearChainCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+		})
 
 		// Removing the chain from either the built-in INPUT/OUTPUT table
 		deleteFromTableCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteFromTableCmd, requestTimeoutSeconds, insertTable, chain)
@@ -376,6 +400,12 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("[INFO] Successfully deleted chain from table", logger.Fields{
+			"command":     deleteFromTableCmdString,
+			"output":      string(cmdOutput),
+			"insertTable": insertTable,
+			"taskArn":     taskArn,
+		})
 
 		// Deleting the chain
 		deleteChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteChainCmd, requestTimeoutSeconds, chain)
@@ -391,6 +421,11 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("[INFO] Successfully deleted chain", logger.Fields{
+			"command": deleteChainCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+		})
 	}
 	return "", nil
 }

--- a/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/ecs-agent/tmds/handlers/v4/state/response.go
@@ -38,7 +38,7 @@ type TaskResponse struct {
 	EphemeralStorageMetrics *EphemeralStorageMetrics `json:"EphemeralStorageMetrics,omitempty"`
 	CredentialsID           string                   `json:"-"`
 	TaskNetworkConfig       *TaskNetworkConfig       `json:"-"`
-	FaultInjectionEnabled   bool                     `json:"FaultInjectionEnabled,omitempty"`
+	FaultInjectionEnabled   bool                     `json:"FaultInjectionEnabled"`
 }
 
 // TaskNetworkConfig contains required network configurations for network faults injection.

--- a/ecs-init/docker/docker_config.go
+++ b/ecs-init/docker/docker_config.go
@@ -15,8 +15,10 @@ package docker
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/aws/amazon-ecs-agent/ecs-init/config"
+	"github.com/cihub/seelog"
 	ctrdapparmor "github.com/containerd/containerd/pkg/apparmor"
 	godocker "github.com/fsouza/go-dockerclient"
 )
@@ -45,6 +47,7 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 		iptablesLegacyDir+":"+iptablesLegacyDir+readOnly,
 		"/usr/bin/lsblk:/usr/bin/lsblk",
 	)
+	binds = append(binds, getNsenterBinds(os.Stat)...)
 
 	logConfig := config.AgentDockerLogDriverConfiguration()
 
@@ -79,4 +82,18 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 	}
 
 	return hostConfig
+}
+
+// Returns nsenter bind as a slice if nsenter is available on the host.
+// Returns an empty slice otherwise.
+func getNsenterBinds(statFn func(string) (os.FileInfo, error)) []string {
+	binds := []string{}
+	const nsenterPath = "/usr/bin/nsenter"
+	if _, err := statFn(nsenterPath); err == nil {
+		binds = append(binds, nsenterPath+":"+nsenterPath)
+	} else {
+		seelog.Warnf("nsenter not found at %s, skip binding it to Agent container: %v",
+			nsenterPath, err)
+	}
+	return binds
 }

--- a/ecs-init/docker/docker_config_test.go
+++ b/ecs-init/docker/docker_config_test.go
@@ -1,0 +1,38 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package docker
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetNsenterBinds(t *testing.T) {
+	t.Run("nsenter not found", func(t *testing.T) {
+		binds := getNsenterBinds(
+			func(s string) (os.FileInfo, error) { return nil, errors.New("not found") })
+		assert.Empty(t, binds)
+	})
+
+	t.Run("nsenter is found", func(t *testing.T) {
+		binds := getNsenterBinds(
+			func(s string) (os.FileInfo, error) { return nil, nil })
+		require.Len(t, binds, 1)
+		assert.Equal(t, "/usr/bin/nsenter:/usr/bin/nsenter", binds[0])
+	})
+}

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -32,7 +32,7 @@ import (
 // Note: Change this value every time when a new bind mount is added to
 // agent for the tests to pass
 const (
-	defaultExpectedAgentBinds = 20
+	defaultExpectedAgentBinds = 21
 )
 
 func TestIsAgentImageLoadedListFailure(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds additional logging to the start and stop functions for the BHP fault.
### Implementation details
<!-- How are the changes implemented? -->
Additional logging statements are added.
### Testing
<!-- How was this tested? -->
Logging for starting black hole port fault
```
level=debug time=2024-10-11T02:32:12Z msg="Handling http request" method="POST" from="172.31.10.171:57844"
level=info time=2024-10-11T02:32:12Z msg="Received new request for request type: start network-blackhole-port" tmdsEndpointContainerID="e8433e65-f1ff-40bb-8589-8a44bc6405f3" request="{\"Protocol\":\"tcp\",\"TrafficType\":\"egress\",\"Port\":1234}" requestType="start network-blackhole-port"
level=debug time=2024-10-11T02:32:12Z msg="Found route" Route={Ifindex: 2 Dst: <nil> Src: 172.31.10.171 Gw: 172.31.0.1 Flags: [] Table: 254 Realm: 0}
level=debug time=2024-10-11T02:32:12Z msg="Found the associated network interface by the index" LinkName="ens5" LinkIndex=2
level=info time=2024-10-11T02:32:12Z msg="Obtained default network interface name on host" taskARN="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/fa06536c65eb46af8f556fb42862b45b" defaultDeviceName="ens5"
level=info time=2024-10-11T02:32:12Z msg="[INFO] Black hole port fault is not running" output="iptables: Bad rule (does a matching rule exist in that chain?).\n" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/fa06536c65eb46af8f556fb42862b45b" exitCode=1 netns="host" command="iptables -w 5 -C egress-tcp-1234 -p tcp --dport 1234 -j DROP"
level=info time=2024-10-11T02:32:12Z msg="[INFO] Attempting to start network black hole port fault" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/fa06536c65eb46af8f556fb42862b45b" netns="host" chain="egress-tcp-1234"
level=info time=2024-10-11T02:32:12Z msg="[INFO] Successfully created new chain" command="iptables -w 5 -N egress-tcp-1234" output="" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/fa06536c65eb46af8f556fb42862b45b" error=<nil>
level=info time=2024-10-11T02:32:12Z msg="[INFO] Successfully appended new rule to iptable chain" command="iptables -w 5 -A egress-tcp-1234 -p tcp --dport 1234 -j DROP" output="" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/fa06536c65eb46af8f556fb42862b45b" error=<nil>
level=debug time=2024-10-11T02:32:12Z msg="Storage stats not reported for container" module=utils_unix.go
level=info time=2024-10-11T02:32:12Z msg="[INFO] Successfully inserted chain into built-in iptable" command="iptables -w 5 -I OUTPUT -j egress-tcp-1234" output="" insertTable="OUTPUT" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/fa06536c65eb46af8f556fb42862b45b" error=<nil>
level=info time=2024-10-11T02:32:12Z msg="Successfully started fault" requestType="start network-blackhole-port" request="{\"Port\":1234,\"Protocol\":\"tcp\",\"TrafficType\":\"egress\"}" response="{\"Status\":\"running\"}"
level=info time=2024-10-11T02:32:12Z msg="The telemetry middleware is complete" StatusCode=200 DurationInMs=7 Request="/api/e8433e65-f1ff-40bb-8589-8a44bc6405f3/fault/v1/network-blackhole-port/start"
```
Logging for stopping black hole port fault
```
level=debug time=2024-10-11T02:32:32Z msg="Handling http request" method="POST" from="172.31.10.171:33026"
level=info time=2024-10-11T02:32:32Z msg="Received new request for request type: stop network-blackhole-port" request="{\"Protocol\":\"tcp\",\"TrafficType\":\"egress\",\"Port\":1234}" requestType="stop network-blackhole-port" tmdsEndpointContainerID="e8433e65-f1ff-40bb-8589-8a44bc6405f3"
level=debug time=2024-10-11T02:32:32Z msg="Successfully parsed fault request payload" request="{\"Port\":1234,\"Protocol\":\"tcp\",\"TrafficType\":\"egress\"}"
level=debug time=2024-10-11T02:32:32Z msg="Found route" Route={Ifindex: 2 Dst: <nil> Src: 172.31.10.171 Gw: 172.31.0.1 Flags: [] Table: 254 Realm: 0}
level=debug time=2024-10-11T02:32:32Z msg="Found the associated network interface by the index" LinkIndex=2 LinkName="ens5"
level=info time=2024-10-11T02:32:32Z msg="Obtained default network interface name on host" taskARN="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/fa06536c65eb46af8f556fb42862b45b" defaultDeviceName="ens5"
level=info time=2024-10-11T02:32:32Z msg="[INFO] Black hole port fault has been found running" command="iptables -w 5 -C egress-tcp-1234 -p tcp --dport 1234 -j DROP" output="" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/fa06536c65eb46af8f556fb42862b45b" netns="host"
level=info time=2024-10-11T02:32:32Z msg="[INFO] Attempting to stop network black hole port fault" netns="host" chain="egress-tcp-1234" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/fa06536c65eb46af8f556fb42862b45b"
level=info time=2024-10-11T02:32:32Z msg="[INFO] Successfully cleared iptable chain" command="iptables -w 5 -F egress-tcp-1234" output="" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/fa06536c65eb46af8f556fb42862b45b"
level=debug time=2024-10-11T02:32:32Z msg="Storage stats not reported for container" module=utils_unix.go
level=info time=2024-10-11T02:32:32Z msg="[INFO] Successfully deleted chain from table" command="iptables -w 5 -D OUTPUT -j egress-tcp-1234" output="" insertTable="OUTPUT" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/fa06536c65eb46af8f556fb42862b45b"
level=info time=2024-10-11T02:32:32Z msg="[INFO] Successfully deleted chain" command="iptables -w 5 -X egress-tcp-1234" output="" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/fa06536c65eb46af8f556fb42862b45b"
level=info time=2024-10-11T02:32:32Z msg="Successfully stopped fault" requestType="stop network-blackhole-port" request="{\"Port\":1234,\"Protocol\":\"tcp\",\"TrafficType\":\"egress\"}" response="{\"Status\":\"stopped\"}"
level=info time=2024-10-11T02:32:32Z msg="The telemetry middleware is complete" DurationInMs=148 Request="/api/e8433e65-f1ff-40bb-8589-8a44bc6405f3/fault/v1/network-blackhole-port/stop" StatusCode=200
```
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
