### PR TITLE
Add SourcesToFilter support for network-blackhole-port fault

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -3806,8 +3806,6 @@ func TestRegisterStartBlackholePortFaultHandler(t *testing.T) {
 			cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
 			exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
 			cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
-			exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
-			cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
 		)
 	}
 	tcs := generateCommonNetworkFaultInjectionTestCases("start blackhole port", "running", setExecExpectations, happyBlackHolePortReqBody)

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -32,6 +32,8 @@ const (
 	missingRequiredFieldError = "required parameter %s is missing"
 	MissingRequestBodyError   = "required request body is missing"
 	invalidValueError         = "invalid value %s for parameter %s"
+	TrafficTypeIngress        = "ingress"
+	TrafficTypeEgress         = "egress"
 )
 
 type NetworkFaultRequest interface {
@@ -43,6 +45,9 @@ type NetworkBlackholePortRequest struct {
 	Port        *uint16 `json:"Port"`
 	Protocol    *string `json:"Protocol"`
 	TrafficType *string `json:"TrafficType"`
+	// SourcesToFilter is a list including IPv4 addresses or IPv4 CIDR blocks that will be excluded from the
+	// network latency fault.
+	SourcesToFilter []*string `json:"SourcesToFilter,omitempty"`
 }
 
 type NetworkFaultInjectionResponse struct {
@@ -65,11 +70,27 @@ func (request NetworkBlackholePortRequest) ValidateRequest() error {
 		return fmt.Errorf(invalidValueError, *request.Protocol, "Protocol")
 	}
 
-	if *request.TrafficType != "ingress" && *request.TrafficType != "egress" {
+	if *request.TrafficType != TrafficTypeIngress && *request.TrafficType != TrafficTypeEgress {
 		return fmt.Errorf(invalidValueError, *request.TrafficType, "TrafficType")
+	}
+	if err := validateNetworkFaultRequestSources(request.SourcesToFilter, "SourcesToFilter"); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+// Adds a source to SourcesToFilter
+func (request *NetworkBlackholePortRequest) AddSourceToFilterIfNotAlready(source string) {
+	if request.SourcesToFilter == nil {
+		request.SourcesToFilter = []*string{}
+	}
+	for _, src := range request.SourcesToFilter {
+		if src != nil && *src == source {
+			return
+		}
+	}
+	request.SourcesToFilter = append(request.SourcesToFilter, aws.String(source))
 }
 
 func (request NetworkBlackholePortRequest) ToString() string {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/server.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/server.go
@@ -32,7 +32,7 @@ const (
 	IPv4         = "127.0.0.1"
 	Port         = 51679
 	IPForTasks   = "169.254.170.2"
-	PortForTasks = "80"
+	PortForTasks = 80
 )
 
 // IPv4 address for TMDS

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
@@ -35,6 +35,7 @@ import (
 	mock_state "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/mocks"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/utils/netconfig"
 	mock_execwrapper "github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper/mocks"
+	"github.com/aws/aws-sdk-go/aws"
 
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
@@ -521,8 +522,6 @@ func generateStartBlackHolePortFaultTestCases() []networkFaultInjectionTestCase 
 					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
 					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
-					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
-					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
 				)
 			},
 		},
@@ -550,8 +549,6 @@ func generateStartBlackHolePortFaultTestCases() []networkFaultInjectionTestCase 
 					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte(iptablesChainNotFoundError), errors.New("exit status 1")),
 					exec.EXPECT().ConvertToExitError(gomock.Any()).Times(1).Return(nil, true),
 					exec.EXPECT().GetExitCode(gomock.Any()).Times(1).Return(1),
-					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
-					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
 					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
@@ -660,6 +657,103 @@ func generateStartBlackHolePortFaultTestCases() []networkFaultInjectionTestCase 
 					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
 					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte(internalError), errors.New("exit status 1")),
