### PR TITLE
Introduce SetCustomReceiver in the logger

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/custom_receiver.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/custom_receiver.go
@@ -1,0 +1,61 @@
+package logger
+
+import (
+	"fmt"
+
+	"github.com/cihub/seelog"
+)
+
+// CustomReceiver defines the interface for custom logging implementations
+type CustomReceiver interface {
+	GetOutputFormat() string
+	Trace(message string)
+	Debug(message string)
+	Info(message string)
+	Warn(message string)
+	Error(message string)
+	Critical(message string)
+	Flush() error
+	Close() error
+}
+
+// internal wrapper that implements seelog.CustomReceiver
+type customReceiverWrapper struct {
+	receiver CustomReceiver
+}
+
+func (w *customReceiverWrapper) ReceiveMessage(message string, level seelog.LogLevel, context seelog.LogContextInterface) error {
+
+	switch level {
+	case seelog.TraceLvl:
+		w.receiver.Trace(message)
+	case seelog.DebugLvl:
+		w.receiver.Debug(message)
+	case seelog.InfoLvl:
+		w.receiver.Info(message)
+	case seelog.WarnLvl:
+		w.receiver.Warn(message)
+	case seelog.ErrorLvl:
+		w.receiver.Error(message)
+	case seelog.CriticalLvl:
+		w.receiver.Critical(message)
+	default:
+		fmt.Printf("Unhandled level: %v", level)
+	}
+	return nil
+}
+
+func (w *customReceiverWrapper) AfterParse(initArgs seelog.CustomReceiverInitArgs) error {
+	return nil
+}
+
+func (w *customReceiverWrapper) Flush() {
+	err := w.receiver.Flush()
+	if err != nil {
+		fmt.Printf("Couldn't flush the logger due to: %v", err)
+	}
+}
+
+func (w *customReceiverWrapper) Close() error {
+	return w.receiver.Close()
+}

--- a/ecs-agent/logger/custom_receiver.go
+++ b/ecs-agent/logger/custom_receiver.go
@@ -1,0 +1,61 @@
+package logger
+
+import (
+	"fmt"
+
+	"github.com/cihub/seelog"
+)
+
+// CustomReceiver defines the interface for custom logging implementations
+type CustomReceiver interface {
+	GetOutputFormat() string
+	Trace(message string)
+	Debug(message string)
+	Info(message string)
+	Warn(message string)
+	Error(message string)
+	Critical(message string)
+	Flush() error
+	Close() error
+}
+
+// internal wrapper that implements seelog.CustomReceiver
+type customReceiverWrapper struct {
+	receiver CustomReceiver
+}
+
+func (w *customReceiverWrapper) ReceiveMessage(message string, level seelog.LogLevel, context seelog.LogContextInterface) error {
+
+	switch level {
+	case seelog.TraceLvl:
+		w.receiver.Trace(message)
+	case seelog.DebugLvl:
+		w.receiver.Debug(message)
+	case seelog.InfoLvl:
+		w.receiver.Info(message)
+	case seelog.WarnLvl:
+		w.receiver.Warn(message)
+	case seelog.ErrorLvl:
+		w.receiver.Error(message)
+	case seelog.CriticalLvl:
+		w.receiver.Critical(message)
+	default:
+		fmt.Printf("Unhandled level: %v", level)
+	}
+	return nil
+}
+
+func (w *customReceiverWrapper) AfterParse(initArgs seelog.CustomReceiverInitArgs) error {
+	return nil
+}
+
+func (w *customReceiverWrapper) Flush() {
+	err := w.receiver.Flush()
+	if err != nil {
+		fmt.Printf("Couldn't flush the logger due to: %v", err)
+	}
+}
+
+func (w *customReceiverWrapper) Close() error {
+	return w.receiver.Close()
+}

