### PR TITLE
Update amazon-ecs-cni-plugins to 2024.09.0

### DIFF
--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -28,8 +28,8 @@ import (
 
 const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated.
-	currentECSCNIVersion = "2020.09.0"
-	currentECSCNIGitHash = "53a8481891251e66e35847554d52a13fc7c4fd03"
+	currentECSCNIVersion = "2024.09.0"
+	currentECSCNIGitHash = "7b4ec6016ab221469fa3abfc00ea7c05f236c26c"
 	currentVPCCNIGitHash = "be5214353252f8315a1341f4df9ffbd8cf69000c"
 )
 


### PR DESCRIPTION
### Summary
Update `amazon-ecs-cni-plugins` to `2024.09.0`. The commit SHA is [7b4ec60](https://github.com/aws/amazon-ecs-cni-plugins/commit/7b4ec6016ab221469fa3abfc00ea7c05f236c26c), which migrates `amazon-ecs-cni-plugins` to `aws-sdk-go-v2`.

### Implementation details
```
cd amazon-ecs-cni-plugins
git remote add aws https://github.com/aws/amazon-ecs-cni-plugins.git
git fetch aws
git checkout 7b4ec60
```

### Testing
GitHub checks pass.

New tests cover the changes: no

### Description for the changelog
Update amazon-ecs-cni-plugins to 2024.09.0

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
