### PR TITLE
Remove unnecessary set driver and instance log level calls

### DIFF
--- a/agent/app/run.go
+++ b/agent/app/run.go
@@ -62,12 +62,13 @@ func Run(arguments []string) int {
 	if *parsedArgs.LogLevel != "" {
 		logger.SetDriverLogLevel(*parsedArgs.LogLevel)
 		logger.SetInstanceLogLevel(*parsedArgs.LogLevel)
-	}
-	if *parsedArgs.DriverLogLevel != "" {
-		logger.SetDriverLogLevel(*parsedArgs.DriverLogLevel)
-	}
-	if *parsedArgs.InstanceLogLevel != "" {
-		logger.SetInstanceLogLevel(*parsedArgs.InstanceLogLevel)
+	} else {
+		if *parsedArgs.DriverLogLevel != "" {
+			logger.SetDriverLogLevel(*parsedArgs.DriverLogLevel)
+		}
+		if *parsedArgs.InstanceLogLevel != "" {
+			logger.SetInstanceLogLevel(*parsedArgs.InstanceLogLevel)
+		}
 	}
 
 	// Create an Agent object

--- a/agent/app/run.go
+++ b/agent/app/run.go
@@ -62,8 +62,11 @@ func Run(arguments []string) int {
 	if *parsedArgs.LogLevel != "" {
 		logger.SetDriverLogLevel(*parsedArgs.LogLevel)
 		logger.SetInstanceLogLevel(*parsedArgs.LogLevel)
-	} else {
+	}
+	if *parsedArgs.DriverLogLevel != "" {
 		logger.SetDriverLogLevel(*parsedArgs.DriverLogLevel)
+	}
+	if *parsedArgs.InstanceLogLevel != "" {
 		logger.SetInstanceLogLevel(*parsedArgs.InstanceLogLevel)
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
If Agent is not started with a `logLevel` command-line argument then it attempts to set driver and instance log level of the logger using `loglevel-driver` and `loglevel-on-instance` command-line arguments regardless of whether they were passed or not. This causes the following misleading error logs to be printed.

```
{"level":"error","time":"2024-10-01T06:24:05Z","msg":"Driver log level mapping not found","module":"log.go"}
{"level":"error","time":"2024-10-01T06:24:05Z","msg":"Instance log level mapping not found","module":"log.go"}
```

This PR fixes this issue by making Agent skip setting driver and instance log levels if the corresponding command-line arguments are not passed.

Fixes #4375.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Ran Agent and verified that the misleading error logs are no longer printed. Log level settings continue to be set and work as before.

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
bugfix - Remove unnecessary set driver and instance log level calls

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
