### PR TITLE
Checking if require tc show command works before advertising fault injection capability

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -553,6 +553,7 @@ func (agent *ecsAgent) appendFaultInjectionCapabilities(capabilities []*ecs.Attr
 
 	if isFaultInjectionToolingAvailable() {
 		capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFaultInjection)
+		seelog.Debug("Fault injection capability is enabled.")
 	} else {
 		seelog.Warn("Fault injection capability not enabled: Required network tools are missing")
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will add a check to see if the `tc` tool that's installed on the host is using a compatible version before advertising the fault injection capability.

### Implementation details
* New function called `checkTCShowTooling()` that will try calling `tc -j q show dev <INTERFACE> parent 1:1` to see if the correct version of `tc` is available to be used on the host. This will be called after checking that all of the tools are installed/bind mounted to the agent container just like with the modules check.
  * Uses the `netconfig` utility package that was added to `ecs-agent` to obtain the default network interface name on the host
  * Uses the `execwrapper` package that was added. to `ecs-agent` in order to make the `tc` commands via OS exec calls 

### Testing
Manual testing: Launched an Ubuntu 20 instance and installed ECS on it with these changes. Was able to see within the agent logs that the fault injection capability was not able to be advertised.

```
level=debug time=2024-11-22T19:38:44Z msg="Found route" Route={Ifindex: 2 Dst: <nil> Src: 172.31.26.194 Gw: 172.31.16.1 Flags: [] Table: 254 Realm: 0}
level=debug time=2024-11-22T19:38:44Z msg="Found the associated network interface by the index" LinkName="ens5" LinkIndex=2
level=warn time=2024-11-22T19:38:44Z msg="Failed to call tc -j q show dev ens5 parent 1:1 which is needed for fault-injection feature: exit status 255" module=agent_capability_unix.go
level=warn time=2024-11-22T19:38:44Z msg="Fault injection capability not enabled: Required network tools are missing" module=agent_capability.go
level=info time=2024-11-22T19:38:44Z msg="Registering Instance with ECS"
level=debug time=2024-11-22T19:38:44Z msg="Attempting to get Instance Identity Document"

```

Checked within ECS whether the instance advertised the capability for fault injection
```
aws ecs list-attributes --cluster test-fis-ubuntu  --region us-west-2 --target-type container-instance --attribute-name "ecs.capability.fault-injection"
{
    "attributes": []
}
```

vs. 
an advertised capability

```
aws ecs list-attributes --cluster test-fis-ubuntu  --region us-west-2 --target-type container-instance --attribute-name "ecs.capability.efsAuth"        
{
    "attributes": [
        {
            "name": "ecs.capability.efsAuth",
            "targetId": "arn:aws:ecs:us-west-2::container-instance/test-fis-ubuntu/3969a54fdb8740d8ba44c791a7ee69ee"
        }
    ]
}
```

New tests cover the changes: Yes

### Description for the changelog
Enhancement: Add check if tc is compatible before advertising fault injection capability

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