+				)
+			},
+		},
+		{
+			name:               "SourcesToFilter validation failure",
+			expectedStatusCode: 400,
+			requestBody: map[string]interface{}{
+				"Port":            port,
+				"Protocol":        protocol,
+				"TrafficType":     trafficType,
+				"SourcesToFilter": aws.StringSlice([]string{"1.2.3.4", "bad"}),
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse("invalid value bad for parameter SourcesToFilter"),
+		},
+		{
+			name: "TMDS IP is added to SourcesToFilter if needed",
+			requestBody: map[string]interface{}{
+				"Port":        80,
+				"Protocol":    protocol,
+				"TrafficType": "egress",
+			},
+			expectedStatusCode:   200,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).
+					Return(happyTaskResponse, nil).
+					Times(1)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
+				gomock.InOrder(
+					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
+					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte(iptablesChainNotFoundError), errors.New("exit status 1")),
+					exec.EXPECT().ConvertToExitError(gomock.Any()).Times(1).Return(nil, true),
+					exec.EXPECT().GetExitCode(gomock.Any()).Times(1).Return(1),
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
+					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
+					exec.EXPECT().CommandContext(gomock.Any(),
+						"nsenter", "--net=/some/path", "iptables", "-w", "5", "-A", "egress-tcp-80",
+						"-p", "tcp", "-d", "169.254.170.2", "--dport", "80", "-j", "ACCEPT",
+					).Times(1).Return(cmdExec),
+					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
+					exec.EXPECT().CommandContext(gomock.Any(),
+						"nsenter", "--net=/some/path", "iptables", "-w", "5", "-A", "egress-tcp-80",
+						"-p", "tcp", "-d", "0.0.0.0/0", "--dport", "80", "-j", "DROP",
+					).Times(1).Return(cmdExec),
+					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
+					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
+				)
+			},
+		},
+		{
+			name: "Sources to filter are filtered",
+			requestBody: map[string]interface{}{
+				"Port":            443,
+				"Protocol":        "udp",
+				"TrafficType":     "ingress",
+				"SourcesToFilter": []string{"1.2.3.4/20", "8.8.8.8"},
+			},
+			expectedStatusCode:   200,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).
+					Return(happyTaskResponse, nil).
+					Times(1)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				cmdExec := mock_execwrapper.NewMockCmd(ctrl)
+				gomock.InOrder(
+					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
+					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte(iptablesChainNotFoundError), errors.New("exit status 1")),
+					exec.EXPECT().ConvertToExitError(gomock.Any()).Times(1).Return(nil, true),
+					exec.EXPECT().GetExitCode(gomock.Any()).Times(1).Return(1),
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
+					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
+					exec.EXPECT().CommandContext(gomock.Any(),
+						"nsenter", "--net=/some/path", "iptables", "-w", "5", "-A", "ingress-udp-443",
+						"-p", "udp", "-d", "1.2.3.4/20", "--dport", "443", "-j", "ACCEPT",
+					).Times(1).Return(cmdExec),
+					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
+					exec.EXPECT().CommandContext(gomock.Any(),
+						"nsenter", "--net=/some/path", "iptables", "-w", "5", "-A", "ingress-udp-443",
+						"-p", "udp", "-d", "8.8.8.8", "--dport", "443", "-j", "ACCEPT",
+					).Times(1).Return(cmdExec),
+					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
+					exec.EXPECT().CommandContext(gomock.Any(),
+						"nsenter", "--net=/some/path", "iptables", "-w", "5", "-A", "ingress-udp-443",
+						"-p", "udp", "-d", "0.0.0.0/0", "--dport", "443", "-j", "DROP",
+					).Times(1).Return(cmdExec),
+					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
+					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
 				)
 			},
 		},

