### PR TITLE
Get Go image from ECR instead of Dockerhub

### DIFF
--- a/scripts/dockerfiles/Dockerfile.buildECSCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildECSCNIPlugins
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 ARG GO_VERSION
-FROM golang:${GO_VERSION}
+FROM public.ecr.aws/docker/library/golang:${GO_VERSION}
 MAINTAINER Amazon Web Services, Inc.
 
 ENV XDG_CACHE_HOME /tmp


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update `scripts/dockerfiles/Dockerfile.buildECSCNIPlugins` so that Go image is fetched from ECR instead of Dockerhub. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Built an image locally with `docker build -t cni -f Dockerfile.buildECSCNIPlugins --build-arg GO_VERSION=1.15.4 .`. It built fine.

```
ip-172-31-7-67 ❱ docker build -t cni -f Dockerfile.buildECSCNIPlugins --build-arg GO_VERSION=1.15.4 .
[+] Building 26.6s (7/7) FINISHED                                                                                                          docker:default
 => [internal] load build definition from Dockerfile.buildECSCNIPlugins                                                                              0.0s
 => => transferring dockerfile: 924B                                                                                                                 0.0s
 => [internal] load metadata for public.ecr.aws/docker/library/golang:1.15.4                                                                         0.6s
 => [internal] load .dockerignore                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                      0.0s
 => [1/3] FROM public.ecr.aws/docker/library/golang:1.15.4@sha256:40d03f2bbdc3d4df0ab1e394fbc4417ef8cc8534ffa8ce66ca42efcdc82e53db                  24.7s
 => => resolve public.ecr.aws/docker/library/golang:1.15.4@sha256:40d03f2bbdc3d4df0ab1e394fbc4417ef8cc8534ffa8ce66ca42efcdc82e53db                   0.0s
 => => sha256:0a0ca1e97c76859f3df6412d5539c2765cd915418bc63f1421d97d70afa0830a 1.79kB / 1.79kB                                                       0.0s
 => => sha256:ad12afc2d6d6bae7f3563d03b658b911d5fa99e75639da5569009b058d4977bf 7.07kB / 7.07kB                                                       0.0s
 => => sha256:101c41d0463bc77661fb3343235b16d536a92d2efb687046164d413e51bd4fc4 7.81MB / 7.81MB                                                       0.5s
 => => sha256:8275efcd805f9905d7def23603618236284b0be6b9e47455c638fbfb03fa9208 10.00MB / 10.00MB                                                     0.4s
 => => sha256:40d03f2bbdc3d4df0ab1e394fbc4417ef8cc8534ffa8ce66ca42efcdc82e53db 2.36kB / 2.36kB                                                       0.0s
 => => sha256:e4c3d3e4f7b024979a1c12daa4073f6353b2ba92d96418bc90451994927c9bff 50.40MB / 50.40MB                                                     2.8s
 => => sha256:751620502a7a2905067c2f32d4982fb9b310b9808670ce82c0e2b40f5307a3ee 51.83MB / 51.83MB                                                     3.6s
 => => sha256:aaabf962c4fc1520bac4e6c525143deca224d303008f02dcf18cd3d1942239d3 68.69MB / 68.69MB                                                     4.4s
 => => sha256:39dada115d32ebb42dd1957aa930ef5ca8be12d3c81e08bc6696c8bec449c0af 120.91MB / 120.91MB                                                   9.7s
 => => extracting sha256:e4c3d3e4f7b024979a1c12daa4073f6353b2ba92d96418bc90451994927c9bff                                                            3.9s
 => => sha256:64a5c27d7bff9eedacb561deab2f56b7fb4c919c8d7f8a49294cbc394a974950 125B / 125B                                                           3.8s
 => => extracting sha256:101c41d0463bc77661fb3343235b16d536a92d2efb687046164d413e51bd4fc4                                                            0.5s
 => => extracting sha256:8275efcd805f9905d7def23603618236284b0be6b9e47455c638fbfb03fa9208                                                            0.4s
 => => extracting sha256:751620502a7a2905067c2f32d4982fb9b310b9808670ce82c0e2b40f5307a3ee                                                            4.1s
 => => extracting sha256:aaabf962c4fc1520bac4e6c525143deca224d303008f02dcf18cd3d1942239d3                                                            3.8s
 => => extracting sha256:39dada115d32ebb42dd1957aa930ef5ca8be12d3c81e08bc6696c8bec449c0af                                                            8.3s
 => => extracting sha256:64a5c27d7bff9eedacb561deab2f56b7fb4c919c8d7f8a49294cbc394a974950                                                            0.0s
 => [2/3] RUN mkdir -p /go/src/github.com/aws/                                                                                                       1.1s
 => [3/3] WORKDIR /go/src/github.com/aws/amazon-ecs-cni-plugins                                                                                      0.0s
 => exporting to image                                                                                                                               0.0s
 => => exporting layers                                                                                                                              0.0s
 => => writing image sha256:0e03a20cc2a080dbf5a3242c3ea451c61bba8fe785e52402ffd8f167d3469528                                                         0.0s
 => => naming to docker.io/library/cni                                                                                                               0.0s
```

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
