### PR TITLE
Modifying Amazon Linux ECS init RPM spec file to bake in the EBS CSI Driver tar file

### DIFF
--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -24,6 +24,7 @@
 %global no_exec_perm 644
 %global debug_package %{nil}
 %global agent_image ecs-agent-v%{version}.tar
+%global ebs_csi_driver_dir /var/lib/ecs/deps/daemons/ebs-csi-driver
 
 Name:           ecs-init
 Version:        1.91.0
@@ -38,6 +39,8 @@ Source2:        ecs.service
 Source3:        amazon-ecs-volume-plugin.service
 Source4:        amazon-ecs-volume-plugin.socket
 Source5:        amazon-ecs-volume-plugin.conf
+Source6:        ebs-csi-driver-arm64-v%{version}.tar
+Source7:        ebs-csi-driver-v%{version}.tar
 
 BuildRequires:  golang >= 1.22.0
 %if %{with systemd}
@@ -171,6 +174,13 @@ mkdir -p %{buildroot}%{_sysconfdir}/ecs
 touch %{buildroot}%{_sysconfdir}/ecs/ecs.config
 touch %{buildroot}%{_sysconfdir}/ecs/ecs.config.json
 
+mkdir -p %{buildroot}%{ebs_csi_driver_dir}
+%ifarch aarch64
+install -m %{no_exec_perm} -D %{SOURCE6} %{buildroot}%{ebs_csi_driver_dir}/ebs-csi-driver.tar
+%else
+install -m %{no_exec_perm} -D %{SOURCE7} %{buildroot}%{ebs_csi_driver_dir}/ebs-csi-driver.tar
+%endif
+
 # Configure ecs-init to reload the bundled ECS container agent image.
 mkdir -p %{buildroot}%{_cachedir}/ecs
 echo 2 > %{buildroot}%{_cachedir}/ecs/state
@@ -198,6 +208,8 @@ install -m %{no_exec_perm} -D %{SOURCE5} %{buildroot}%{_sysconfdir}/init/amazon-
 %{_cachedir}/ecs/%{basename:%{agent_image}}
 %{_cachedir}/ecs/state
 %dir %{_sharedstatedir}/ecs/data
+%dir %{ebs_csi_driver_dir}
+%{ebs_csi_driver_dir}/ebs-csi-driver.tar
 
 %if %{with systemd}
 %{_unitdir}/ecs.service


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will introduce baking in the EBS CSI driver image tar file as part of the ECS Init RPM builds for Amazon Linux platforms. This essentially should have no functional changes/impact to ECS.

### Implementation details
* `Makefile`
  * New make target called `ebs-csi-driver-codebuild` which will build and move the EBS CSI Driver tar files (for both x86 and ARM) into the working directory for ECS Init RPM build.
  * Modify the `amazon-linux-rpm-codebuild-done` make target to call `ebs-csi-driver-codebuild` so that the CSI drivers get built as part of our Codebuild project dor ECS init RPM build for Amazon Linux platforms
* `packaging/amazon-linux-ami-integrated/ecs-agent.spec`
  * Added both ARM and x86 EBS CSI driver tar file as sources for the Amazon Linux ECS Init RPM build but will only bake in/include the corresponding TAR file based on the platform

### Testing

Manual/Local testing:

Ran `make amazon-linux-rpm-codebuild ` locally
```
[ec2-user@ip-172-31-22-20 amazon-ecs-agent]$ make amazon-linux-rpm-codebuild
pattern ./agent/...: directory prefix agent does not contain main module or its selected dependencies
pattern ./ecs-agent/...: directory prefix ecs-agent does not contain main module or its selected dependencies
git submodule update --init --recursive
make -C ./ecs-agent/daemonimages/csidriver  tarfiles/ebs-csi-driver.tar
make[1]: Entering directory `/home/ec2-user/go/src/github.com/aws/amazon-ecs-agent/ecs-agent/daemonimages/csidriver'
docker build --build-arg GO_VERSION=1.22.7 -t "ebs-csi-driver:latest" .
[+] Building 34.9s (12/12) FINISHED                                                                                                                                                                  docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                           0.0s
 => => transferring dockerfile: 1.04kB                                                                                                                                                                         0.0s
 => [internal] load metadata for public.ecr.aws/docker/library/golang:1.22.7                                                                                                                                   0.2s
 => [internal] load metadata for public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest-al2                                                                                            0.2s
 => [internal] load .dockerignore                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                0.0s
 => CACHED [stage-1 1/2] FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest-al2@sha256:3cc57051405bc34c84c5c027e50394bf78550abf7ce4813834b47d52b9f5873e                       0.0s
 => [build 1/4] FROM public.ecr.aws/docker/library/golang:1.22.7@sha256:ddad33062f94a276b78c1d536b70d23f5d2548f619e3dd67aa5972bb415fe648                                                                       0.0s
 => [internal] load build context                                                                                                                                                                              0.5s
 => => transferring context: 59.71MB                                                                                                                                                                           0.5s
 => CACHED [build 2/4] WORKDIR /go/src/                                                                                                                                                                        0.0s
 => [build 3/4] ADD . /go/src/                                                                                                                                                                                 1.0s
 => [build 4/4] RUN make bin/ebs-csi-driver                                                                                                                                                                   32.7s
 => [stage-1 2/2] COPY --from=build /go/src/bin/ebs-csi-driver /bin/ebs-csi-driver                                                                                                                             0.1s 
 => exporting to image                                                                                                                                                                                         0.1s 
 => => exporting layers                                                                                                                                                                                        0.1s 
 => => writing image sha256:469fcd5ae3f0ea9bd201e21ba20867f2a51631e6d2c9beb2e04c31a80de3408d                                                                                                                   0.0s 
 => => naming to docker.io/library/ebs-csi-driver:latest                                                                                                                                                       0.0s
