### PR TITLE
Checking if required fault injection kernel modules are available before fault injection agent advertisement

### DIFF
--- a/ecs-init/docker/docker_config_test.go
+++ b/ecs-init/docker/docker_config_test.go
@@ -36,3 +36,17 @@ func TestGetNsenterBinds(t *testing.T) {
 		assert.Equal(t, "/usr/bin/nsenter:/usr/bin/nsenter", binds[0])
 	})
 }
+
+func TestGetModinfoBinds(t *testing.T) {
+	t.Run("modinfo not found", func(t *testing.T) {
+		binds := getModInfoBinds(
+			func(s string) (os.FileInfo, error) { return nil, errors.New("not found") })
+		assert.Empty(t, binds)
+	})
+	t.Run("modinfo is found", func(t *testing.T) {
+		binds := getModInfoBinds(
+			func(s string) (os.FileInfo, error) { return nil, nil })
+		require.Len(t, binds, 1)
+		assert.Equal(t, "/sbin/modinfo:/sbin/modinfo", binds[0])
+	})
+}

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -32,7 +32,7 @@ import (
 // Note: Change this value every time when a new bind mount is added to
 // agent for the tests to pass
 const (
-	defaultExpectedAgentBinds = 21
+	defaultExpectedAgentBinds = 22
 )
 
 func TestIsAgentImageLoadedListFailure(t *testing.T) {


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will check whether the required kernel modules (`sch_netem `) are available and installed within the host before advertising the fault injection capability for the container instance. We will use the `modinfo` utility tool to check whether `sch_netem` module is available and installed.

### Implementation details
* New `checkFaultInjectionModules()` method that will run the `modinfo sch_netem` command via an exec call (uses the execwrapper wrapper). It will be called after we've checked that the required utility tools for fault injection are available on the host in `checkFaultInjectionTooling()`
* New `getModInfoBinds()` to find the location of `modinfo` within the host and then add it to the list of bind mounts for agent if it's present on the host.

### Testing
New unit tests have been added.

Manual testing:

Launched instance and replaced ECS Init. Was able to advertise the capability on AL2023
```
 {
                    "name": "ecs.capability.network.container-port-range"
                },
                {
                    "name": "ecs.capability.fault-injection"
                },
                {
                    "name": "ecs.capability.container-ordering"
                },
```

Launched instance with RHEL and started ECS Agent (was not able to find the kernel modules)
```
level=warn time=2024-10-28T21:58:16Z msg="Failed to find kernel module sch_netem that is needed for fault-injection feature: exit status 1" module=agent_capability_unix.go
level=warn time=2024-10-28T21:58:16Z msg="Fault injection capability not enabled: Required network tools are missing" module=agent_capability.go
```

After installing `sch_netem` via 
```
sudo yum install kernel-modules-extra -y
sudo reboot
sudo depmod -a
sudo modprobe sch_netem
```

launched a task that starts a latency fault injection
```
level=info time=2024-10-28T22:30:45Z msg="Received new request for request type: start network-latency" request="{\"DelayMilliseconds\":100, \"JitterMilliseconds\":10, \"Sources\":[\"192.168.0.1\"]}" requestType="start network-latency" tmdsEndpointContainerID="b44b829e-0e78-4a41-8ec8-f9b461c2f2df"
level=info time=2024-10-28T22:30:45Z msg="Command execution completed" commandString="nsenter --net=/host/proc/3894/ns/net tc -j q show dev eth0 parent 1:1" commandOutput="[]\n"
level=info time=2024-10-28T22:30:45Z msg="Command execution completed" commandString="nsenter --net=/host/proc/3894/ns/net tc qdisc add dev eth0 root handle 1: prio priomap 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2" commandOutput=""
level=info time=2024-10-28T22:30:45Z msg="Command execution completed" commandString="nsenter --net=/host/proc/3894/ns/net tc qdisc add dev eth0 parent 1:1 handle 10: netem delay 100ms 10ms" commandOutput=""
level=info time=2024-10-28T22:30:45Z msg="Successfully started fault" requestType="start network-latency" request="{\"DelayMilliseconds\":100,\"JitterMilliseconds\":10,\"Sources\":[\"192.168.0.1\"]}" response="{\"Status\":\"running\"}"
level=info time=2024-10-28T22:30:45Z msg="The telemetry middleware is complete" StatusCode=200 DurationInMs=167 Request="/api/b44b829e-0e78-4a41-8ec8-f9b461c2f2df/fault/v1/network-latency/start"

```


`modinfo` locations:
```
RHEL: /usr/sbin/modinfo
Ubuntu 24: /usr/sbin/modinfo
Ubuntu 22: /usr/sbin/modinfo
Ubuntu 20 Minimal: /usr/sbin/modinfo
Ubuntu 20: /usr/sbin/modinfo
Ubuntu 18: /sbin/modinfo
Centos 7: /usr/sbin/modinfo
Centos 8: /usr/sbin/modinfo
Centos 9: /usr/sbin/modinfo
Debian 10: /usr/sbin/modinfo
Debian 11: /usr/sbin/modinfo
Debian 12: /usr/sbin/modinfo
Suse 15: /usr/sbin/modinfo
```

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
