### PR TITLE
Run Github action Linux tests on ubuntu-22.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   unit-tests:
     name: Linux unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Explicitly run Linux unit tests Github action using ubuntu-22.04 instead of ubuntu-latest (which recently was updated to point to ubuntu-24.04 instead of ubuntu-22.04). 

Currently, some ecs-init unit tests make an assumption on the expected total number of Agent host config binds. However, when running these tests on ubuntu-24.04 a different number of Agent host config binds end up occurring since some Agent host config binds are binded dynamically depending on host configuration. This results in Linux unit tests Github action workflow failing on new pull requests opened to amazon-ecs-agent repository, which blocks merging of new functionality.

This pull request is to go back to using ubuntu-22.04 (which has an LTS end-of-life date of Apr 2027; [ref](https://ubuntu.com/about/release-cycle)) to run Linux unit tests. This aligns with what was being done up until the point ubuntu-latest was recently updated to point to ubuntu-24.04. This is so that merging new pull requests is unblocked. Separately, ECS Agent team will re-visit its test implementation for ecs-init unit tests which make assumptions on  expected total number of Agent host config binds and see if improvements can be made for those tests to be more resilient to dependency changes which ECS Agent team does not control.

### Implementation details
<!-- How are the changes implemented? -->
See "Summary" section above.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Automated pull request tests.

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Run Github action Linux tests on ubuntu-22.04

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
