### PR TITLE
Add metrics for DiscoverPollEndpoint and ACSSession

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
@@ -39,6 +39,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/httpclient"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 )
@@ -77,6 +78,7 @@ type ecsClient struct {
 	shouldExcludeIPv6PortBinding     bool
 	sascCustomRetryBackoff           func(func() error) error
 	stscAttachmentCustomRetryBackoff func(func() error) error
+	metricsFactory                   metrics.EntryFactory
 }
 
 // NewECSClient creates a new ECSClient interface object.
@@ -111,6 +113,9 @@ func NewECSClient(
 	}
 	if client.submitStateChangeClient == nil {
 		client.submitStateChangeClient = newSubmitStateChangeClient(&ecsConfig)
+	}
+	if client.metricsFactory == nil {
+		client.metricsFactory = metrics.NewNopEntryFactory()
 	}
 
 	return client, nil
@@ -747,7 +752,7 @@ func (client *ecsClient) discoverPollEndpoint(containerInstanceArn string,
 			}
 		}
 	}
-
+	discoverPollEndpointStartTime := time.Now()
 	// Cache miss or expired, invoke the ECS DiscoverPollEndpoint API.
 	logger.Debug("Invoking DiscoverPollEndpoint", logger.Fields{
 		field.ContainerInstanceARN: containerInstanceArn,
@@ -758,6 +763,7 @@ func (client *ecsClient) discoverPollEndpoint(containerInstanceArn string,
 		Cluster:           aws.String(client.configAccessor.Cluster()),
 		ZoneId:            aws.String(availabilityZone),
 	})
+	client.metricsFactory.New(metrics.DiscoverPollEndpointCallName).Done(err)
 	if err != nil {
 		// If we got an error calling the API, fallback to an expired cached endpoint if
 		// we have it.
@@ -776,7 +782,7 @@ func (client *ecsClient) discoverPollEndpoint(containerInstanceArn string,
 		}
 		return nil, err
 	}
-
+	client.metricsFactory.New(metrics.DiscoverPollEndpointDurationName).WithGauge(time.Since(discoverPollEndpointStartTime)).Done(nil)
 	// Cache the response from ECS.
 	client.pollEndpointCache.Set(containerInstanceArn, output)
 	return output, nil

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client_option.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client_option.go
@@ -16,6 +16,7 @@ package ecsclient
 import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/async"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
 )
 
 // ECSClientOption allows for configuration of an ecsClient.