--- a/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -32,6 +32,8 @@ const (
 	missingRequiredFieldError = "required parameter %s is missing"
 	MissingRequestBodyError   = "required request body is missing"
 	invalidValueError         = "invalid value %s for parameter %s"
+	TrafficTypeIngress        = "ingress"
+	TrafficTypeEgress         = "egress"
 )
 
 type NetworkFaultRequest interface {
@@ -43,6 +45,9 @@ type NetworkBlackholePortRequest struct {
 	Port        *uint16 `json:"Port"`
 	Protocol    *string `json:"Protocol"`
 	TrafficType *string `json:"TrafficType"`
+	// SourcesToFilter is a list including IPv4 addresses or IPv4 CIDR blocks that will be excluded from the
+	// network latency fault.
+	SourcesToFilter []*string `json:"SourcesToFilter,omitempty"`
 }
 
 type NetworkFaultInjectionResponse struct {
@@ -65,11 +70,27 @@ func (request NetworkBlackholePortRequest) ValidateRequest() error {
 		return fmt.Errorf(invalidValueError, *request.Protocol, "Protocol")
 	}
 
-	if *request.TrafficType != "ingress" && *request.TrafficType != "egress" {
+	if *request.TrafficType != TrafficTypeIngress && *request.TrafficType != TrafficTypeEgress {
 		return fmt.Errorf(invalidValueError, *request.TrafficType, "TrafficType")
+	}
+	if err := validateNetworkFaultRequestSources(request.SourcesToFilter, "SourcesToFilter"); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+// Adds a source to SourcesToFilter
+func (request *NetworkBlackholePortRequest) AddSourceToFilterIfNotAlready(source string) {
+	if request.SourcesToFilter == nil {
+		request.SourcesToFilter = []*string{}
+	}
+	for _, src := range request.SourcesToFilter {
+		if src != nil && *src == source {
+			return
+		}
+	}
+	request.SourcesToFilter = append(request.SourcesToFilter, aws.String(source))
 }
 
 func (request NetworkBlackholePortRequest) ToString() string {

--- a/ecs-agent/tmds/handlers/fault/v1/types/types_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/types/types_test.go
@@ -22,19 +22,19 @@ import (
 
 func TestNetworkBlackholePortAddSourceToFilterIfNotAlready(t *testing.T) {
 	t.Run("nil SourcesToFilter is initialized", func(t *testing.T) {
-		var req *NetworkBlackholePortRequest = &NetworkBlackholePortRequest{}
+		var req NetworkBlackholePortRequest = NetworkBlackholePortRequest{}
 		req.AddSourceToFilterIfNotAlready("1.2.3.4")
 		require.Equal(t, aws.StringValueSlice(req.SourcesToFilter), []string{"1.2.3.4"})
 	})
 	t.Run("Source can be added", func(t *testing.T) {
-		var req *NetworkBlackholePortRequest = &NetworkBlackholePortRequest{
+		var req NetworkBlackholePortRequest = NetworkBlackholePortRequest{
 			SourcesToFilter: aws.StringSlice([]string{"8.8.8.8"}),
 		}
 		req.AddSourceToFilterIfNotAlready("1.2.3.4")
 		require.Equal(t, aws.StringValueSlice(req.SourcesToFilter), []string{"8.8.8.8", "1.2.3.4"})
 	})
 	t.Run("Duplicate source is not added", func(t *testing.T) {
-		var req *NetworkBlackholePortRequest = &NetworkBlackholePortRequest{
+		var req NetworkBlackholePortRequest = NetworkBlackholePortRequest{
 			SourcesToFilter: aws.StringSlice([]string{"8.8.8.8", "1.2.3.4"}),
 		}
 		req.AddSourceToFilterIfNotAlready("1.2.3.4")

--- a/ecs-agent/tmds/handlers/fault/v1/types/types_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/types/types_test.go
@@ -1,0 +1,43 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetworkBlackholePortAddSourceToFilterIfNotAlready(t *testing.T) {
+	t.Run("nil SourcesToFilter is initialized", func(t *testing.T) {
+		var req *NetworkBlackholePortRequest = &NetworkBlackholePortRequest{}
+		req.AddSourceToFilterIfNotAlready("1.2.3.4")
+		require.Equal(t, aws.StringValueSlice(req.SourcesToFilter), []string{"1.2.3.4"})
+	})
+	t.Run("Source can be added", func(t *testing.T) {
+		var req *NetworkBlackholePortRequest = &NetworkBlackholePortRequest{
+			SourcesToFilter: aws.StringSlice([]string{"8.8.8.8"}),
+		}
+		req.AddSourceToFilterIfNotAlready("1.2.3.4")
+		require.Equal(t, aws.StringValueSlice(req.SourcesToFilter), []string{"8.8.8.8", "1.2.3.4"})
+	})
+	t.Run("Duplicate source is not added", func(t *testing.T) {
+		var req *NetworkBlackholePortRequest = &NetworkBlackholePortRequest{
+			SourcesToFilter: aws.StringSlice([]string{"8.8.8.8", "1.2.3.4"}),
+		}
+		req.AddSourceToFilterIfNotAlready("1.2.3.4")
+		require.Equal(t, aws.StringValueSlice(req.SourcesToFilter), []string{"8.8.8.8", "1.2.3.4"})
+	})
+}

--- a/ecs-agent/tmds/server.go
+++ b/ecs-agent/tmds/server.go
@@ -32,7 +32,7 @@ const (
 	IPv4         = "127.0.0.1"
 	Port         = 51679
 	IPForTasks   = "169.254.170.2"
-	PortForTasks = "80"
+	PortForTasks = 80
 )
 
 // IPv4 address for TMDS


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds support for `SourcesToFilter` parameter to network-blackhole-port fault. This field is needed to supply IPs that should be protected from the fault. This will be helpful for certain sidecar containers such as FIS sidecar to protect their service related endpoints from getting impacted by the fault. We already have this for network-latency and network-packet-loss faults.

### Implementation details
<!-- How are the changes implemented? -->
* Add new field `SourcesToFilter` to `NetworkFaultRequest`
* Update network-blackhole-port fault injection function so that it loops through `SourcesToFilter` and adds an ACCEPT rule for each source to the fault chain.
* Update network-blackhole-port/start request handler so that it adds TMDS IP to `SourcesToFilter` if the fault is for egress traffic and the port of the fault matches TMDS port. TMDS access is blocked for the task only by egress faults so we need to protect TMDS IP only for egress faults.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Ran a bunch of manual tests for host and awsvpc network mode tasks. Verified that 
1. IPs provided to the API in `SourcesToFilter` field are still accessible after an egress network-blackhole-port fault is injected. Other IP on the fault's port are not accessible. 
2. TMDS IP is protected if the fault is of egress type and port 80. 

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: Add SourcesToFilter support for network-blackhole-port fault

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
