### PR TITLE
Add /etc/pki directory to appnet agent's bind mounts

### DIFF
--- a/agent/engine/serviceconnect/manager_linux.go
+++ b/agent/engine/serviceconnect/manager_linux.go
@@ -84,6 +84,12 @@ const (
 
 	ecsAgentLogFileENV              = "ECS_LOGFILE"
 	defaultECSAgentLogPathContainer = "/log"
+
+	// This is the path to the host's PKI directory. The appnet agent container needs
+	// this directory mounted so that it can access the host's PKI directory for the
+	// purpose of utilizing any special CA certs that the underlying EC2 instance has
+	// configured.
+	hostPKIDirPath = "/etc/pki"
 )
 
 type manager struct {
@@ -207,6 +213,7 @@ func (m *manager) initAgentDirectoryMounts(taskId string, container *apicontaine
 
 	hostConfig.Binds = append(hostConfig.Binds, getBindMountMapping(statusPathHost, m.statusPathContainer))
 	hostConfig.Binds = append(hostConfig.Binds, getBindMountMapping(m.relayPathHost, m.relayPathContainer))
+	hostConfig.Binds = append(hostConfig.Binds, getBindMountMapping(hostPKIDirPath, hostPKIDirPath))
 
 	// create logging directory and bind mount, if customer has not configured a logging driver
 	if container.GetLogDriver() == "" {

--- a/agent/engine/serviceconnect/manager_linux_test_common.go
+++ b/agent/engine/serviceconnect/manager_linux_test_common.go
@@ -129,6 +129,7 @@ func testAgentContainerModificationsForServiceConnect(t *testing.T, privilegedMo
 		fmt.Sprintf("%s/status/%s:%s", tempDir, scTask.GetID(), "/some/other/run"),
 		fmt.Sprintf("%s/relay:%s", tempDir, "/not/var/run"),
 		fmt.Sprintf("%s/log/%s:%s", tempDir, scTask.GetID(), "/some/other/log"),
+		"/etc/pki:/etc/pki",
 	}
 	expectedENVs := map[string]string{
 		"ReLaYgOeShErE":                 "unix:///not/var/run/relay_file_of_holiness",
@@ -190,7 +191,7 @@ func testAgentContainerModificationsForServiceConnect(t *testing.T, privilegedMo
 			if err != nil {
 				t.Fatal(err)
 			}
-			assert.Equal(t, tc.expectedBinds, hostConfig.Binds)
+			assert.ElementsMatch(t, tc.expectedBinds, hostConfig.Binds)
 			assert.Equal(t, tc.expectedENV, tc.container.Environment)
 			if privilegedMode {
 				for _, bind := range hostConfig.Binds {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This is the path to the host's PKI directory. The appnet agent container needs
this directory mounted so that it can access the host's PKI directory for the
purpose of utilizing any special CA certs that the underlying EC2 instance has
configured.

Without this change the appnet agent is not able to operate and the service
connect feature does not work in situations where the EC2 instance has 
non-standard CA certs configured.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no, modified existing unit test

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement: Add /etc/pki directory to appnet agent's bind mounts for service connect

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
