### PR TITLE
Implement reference counting of volume mounts in amazon-ecs-volume-plugin

### DIFF
--- a/ecs-init/volumes/ecs_volume_plugin_test.go
+++ b/ecs-init/volumes/ecs_volume_plugin_test.go
@@ -643,7 +643,7 @@ func TestPluginLoadState(t *testing.T) {
 				assert.Equal(t, "efs", volInfo.Type)
 				assert.Equal(t, VolumeMountPathPrefix+"efsVolume", volInfo.Path)
 
-				// Test for backwards compatibility of old state format following implmentation of
+				// Test for backwards compatibility of old state format following implementation of
 				// reference counting of volume mounts null value for mount IDs should be converted to 1.
 				assert.Equal(t, map[string]int{"id1": 1}, vols["efsVolume"].Mounts)
 			},

--- a/ecs-init/volumes/state_manager.go
+++ b/ecs-init/volumes/state_manager.go
@@ -47,11 +47,11 @@ type VolumeState struct {
 
 // VolumeInfo contains the information of managed volumes
 type VolumeInfo struct {
-	Type      string             `json:"type,omitempty"`
-	Path      string             `json:"path,omitempty"`
-	Options   map[string]string  `json:"options,omitempty"`
-	CreatedAt string             `json:"createdAt,omitempty"`
-	Mounts    map[string]*string `json:"mounts,omitempty"`
+	Type      string            `json:"type,omitempty"`
+	Path      string            `json:"path,omitempty"`
+	Options   map[string]string `json:"options,omitempty"`
+	CreatedAt string            `json:"createdAt,omitempty"`
+	Mounts    map[string]int    `json:"mounts,omitempty"`
 }
 
 // NewStateManager initializes the state manager of volume plugin
@@ -65,7 +65,7 @@ func NewStateManager() *StateManager {
 
 func (s *StateManager) recordVolume(volName string, vol *types.Volume) error {
 	// Copy the mounts so that the map is not shared
-	mountsCopy := map[string]*string{}
+	mountsCopy := map[string]int{}
 	for k, v := range vol.Mounts {
 		mountsCopy[k] = v
 	}

--- a/ecs-init/volumes/types/types.go
+++ b/ecs-init/volumes/types/types.go
@@ -41,7 +41,7 @@ func (v *Volume) RemoveMount(mountID string) bool {
 	}
 
 	v.Mounts[mountID] -= 1
-	if v.Mounts[mountID] == 0 {
+	if v.Mounts[mountID] <= 0 {
 		delete(v.Mounts, mountID)
 	}
 

--- a/ecs-init/volumes/types/types.go
+++ b/ecs-init/volumes/types/types.go
@@ -41,7 +41,7 @@ func (v *Volume) RemoveMount(mountID string) bool {
 	}
 
 	v.Mounts[mountID] -= 1
-	if v.Mounts[mountID] <= 0 {
+	if v.Mounts[mountID] == 0 {
 		delete(v.Mounts, mountID)
 	}
 

--- a/ecs-init/volumes/types/types.go
+++ b/ecs-init/volumes/types/types.go
@@ -19,16 +19,16 @@ type Volume struct {
 	Path      string
 	Options   map[string]string
 	CreatedAt string
-	Mounts    map[string]*string
+	Mounts    map[string]int
 }
 
 // Adds a new mount to the volume.
 // This method is not thread-safe, caller is responsible for holding any locks on the volume.
 func (v *Volume) AddMount(mountID string) {
 	if v.Mounts == nil {
-		v.Mounts = map[string]*string{}
+		v.Mounts = map[string]int{}
 	}
-	v.Mounts[mountID] = nil
+	v.Mounts[mountID] += 1
 }
 
 // Removes a mount from the volume.
@@ -36,6 +36,14 @@ func (v *Volume) AddMount(mountID string) {
 // Returns a bool indicating whether the mountID was found in mounts or not.
 func (v *Volume) RemoveMount(mountID string) bool {
 	_, exists := v.Mounts[mountID]
-	delete(v.Mounts, mountID)
-	return exists
+	if !exists {
+		return false
+	}
+
+	v.Mounts[mountID] -= 1
+	if v.Mounts[mountID] <= 0 {
+		delete(v.Mounts, mountID)
+	}
+
+	return true
 }

--- a/ecs-init/volumes/types/types_test.go
+++ b/ecs-init/volumes/types/types_test.go
@@ -52,7 +52,7 @@ func TestRemoveMount(t *testing.T) {
 		assert.True(t, v.RemoveMount("id"))
 		assert.Equal(t, map[string]int{"id": 1}, v.Mounts)
 	})
-	t.Run("mount should be removed if it exists", func(t *testing.T) {
+	t.Run("mount should be removed if it exists and mount reference count is 1", func(t *testing.T) {
 		v := &Volume{}
 		v.AddMount("id")
 		assert.True(t, v.RemoveMount("id"))

--- a/ecs-init/volumes/types/types_test.go
+++ b/ecs-init/volumes/types/types_test.go
@@ -23,18 +23,19 @@ func TestAddMount(t *testing.T) {
 	t.Run("new map is created when Mounts is nil", func(t *testing.T) {
 		v := &Volume{}
 		v.AddMount("id")
-		assert.Equal(t, map[string]*string{"id": nil}, v.Mounts)
+		assert.Equal(t, map[string]int{"id": 1}, v.Mounts)
 	})
 	t.Run("second mount", func(t *testing.T) {
 		v := &Volume{}
 		v.AddMount("id")
 		v.AddMount("id2")
-		assert.Equal(t, map[string]*string{"id": nil, "id2": nil}, v.Mounts)
+		assert.Equal(t, map[string]int{"id": 1, "id2": 1}, v.Mounts)
 	})
-	t.Run("mount already exists", func(t *testing.T) {
+	t.Run("mount reference count is incremented if a mount already exists", func(t *testing.T) {
 		v := &Volume{}
 		v.AddMount("id")
-		assert.Equal(t, map[string]*string{"id": nil}, v.Mounts)
+		v.AddMount("id")
+		assert.Equal(t, map[string]int{"id": 2}, v.Mounts)
 	})
 }
 
@@ -43,6 +44,13 @@ func TestRemoveMount(t *testing.T) {
 		v := &Volume{}
 		assert.False(t, v.RemoveMount("id"))
 		assert.Empty(t, v.Mounts)
+	})
+	t.Run("mount reference count is decremented", func(t *testing.T) {
+		v := &Volume{}
+		v.AddMount("id")
+		v.AddMount("id")
+		assert.True(t, v.RemoveMount("id"))
+		assert.Equal(t, map[string]int{"id": 1}, v.Mounts)
 	})
 	t.Run("mount should be removed if it exists", func(t *testing.T) {
 		v := &Volume{}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
ECS Agent uses amazon-ecs-volume-plugin for mounting and unmounting EFS volumes on ECS container instances. The plugin implements [Docker volume plugins protocol](https://docs.docker.com/engine/extend/plugins_volume/). It supports operations for creating/removing a volume (called when `docker volume create` and `docker volume rm` or equivalent happen) and mounting/unmounting clients to a volume (happens during container create/stop and other events such as `docker cp`). Each mount/unmount request has a unique ID for the mount. 

Currently, the plugin assumes that it will only get one mount and unmount request for a mount ID, however this is not true and we have seen `docker cp` command reusing the same mount ID as container start/stop. Docker's expectation is for the plugin to keep track of number of mounts for a mount ID, that is, it should increment the number of mounts for mount requests and decrement for unmount requests. Due to this mismatch in expectations, volume plugin currently ignores a mount request with a mount ID it is already tracking and ends up unmounting the volume when it gets a corresponding unmount request for the mount ID. So, a `docker cp` operation on the volume on the container can cause the plugin to unmount the volume from the host prematurely. 

This PR fixes this issue by updating the plugin to keep a track of number of mounts for a mount ID. 

Related to https://github.com/moby/moby/issues/34665

### Implementation details
<!-- How are the changes implemented? -->
1. Update the type of `Volume.Mounts` field from `map[string]*string` (a set) to `map[string]int`. This field keeps track of mounts on a volume and I am changing its type so that it can keep track of number of mounts for a mount ID.
2. Update `Volume.AddMount` and `Volume.Unmount` methods accordingly so that they increment and decrement the number of mounts for a mount ID.
3. Update `VolumeInfo.Mounts` field accordingly. This type is used to persist and load state of a volume from disk. 
4. Update `AmazonECSVolumePlugin.LoadState` method so that it resets any `VolumInfo.Mounts` zero values to one. This is to make this change backwards-compatible with old state files that do not have mount counts. Old state files have `null` against mount IDs and JSON decoding converts `null`s to `0` by default. The method updates `0`s to `1` so that existing mounts in old state files start with a mount count of 1 instead of 0. Typically a mount ID would always have a mount count of 1 for most cases, so this change should help all such users to upgrade the plugin version safely. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
I ran a task with a container that is configured to have an EFS volume mounted and verified that `docker cp` no longer causes premature unmounting of the EFS volume from the container instance. I also monitored the state file and verified that it has counts for mount IDs now. 

Also verified that the updated plugin is able to read old state files and convert `null` against mount IDs to a mount count of `1`. 

Also ran a task with two containers and verified that the plugin is able to keep track of mount counts for both containers correctly in the state file. Each container gets its own mount ID and `docker cp` on one container does not affect the other. Also verified that stopping one container does not cause the volume to unmount from the container instance and stopping the second container afterwards does cause the volume to be unmounted from the container instance as expected.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
bugfix: Implement reference counting of volume mounts in amazon-ecs-volume-plugin

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