--- a/ecs-agent/logger/mocks/custom_logger_receiver.go
+++ b/ecs-agent/logger/mocks/custom_logger_receiver.go
@@ -1,0 +1,99 @@
+package mock_seelog
+
+import (
+	"sync"
+
+	"github.com/cihub/seelog"
+)
+
+type CustomLoggerReceiver struct {
+	OutputFormat        string
+	Mu                  sync.Mutex
+	TraceCalled         bool
+	LastTraceMessage    string
+	DebugCalled         bool
+	LastDebugMessage    string
+	InfoCalled          bool
+	LastInfoMessage     string
+	WarnCalled          bool
+	LastWarnMessage     string
+	ErrorCalled         bool
+	LastErrorMessage    string
+	CriticalCalled      bool
+	LastCriticalMessage string
+}
+
+func (m *CustomLoggerReceiver) GetOutputFormat() string {
+	return m.OutputFormat
+}
+
+func (m *CustomLoggerReceiver) Trace(message string) {
+	m.Mu.Lock()
+	defer m.Mu.Unlock()
+	m.TraceCalled = true
+	m.LastTraceMessage = message
+}
+
+func (m *CustomLoggerReceiver) Debug(message string) {
+	m.Mu.Lock()
+	defer m.Mu.Unlock()
+	m.DebugCalled = true
+	m.LastDebugMessage = message
+}
+
+func (m *CustomLoggerReceiver) Info(message string) {
+	m.Mu.Lock()
+	defer m.Mu.Unlock()
+	m.InfoCalled = true
+	m.LastInfoMessage = message
+}
+
+func (m *CustomLoggerReceiver) Warn(message string) {
+	m.Mu.Lock()
+	defer m.Mu.Unlock()
+	m.WarnCalled = true
+	m.LastWarnMessage = message
+}
+
+func (m *CustomLoggerReceiver) Error(message string) {
+	m.Mu.Lock()
+	defer m.Mu.Unlock()
+	m.ErrorCalled = true
+	m.LastErrorMessage = message
+}
+
+func (m *CustomLoggerReceiver) Critical(message string) {
+	m.Mu.Lock()
+	defer m.Mu.Unlock()
+	m.CriticalCalled = true
+	m.LastCriticalMessage = message
+}
+
+func (m *CustomLoggerReceiver) Flush() error {
+	return nil
+}
+func (m *CustomLoggerReceiver) AfterParse(args interface{}) error {
+	return nil
+}
+
+func (m *CustomLoggerReceiver) Close() error {
+	return nil
+}
+
+func (m *CustomLoggerReceiver) ReceiveMessage(message string, level seelog.LogLevel,
+	context seelog.LogContextInterface) error {
+
+	switch level {
+	case seelog.DebugLvl:
+		m.Debug(message)
+	case seelog.InfoLvl:
+		m.Info(message)
+	case seelog.WarnLvl:
+		m.Warn(message)
+	case seelog.ErrorLvl:
+		m.Error(message)
+	case seelog.CriticalLvl:
+		m.Error(message)
+	}
+	return nil
+}

--- a/scripts/changelog/changelog.go
+++ b/scripts/changelog/changelog.go
@@ -148,10 +148,11 @@ func getRPMChangeString(allChange []Change) string {
 //
 // amazon-ecs-init (1.36.0-1) stable; urgency=medium
 //
-//  * Cache Agent version 1.36.0
-//  * capture a fixed tail of container logs when removing a container
+//   - Cache Agent version 1.36.0
 //
-//  -- Cameron Sparr <cssparr@amazon.com> Wed, 08 Jan 2020 11:00:00 -0800
+//   - capture a fixed tail of container logs when removing a container
+//
+//     -- Cameron Sparr <cssparr@amazon.com> Wed, 08 Jan 2020 11:00:00 -0800
 func getUbuntuChangeString(allChange []Change) string {
 	result := ""
 	for _, change := range allChange {
@@ -171,9 +172,9 @@ func getUbuntuChangeString(allChange []Change) string {
 // -------------------------------------------------------------------
 // Tue Apr 22 20:54:26 UTC 2013 - your@email.com
 //
-// - level 1 bullet point; long descriptions
-//   should wrap
-// - another l1 bullet point
+//   - level 1 bullet point; long descriptions
+//     should wrap
+//   - another l1 bullet point
 func getSuseChangeString(allChange []Change) string {
 	result := ""
 	for _, change := range allChange {
@@ -190,9 +191,9 @@ func getSuseChangeString(allChange []Change) string {
 
 // format as follows
 //
-//  ## 1.35.0
-//  * Cache Agent version 1.36.0
-//  * capture a fixed tail of container logs when removing a container
+//	## 1.35.0
+//	* Cache Agent version 1.36.0
+//	* capture a fixed tail of container logs when removing a container
 func getTopLevelChangeString(allChange []Change) string {
 	result := "# Changelog\n\n"
 	for _, change := range allChange {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
SetCustomReceiver configures the ECS Agent logger to use a custom logger implementation. This allows external applications to intercept and handle ECS Agent logs in their own way, such as sending logs to a custom destination or formatting them differently. More details can be found [here](https://github.com/cihub/seelog/wiki/Custom-receivers)
The custom receiver must implement the CustomReceiver interface, which requires:
- GetOutputFormat(): returns the desired output format ("logfmt", "json", or "windows")
- Log handling methods (Debug, Info, Warn, etc.)

### Implementation details
- Introduce a new public API `SetCustomReceiver` which accepts a customReceiver. This path is independent of the Config and creates its own custom config. It uses this config along with the receiver to create a replacement logger. The formatting of the message is still handled by seelog. 
- Introduce locks for timestampFormat to avoid race conditions while accessing it asynchronously


### Testing
Tested via the unit tests to make sure that the logging functions in the receiver were triggered with the correct message
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
