### PR TITLE
Bug Fix: Block IMDS in branch ENIs

### DIFF
--- a/ecs-agent/netlib/platform/cniconf_linux.go
+++ b/ecs-agent/netlib/platform/cniconf_linux.go
@@ -139,6 +139,7 @@ func createBranchENIConfig(
 	netNSPath string,
 	iface *networkinterface.NetworkInterface,
 	ifType string,
+	blockInstanceMetadata bool,
 ) ecscni.PluginConfig {
 	cniConfig := ecscni.CNIConfig{
 		NetNSPath:      netNSPath,
@@ -162,6 +163,7 @@ func createBranchENIConfig(
 		BranchMACAddress:   iface.MacAddress,
 		IPAddresses:        iface.GetIPAddressesWithPrefixLength(),
 		GatewayIPAddresses: []string{iface.GetSubnetGatewayIPv4Address()},
+		BlockIMDS:          blockInstanceMetadata,
 		InterfaceType:      ifType,
 		UID:                strconv.Itoa(int(iface.UserID)),
 		GID:                strconv.Itoa(int(iface.UserID)),

--- a/ecs-agent/netlib/platform/cniconf_linux_test.go
+++ b/ecs-agent/netlib/platform/cniconf_linux_test.go
@@ -132,11 +132,12 @@ func TestCreateBranchENIConfig(t *testing.T) {
 		IPAddresses:        eni.GetIPAddressesWithPrefixLength(),
 		GatewayIPAddresses: []string{eni.GetSubnetGatewayIPv4Address()},
 		InterfaceType:      VPCBranchENIInterfaceTypeVlan,
+		BlockIMDS:          true,
 		UID:                strconv.Itoa(int(eni.UserID)),
 		GID:                strconv.Itoa(int(eni.UserID)),
 		IfName:             "eth1.13",
 	}
-	require.Equal(t, expected, createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan))
+	require.Equal(t, expected, createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan, blockInstanceMetadataDefault))
 
 	expected = &ecscni.VPCBranchENIConfig{
 		CNIConfig:          cniConfig,
@@ -146,11 +147,12 @@ func TestCreateBranchENIConfig(t *testing.T) {
 		IPAddresses:        eni.GetIPAddressesWithPrefixLength(),
 		GatewayIPAddresses: []string{eni.GetSubnetGatewayIPv4Address()},
 		InterfaceType:      VPCBranchENIInterfaceTypeTap,
+		BlockIMDS:          false,
 		UID:                strconv.Itoa(int(eni.UserID)),
 		GID:                strconv.Itoa(int(eni.UserID)),
 		IfName:             "eth0",
 	}
-	require.Equal(t, expected, createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeTap))
+	require.Equal(t, expected, createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeTap, false))
 }
 
 func getTestRegularENI() *networkinterface.NetworkInterface {

--- a/ecs-agent/netlib/platform/common_linux.go
+++ b/ecs-agent/netlib/platform/common_linux.go
@@ -707,9 +707,10 @@ func (c *common) configureBranchENI(ctx context.Context, netNSPath string, eni *
 		if eni.IsPrimary() {
 			cniNetConf = append(cniNetConf, createBridgePluginConfig(netNSPath))
 		}
-		cniNetConf = append(cniNetConf, createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan))
+		// We block IMDS access in awsvpc tasks.
+		cniNetConf = append(cniNetConf, createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan, blockInstanceMetadataDefault))
 	case status.NetworkDeleted:
-		cniNetConf = append(cniNetConf, createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan))
+		cniNetConf = append(cniNetConf, createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan, blockInstanceMetadataDefault))
 		add = false
 	}
 

