### PR TITLE
Use newer AMI and bigger instance in ec2_stage_arm.sh

### DIFF
--- a/scripts/ec2_stage_arm.sh
+++ b/scripts/ec2_stage_arm.sh
@@ -19,7 +19,7 @@ DRYRUN=true
 
 AWS_PROFILE=""
 AWS_REGION="us-east-1"
-AMI_ID="ami-053b2a8c2f3e87928" #amzn2-ami-hvm-2.0.20181020.0-aarch64-gp2
+AMI_ID="ami-01180c1a1421554af" #amzn2-ami-ecs-hvm-2.0.20241120-arm64-ebs
 ARTIFACT_BUCKET=""
 SOURCE_BUCKET=""
 KEY_NAME=""
@@ -168,7 +168,7 @@ ec2_instance_id=$(dryval aws ${profile} "--region=${AWS_REGION}" \
 	"--image-id=${AMI_ID}" \
 	"--key-name=${KEY_NAME}" \
 	"--security-groups=${SECURITY_GROUP}" \
-	"--instance-type=a1.xlarge" \
+	"--instance-type=c8g.2xlarge" \
 	"--instance-initiated-shutdown-behavior=terminate" \
 	"--iam-instance-profile=Name=${INSTANCE_PROFILE}" \
 	"--query=Instances[0].InstanceId" \


### PR DESCRIPTION
### Summary
Update `ec2_stage_arm.sh` to use a newer AMI and a bigger EC2 instance. This will speed up build times because
- the new AMI doesn't run `yum update` at launch, so the instance won't be downloading and installing packages while trying to build Agent at the same time
- the new instance type has 2x vCPU and memory as the old instance type, and a +5 Gbps increase to network bandwidth

### Implementation details
- Update the AMI ID from `ami-053b2a8c2f3e87928` (`amzn2-ami-hvm-2.0.20181020.0-aarch64-gp2`) to `ami-01180c1a1421554af` (`amzn2-ami-ecs-hvm-2.0.20241120-arm64-ebs`).
- Update the instance type from [a1.xlarge](https://aws.amazon.com/blogs/compute/getting-started-with-the-a1-instance/) to [c8g.2xlarge](https://aws.amazon.com/ec2/instance-types/c8g/).

### Testing
On `dev`, the script takes ~9.5 minutes.
On this branch, the script takes ~4.5 minutes.

New tests cover the changes: no

### Description for the changelog
Use newer AMI and bigger instance in `ec2_stage_arm.sh`

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
