### PR TITLE
Handle specific exception codes on RCI call.

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -468,10 +468,15 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 	// Register the container instance
 	err = agent.registerContainerInstance(client, vpcSubnetAttributes)
 	if err != nil {
-		if isTransient(err) {
-			return exitcodes.ExitError
+		if isTerminal(err) {
+			// On unrecoverable error codes, agent should terminally exit.
+			logger.Critical("Agent will terminally exit, unable to register container instance:", logger.Fields{
+				field.Error: err,
+			})
+			return exitcodes.ExitTerminal
 		}
-		return exitcodes.ExitTerminal
+		// Other errors are considered recoverable and will be retried.
+		return exitcodes.ExitError
 	}
 
 	// Load Managed Daemon images asynchronously
@@ -855,13 +860,19 @@ func (agent *ecsAgent) registerContainerInstance(
 			field.Error: err,
 		})
 		if retriable, ok := err.(apierrors.Retriable); ok && !retriable.Retry() {
-			return err
+			return terminalError{err}
 		}
 		if utils.IsAWSErrorCodeEqual(err, ecsmodel.ErrCodeInvalidParameterException) {
 			logger.Critical("Instance registration attempt with an invalid parameter", logger.Fields{
 				field.Error: err,
 			})
-			return err
+			return terminalError{err}
+		}
+		if utils.IsAWSErrorCodeEqual(err, ecsmodel.ErrCodeClientException) {
+			logger.Critical("Instance registration attempt with client performing invalid action", logger.Fields{
+				field.Error: err,
+			})
+			return terminalError{err}
 		}
 		if _, ok := err.(apierrors.AttributeError); ok {
 			attributeErrorMsg := ""
@@ -871,9 +882,9 @@ func (agent *ecsAgent) registerContainerInstance(
 			logger.Critical("Instance registration attempt with invalid attribute(s)", logger.Fields{
 				field.Error: attributeErrorMsg,
 			})
-			return err
+			return terminalError{err}
 		}
-		return transientError{err}
+		return err
 	}
 	logger.Info("Instance registration completed successfully", logger.Fields{
 		"instanceArn": containerInstanceArn,
@@ -903,7 +914,19 @@ func (agent *ecsAgent) reregisterContainerInstance(client ecs.ECSClient, capabil
 	})
 	if apierrors.IsInstanceTypeChangedError(err) {
 		seelog.Criticalf(instanceTypeMismatchErrorFormat, err)
-		return err
+		return terminalError{err}
+	}
+	if utils.IsAWSErrorCodeEqual(err, ecsmodel.ErrCodeInvalidParameterException) {
+		logger.Critical("Instance re-registration attempt with an invalid parameter", logger.Fields{
+			field.Error: err,
+		})
+		return terminalError{err}
+	}
+	if utils.IsAWSErrorCodeEqual(err, ecsmodel.ErrCodeClientException) {
+		logger.Critical("Instance re-registration attempt with client performing invalid action", logger.Fields{
+			field.Error: err,
+		})
+		return terminalError{err}
 	}
 	if _, ok := err.(apierrors.AttributeError); ok {
 		attributeErrorMsg := ""
@@ -913,9 +936,9 @@ func (agent *ecsAgent) reregisterContainerInstance(client ecs.ECSClient, capabil
 		logger.Critical("Instance re-registration attempt with invalid attribute(s)", logger.Fields{
 			field.Error: attributeErrorMsg,
 		})
-		return err
+		return terminalError{err}
 	}
-	return transientError{err}
+	return err
 }
 
 // startAsyncRoutines starts all background methods

--- a/agent/app/errors.go
+++ b/agent/app/errors.go
@@ -13,15 +13,16 @@
 
 package app
 
-// transientError represents a transient error when executing the ECS Agent
-type transientError struct {
+type terminalError struct {
 	error
 }
 
-// isTransient returns true if the error is transient
-func isTransient(err error) bool {
-	_, ok := err.(transientError)
-	return ok
+// isTerminal returns true if the error is already wrapped as an unrecoverable condition
+// which will allow agent to exit terminally.
+func isTerminal(err error) bool {
+	// Check if the error is already wrapped as a terminalError
+	_, terminal := err.(terminalError)
+	return terminal
 }
 
 // clusterMismatchError represents a mismatch in cluster name between the


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
1. This adds a terminalError wrapper around 2 exception codes that are known to not be recoverable by retrying (this can help avoid retry storm). This data was verified from internal investigation. 
2. Separately, it also checks that throttlingError does return exitcode 1 i.e. it will be retried. 
3. Refactored from isTransient to isTerminal because the terminal cases are what we want to specifically handle while the default is to delegate to existing retry mechanism for other cases.

### Implementation details
<!-- How are the changes implemented? -->
Changes are implemented on agent calling RCi.

### Testing
<!-- How was this tested? -->
Added 2 new tests, one to verify throttlingError returns exitcode 1 + one to verify ClientException will result in exit code 5 i.e. the terminal state for agent.

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Terminally exit on unrecoverable RCI exception errors.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
