### PR TITLE
Set firelens mem_buf_limit by default

### DIFF
--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -751,6 +751,48 @@ func TestGetNetworkModeFromHostConfig(t *testing.T) {
 	}
 }
 
+func TestGetMemoryReservationFromHostConfig(t *testing.T) {
+	getContainer := func(hostConfig *string) *Container {
+		c := &Container{
+			Name: "c",
+		}
+		c.DockerConfig.HostConfig = hostConfig
+		return c
+	}
+
+	getStrPtr := func(s string) *string {
+		return &s
+	}
+
+	testCases := []struct {
+		name           string
+		container      *Container
+		expectedOutput int64
+	}{
+		{
+			name:           "happy case",
+			container:      getContainer(getStrPtr("{\"MemoryReservation\":268435456}")),
+			expectedOutput: 256,
+		},
+		{
+			name:           "invalid case",
+			container:      getContainer(getStrPtr("invalid")),
+			expectedOutput: 0,
+		},
+		{
+			name:           "nil case",
+			container:      getContainer(nil),
+			expectedOutput: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, tc.container.GetMemoryReservationFromHostConfig())
+		})
+	}
+}
+
 func TestShouldCreateWithEnvfiles(t *testing.T) {
 	cases := []struct {
 		in  Container

--- a/agent/taskresource/firelens/firelens_unimplemented.go
+++ b/agent/taskresource/firelens/firelens_unimplemented.go
@@ -53,7 +53,7 @@ type FirelensResource struct{}
 // NewFirelensResource returns a new FirelensResource.
 func NewFirelensResource(cluster, taskARN, taskDefinition, ec2InstanceID, dataDir, firelensConfigType, region, networkMode string,
 	firelensOptions map[string]string, containerToLogOptions map[string]map[string]string, credentialsManager credentials.Manager,
-	executionCredentialsID string) (*FirelensResource, error) {
+	executionCredentialsID string, containerMemoryLimit int64) (*FirelensResource, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/agent/taskresource/firelens/firelens_unix.go
+++ b/agent/taskresource/firelens/firelens_unix.go
@@ -83,6 +83,7 @@ type FirelensResource struct {
 	networkMode            string
 	ioutil                 ioutilwrapper.IOUtil
 	s3ClientCreator        factory.S3ClientCreator
+	containerMemoryLimit   int64
 
 	// Fields for the common functionality of task resource. Access to these fields are protected by lock.
 	createdAtUnsafe     time.Time
@@ -98,7 +99,7 @@ type FirelensResource struct {
 // NewFirelensResource returns a new FirelensResource.
 func NewFirelensResource(cluster, taskARN, taskDefinition, ec2InstanceID, dataDir, firelensConfigType, region, networkMode string,
 	firelensOptions map[string]string, containerToLogOptions map[string]map[string]string, credentialsManager credentials.Manager,
-	executionCredentialsID string) (*FirelensResource, error) {
+	executionCredentialsID string, containerMemoryLimit int64) (*FirelensResource, error) {
 	firelensResource := &FirelensResource{
 		cluster:                cluster,
 		taskARN:                taskARN,
@@ -112,6 +113,7 @@ func NewFirelensResource(cluster, taskARN, taskDefinition, ec2InstanceID, dataDi
 		s3ClientCreator:        factory.NewS3ClientCreator(),
 		executionCredentialsID: executionCredentialsID,
 		credentialsManager:     credentialsManager,
+		containerMemoryLimit:   containerMemoryLimit,
 	}
 
 	fields := strings.Split(taskARN, "/")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
`awsfirelens` logging driver uses a Fluentbit-based image. Fluentbit supports `mem_buf_limit` configuration parameter which controls the amount of buffer memory that can be used by a log input. This prevents excessive memory usage of the buffer which may lead to container and task OOM kill. (see https://docs.fluentbit.io/manual/administration/backpressure)

`mem_buf_limit` is not enabled by Fluentbit by default, making buffer unbounded. In this PR we let ECS Agent sets a default `mem_buf_limit` when generating Fluentbit configuration. 

### Implementation details
<!-- How are the changes implemented? -->
The value of the `mem_buf_limit` is determined as follows:
1. if firelens container `memoryReservation` is specified, `mem_buf_limit` = `memoryReservation` / 2. We resolve `memoryReservation` from container host config property (a json blob). 
2. else if firelens container `memory` is specified, `mem_buf_limit` = `memory` / 2. We resolve `memory` from container property directly. 
(`memoryReservation` and `memory` are optional parameters indicating container soft and hard memory limit respectively. The goal here is to scale the `mem_buf_limit` in accordance with the memory allocation for the firelens container. The scaling factor is derived from this [recommendation](https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/mainline/examples/fluent-bit/oomkill-prevention#case-1-memory-buffering-only-default-or-storagetype-memory))
3. if neither `memoryReservation` nor `memory` is specified, we set `mem_buf_limit` to a fixed amount of 25MB ([rationale](https://aws.amazon.com/blogs/containers/preventing-log-loss-with-non-blocking-mode-in-the-awslogs-container-log-driver/))

Main changes are:
- Updated `NewFirelensResource` method to take in a new `containerMemoryLimit` argument, and updated caller to pass in this argument after resolving the value from container `memory` and `memoryReservation`
- Added `container` helper method `GetMemoryReservationFromHostConfig` to retrieve container `memoryReservation`
- Updated firelens `generateConfig` method to write `Mem_Buf_Limit` config for the default input, after resolving the value from `resolveMemBufLimit` helper method


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Set firelens mem_buf_limit by default

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
N/A

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
