### PR TITLE
Update image registry of base container images from Dockerhub to ECR

### DIFF
--- a/misc/certs/Dockerfile
+++ b/misc/certs/Dockerfile
@@ -1,10 +1,5 @@
-FROM debian:stable-20201012
+FROM public.ecr.aws/docker/library/debian:stable-20240110-slim
 
 RUN apt-get update &&  \
     apt-get install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-
-# If anyone has a better idea for how to trim undesired certs or a better ca list to use, I'm all ears
-RUN cp /etc/ca-certificates.conf /tmp/caconf && cat /tmp/caconf | \
-  grep -v "mozilla/CNNIC_ROOT\.crt" > /etc/ca-certificates.conf && \
-  update-ca-certificates --fresh

--- a/misc/container-health/Dockerfile
+++ b/misc/container-health/Dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM busybox:1.32.0
+FROM public.ecr.aws/docker/library/busybox:1.32.0
 
 HEALTHCHECK --interval=1s --timeout=1s --retries=3 CMD echo hello
 

--- a/misc/fluent-logger/Dockerfile
+++ b/misc/fluent-logger/Dockerfile
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 ARG GO_VERSION
-FROM golang:${GO_VERSION}
+FROM public.ecr.aws/docker/library/golang:${GO_VERSION}
 
 MAINTAINER Amazon Web Services, Inc.
 COPY fluent-logger /

--- a/misc/fluentd/Dockerfile
+++ b/misc/fluentd/Dockerfile
@@ -1,3 +1,3 @@
-FROM fluent/fluentd:v1.11.5-1.0
+FROM public.ecr.aws/docker/library/fluentd:v1.14.0-1.0
 
 COPY fluent.conf /fluentd/etc/

--- a/misc/gremlin/Dockerfile
+++ b/misc/gremlin/Dockerfile
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 ARG GO_VERSION
-FROM golang:${GO_VERSION} as build
+FROM public.ecr.aws/docker/library/golang:${GO_VERSION} as build
 
 WORKDIR /go/src/
 ADD . /go/src/

--- a/misc/netkitten/Dockerfile.linux
+++ b/misc/netkitten/Dockerfile.linux
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 ARG GO_VERSION
-FROM golang:${GO_VERSION} as build
+FROM public.ecr.aws/docker/library/golang:${GO_VERSION}
 
 WORKDIR /go/src/
 ADD . /go/src/

--- a/misc/pause-container/Dockerfile
+++ b/misc/pause-container/Dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM gcc:7.3.0 as build
+FROM public.ecr.aws/docker/library/gcc:11.2.0 as build
 
 WORKDIR /src/
 ADD . /src/

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 ARG GO_VERSION
-FROM golang:${GO_VERSION}
+FROM public.ecr.aws/docker/library/golang:${GO_VERSION}
 MAINTAINER Amazon Web Services, Inc.
 
 ENV XDG_CACHE_HOME /tmp

--- a/scripts/dockerfiles/Dockerfile.cleanbuild
+++ b/scripts/dockerfiles/Dockerfile.cleanbuild
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 ARG GO_VERSION
-FROM golang:${GO_VERSION}
+FROM public.ecr.aws/docker/library/golang:${GO_VERSION}
 MAINTAINER Amazon Web Services, Inc.
 
 ENV XDG_CACHE_HOME /tmp

--- a/scripts/dockerfiles/mock-agent.dockerfile
+++ b/scripts/dockerfiles/mock-agent.dockerfile
@@ -13,7 +13,7 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 
-FROM busybox
+FROM public.ecr.aws/docker/library/busybox
 
 COPY scripts/mock-ecs-agent.sh /mock-ecs-agent.sh
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR updates source image registry of various base images we use from Dockerhub to ECR in `AmazonLinuxLegacy2018` branch. 

Following images were updated - 
* `misc/certs/Dockerfile` - `FROM debian:stable-20201012` to `FROM public.ecr.aws/docker/library/debian:stable-20240110-slim` - this is because the older image no longer works (same change was made for dev branch in https://github.com/aws/amazon-ecs-agent/pull/4153)
* `misc/fluentd/Dockerfile` - `FROM fluent/fluentd:v1.11.5-1.0` to `FROM public.ecr.aws/docker/library/fluentd:v1.14.0-1.0` - following https://github.com/aws/amazon-ecs-agent/pull/3101, older image version is not available in ECR
* `misc/pause-container/Dockerfile` - `FROM gcc:7.3.0 as build` to `FROM public.ecr.aws/docker/library/gcc:11.2.0 as build` - Older gcc is not available in ECR, following https://github.com/aws/amazon-ecs-agent/pull/3108

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Built all the images locally. 

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
