### PR TITLE
 Rename duplicate time field to be more descriptive and unique

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3006,9 +3006,9 @@ func (task *Task) RecordExecutionStoppedAt(container *apicontainer.Container) {
 		return
 	}
 	logger.Info("Essential container stopped; recording task stopped time", logger.Fields{
-		field.TaskID:    task.GetID(),
-		field.Container: container.Name,
-		field.Time:      now.String(),
+		field.TaskID:             task.GetID(),
+		field.Container:          container.Name,
+		field.ExecutionStoppedAt: now.String(),
 	})
 }
 

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
@@ -34,7 +34,6 @@ const (
 	Event                   = "event"
 	Image                   = "image"
 	Volume                  = "volume"
-	Time                    = "time"
 	NetworkMode             = "networkMode"
 	Cluster                 = "cluster"
 	ServiceName             = "ServiceName"
@@ -72,4 +71,5 @@ const (
 	CommandString           = "commandString"
 	CommandOutput           = "commandOutput"
 	RegistryID              = "registryID"
+	ExecutionStoppedAt      = "executionStoppedAt"
 )

--- a/ecs-agent/logger/field/constants.go
+++ b/ecs-agent/logger/field/constants.go
@@ -34,7 +34,6 @@ const (
 	Event                   = "event"
 	Image                   = "image"
 	Volume                  = "volume"
-	Time                    = "time"
 	NetworkMode             = "networkMode"
 	Cluster                 = "cluster"
 	ServiceName             = "ServiceName"
@@ -72,4 +71,5 @@ const (
 	CommandString           = "commandString"
 	CommandOutput           = "commandOutput"
 	RegistryID              = "registryID"
+	ExecutionStoppedAt      = "executionStoppedAt"
 )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR cherry-picks the commits from #4444 and runs `go mod tidy && go mod vendor` to resolve failing PR checks and merge the change before next ECS agent release.

---

Rename the log field used to show when an essential container was stopped, from `time` to `ExecutionStoppedAt`.
When logging that an essential container is stopped, we log the time that the container was stopped at. As all logs contain the fields `level`, `time` and `msg`, we end up with a duplicated `time` field, which some log processors are unable to handle - here is an example log:

```
{"level":"info","time":"2024-11-27T12:50:26Z","msg":"Essential container stopped; recording task stopped time","container":"ecs-appmesh-task-helper","task":"ad289555e6d74bf696db794907dcf1d4","time":"2024-11-27 12:50:26.023783669 +0000 UTC m=+89089.452265064"}
```

### Implementation details
Renamed the extra logging field from `time` to `ExecutionStoppedAt`

### Testing

Automated tests

New tests cover the changes: no

### Description for the changelog
Enhancement: Renamed duplicated time field when logging container stopped events

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No  

**Does this PR include the addition of new environment variables in the README?**
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
