### PR TITLE
Adds config parameter to shared netlib platform

### DIFF
--- a/ecs-agent/netlib/network_builder.go
+++ b/ecs-agent/netlib/network_builder.go
@@ -48,13 +48,13 @@ type networkBuilder struct {
 }
 
 func NewNetworkBuilder(
-	platformString string,
+	platformConfig platform.Config,
 	metricsFactory metrics.EntryFactory,
 	volumeAccessor volume.TaskVolumeAccessor,
 	networkDao data.NetworkDataClient,
 	stateDBDir string) (NetworkBuilder, error) {
 	pAPI, err := platform.NewPlatform(
-		platformString,
+		platformConfig,
 		volumeAccessor,
 		stateDBDir,
 		netwrapper.NewNet(),

--- a/ecs-agent/netlib/network_builder_linux_test.go
+++ b/ecs-agent/netlib/network_builder_linux_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/tasknetworkconfig"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/platform"
+	platform "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/platform"
 	mock_platform "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/platform/mocks"
 	mock_netwrapper "github.com/aws/amazon-ecs-agent/ecs-agent/utils/netwrapper/mocks"
 
@@ -42,12 +42,12 @@ import (
 )
 
 func TestNewNetworkBuilder(t *testing.T) {
-	nbi, err := NewNetworkBuilder(platform.WarmpoolPlatform, nil, nil, nil, "")
+	nbi, err := NewNetworkBuilder(platform.Config{Name: platform.WarmpoolPlatform}, nil, nil, nil, "")
 	nb := nbi.(*networkBuilder)
 	require.NoError(t, err)
 	require.NotNil(t, nb.platformAPI)
 
-	nbi, err = NewNetworkBuilder("invalid-platform", nil, nil, nil, "")
+	nbi, err = NewNetworkBuilder(platform.Config{Name: "invalid-platform"}, nil, nil, nil, "")
 	require.Error(t, err)
 	require.Nil(t, nbi)
 }
@@ -88,7 +88,8 @@ func getTestFunc(
 
 		// Create a networkBuilder for the warmpool platform.
 		mockNet := mock_netwrapper.NewMockNet(ctrl)
-		platformAPI, err := platform.NewPlatform(plt, nil, "", mockNet)
+		platformConfig := platform.Config{Name: plt}
+		platformAPI, err := platform.NewPlatform(platformConfig, nil, "", mockNet)
 		require.NoError(t, err)
 		netBuilder := &networkBuilder{
 			platformAPI: platformAPI,

--- a/ecs-agent/netlib/network_builder_windows_test.go
+++ b/ecs-agent/netlib/network_builder_windows_test.go
@@ -49,7 +49,8 @@ func getTestFunc(
 
 		// Create a networkBuilder for the warmpool platform.
 		mockNet := mock_netwrapper.NewMockNet(ctrl)
-		platformAPI, err := platform.NewPlatform(plt, nil, "", mockNet)
+		config := platform.Config{Name: plt}
+		platformAPI, err := platform.NewPlatform(config, nil, "", mockNet)
 		require.NoError(t, err)
 		netBuilder := &networkBuilder{
 			platformAPI: platformAPI,

--- a/ecs-agent/netlib/platform/api.go
+++ b/ecs-agent/netlib/platform/api.go
@@ -79,3 +79,12 @@ type API interface {
 		scConfig *serviceconnect.ServiceConnectConfig,
 	) error
 }
+
+// Config contains platform-specific data.
+type Config struct {
+	// Name specifies which platform to use (Linux, Windows, ec2-debug, etc).
+	Name string
+	// ResolvConfPath specifies path to resolv.conf file for DNS config.
+	// Different platforms may have different paths for this file.
+	ResolvConfPath string
+}

--- a/ecs-agent/netlib/platform/containerd_windows.go
+++ b/ecs-agent/netlib/platform/containerd_windows.go
@@ -56,7 +56,7 @@ type containerdDebug struct {
 
 // NewPlatform returns a platform instance with windows specific implementations of the API interface.
 func NewPlatform(
-	platformString string,
+	config Config,
 	_ volume.TaskVolumeAccessor,
 	_ string,
 	net netwrapper.Net) (API, error) {
@@ -68,7 +68,7 @@ func NewPlatform(
 			net:       net,
 		},
 	}
-	switch platformString {
+	switch config.Name {
 	case WarmpoolPlatform:
 		return &c, nil
 	case WarmpoolDebugPlatform:
@@ -76,7 +76,7 @@ func NewPlatform(
 			containerd: c,
 		}, nil
 	default:
-		return nil, errors.New("invalid platform string: " + platformString)
+		return nil, errors.New("invalid platform string: " + config.Name)
 	}
 	return nil, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This fixes Fargate Agent network configuration when running in ec2-debug mode on BottleRocket OS. 
This unblocks end-to-end functional tests in internal Fargate Agent CI/CD pipeline. 

### Implementation details
<!-- How are the changes implemented? -->
Add configuration struct to shared netlib platform initializer. In order to support Fargate EC2 Debug mode in all platform types and OS combinations. Bottlerocket has a different path for the resolv.conf file

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
Yes. Created `TestCommon_CreateDNSFilesForDebug` in `ecs-agent/netlib/platform`
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
NO
**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
NO
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
