### PR TITLE
fix[credentialsfetcher]: Assign gMSA leasId to CredentialSpecResource

### DIFF
--- a/agent/taskresource/credentialspec/credentialspec_linux.go
+++ b/agent/taskresource/credentialspec/credentialspec_linux.go
@@ -290,6 +290,7 @@ func (cs *CredentialSpecResource) handleDomainlessKerberosTicketCreation() error
 				cs.setTerminalReason(err.Error())
 				return fmt.Errorf("failed to create kerberos tickets associated service account %s: %w", v.domainlessGmsaUserArn, err)
 			}
+			cs.leaseID = response.LeaseID
 			seelog.Infof("credentials fetcher response leaseID: %v", cs.leaseID)
 			cs.CredSpecMap[k] = response.KerberosTicketPaths[0]
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Fix gMSA on Linux credentialSpec container cleanup for credentialfetcher tasks by properly assigning leaseId to taskResource, ensuring ticket cleanup when tasks are stopped.

### Implementation details
- Assigned leaseId from gMSA client response to credentialSpec taskResource object
- This enables the task resource [cleanup](https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/task_manager.go#L1537) method to properly delete tickets using leaseId during [task cleanup](https://github.com/aws/amazon-ecs-agent/blob/0f876b5372c9ecb15228f607f11d2c4be629d364/agent/taskresource/credentialspec/credentialspec_linux.go#L581)
- Previously, tickets remained after task stopping due to missing leaseId assignment in taskResource

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
**Unit Test**
- `make test`

**Function Test**
- Ran a credentialfetcher task on an AL2023 EC2 instance - [Using gMSA for EC2 Linux containers on Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/linux-gmsa.html#linux-gmsa-prerequisites)
- Verified the ticket has been created in `/var/credentials-fetcher/krbdir/`
- Stopped the task 
- Verified the ticket has been deleted after a [default wait period](https://github.com/aws/amazon-ecs-agent/blob/0f876b5372c9ecb15228f607f11d2c4be629d364/agent/config/config.go#L59) of 3 hours
```
/var/log/ecs/ecs-agent.log.2025-02-06-01:level=info time=2025-02-06T01:50:40Z msg="Managed task has reached stopped; waiting for container cleanup" task="xxx"
/var/log/ecs/ecs-agent.log.2025-02-06-04:level=info time=2025-02-06T04:50:40Z msg="Resource cleanup complete" task="xxx" resource="credentialspec"
```

New tests cover the changes: <!-- n/a -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug: Ensure proper cleanup of gMSA Linux credentials by assigning leaseId to taskResource for credentialfetcher tasks
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** - No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** - No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