--- a/ecs-agent/netlib/platform/common_linux_test.go
+++ b/ecs-agent/netlib/platform/common_linux_test.go
@@ -353,7 +353,7 @@ func testBranchENIConfiguration(t *testing.T) {
 	branchENI := getTestBranchENI()
 	branchENI.DesiredStatus = status.NetworkReadyPull
 	bridgeConfig := createBridgePluginConfig(netNSPath)
-	cniConfig := createBranchENIConfig(netNSPath, branchENI, VPCBranchENIInterfaceTypeVlan)
+	cniConfig := createBranchENIConfig(netNSPath, branchENI, VPCBranchENIInterfaceTypeVlan, blockInstanceMetadataDefault)
 	gomock.InOrder(
 		osWrapper.EXPECT().Setenv("IPAM_DB_PATH", filepath.Join(commonPlatform.stateDBDir, "eni-ipam.db")),
 		cniClient.EXPECT().Add(gomock.Any(), bridgeConfig).Return(nil, nil).Times(1),

--- a/ecs-agent/netlib/platform/firecracker_linux.go
+++ b/ecs-agent/netlib/platform/firecracker_linux.go
@@ -201,15 +201,17 @@ func (f *firecraker) configureBranchENI(ctx context.Context, netNSPath string, e
 	var cniNetConf ecscni.PluginConfig
 	var err error
 	add := true
+	// On Firecracker, we don't want to block IMDS because we run MMDS on that address.
+	blockIMDS := false
 
 	// Generate CNI network configuration based on the ENI's desired state.
 	switch eni.DesiredStatus {
 	case status.NetworkReadyPull:
-		cniNetConf = createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan)
+		cniNetConf = createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan, blockIMDS)
 	case status.NetworkReady:
-		cniNetConf = createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeTap)
+		cniNetConf = createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeTap, blockIMDS)
 	case status.NetworkDeleted:
-		cniNetConf = createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeTap)
+		cniNetConf = createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeTap, blockIMDS)
 		add = false
 	}
 

--- a/ecs-agent/netlib/platform/firecracker_linux_test.go
+++ b/ecs-agent/netlib/platform/firecracker_linux_test.go
@@ -161,20 +161,20 @@ func TestFirecracker_BranchENIConfiguration(t *testing.T) {
 
 	branchENI := getTestBranchENI()
 
-	cniConfig := createBranchENIConfig(netNSPath, branchENI, VPCBranchENIInterfaceTypeVlan)
+	cniConfig := createBranchENIConfig(netNSPath, branchENI, VPCBranchENIInterfaceTypeVlan, false)
 	cniClient.EXPECT().Add(gomock.Any(), cniConfig).Return(nil, nil).Times(1)
 	err := fc.ConfigureInterface(ctx, netNSPath, branchENI, nil)
 	require.NoError(t, err)
 
 	branchENI.DesiredStatus = status.NetworkReady
-	cniConfig = createBranchENIConfig(netNSPath, branchENI, VPCBranchENIInterfaceTypeTap)
+	cniConfig = createBranchENIConfig(netNSPath, branchENI, VPCBranchENIInterfaceTypeTap, false)
 	cniClient.EXPECT().Add(gomock.Any(), cniConfig).Return(nil, nil).Times(1)
 	err = fc.ConfigureInterface(ctx, netNSPath, branchENI, nil)
 	require.NoError(t, err)
 
 	// Delete workflow.
 	branchENI.DesiredStatus = status.NetworkDeleted
-	cniConfig = createBranchENIConfig(netNSPath, branchENI, VPCBranchENIInterfaceTypeTap)
+	cniConfig = createBranchENIConfig(netNSPath, branchENI, VPCBranchENIInterfaceTypeTap, false)
 	cniClient.EXPECT().Del(gomock.Any(), cniConfig).Return(nil).Times(1)
 	err = fc.ConfigureInterface(ctx, netNSPath, branchENI, nil)
 	require.NoError(t, err)


### PR DESCRIPTION

### Summary
This PR fixes an issue in warmpool branch ENIs.  Tasks running on trunk ENIs in awsvpc mode need to block access to IMDS endpoint to be consistent with existing awsvpc behaviour. 

### Implementation details
Populate the `BlockIMDS` attribute in `VPCBranchENIConfig` when we create branch ENIs. This attribute is a config parameter for the CNI plugin to configures vpc branch enis. 

### Testing
- Tested on Fargate warmpool instances with trunk ENI's using gamma endpoint. 
(See internal document for details)
- make test

Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
No, we have end to end tests in Fargate Agent that validates this behavior. 

### Description for the changelog

Bug: Fixed issue in Fargate Trunk ENIs in non-firecracker platforms. This change blocks IMDS in awsvpc task network namespace. 
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
