### PR TITLE
making ecs-init unit tests deterministic

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   unit-tests:
     name: Linux unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ecs-init/apparmor/apparmor.go
+++ b/ecs-init/apparmor/apparmor.go
@@ -92,7 +92,6 @@ var (
 	isProfileLoaded = aaprofile.IsLoaded
 	loadPath        = loadProfile
 	createFile      = os.Create
-	statFile        = os.Stat
 )
 
 // loadPath runs `apparmor_parser -Kr` on a specified apparmor profile to
@@ -152,7 +151,7 @@ func LoadDefaultProfile(profileName string) error {
 }
 
 func fileExists(path string) (bool, error) {
-	_, err := statFile(path)
+	_, err := config.OsStat(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return false, nil

--- a/ecs-init/apparmor/apparmor_test.go
+++ b/ecs-init/apparmor/apparmor_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aws/amazon-ecs-agent/ecs-init/config"
 	aaprofile "github.com/docker/docker/profiles/apparmor"
 
 	"github.com/stretchr/testify/assert"
@@ -108,7 +109,7 @@ func TestLoadDefaultProfile(t *testing.T) {
 		isProfileLoaded = aaprofile.IsLoaded
 		loadPath = loadProfile
 		createFile = os.Create
-		statFile = os.Stat
+		config.OsStat = os.Stat
 	}()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -123,7 +124,7 @@ func TestLoadDefaultProfile(t *testing.T) {
 				return f, err
 			}
 
-			statFile = func(fileName string) (os.FileInfo, error) {
+			config.OsStat = func(fileName string) (os.FileInfo, error) {
 				relativePath, err := filepath.Rel(appArmorProfileDir, fileName)
 				require.NoError(t, err)
 				return nil, tc.statErrors[relativePath]

--- a/ecs-init/cache/dependencies.go
+++ b/ecs-init/cache/dependencies.go
@@ -26,6 +26,8 @@ import (
 	"os"
 	"path/filepath"
 
+	cfg "github.com/aws/amazon-ecs-agent/ecs-init/config"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
@@ -185,7 +187,7 @@ func (s *standardFS) Open(name string) (io.ReadCloser, error) {
 }
 
 func (s *standardFS) Stat(name string) (fileSizeInfo, error) {
-	return os.Stat(name)
+	return cfg.OsStat(name)
 }
 
 func (s *standardFS) Base(path string) string {

--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -110,6 +110,9 @@ const (
 	ECSAgentAppArmorDefaultProfileName = "ecs-agent-default"
 )
 
+// OsStat is useful for mocking in unit tests
+var OsStat = os.Stat
+
 // partitionBucketRegion provides the "partitional" bucket region
 // suitable for downloading agent from.
 var partitionBucketRegion = map[string]string{
@@ -256,17 +259,17 @@ func MountDirectoryEBS() string {
 	return directoryPrefix + "/mnt/ecs/ebs"
 }
 
-// HostCertsDirPath() returns the CA store path on the host
+// HostCertsDirPath returns the CA store path on the host
 func HostCertsDirPath() string {
-	if _, err := os.Stat(hostCertsDirPath); err != nil {
+	if _, err := OsStat(hostCertsDirPath); err != nil {
 		return ""
 	}
 	return hostCertsDirPath
 }
 
-// HostPKIDirPath() returns the CA store path on the host
+// HostPKIDirPath returns the CA store path on the host
 func HostPKIDirPath() string {
-	if _, err := os.Stat(hostPKIDirPath); err != nil {
+	if _, err := OsStat(hostPKIDirPath); err != nil {
 		return ""
 	}
 	return hostPKIDirPath

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -117,6 +117,19 @@ const (
 	// nvidiaGPUDevicesPresentMaxRetries specifies the maximum number of retries to attempt for checking if NVIDIA
 	// GPU devices are present.
 	nvidiaGPUDevicesPresentMaxRetries = 10
+
+	// lsblk lists information about block devices. This is used by the ECS agent for the EBS task attach functionality.
+	// Ref: https://man7.org/linux/man-pages/man8/lsblk.8.html
+	lsblkDir = "/usr/bin/lsblk"
+
+	// nsenter helps run program in different namespaces. This is used by the ECS agent for the fault inject functionality.
+	// Ref: https://man7.org/linux/man-pages/man1/nsenter.1.html
+	nsEnterDir = "/usr/bin/nsenter"
+
+	// modinfo is used to display information about a Linux kernel module. This is used by the ECS agent for the
+	// fault inject functionality. Ref: https://man7.org/linux/man-pages/man8/modinfo.8.html
+	modInfoSbinDir    = "/sbin/modinfo"
+	modInfoUsrSbinDir = "/usr/sbin/modinfo"
 )
 
 // Do NOT include "CAP_" in capability string
@@ -495,7 +508,7 @@ func getCredentialsFetcherSocketBind() (string, bool) {
 	credentialsFetcherUnixSocketHostPath, ok := config.HostCredentialsFetcherPath()
 	if ok && credentialsFetcherUnixSocketHostPath != "" {
 		// check whether the path to the credentials fetcher socket exists
-		_, err := os.Stat(credentialsFetcherUnixSocketHostPath)
+		_, err := config.OsStat(credentialsFetcherUnixSocketHostPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return "", false
@@ -508,7 +521,7 @@ func getCredentialsFetcherSocketBind() (string, bool) {
 }
 
 // getDockerSocketBind returns the bind for Docker socket.
-// Value for the bind is as follow:
+// Value for the bind is as follows:
 //  1. DOCKER_HOST (as in os.Getenv) not set: source /var/run, dest /var/run
 //  2. DOCKER_HOST (as in os.Getenv) set: source DOCKER_HOST (as in os.Getenv, trim unix:// prefix),
 //     dest DOCKER_HOST (as in /etc/ecs/ecs.config, trim unix:// prefix)
@@ -562,7 +575,7 @@ func getCapabilityBinds() []string {
 }
 
 func defaultIsPathValid(path string, shouldBeDirectory bool) bool {
-	fileInfo, err := os.Stat(path)
+	fileInfo, err := config.OsStat(path)
 	if err != nil {
 		return false
 	}

--- a/ecs-init/docker/docker_config.go
+++ b/ecs-init/docker/docker_config.go
@@ -45,10 +45,10 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 		iptablesExecutableHostDir+":"+iptablesExecutableContainerDir+readOnly,
 		iptablesAltDir+":"+iptablesAltDir+readOnly,
 		iptablesLegacyDir+":"+iptablesLegacyDir+readOnly,
-		"/usr/bin/lsblk:/usr/bin/lsblk",
+		lsblkDir+":"+lsblkDir,
 	)
-	binds = append(binds, getNsenterBinds(os.Stat)...)
-	binds = append(binds, getModInfoBinds(os.Stat)...)
+	binds = append(binds, getNsenterBinds(config.OsStat)...)
+	binds = append(binds, getModInfoBinds(config.OsStat)...)
 
 	logConfig := config.AgentDockerLogDriverConfiguration()
 
@@ -89,12 +89,11 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 // Returns an empty slice otherwise.
 func getNsenterBinds(statFn func(string) (os.FileInfo, error)) []string {
 	binds := []string{}
-	const nsenterPath = "/usr/bin/nsenter"
-	if _, err := statFn(nsenterPath); err == nil {
-		binds = append(binds, nsenterPath+":"+nsenterPath)
+	if _, err := statFn(nsEnterDir); err == nil {
+		binds = append(binds, nsEnterDir+":"+nsEnterDir)
 	} else {
 		seelog.Warnf("nsenter not found at %s, skip binding it to Agent container: %v",
-			nsenterPath, err)
+			nsEnterDir, err)
 	}
 	return binds
 }
@@ -104,8 +103,8 @@ func getNsenterBinds(statFn func(string) (os.FileInfo, error)) []string {
 func getModInfoBinds(statFn func(string) (os.FileInfo, error)) []string {
 	binds := []string{}
 	modInfoPathLocations := []string{
-		"/sbin/modinfo",
-		"/usr/sbin/modinfo",
+		modInfoSbinDir,
+		modInfoUsrSbinDir,
 	}
 	for _, path := range modInfoPathLocations {
 		if _, err := statFn(path); err == nil {

--- a/ecs-init/volumes/state_manager.go
+++ b/ecs-init/volumes/state_manager.go
@@ -20,7 +20,9 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/aws/amazon-ecs-agent/ecs-init/config"
 	"github.com/aws/amazon-ecs-agent/ecs-init/volumes/types"
+
 	"github.com/cihub/seelog"
 )
 
@@ -138,7 +140,7 @@ func saveState(b []byte) error {
 var fileExists = checkFile
 
 func checkFile(filename string) bool {
-	_, err := os.Stat(filename)
+	_, err := config.OsStat(filename)
 	return !os.IsNotExist(err)
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Some of the ECS-init unit tests started failing recently due to an update of the GitHub action runner. We use the `ubuntu-latest` runner type. A newer version (v24) was pushed to this "latest" type, that led to unit test failures.

In some of our unit tests, we verify the number of bind mounts that should be present instead of the actual list of mounts. I assume this was done this way because we add a few mounts only on certain platforms ([example](https://github.com/aws/amazon-ecs-agent/blob/0f876b5372c9ecb15228f607f11d2c4be629d364/ecs-init/docker/docker.go#L457)), and the list would vary in different environments.

This PR modifies the unit tests to be deterministic. it refactors the test to mock `os.Stat` calls, so that it returns the same thing regardless of where the tests run. I also reverted the workaround from #4479, and also put some bind mounts into a common top-level variables block for better readability.

### Implementation details
<!-- How are the changes implemented? -->
- Create a `config.OsStat` so that unit tests can mock it.
- Modify assertions in unit tests to mock the above.
- Remove the assertion on number of bind mounts present.
- Explicitly assert what bind mounts should be present.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

N/A

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
