### PR TITLE
Migrating awserr ResponseError to smithy ResponseError in GetRequestFailureStatusCode 

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -551,7 +551,7 @@ func (agent *ecsAgent) waitUntilInstanceInService(pollWaitDuration time.Duration
 		if err != nil {
 			// Do not exit if error is due to throttling or temporary server errors
 			// These are likely transient, as at this point IMDS has been successfully queried for state
-			switch utils.GetRequestFailureStatusCode(err) {
+			switch utils.GetResponseErrorStatusCode(err) {
 			case 429, 500, 502, 503, 504:
 				seelog.Warnf("Encountered error while waiting for warmed instance to go in service: %v", err)
 			default:
@@ -569,7 +569,7 @@ func (agent *ecsAgent) pollUntilTargetLifecyclePresent(pollWaitDuration time.Dur
 	for i := 0; i < pollMaxTimes; i++ {
 		targetState, err = agent.getTargetLifecycle(maxRetries)
 		if targetState != "" ||
-			(err != nil && utils.GetRequestFailureStatusCode(err) != 404) {
+			(err != nil && utils.GetResponseErrorStatusCode(err) != 404) {
 			break
 		}
 		time.Sleep(pollWaitDuration)

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.42
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.18
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.41.1
+	github.com/aws/smithy-go v1.22.2
 	github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit v0.0.0-20210308162251-8959c62cb8f9
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
 	github.com/container-storage-interface/spec v1.8.0
@@ -53,7 +54,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.32.3 // indirect
-	github.com/aws/smithy-go v1.22.2 // indirect
 	github.com/cilium/ebpf v0.16.0 // indirect
 	github.com/containerd/containerd v1.7.24 // indirect
 	github.com/containerd/log v0.1.0 // indirect


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will aim to fix an issue where we're trying to type cast the `RequestError` type from AWS SDK Go V1 for any errors in EC2 IMDS `GetMetadata` calls which we are now using AWS SDK Go V2. Because of this when we hit an issue where when we're polling for the container instance to join an ASG and we hit any errors, agent will exit because it couldn't recognize the error as different error types are being used in V2. There's specific status codes that agent checks for to continue polling in case of any transient issue which it currently can't get any at all.

This issue can only happen when `ECS_WARM_POOLS_CHECK` is set to `true`. 

https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/handle-errors.html

Related Github Issue: https://github.com/aws/amazon-ecs-agent/issues/4487

### Implementation details
* `GetRequestFailureStatusCode` -> `GetResponseErrorStatusCode`
  *  Changed `awserr.RequestFailure` to `smithy.ResponseError` to obtain the status code

### Testing
* Updated test cases to use `smithy.OperationError` as well from `awserr.RequestFailure`.

Manual testing:
* Created a custom AMI with changes and launched a container instance with `ECS_WARM_POOLS_CHECK` set to `true`. Expected behavior is for agent to no longer exit with non-zero and continue polling.

Standalone instance:
```
level=info time=2025-02-27T19:29:23Z msg="Event stream ContainerChange start listening..." module=eventstream.go
level=info time=2025-02-27T19:29:23Z msg="Loading state!" module=state_manager.go
level=info time=2025-02-27T19:29:23Z msg="Waiting for instance to go InService" module=agent.go
level=debug time=2025-02-27T19:29:23Z msg="Error when getting intended lifecycle state: operation error ec2imds: GetMetadata, http response error StatusCode: 404, request to EC2 IMDS failed" module=agent.go
level=debug time=2025-02-27T19:29:25Z msg="Error when getting intended lifecycle state:
[ec2-user@ip-172-31-17-238 ~]$ docker ps
CONTAINER ID   IMAGE                            COMMAND    CREATED         STATUS                     PORTS     NAMES
ce1a28ad4010   amazon/amazon-ecs-agent:latest   "/agent"   7 minutes ago   Up 7 minutes (unhealthy)             ecs-agent
```

Warmpool instance that eventually joins an ASG
```
level=info time=2025-02-27T19:38:29Z msg="Event stream ContainerChange start listening..." module=eventstream.go
level=info time=2025-02-27T19:38:29Z msg="Loading state!" module=state_manager.go
level=info time=2025-02-27T19:38:29Z msg="Waiting for instance to go InService" module=agent.go
level=debug time=2025-02-27T19:38:29Z msg="Error when getting intended lifecycle state: operation error ec2imds: GetMetadata, http response error StatusCode: 404, request to EC2 IMDS failed" module=agent.go
level=debug time=2025-02-27T19:38:30Z msg="Error when getting intended lifecycle state: operation error ec2imds: GetMetadata, http response error StatusCode: 404, request to EC2 IMDS failed" module=agent.go
level=debug time=2025-02-27T19:38:31Z msg="Error when getting intended lifecycle state: operation error ec2imds: GetMetadata, http response error StatusCode: 404, request to EC2 IMDS failed" module=agent.go
level=debug time=2025-02-27T19:38:33Z msg="Target lifecycle state of instance: " module=agent.go
level=debug time=2025-02-27T19:39:33Z msg="Error when getting intended lifecycle state: operation error ec2imds: GetMetadata, http response error StatusCode: 404, request to EC2 IMDS failed" module=agent.go
level=debug time=2025-02-27T19:39:34Z msg="Error when getting intended lifecycle state: operation error ec2imds: GetMetadata, http response error StatusCode: 404, request to EC2 IMDS failed" module=agent.go
level=debug time=2025-02-27T19:39:36Z msg="Error when getting intended lifecycle state: operation error ec2imds: GetMetadata, http response error StatusCode: 404, request to EC2 IMDS failed" module=agent.go
level=debug time=2025-02-27T19:39:38Z msg="Target lifecycle state of instance: " module=agent.go
level=debug time=2025-02-27T19:40:38Z msg="Target lifecycle state of instance: InService" module=agent.go
level=debug time=2025-02-27T19:40:38Z msg="Loading pause container tarball:" image="/images/amazon-ecs-pause.tar"
level=debug time=2025-02-27T19:40:38Z msg="Inspecting container image: " image="amazon/amazon-ecs-pause:0.1.0"
level=debug time=2025-02-27T19:40:38Z msg="Setting up ENI Watcher" module=agent_unix.go
level=info time=2025-02-27T19:40:38Z msg="eni watcher has been initialized" module=watcher_linux.go
level=info time=2025-02-27T19:40:38Z msg="Successfully got ECS instance credentials from provider: EC2RoleProvider"
level=debug time=2025-02-27T19:40:38Z msg="Extended supported docker API versions" supportedAPIVersions=[1.17 1.18 1.19 1.20 1.21 1.22 1.23 1.24 1.25 1.26 1.27 1.28 1.29 1.30 1.31 1.32 1.33 1.34 1.35 1.36 1.37 1.38 1.39 1.40 1.41 1.42 1.43 1.44]
level=debug time=2025-02-27T19:40:38Z msg="Inspecting container image: " image="amazon/amazon-ecs-pause:0.1.0"
level=debug time=2025-02-27T19:40:38Z msg="Inspecting container image: " image="ecs-service-connect-agent:interface-"
level=debug time=2025-02-27T19:40:38Z msg="Loading Appnet agent container tarball: /managed-agents/serviceconnect/ecs-service-connect-agent.interface-v1.tar"
level=info time=2025-02-27T19:40:58Z msg="Successfully loaded Appnet agent container tarball: /managed-agents/serviceconnect/ecs-service-connect-agent.interface-v1.tar" image="ecs-service-connect-agent:interface-v1"
level=debug time=2025-02-27T19:40:58Z msg="Inspecting container image: " image="ecs-service-connect-agent:interface-v1"
level=debug time=2025-02-27T19:40:58Z msg="Found route" Route={Ifindex: 2 Dst: <nil> Src: 172.31.19.51 Gw: 172.31.16.1 Flags: [] Table: 254 Realm: 0}
level=debug time=2025-02-27T19:40:58Z msg="Found the associated network interface by the index" LinkName="ens5" LinkIndex=2
level=debug time=2025-02-27T19:40:59Z msg="Fault injection capability is enabled." module=agent_capability.go
level=info time=2025-02-27T19:40:59Z msg="Registering Instance with ECS"
level=debug time=2025-02-27T19:40:59Z msg="Attempting to get Instance Identity Document"
level=debug time=2025-02-27T19:40:59Z msg="Successfully retrieved Instance Identity Document"
level=debug time=2025-02-27T19:40:59Z msg="Attempting to get Instance Identity Signature"
level=debug time=2025-02-27T19:40:59Z msg="Successfully retrieved Instance Identity Signature"
level=info time=2025-02-27T19:40:59Z msg="Remaining memory" remainingMemory=3785
level=info time=2025-02-27T19:40:59Z msg="Registered container instance with cluster!"
level=info time=2025-02-27T19:40:59Z msg="Instance registration completed successfully" instanceArn="arn:aws:ecs:us-west-2:113424923516:container-instance/default/8f0f52f80d164d76a421a030738c293b" cluster="default"
[ec2-user@ip-172-31-19-51 ~]$ docker ps
CONTAINER ID   IMAGE                            COMMAND    CREATED          STATUS                    PORTS     NAMES
4e14792aad5b   amazon/amazon-ecs-agent:latest   "/agent"   13 minutes ago   Up 13 minutes (healthy)             ecs-agent
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Bugfix: Migrate over to smithy ResponseError for obtaining status code of IMDS GetMetadata calls

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