mkdir -p tarfiles
docker save "ebs-csi-driver:latest" > tarfiles/ebs-csi-driver.tar
make[1]: Leaving directory `/home/ec2-user/go/src/github.com/aws/amazon-ecs-agent/ecs-agent/daemonimages/csidriver'
cp ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar ebs-csi-driver-v1.91.0.tar
cp ecs-agent/daemonimages/csidriver/tarfiles/ebs-csi-driver.tar ebs-csi-driver-arm64-v1.91.0.tar
...
solv.so.2()(64bit) libresolv.so.2(GLIBC_2.2.5)(64bit) rtld(GNU_HASH)
Checking for unpackaged file(s): /usr/lib/rpm/check-files /home/ec2-user/go/src/github.com/aws/amazon-ecs-agent/BUILDROOT/ecs-init-1.91.0-1.amzn2.x86_64
Wrote: /home/ec2-user/go/src/github.com/aws/amazon-ecs-agent/RPMS/x86_64/ecs-init-1.91.0-1.amzn2.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.0ysyFF
+ umask 022
+ cd /home/ec2-user/go/src/github.com/aws/amazon-ecs-agent/BUILD
+ cd ecs-init-1.91.0
+ /usr/bin/rm -rf /home/ec2-user/go/src/github.com/aws/amazon-ecs-agent/BUILDROOT/ecs-init-1.91.0-1.amzn2.x86_64
+ exit 0
find RPMS/ -type f -exec cp {} . \;
touch .amazon-linux-rpm-codebuild-done
[ec2-user@ip-172-31-22-20 amazon-ecs-agent]$ ls
agent                             amazon-vpc-cni-plugins         buildspec-ecr-upload.yml  dependencies_mocks.go             ecs.conf                            INIT_CHANGELOG.md  proposals   sources.tgz
agent-container                   aws-sdk-go-v2                  buildspecs                doc                               ecs-init                            LICENSE            README.md   SPECS
amazon-ecs-cni-plugins            BUILD                          buildspec.yml             ebs-csi-driver-arm64-v1.91.0.tar  ecs-init-1.91.0-1.amzn2.x86_64.rpm  Makefile           RPMS        SRPMS
amazon-ecs-volume-plugin.conf     build-infrastructure           CHANGELOG.md              ebs-csi-driver-v1.91.0.tar        ecs.service                         misc               scripts     VERSION
amazon-ecs-volume-plugin.service  BUILDROOT                      CODE_OF_CONDUCT.md        ecs-agent                         GO_VERSION                          NOTICE             seelog.xml
amazon-ecs-volume-plugin.socket   buildspec-ecr-replication.yml  CONTRIBUTING.md           ecs-agent.spec                    GO_VERSION_WINDOWS                  packaging          SOURCES
```

Created AMIs (both x86 and ARM) with the new ECS Init RPMs

