### PR TITLE
Add additional logging for BHP fault

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -189,7 +189,7 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 		return cmdOutput, err
 	}
 	if !running {
-		logger.Info("[INFO] Attempting to start network black hole port fault", logger.Fields{
+		logger.Info("Attempting to start network black hole port fault", logger.Fields{
 			"netns":   netNs,
 			"chain":   chain,
 			"taskArn": taskArn,
@@ -214,6 +214,11 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("Successfully created new chain", logger.Fields{
+			"command": newChainCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+		})
 
 		// Appending a new rule based on the protocol and port number from the request body
 		appendRuleCmdString := nsenterPrefix + fmt.Sprintf(iptablesAppendChainRuleCmd, requestTimeoutSeconds, chain, protocol, port)
@@ -228,6 +233,11 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("Successfully appended new rule to iptable chain", logger.Fields{
+			"command": appendRuleCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+		})
 
 		// Inserting the chain into the built-in INPUT/OUTPUT table
 		insertChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesInsertChainCmd, requestTimeoutSeconds, insertTable, chain)
@@ -243,6 +253,12 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("Successfully inserted chain into built-in iptable", logger.Fields{
+			"insertTable": insertTable,
+			"taskArn":     taskArn,
+			"command":     insertChainCmdString,
+			"output":      string(cmdOutput),
+		})
 	}
 	return "", nil
 }
@@ -336,7 +352,7 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 		return cmdOutput, err
 	}
 	if running {
-		logger.Info("[INFO] Attempting to stop network black hole port fault", logger.Fields{
+		logger.Info("Attempting to stop network black hole port fault", logger.Fields{
 			"netns":   netNs,
 			"chain":   chain,
 			"taskArn": taskArn,
@@ -361,6 +377,11 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("Successfully cleared iptable chain", logger.Fields{
+			"command": clearChainCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+		})
 
 		// Removing the chain from either the built-in INPUT/OUTPUT table
 		deleteFromTableCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteFromTableCmd, requestTimeoutSeconds, insertTable, chain)
@@ -376,6 +397,12 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("Successfully deleted chain from table", logger.Fields{
+			"command":     deleteFromTableCmdString,
+			"output":      string(cmdOutput),
+			"insertTable": insertTable,
+			"taskArn":     taskArn,
+		})
 
 		// Deleting the chain
 		deleteChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteChainCmd, requestTimeoutSeconds, chain)
@@ -391,6 +418,11 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("Successfully deleted chain", logger.Fields{
+			"command": deleteChainCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+		})
 	}
 	return "", nil
 }
@@ -487,7 +519,7 @@ func (h *FaultHandler) checkNetworkBlackHolePort(ctx context.Context, protocol, 
 	cmdOutput, err := h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		if exitErr, eok := h.osExecWrapper.ConvertToExitError(err); eok {
-			logger.Info("[INFO] Black hole port fault is not running", logger.Fields{
+			logger.Info("Black hole port fault is not running", logger.Fields{
 				"netns":    netNs,
 				"command":  strings.Join(cmdList, " "),
 				"output":   string(cmdOutput),
@@ -505,7 +537,7 @@ func (h *FaultHandler) checkNetworkBlackHolePort(ctx context.Context, protocol, 
 		})
 		return false, string(cmdOutput), err
 	}
-	logger.Info("[INFO] Black hole port fault has been found running", logger.Fields{
+	logger.Info("Black hole port fault has been found running", logger.Fields{
 		"netns":   netNs,
 		"command": strings.Join(cmdList, " "),
 		"output":  string(cmdOutput),

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -189,7 +189,7 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 		return cmdOutput, err
 	}
 	if !running {
-		logger.Info("[INFO] Attempting to start network black hole port fault", logger.Fields{
+		logger.Info("Attempting to start network black hole port fault", logger.Fields{
 			"netns":   netNs,
 			"chain":   chain,
 			"taskArn": taskArn,
@@ -214,6 +214,11 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("Successfully created new chain", logger.Fields{
+			"command": newChainCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+		})
 
 		// Appending a new rule based on the protocol and port number from the request body
 		appendRuleCmdString := nsenterPrefix + fmt.Sprintf(iptablesAppendChainRuleCmd, requestTimeoutSeconds, chain, protocol, port)
@@ -228,6 +233,11 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("Successfully appended new rule to iptable chain", logger.Fields{
+			"command": appendRuleCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+		})
 
 		// Inserting the chain into the built-in INPUT/OUTPUT table
 		insertChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesInsertChainCmd, requestTimeoutSeconds, insertTable, chain)
@@ -243,6 +253,12 @@ func (h *FaultHandler) startNetworkBlackholePort(ctx context.Context, protocol, 
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("Successfully inserted chain into built-in iptable", logger.Fields{
+			"insertTable": insertTable,
+			"taskArn":     taskArn,
+			"command":     insertChainCmdString,
+			"output":      string(cmdOutput),
+		})
 	}
 	return "", nil
 }
@@ -336,7 +352,7 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 		return cmdOutput, err
 	}
 	if running {
-		logger.Info("[INFO] Attempting to stop network black hole port fault", logger.Fields{
+		logger.Info("Attempting to stop network black hole port fault", logger.Fields{
 			"netns":   netNs,
 			"chain":   chain,
 			"taskArn": taskArn,
@@ -361,6 +377,11 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("Successfully cleared iptable chain", logger.Fields{
+			"command": clearChainCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+		})
 
 		// Removing the chain from either the built-in INPUT/OUTPUT table
 		deleteFromTableCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteFromTableCmd, requestTimeoutSeconds, insertTable, chain)
@@ -376,6 +397,12 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("Successfully deleted chain from table", logger.Fields{
+			"command":     deleteFromTableCmdString,
+			"output":      string(cmdOutput),
+			"insertTable": insertTable,
+			"taskArn":     taskArn,
+		})
 
 		// Deleting the chain
 		deleteChainCmdString := nsenterPrefix + fmt.Sprintf(iptablesDeleteChainCmd, requestTimeoutSeconds, chain)
@@ -391,6 +418,11 @@ func (h *FaultHandler) stopNetworkBlackHolePort(ctx context.Context, protocol, p
 			})
 			return string(cmdOutput), err
 		}
+		logger.Info("Successfully deleted chain", logger.Fields{
+			"command": deleteChainCmdString,
+			"output":  string(cmdOutput),
+			"taskArn": taskArn,
+		})
 	}
 	return "", nil
 }
@@ -487,7 +519,7 @@ func (h *FaultHandler) checkNetworkBlackHolePort(ctx context.Context, protocol, 
 	cmdOutput, err := h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		if exitErr, eok := h.osExecWrapper.ConvertToExitError(err); eok {
-			logger.Info("[INFO] Black hole port fault is not running", logger.Fields{
+			logger.Info("Black hole port fault is not running", logger.Fields{
 				"netns":    netNs,
 				"command":  strings.Join(cmdList, " "),
 				"output":   string(cmdOutput),
@@ -505,7 +537,7 @@ func (h *FaultHandler) checkNetworkBlackHolePort(ctx context.Context, protocol, 
 		})
 		return false, string(cmdOutput), err
 	}
-	logger.Info("[INFO] Black hole port fault has been found running", logger.Fields{
+	logger.Info("Black hole port fault has been found running", logger.Fields{
 		"netns":   netNs,
 		"command": strings.Join(cmdList, " "),
 		"output":  string(cmdOutput),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds additional logging to the start and stop functions for the BHP fault.
### Implementation details
<!-- How are the changes implemented? -->
Additional logging statements are added.
### Testing
<!-- How was this tested? -->
Logging for starting black hole port fault
```
level=debug time=2024-10-11T20:03:04Z msg="Handling http request" from="172.31.10.171:52002" method="POST"
level=info time=2024-10-11T20:03:04Z msg="Received new request for request type: start network-blackhole-port" request="{\"Protocol\":\"tcp\",\"TrafficType\":\"egress\",\"Port\":1234}" requestType="start network-blackhole-port" tmdsEndpointContainerID="b8f5fb69-ea5b-4dbf-b925-d90ee7b8ad07"
level=debug time=2024-10-11T20:03:04Z msg="Found route" Route={Ifindex: 2 Dst: <nil> Src: 172.31.10.171 Gw: 172.31.0.1 Flags: [] Table: 254 Realm: 0}
level=debug time=2024-10-11T20:03:04Z msg="Found the associated network interface by the index" LinkName="ens5" LinkIndex=2
level=info time=2024-10-11T20:03:04Z msg="Obtained default network interface name on host" taskARN="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/f941ed202d964d7a9c3e3539d8df0f67" defaultDeviceName="ens5"
level=info time=2024-10-11T20:03:04Z msg="Black hole port fault is not running" netns="host" command="iptables -w 5 -C egress-tcp-1234 -p tcp --dport 1234 -j DROP" output="iptables: Bad rule (does a matching rule exist in that chain?).\n" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/f941ed202d964d7a9c3e3539d8df0f67" exitCode=1
level=info time=2024-10-11T20:03:04Z msg="Attempting to start network black hole port fault" netns="host" chain="egress-tcp-1234" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/f941ed202d964d7a9c3e3539d8df0f67"
level=info time=2024-10-11T20:03:04Z msg="Successfully created new chain" command="iptables -w 5 -N egress-tcp-1234" output="" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/f941ed202d964d7a9c3e3539d8df0f67"
level=info time=2024-10-11T20:03:04Z msg="Successfully appended new rule to iptable chain" command="iptables -w 5 -A egress-tcp-1234 -p tcp --dport 1234 -j DROP" output="" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/f941ed202d964d7a9c3e3539d8df0f67"
level=debug time=2024-10-11T20:03:04Z msg="Storage stats not reported for container" module=utils_unix.go
level=info time=2024-10-11T20:03:04Z msg="Successfully inserted chain into built-in iptable" insertTable="OUTPUT" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/f941ed202d964d7a9c3e3539d8df0f67" command="iptables -w 5 -I OUTPUT -j egress-tcp-1234" output=""
level=info time=2024-10-11T20:03:04Z msg="Successfully started fault" requestType="start network-blackhole-port" request="{\"Port\":1234,\"Protocol\":\"tcp\",\"TrafficType\":\"egress\"}" response="{\"Status\":\"running\"}"
level=info time=2024-10-11T20:03:04Z msg="The telemetry middleware is complete" StatusCode=200 DurationInMs=7 Request="/api/b8f5fb69-ea5b-4dbf-b925-d90ee7b8ad07/fault/v1/network-blackhole-port/start"
```
Logging for stopping black hole port fault
```
level=debug time=2024-10-11T20:03:24Z msg="Handling http request" method="POST" from="172.31.10.171:59558"
level=info time=2024-10-11T20:03:24Z msg="Received new request for request type: stop network-blackhole-port" request="{\"Protocol\":\"tcp\",\"TrafficType\":\"egress\",\"Port\":1234}" requestType="stop network-blackhole-port" tmdsEndpointContainerID="b8f5fb69-ea5b-4dbf-b925-d90ee7b8ad07"
level=debug time=2024-10-11T20:03:24Z msg="Successfully parsed fault request payload" request="{\"Port\":1234,\"Protocol\":\"tcp\",\"TrafficType\":\"egress\"}"
level=debug time=2024-10-11T20:03:24Z msg="Found route" Route={Ifindex: 2 Dst: <nil> Src: 172.31.10.171 Gw: 172.31.0.1 Flags: [] Table: 254 Realm: 0}
level=debug time=2024-10-11T20:03:24Z msg="Found the associated network interface by the index" LinkName="ens5" LinkIndex=2
level=info time=2024-10-11T20:03:24Z msg="Obtained default network interface name on host" defaultDeviceName="ens5" taskARN="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/f941ed202d964d7a9c3e3539d8df0f67"
level=info time=2024-10-11T20:03:24Z msg="Black hole port fault has been found running" netns="host" command="iptables -w 5 -C egress-tcp-1234 -p tcp --dport 1234 -j DROP" output="" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/f941ed202d964d7a9c3e3539d8df0f67"
level=info time=2024-10-11T20:03:24Z msg="Attempting to stop network black hole port fault" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/f941ed202d964d7a9c3e3539d8df0f67" netns="host" chain="egress-tcp-1234"
level=info time=2024-10-11T20:03:24Z msg="Successfully cleared iptable chain" output="" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/f941ed202d964d7a9c3e3539d8df0f67" command="iptables -w 5 -F egress-tcp-1234"
level=debug time=2024-10-11T20:03:24Z msg="Storage stats not reported for container" module=utils_unix.go
level=info time=2024-10-11T20:03:24Z msg="Successfully deleted chain from table" insertTable="OUTPUT" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/f941ed202d964d7a9c3e3539d8df0f67" command="iptables -w 5 -D OUTPUT -j egress-tcp-1234" output=""
level=info time=2024-10-11T20:03:24Z msg="Successfully deleted chain" taskArn="arn:aws:ecs:us-west-2:817190723229:task/harishxr-ecs/f941ed202d964d7a9c3e3539d8df0f67" command="iptables -w 5 -X egress-tcp-1234" output=""
level=info time=2024-10-11T20:03:24Z msg="Successfully stopped fault" requestType="stop network-blackhole-port" request="{\"Port\":1234,\"Protocol\":\"tcp\",\"TrafficType\":\"egress\"}" response="{\"Status\":\"stopped\"}"
level=info time=2024-10-11T20:03:24Z msg="The telemetry middleware is complete" StatusCode=200 DurationInMs=188 Request="/api/b8f5fb69-ea5b-4dbf-b925-d90ee7b8ad07/fault/v1/network-blackhole-port/stop"
```
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add additional logging for BHP fault
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