@@ -85,5 +86,14 @@ func WithStandardClient(s ecs.ECSStandardSDK) ECSClientOption {
 func WithSubmitStateChangeClient(s ecs.ECSSubmitStateSDK) ECSClientOption {
 	return func(client *ecsClient) {
 		client.submitStateChangeClient = s
+	}
+}
+
+// WithMetricsFactory is an ECSClientOption that configures
+// ecsClient.metricsFactory with the value passed as a parameter.
+// This is especially useful for emitting metrics in the ECS Client
+func WithMetricsFactory(metricsFactory metrics.EntryFactory) ECSClientOption {
+	return func(client *ecsClient) {
+		client.metricsFactory = metricsFactory
 	}
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
@@ -46,6 +46,16 @@ const (
 	ACSDisconnectTimeoutMetricName = agentAvailabilityNamespace + ".ACSDisconnectTimeout"
 	TCSDisconnectTimeoutMetricName = agentAvailabilityNamespace + ".TCSDisconnectTimeout"
 
+	// ACS Session Metrics
+	acsSessionNamespace        = "ACSSession"
+	ACSSessionCallName         = acsSessionNamespace + ".ACSConnect"
+	ACSSessionCallDurationName = acsSessionNamespace + ".ACSConnectDuration"
+
+	// ECS Client Metrics
+	ecsClientNamespace               = "ECSClient"
+	DiscoverPollEndpointCallName     = ecsClientNamespace + ".DiscoverPollEndpoint"
+	DiscoverPollEndpointDurationName = ecsClientNamespace + ".DiscoverPollEndpointDuration"
+
 	dbClientMetricNamespace                 = "Data"
 	GetNetworkConfigurationByTaskMetricName = dbClientMetricNamespace + ".GetNetworkConfigurationByTask"
 	SaveNetworkNamespaceMetricName          = dbClientMetricNamespace + ".SaveNetworkNamespace"

--- a/ecs-agent/acs/session/session_test.go
+++ b/ecs-agent/acs/session/session_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/doctor"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
 	metricsfactory "github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
+	mock_metrics "github.com/aws/amazon-ecs-agent/ecs-agent/metrics/mocks"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 	mock_retry "github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry/mock"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/wsclient"
@@ -224,6 +225,17 @@ func TestSessionReconnectsOnConnectErrors(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockMetricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+	mockACSConnectEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockACSConnectEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnect").Return(mockACSConnectEndpointEntry).AnyTimes()
+
+	mockACSConnectDurationEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
@@ -253,6 +265,7 @@ func TestSessionReconnectsOnConnectErrors(t *testing.T) {
 		containerInstanceARN: testconst.ContainerInstanceARN,
 		ecsClient:            ecsClient,
 		clientFactory:        mockClientFactory,
+		metricsFactory:       mockMetricsFactory,
 		heartbeatTimeout:     20 * time.Millisecond,
 		heartbeatJitter:      10 * time.Millisecond,
 		disconnectTimeout:    30 * time.Millisecond,
@@ -345,6 +358,17 @@ func TestSessionReconnectsWithoutBackoffOnEOFError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockMetricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+	mockACSConnectEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockACSConnectEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnect").Return(mockACSConnectEndpointEntry).AnyTimes()
+
+	mockACSConnectDurationEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
@@ -377,6 +401,7 @@ func TestSessionReconnectsWithoutBackoffOnEOFError(t *testing.T) {
 		inactiveInstanceCB:             noopFunc,
 		backoff:                        mockBackoff,
 		clientFactory:                  mockClientFactory,
+		metricsFactory:                 mockMetricsFactory,
 		heartbeatTimeout:               20 * time.Millisecond,
 		heartbeatJitter:                10 * time.Millisecond,
 		disconnectTimeout:              30 * time.Millisecond,
@@ -393,6 +418,17 @@ func TestSessionReconnectsWithoutBackoffOnEOFError(t *testing.T) {
 func TestSessionReconnectsWithBackoffOnNonEOFError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	mockMetricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+	mockACSConnectEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockACSConnectEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnect").Return(mockACSConnectEndpointEntry).AnyTimes()
+
+	mockACSConnectDurationEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
@@ -427,6 +463,7 @@ func TestSessionReconnectsWithBackoffOnNonEOFError(t *testing.T) {
 		inactiveInstanceCB:   noopFunc,
 		backoff:              mockBackoff,
 		clientFactory:        mockClientFactory,
+		metricsFactory:       mockMetricsFactory,
 		heartbeatTimeout:     20 * time.Millisecond,
 		heartbeatJitter:      10 * time.Millisecond,
 		disconnectTimeout:    30 * time.Millisecond,
@@ -443,6 +480,17 @@ func TestSessionReconnectsWithBackoffOnNonEOFError(t *testing.T) {
 func TestSessionCallsInactiveInstanceCB(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	mockMetricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+	mockACSConnectEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockACSConnectEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnect").Return(mockACSConnectEndpointEntry).AnyTimes()
+
+	mockACSConnectDurationEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
@@ -480,6 +528,7 @@ func TestSessionCallsInactiveInstanceCB(t *testing.T) {
 		ecsClient:                      ecsClient,
 		inactiveInstanceCB:             inactiveInstanceCB,
 		clientFactory:                  mockClientFactory,
+		metricsFactory:                 mockMetricsFactory,
 		heartbeatTimeout:               20 * time.Millisecond,
 		heartbeatJitter:                10 * time.Millisecond,
 		disconnectTimeout:              30 * time.Millisecond,
@@ -498,6 +547,17 @@ func TestSessionCallsInactiveInstanceCB(t *testing.T) {
 func TestSessionReconnectDelayForInactiveInstanceError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	mockMetricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+	mockACSConnectEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockACSConnectEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnect").Return(mockACSConnectEndpointEntry).AnyTimes()
+
+	mockACSConnectDurationEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
@@ -540,6 +600,7 @@ func TestSessionReconnectDelayForInactiveInstanceError(t *testing.T) {
 		ecsClient:                      ecsClient,
 		inactiveInstanceCB:             noopFunc,
 		clientFactory:                  mockClientFactory,
+		metricsFactory:                 mockMetricsFactory,
 		heartbeatTimeout:               20 * time.Millisecond,
 		heartbeatJitter:                10 * time.Millisecond,
 		disconnectTimeout:              30 * time.Millisecond,
@@ -558,6 +619,17 @@ func TestSessionReconnectDelayForInactiveInstanceError(t *testing.T) {
 func TestSessionReconnectsOnServeErrors(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	mockMetricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+	mockACSConnectEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockACSConnectEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnect").Return(mockACSConnectEndpointEntry).AnyTimes()
+
+	mockACSConnectDurationEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
@@ -590,6 +662,7 @@ func TestSessionReconnectsOnServeErrors(t *testing.T) {
 		ecsClient:            ecsClient,
 		inactiveInstanceCB:   noopFunc,
 		clientFactory:        mockClientFactory,
+		metricsFactory:       mockMetricsFactory,
 		heartbeatTimeout:     20 * time.Millisecond,
 		heartbeatJitter:      10 * time.Millisecond,
 		disconnectTimeout:    30 * time.Millisecond,
@@ -607,6 +680,17 @@ func TestSessionReconnectsOnServeErrors(t *testing.T) {
 func TestSessionStopsWhenContextIsCanceled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	mockMetricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+	mockACSConnectEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockACSConnectEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnect").Return(mockACSConnectEndpointEntry).AnyTimes()
+
+	mockACSConnectDurationEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
@@ -635,6 +719,7 @@ func TestSessionStopsWhenContextIsCanceled(t *testing.T) {
 		ecsClient:            ecsClient,
 		inactiveInstanceCB:   noopFunc,
 		clientFactory:        mockClientFactory,
+		metricsFactory:       mockMetricsFactory,
 		heartbeatTimeout:     20 * time.Millisecond,
 		heartbeatJitter:      10 * time.Millisecond,
 		disconnectTimeout:    30 * time.Millisecond,
@@ -652,6 +737,17 @@ func TestSessionStopsWhenContextIsCanceled(t *testing.T) {
 func TestSessionStopsWhenContextIsErrorDueToTimeout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	mockMetricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+	mockACSConnectEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockACSConnectEndpointEntry.EXPECT().Done(gomock.Any())
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnect").Return(mockACSConnectEndpointEntry)
+
+	mockACSConnectDurationEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
@@ -677,6 +773,7 @@ func TestSessionStopsWhenContextIsErrorDueToTimeout(t *testing.T) {
 		ecsClient:                      ecsClient,
 		inactiveInstanceCB:             noopFunc,
 		clientFactory:                  mockClientFactory,
+		metricsFactory:                 mockMetricsFactory,
 		heartbeatTimeout:               20 * time.Millisecond,
 		heartbeatJitter:                10 * time.Millisecond,
 		inactiveInstanceReconnectDelay: 1 * time.Hour,
@@ -693,6 +790,17 @@ func TestSessionStopsWhenContextIsErrorDueToTimeout(t *testing.T) {
 func TestSessionReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	mockMetricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+	mockACSConnectEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockACSConnectEndpointEntry.EXPECT().Done(gomock.Any())
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnect").Return(mockACSConnectEndpointEntry)
+
+	mockACSConnectDurationEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -725,6 +833,7 @@ func TestSessionReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 		ecsClient:            ecsClient,
 		inactiveInstanceCB:   noopFunc,
 		clientFactory:        mockClientFactory,
+		metricsFactory:       mockMetricsFactory,
 		heartbeatTimeout:     20 * time.Millisecond,
 		heartbeatJitter:      10 * time.Millisecond,
 		disconnectTimeout:    30 * time.Millisecond,
@@ -756,6 +865,17 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockMetricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+	mockACSConnectEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnect").Return(mockACSConnectEndpointEntry)
+	mockACSConnectEndpointEntry.EXPECT().Done(gomock.Any())
+
+	mockACSConnectDurationEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -783,6 +903,7 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 		ecsClient:            ecsClient,
 		inactiveInstanceCB:   noopFunc,
 		clientFactory:        mockClientFactory,
+		metricsFactory:       mockMetricsFactory,
 		heartbeatTimeout:     20 * time.Millisecond,
 		heartbeatJitter:      10 * time.Millisecond,
 		disconnectTimeout:    30 * time.Millisecond,
@@ -1003,6 +1124,17 @@ func TestSessionCorrectlySetsSendCredentials(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockMetricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+	mockACSConnectEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnect").Return(mockACSConnectEndpointEntry).Times(10)
+	mockACSConnectEndpointEntry.EXPECT().Done(gomock.Any()).Times(10)
+
+	mockACSConnectDurationEndpointEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
+	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+
 	const numInvocations = 10
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
@@ -1025,7 +1157,7 @@ func TestSessionCorrectlySetsSendCredentials(t *testing.T) {
 		nil,
 		noopFunc,
 		mockClientFactory,
-		metricsfactory.NewNopEntryFactory(),
+		mockMetricsFactory,
 		agentVersion,
 		agentGitShortHash,
 		dockerVersion,

--- a/ecs-agent/api/ecs/client/ecs_client.go
+++ b/ecs-agent/api/ecs/client/ecs_client.go
@@ -39,6 +39,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/httpclient"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 )
@@ -77,6 +78,7 @@ type ecsClient struct {
 	shouldExcludeIPv6PortBinding     bool
 	sascCustomRetryBackoff           func(func() error) error
 	stscAttachmentCustomRetryBackoff func(func() error) error
+	metricsFactory                   metrics.EntryFactory
 }
 
 // NewECSClient creates a new ECSClient interface object.
@@ -111,6 +113,9 @@ func NewECSClient(
 	}
 	if client.submitStateChangeClient == nil {
 		client.submitStateChangeClient = newSubmitStateChangeClient(&ecsConfig)
+	}
+	if client.metricsFactory == nil {
+		client.metricsFactory = metrics.NewNopEntryFactory()
 	}
 
 	return client, nil
@@ -747,7 +752,7 @@ func (client *ecsClient) discoverPollEndpoint(containerInstanceArn string,
 			}
 		}
 	}
-
+	discoverPollEndpointStartTime := time.Now()
 	// Cache miss or expired, invoke the ECS DiscoverPollEndpoint API.
 	logger.Debug("Invoking DiscoverPollEndpoint", logger.Fields{
 		field.ContainerInstanceARN: containerInstanceArn,
@@ -758,6 +763,7 @@ func (client *ecsClient) discoverPollEndpoint(containerInstanceArn string,
 		Cluster:           aws.String(client.configAccessor.Cluster()),
 		ZoneId:            aws.String(availabilityZone),
 	})
+	client.metricsFactory.New(metrics.DiscoverPollEndpointCallName).Done(err)
 	if err != nil {
 		// If we got an error calling the API, fallback to an expired cached endpoint if
 		// we have it.
@@ -776,7 +782,7 @@ func (client *ecsClient) discoverPollEndpoint(containerInstanceArn string,
 		}
 		return nil, err
 	}
-
+	client.metricsFactory.New(metrics.DiscoverPollEndpointDurationName).WithGauge(time.Since(discoverPollEndpointStartTime)).Done(nil)
 	// Cache the response from ECS.
 	client.pollEndpointCache.Set(containerInstanceArn, output)
 	return output, nil

--- a/ecs-agent/api/ecs/client/ecs_client_option.go
+++ b/ecs-agent/api/ecs/client/ecs_client_option.go
@@ -16,6 +16,7 @@ package ecsclient
 import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/async"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
 )
 
 // ECSClientOption allows for configuration of an ecsClient.
@@ -85,5 +86,14 @@ func WithStandardClient(s ecs.ECSStandardSDK) ECSClientOption {
 func WithSubmitStateChangeClient(s ecs.ECSSubmitStateSDK) ECSClientOption {
 	return func(client *ecsClient) {
 		client.submitStateChangeClient = s
+	}
+}
+
+// WithMetricsFactory is an ECSClientOption that configures
+// ecsClient.metricsFactory with the value passed as a parameter.
+// This is especially useful for emitting metrics in the ECS Client
+func WithMetricsFactory(metricsFactory metrics.EntryFactory) ECSClientOption {
+	return func(client *ecsClient) {
+		client.metricsFactory = metricsFactory
 	}
 }

--- a/ecs-agent/api/ecs/client/ecs_client_option_test.go
+++ b/ecs-agent/api/ecs/client/ecs_client_option_test.go
@@ -22,6 +22,7 @@ import (
 
 	mock_ecs "github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/mocks"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/async"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -101,4 +102,11 @@ func TestWithSubmitStateChangeClient(t *testing.T) {
 	option := WithSubmitStateChangeClient(newSubmitStateChangeClient)
 	option(client)
 	assert.Equal(t, newSubmitStateChangeClient, client.submitStateChangeClient)
+}
+
+func TestWithMetricsFactory(t *testing.T) {
+	client := &ecsClient{} // client.metricsFactory is nil by default
+	option := WithMetricsFactory(metrics.NewNopEntryFactory())
+	option(client)
+	assert.NotNil(t, client.metricsFactory)
 }

--- a/ecs-agent/metrics/constants.go
+++ b/ecs-agent/metrics/constants.go
@@ -46,6 +46,16 @@ const (
 	ACSDisconnectTimeoutMetricName = agentAvailabilityNamespace + ".ACSDisconnectTimeout"
 	TCSDisconnectTimeoutMetricName = agentAvailabilityNamespace + ".TCSDisconnectTimeout"
 
+	// ACS Session Metrics
+	acsSessionNamespace        = "ACSSession"
+	ACSSessionCallName         = acsSessionNamespace + ".ACSConnect"
+	ACSSessionCallDurationName = acsSessionNamespace + ".ACSConnectDuration"
+
+	// ECS Client Metrics
+	ecsClientNamespace               = "ECSClient"
+	DiscoverPollEndpointCallName     = ecsClientNamespace + ".DiscoverPollEndpoint"
+	DiscoverPollEndpointDurationName = ecsClientNamespace + ".DiscoverPollEndpointDuration"
+
 	dbClientMetricNamespace                 = "Data"
 	GetNetworkConfigurationByTaskMetricName = dbClientMetricNamespace + ".GetNetworkConfigurationByTask"
 	SaveNetworkNamespaceMetricName          = dbClientMetricNamespace + ".SaveNetworkNamespace"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adding new metrics and variables in acs session

### Implementation details
<!-- How are the changes implemented? -->
Added new metrics and variables in acs session for `StartSessionOnce`, and new metrics and variables in ecs clilent for `DiscoverPollEndpoint`. These metric are for helping us track success/failure rates and monitoring latency for both these calls, which will be useful in cases where we have to root cause issues in the ENI provisioning workflow. 

### Testing
<!-- How was this tested? -->
Tested by running all unit tests in acs
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
No new tests, but modified existing tests to account for new metrics (ie mocked the calls to create metrics)

### Description for the changelog
Enhancement - add metrics to monitor latency in acs session
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