AL2 AMI
```
[ec2-user@ip-172-31-20-219 ~]$ docker ps
CONTAINER ID   IMAGE                            COMMAND    CREATED              STATUS                        PORTS     NAMES
ce55f624912a   amazon/amazon-ecs-agent:latest   "/agent"   About a minute ago   Up About a minute (healthy)             ecs-agent
[ec2-user@ip-172-31-20-219 ~]$ docker images
REPOSITORY                  TAG            IMAGE ID       CREATED             SIZE
amazon/amazon-ecs-agent     latest         41779a717384   About an hour ago   106MB
ecs-service-connect-agent   interface-v1   e1f354809f1d   4 weeks ago         168MB
ebs-csi-driver              latest         d474c3f07556   5 weeks ago         57.1MB
busybox                     latest         31311c5853a2   5 months ago        4.27MB
amazon/amazon-ecs-pause     0.1.0          9dd4685d3644   10 years ago        702kB
[ec2-user@ip-172-31-20-219 ~]$ docker ps
CONTAINER ID   IMAGE                            COMMAND                  CREATED          STATUS                   PORTS     NAMES
51895b04d7fd   busybox:latest                   "sh -c 'echo 'Help I…"   37 seconds ago   Up 37 seconds                      ecs-trapped-once-1-trapped1-82e4dfdb80e4be8d1f00
6ce9bb65409b   ebs-csi-driver:latest            "/bin/ebs-csi-driver…"   44 seconds ago   Up 43 seconds                      ecs---ecs-managed-ebs-csi-driver-e6aed0e6ad8e8cf8da01
ea7606f5a8a5   amazon/amazon-ecs-agent:latest   "/agent"                 3 minutes ago    Up 3 minutes (healthy)             ecs-agent
[ec2-user@ip-172-31-20-219 ~]$ lsblk
NAME          MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
nvme0n1       259:0    0  30G  0 disk 
├─nvme0n1p1   259:1    0  30G  0 part /
└─nvme0n1p128 259:2    0   1M  0 part 
nvme1n1       259:3    0   5G  0 disk /mnt/ecs/ebs/d8ec2cbc3bf44924b2eb827e466851e6_vol-03bcdab42bfb0e014
[ec2-user@ip-172-31-20-219 ~]$ cat /var/log/ecs/daemons/ebs-csi-driver/csi.log
Log file created at: 2025/03/05 00:29:58
Running on machine: 6ce9bb65409b
Binary: Built with gc go1.22.7 for linux/amd64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
I0305 00:29:58.775004       1 driver.go:51] "Driver Information" Driver="csi-driver" Version="v1.0.0"
I0305 00:29:58.981739       1 node_linux.go:61] "Device Path:" Driver="/dev/nvme1n1" VolumeID="vol-03bcdab42bfb0e014" Partition=""
I0305 00:29:58.981758       1 node_linux.go:75] "Device Path:" Driver="/dev/nvme1n1" VolumeID="vol-03bcdab42bfb0e014" Partition=""
I0305 00:29:59.000691       1 mount_linux.go:572] Disk "/dev/nvme1n1" appears to be unformatted, attempting to format as type: "ext4" with options: [-F -m0 /dev/nvme1n1]
I0305 00:29:59.227752       1 mount_linux.go:583] Disk successfully formatted (mkfs): ext4 - /dev/nvme1n1 /mnt/ecs/ebs/d8ec2cbc3bf44924b2eb827e466851e6_vol-03bcdab42bfb0e014
[ec2-user@ip-172-31-20-219 ~]$ cat /mnt/ecs/ebs/d8ec2cbc3bf44924b2eb827e466851e6_vol-03bcdab42bfb0e014/hello.txt 
Help I am trapped in a container
[ec2-user@ip-172-31-20-219 ~]$ docker ps
CONTAINER ID   IMAGE                            COMMAND                  CREATED         STATUS                   PORTS     NAMES
6ce9bb65409b   ebs-csi-driver:latest            "/bin/ebs-csi-driver…"   4 minutes ago   Up 4 minutes                       ecs---ecs-managed-ebs-csi-driver-e6aed0e6ad8e8cf8da01
ea7606f5a8a5   amazon/amazon-ecs-agent:latest   "/agent"                 7 minutes ago   Up 7 minutes (healthy)             ecs-agent
[ec2-user@ip-172-31-20-219 ~]$ lsblk
NAME          MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
nvme0n1       259:0    0  30G  0 disk 
├─nvme0n1p1   259:1    0  30G  0 part /
└─nvme0n1p128 259:2    0   1M  0 part 
[ec2-user@ip-172-31-20-219 ~]$ ls /mnt/ecs/ebs/
```

