### PR TITLE
Add validation for IPv6 addresses passed to Fault Injection APIs

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -19,6 +19,8 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	"github.com/aws/aws-sdk-go/aws"
 )
 
@@ -218,6 +220,10 @@ func validateNetworkFaultRequestSource(source string, sourceType string) error {
 	if err == nil && ipnet.IP.To4() != nil {
 		return nil // IPv4 CIDR successful
 	}
+	logger.Info("Failed to parse fault source as IPv4 CIDR block", logger.Fields{
+		"source":    source,
+		field.Error: err,
+	})
 
 	return fmt.Errorf(invalidValueError, source, sourceType)
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -220,10 +220,12 @@ func validateNetworkFaultRequestSource(source string, sourceType string) error {
 	if err == nil && ipnet.IP.To4() != nil {
 		return nil // IPv4 CIDR successful
 	}
-	logger.Info("Failed to parse fault source as IPv4 CIDR block", logger.Fields{
-		"source":    source,
-		field.Error: err,
-	})
+	if err != nil {
+		logger.Info("Failed to parse fault source as IPv4 CIDR block", logger.Fields{
+			"source":    source,
+			field.Error: err,
+		})
+	}
 
 	return fmt.Errorf(invalidValueError, source, sourceType)
 }

--- a/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -19,6 +19,8 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	"github.com/aws/aws-sdk-go/aws"
 )
 
@@ -218,6 +220,10 @@ func validateNetworkFaultRequestSource(source string, sourceType string) error {
 	if err == nil && ipnet.IP.To4() != nil {
 		return nil // IPv4 CIDR successful
 	}
+	logger.Info("Failed to parse fault source as IPv4 CIDR block", logger.Fields{
+		"source":    source,
+		field.Error: err,
+	})
 
 	return fmt.Errorf(invalidValueError, source, sourceType)
 }

--- a/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -220,10 +220,12 @@ func validateNetworkFaultRequestSource(source string, sourceType string) error {
 	if err == nil && ipnet.IP.To4() != nil {
 		return nil // IPv4 CIDR successful
 	}
-	logger.Info("Failed to parse fault source as IPv4 CIDR block", logger.Fields{
-		"source":    source,
-		field.Error: err,
-	})
+	if err != nil {
+		logger.Info("Failed to parse fault source as IPv4 CIDR block", logger.Fields{
+			"source":    source,
+			field.Error: err,
+		})
+	}
 
 	return fmt.Errorf(invalidValueError, source, sourceType)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fault Injection APIs only support IPv4 addresses. However, they currently do not validate that an IP address passed to them is IPv4 and not IPv6 which causes a server error. This change makes the APIs fail with a validation error if an IP address passed is IPv6.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Did some manual testing.
```
bash-5.2# curl -XPOST --data '{"DelayMilliseconds": 500, "JitterMilliseconds": 0, "Sources": ["2001:db8::68"]}' ${ECS_AGENT_URI}/fault/v1/network-latency/start
{"Error":"invalid value 2001:db8::68 for parameter Sources"}bash-5.2#
bash-5.2# curl -XPOST --data '{"DelayMilliseconds": 500, "JitterMilliseconds": 0, "Sources": ["2001:db8::/32"]}' ${ECS_AGENT_URI}/fault/v1/network-latency/start
{"Error":"invalid value 2001:db8::/32 for parameter Sources"}bash-5.2#
bash-5.2# curl -XPOST --data '{"LossPercent": 50, "Sources": ["2001:db8::68"]}' ${ECS_AGENT_URI}/fault/v1/network-packet-loss/start
{"Error":"invalid value 2001:db8::68 for parameter Sources"}bash-5.2#
bash-5.2# curl -XPOST --data '{"LossPercent": 50, "Sources": ["2001:db8::/32"]}' ${ECS_AGENT_URI}/fault/v1/network-packet-loss/start
{"Error":"invalid value 2001:db8::/32 for parameter Sources"}bash-5.2#
bash-5.2# curl -XPOST --data '{"Port": 80, "Protocol": "tcp", "TrafficType": "egress", "SourcesToFilter":["2001:db8::68"]}' ${ECS_AGENT_URI}/fault/v1/network-blackhole-port/start
{"Error":"invalid value 2001:db8::68 for parameter SourcesToFilter"}bash-5.2#
bash-5.2# curl -XPOST --data '{"Port": 80, "Protocol": "tcp", "TrafficType": "egress", "SourcesToFilter":["2001:db8::/32"]}' ${ECS_AGENT_URI}/fault/v1/network-blackhole-port/start
{"Error":"invalid value 2001:db8::/32 for parameter SourcesToFilter"}bash-5.2#
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bugfix: Add validation to prevent Fault Injection APIs from accepting IPv6 addresses.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
