### PR TITLE
Remove unused GetPublishMetricsTicker method from stats engine

### DIFF
--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -81,7 +81,6 @@ type Engine interface {
 	GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error)
 	GetPublishServiceConnectTickerInterval() int32
 	SetPublishServiceConnectTickerInterval(int32)
-	GetPublishMetricsTicker() *time.Ticker
 }
 
 // DockerStatsEngine is used to monitor docker container events and to report
@@ -1081,10 +1080,6 @@ func (engine *DockerStatsEngine) SetPublishServiceConnectTickerInterval(publishS
 	defer engine.lock.Unlock()
 
 	engine.publishServiceConnectTickerInterval = publishServiceConnectTickerInterval
-}
-
-func (engine *DockerStatsEngine) GetPublishMetricsTicker() *time.Ticker {
-	return engine.publishMetricsTicker
 }
 
 func (engine *DockerStatsEngine) getEBSVolumeMetrics(taskArn string) []*ecstcs.VolumeMetric {

--- a/agent/stats/mock/engine.go
+++ b/agent/stats/mock/engine.go
@@ -20,7 +20,6 @@ package mock_stats
 
 import (
 	reflect "reflect"
-	time "time"
 
 	stats "github.com/aws/amazon-ecs-agent/ecs-agent/stats"
 	ecstcs "github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
@@ -81,20 +80,6 @@ func (m *MockEngine) GetInstanceMetrics(arg0 bool) (*ecstcs.MetricsMetadata, []*
 func (mr *MockEngineMockRecorder) GetInstanceMetrics(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceMetrics", reflect.TypeOf((*MockEngine)(nil).GetInstanceMetrics), arg0)
-}
-
-// GetPublishMetricsTicker mocks base method.
-func (m *MockEngine) GetPublishMetricsTicker() *time.Ticker {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPublishMetricsTicker")
-	ret0, _ := ret[0].(*time.Ticker)
-	return ret0
-}
-
-// GetPublishMetricsTicker indicates an expected call of GetPublishMetricsTicker.
-func (mr *MockEngineMockRecorder) GetPublishMetricsTicker() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublishMetricsTicker", reflect.TypeOf((*MockEngine)(nil).GetPublishMetricsTicker))
 }
 
 // GetPublishServiceConnectTickerInterval mocks base method.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