AL2 ARM AMI:
```
[ec2-user@ip-172-31-3-132 ~]$ docker ps
CONTAINER ID   IMAGE                            COMMAND    CREATED          STATUS                    PORTS     NAMES
961b5ff8260f   amazon/amazon-ecs-agent:latest   "/agent"   41 seconds ago   Up 35 seconds (healthy)             ecs-agent
[ec2-user@ip-172-31-3-132 ~]$ docker images
REPOSITORY                  TAG            IMAGE ID       CREATED          SIZE
amazon/amazon-ecs-agent     latest         e51ce587696a   48 minutes ago   100MB
ecs-service-connect-agent   interface-v1   8ec1951a2963   4 weeks ago      166MB
ebs-csi-driver              latest         ec03f46f7b89   5 weeks ago      73.9MB
amazon/amazon-ecs-pause     0.1.0          cbcb5efed8f0   10 years ago     630kB
[ec2-user@ip-172-31-3-132 ~]$ docker ps
CONTAINER ID   IMAGE                            COMMAND                  CREATED              STATUS                    PORTS     NAMES
5b45e43be64c   busybox:latest                   "sh -c 'echo 'Help I…"   About a minute ago   Up About a minute                   ecs-trapped-once-1-trapped1-acd7e18bd980d9de8e01
d44d9e09bc5a   ebs-csi-driver:latest            "/bin/ebs-csi-driver…"   About a minute ago   Up About a minute                   ecs---ecs-managed-ebs-csi-driver-94bfb18de0c9d9e27200
961b5ff8260f   amazon/amazon-ecs-agent:latest   "/agent"                 20 minutes ago       Up 20 minutes (healthy)             ecs-agent
[ec2-user@ip-172-31-3-132 ~]$ lsblk
NAME          MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
nvme0n1       259:0    0  30G  0 disk 
├─nvme0n1p1   259:1    0  30G  0 part /
└─nvme0n1p128 259:2    0  10M  0 part /boot/efi
nvme1n1       259:3    0   5G  0 disk /mnt/ecs/ebs/5177cadcdee9478382877f43312e1ad0_vol-0496667849586f541
[ec2-user@ip-172-31-3-132 ~]$ cat /var/log/
amazon/                btmp                   cloud-init-output.log  ecs/                   lastlog                secure                 wtmp                   
audit/                 chrony/                cron                   grubby_prune_debug     maillog                spooler                yum.log                
boot.log               cloud-init.log         dmesg                  journal/               messages               tallylog               
[ec2-user@ip-172-31-3-132 ~]$ cat /var/log/ecs/
daemons/               ecs-agent.log          ecs-init.log           ecs-volume-plugin.log  exec/                  
[ec2-user@ip-172-31-3-132 ~]$ cat /var/log/ecs/daemons/ebs-csi-driver/csi.log 
Log file created at: 2025/03/05 00:27:45
Running on machine: d44d9e09bc5a
Binary: Built with gc go1.22.7 for linux/arm64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
I0305 00:27:45.804960       1 driver.go:51] "Driver Information" Driver="csi-driver" Version="v1.0.0"
I0305 00:27:45.925199       1 node_linux.go:61] "Device Path:" Driver="/dev/nvme1n1" VolumeID="vol-0496667849586f541" Partition=""
I0305 00:27:45.925223       1 node_linux.go:75] "Device Path:" Driver="/dev/nvme1n1" VolumeID="vol-0496667849586f541" Partition=""
I0305 00:27:45.943754       1 mount_linux.go:572] Disk "/dev/nvme1n1" appears to be unformatted, attempting to format as type: "xfs" with options: [-f /dev/nvme1n1]
I0305 00:27:45.990710       1 mount_linux.go:583] Disk successfully formatted (mkfs): xfs - /dev/nvme1n1 /mnt/ecs/ebs/5177cadcdee9478382877f43312e1ad0_vol-0496667849586f541
[ec2-user@ip-172-31-3-132 ~]$ cat /mnt/ecs/ebs/5177cadcdee9478382877f43312e1ad0_vol-0496667849586f541/hello.txt 
Help I am trapped in a container
[ec2-user@ip-172-31-3-132 ~]$ docker ps
CONTAINER ID   IMAGE                            COMMAND                  CREATED          STATUS                    PORTS     NAMES
d44d9e09bc5a   ebs-csi-driver:latest            "/bin/ebs-csi-driver…"   5 minutes ago    Up 5 minutes                        ecs---ecs-managed-ebs-csi-driver-94bfb18de0c9d9e27200
961b5ff8260f   amazon/amazon-ecs-agent:latest   "/agent"                 24 minutes ago   Up 24 minutes (healthy)             ecs-agent
[ec2-user@ip-172-31-3-132 ~]$ lsblk
NAME          MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
nvme0n1       259:0    0  30G  0 disk 
├─nvme0n1p1   259:1    0  30G  0 part /
└─nvme0n1p128 259:2    0  10M  0 part /boot/efi
```

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
Enhancement: Modify ECS agent spec file for Amazon Linux ECS RPM builds to include EBS CSI tar files

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
