### PR TITLE
Introspection: do not return version for Fargate agent

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/introspection/server.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/introspection/server.go
@@ -59,7 +59,7 @@ type Config struct {
 	readTimeout        time.Duration // http server read timeout
 	writeTimeout       time.Duration // http server write timeout
 	enableRuntimeStats bool          // enable profiling handlers
-	isManagedAgent     bool          // if true, do not show Version in metadata
+	hideAgentVersion   bool          // if true, do not show Version in metadata
 }
 
 // Function type for updating Introspection Server config
@@ -86,11 +86,11 @@ func WithWriteTimeout(writeTimeout time.Duration) ConfigOpt {
 	}
 }
 
-// Set Introspection Server managed agent flag. If true, the Version
+// Set flag to hide the agent version. If true, the Version
 // will be omitted from Agent Metadata responses.
-func IsManagedAgent(isManaged bool) ConfigOpt {
+func HideAgentVersion(isHidden bool) ConfigOpt {
 	return func(c *Config) {
-		c.isManagedAgent = isManaged
+		c.hideAgentVersion = isHidden
 	}
 }
 
@@ -106,8 +106,8 @@ func NewServer(agentState v1.AgentState, metricsFactory metrics.EntryFactory, op
 func v1HandlersSetup(serverMux *http.ServeMux,
 	agentState v1.AgentState,
 	metricsFactory metrics.EntryFactory,
-	isManagedAgent bool) {
-	serverMux.HandleFunc(handlers.V1AgentMetadataPath, handlers.AgentMetadataHandler(agentState, metricsFactory, isManagedAgent))
+	hideAgentVersion bool) {
+	serverMux.HandleFunc(handlers.V1AgentMetadataPath, handlers.AgentMetadataHandler(agentState, metricsFactory, hideAgentVersion))
 	serverMux.HandleFunc(handlers.V1TasksMetadataPath, handlers.TasksMetadataHandler(agentState, metricsFactory))
 	serverMux.HandleFunc(licensePath, licenseHandler(agentState, metricsFactory))
 }
@@ -152,7 +152,7 @@ func setup(
 	serveMux := http.NewServeMux()
 	serveMux.HandleFunc("/", defaultHandler)
 
-	v1HandlersSetup(serveMux, agentState, metricsFactory, config.isManagedAgent)
+	v1HandlersSetup(serveMux, agentState, metricsFactory, config.hideAgentVersion)
 	wTimeout := config.writeTimeout
 	if config.enableRuntimeStats {
 		pprofHandlerSetup(serveMux)

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/introspection/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/introspection/v1/handlers/handlers.go
@@ -65,16 +65,16 @@ func getHTTPErrorCode(err error) (int, string) {
 func AgentMetadataHandler(
 	agentState v1.AgentState,
 	metricsFactory metrics.EntryFactory,
-	isManagedAgent bool,
+	hideAgentVersion bool,
 ) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		agentMetadata, err := agentState.GetAgentMetadata()
-		if isManagedAgent {
-			managedAgentMetadata := v1.ManagedAgentMetadataResponse{
+		if hideAgentVersion {
+			unversionedAgentMetadata := v1.UnversionedAgentMetadataResponse{
 				Cluster:              agentMetadata.Cluster,
 				ContainerInstanceArn: agentMetadata.ContainerInstanceArn,
 			}
-			handleAgentMetadata(err, v1.ManagedAgentMetadataResponse{}, managedAgentMetadata, metricsFactory, w)
+			handleAgentMetadata(err, v1.UnversionedAgentMetadataResponse{}, unversionedAgentMetadata, metricsFactory, w)
 			return
 		}
 		handleAgentMetadata(err, v1.AgentMetadataResponse{}, agentMetadata, metricsFactory, w)

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/introspection/v1/response.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/introspection/v1/response.go
@@ -28,6 +28,13 @@ type AgentMetadataResponse struct {
 	Version              string  `json:"Version"`
 }
 
+// ManagedAgentMetadataResponse is the schema for the metadata response JSON object for
+// the managed agent platform.
+type ManagedAgentMetadataResponse struct {
+	Cluster              string  `json:"Cluster"`
+	ContainerInstanceArn *string `json:"ContainerInstanceArn"`
+}
+
 // TaskResponse is the schema for the task response JSON object.
 type TaskResponse struct {
 	Arn           string              `json:"Arn"`

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/introspection/v1/response.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/introspection/v1/response.go
@@ -28,9 +28,9 @@ type AgentMetadataResponse struct {
 	Version              string  `json:"Version"`
 }
 
-// ManagedAgentMetadataResponse is the schema for the metadata response JSON object for
-// the managed agent platform.
-type ManagedAgentMetadataResponse struct {
+// UnversionedAgentMetadataResponse is the schema for the metadata response JSON object
+// without the agent version.
+type UnversionedAgentMetadataResponse struct {
 	Cluster              string  `json:"Cluster"`
 	ContainerInstanceArn *string `json:"ContainerInstanceArn"`
 }

--- a/ecs-agent/introspection/server.go
+++ b/ecs-agent/introspection/server.go
@@ -59,7 +59,7 @@ type Config struct {
 	readTimeout        time.Duration // http server read timeout
 	writeTimeout       time.Duration // http server write timeout
 	enableRuntimeStats bool          // enable profiling handlers
-	isManagedAgent     bool          // if true, do not show Version in metadata
+	hideAgentVersion   bool          // if true, do not show Version in metadata
 }
 
 // Function type for updating Introspection Server config
@@ -86,11 +86,11 @@ func WithWriteTimeout(writeTimeout time.Duration) ConfigOpt {
 	}
 }
 
-// Set Introspection Server managed agent flag. If true, the Version
+// Set flag to hide the agent version. If true, the Version
 // will be omitted from Agent Metadata responses.
-func IsManagedAgent(isManaged bool) ConfigOpt {
+func HideAgentVersion(isHidden bool) ConfigOpt {
 	return func(c *Config) {
-		c.isManagedAgent = isManaged
+		c.hideAgentVersion = isHidden
 	}
 }
 
@@ -106,8 +106,8 @@ func NewServer(agentState v1.AgentState, metricsFactory metrics.EntryFactory, op
 func v1HandlersSetup(serverMux *http.ServeMux,
 	agentState v1.AgentState,
 	metricsFactory metrics.EntryFactory,
-	isManagedAgent bool) {
-	serverMux.HandleFunc(handlers.V1AgentMetadataPath, handlers.AgentMetadataHandler(agentState, metricsFactory, isManagedAgent))
+	hideAgentVersion bool) {
+	serverMux.HandleFunc(handlers.V1AgentMetadataPath, handlers.AgentMetadataHandler(agentState, metricsFactory, hideAgentVersion))
 	serverMux.HandleFunc(handlers.V1TasksMetadataPath, handlers.TasksMetadataHandler(agentState, metricsFactory))
 	serverMux.HandleFunc(licensePath, licenseHandler(agentState, metricsFactory))
 }
@@ -152,7 +152,7 @@ func setup(
 	serveMux := http.NewServeMux()
 	serveMux.HandleFunc("/", defaultHandler)
 
-	v1HandlersSetup(serveMux, agentState, metricsFactory, config.isManagedAgent)
+	v1HandlersSetup(serveMux, agentState, metricsFactory, config.hideAgentVersion)
 	wTimeout := config.writeTimeout
 	if config.enableRuntimeStats {
 		pprofHandlerSetup(serveMux)

--- a/ecs-agent/introspection/v1/handlers/handlers.go
+++ b/ecs-agent/introspection/v1/handlers/handlers.go
@@ -65,16 +65,16 @@ func getHTTPErrorCode(err error) (int, string) {
 func AgentMetadataHandler(
 	agentState v1.AgentState,
 	metricsFactory metrics.EntryFactory,
-	isManagedAgent bool,
+	hideAgentVersion bool,
 ) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		agentMetadata, err := agentState.GetAgentMetadata()
-		if isManagedAgent {
-			managedAgentMetadata := v1.ManagedAgentMetadataResponse{
+		if hideAgentVersion {
+			unversionedAgentMetadata := v1.UnversionedAgentMetadataResponse{
 				Cluster:              agentMetadata.Cluster,
 				ContainerInstanceArn: agentMetadata.ContainerInstanceArn,
 			}
-			handleAgentMetadata(err, v1.ManagedAgentMetadataResponse{}, managedAgentMetadata, metricsFactory, w)
+			handleAgentMetadata(err, v1.UnversionedAgentMetadataResponse{}, unversionedAgentMetadata, metricsFactory, w)
 			return
 		}
 		handleAgentMetadata(err, v1.AgentMetadataResponse{}, agentMetadata, metricsFactory, w)

--- a/ecs-agent/introspection/v1/handlers/handlers_test.go
+++ b/ecs-agent/introspection/v1/handlers/handlers_test.go
@@ -208,7 +208,7 @@ func TestAgentMetadataHandler(t *testing.T) {
 			name: "not found",
 			testCase: IntrospectionTestCase[*v1.AgentMetadataResponse]{
 				Path:          V1AgentMetadataPath,
-				AgentResponse: testAgentMetadata(),
+				AgentResponse: nil,
 				Err:           v1.NewErrorNotFound(internalErrorText),
 				MetricName:    metrics.IntrospectionNotFound,
 			},
@@ -220,7 +220,7 @@ func TestAgentMetadataHandler(t *testing.T) {
 			name: "fetch failure",
 			testCase: IntrospectionTestCase[*v1.AgentMetadataResponse]{
 				Path:          V1AgentMetadataPath,
-				AgentResponse: testAgentMetadata(),
+				AgentResponse: nil,
 				Err:           v1.NewErrorFetchFailure(internalErrorText),
 				MetricName:    metrics.IntrospectionFetchFailure,
 			},
@@ -232,7 +232,7 @@ func TestAgentMetadataHandler(t *testing.T) {
 			name: "unkown error",
 			testCase: IntrospectionTestCase[*v1.AgentMetadataResponse]{
 				Path:          V1AgentMetadataPath,
-				AgentResponse: testAgentMetadata(),
+				AgentResponse: nil,
 				Err:           errors.New(internalErrorText),
 				MetricName:    metrics.IntrospectionInternalServerError,
 			},

--- a/ecs-agent/introspection/v1/handlers/handlers_test.go
+++ b/ecs-agent/introspection/v1/handlers/handlers_test.go
@@ -68,6 +68,23 @@ func testAgentMetadata() *v1.AgentMetadataResponse {
 	}
 }
 
+func testAgentMetadataJson() string {
+	json, _ := json.Marshal(testAgentMetadata())
+	return string(json)
+}
+
+func testManagedAgentMetadata() *v1.ManagedAgentMetadataResponse {
+	return &v1.ManagedAgentMetadataResponse{
+		Cluster:              cluster,
+		ContainerInstanceArn: aws.String(conatinerInstanceArn),
+	}
+}
+
+func testManagedAgentMetadataJson() string {
+	json, _ := json.Marshal(testManagedAgentMetadata())
+	return string(json)
+}
+
 func testTask() *v1.TaskResponse {
 	return &v1.TaskResponse{
 		Arn:           "t1",
@@ -126,6 +143,14 @@ type IntrospectionTestCase[R IntrospectionResponse] struct {
 	MetricName    string
 }
 
+type agentMetadataTestCase struct {
+	name               string
+	testCase           IntrospectionTestCase[*v1.AgentMetadataResponse]
+	expectedStatusCode int
+	expectedResponse   string
+	isManaged          bool
+}
+
 func testHandlerSetup[R IntrospectionResponse](t *testing.T, testCase IntrospectionTestCase[R]) (
 	*gomock.Controller, *mock_v1.MockAgentState, *mock_metrics.MockEntryFactory, *http.Request, *httptest.ResponseRecorder) {
 	ctrl := gomock.NewController(t)
@@ -142,7 +167,7 @@ func testHandlerSetup[R IntrospectionResponse](t *testing.T, testCase Introspect
 }
 
 func TestAgentMetadataHandler(t *testing.T) {
-	var performMockRequest = func(t *testing.T, testCase IntrospectionTestCase[*v1.AgentMetadataResponse]) *httptest.ResponseRecorder {
+	var performMockRequest = func(t *testing.T, testCase IntrospectionTestCase[*v1.AgentMetadataResponse], isManaged bool) *httptest.ResponseRecorder {
 		mockCtrl, mockAgentState, mockMetricsFactory, req, recorder := testHandlerSetup(t, testCase)
 		mockAgentState.EXPECT().
 			GetAgentMetadata().
@@ -153,66 +178,124 @@ func TestAgentMetadataHandler(t *testing.T) {
 			mockMetricsFactory.EXPECT().
 				New(testCase.MetricName).Return(mockEntry)
 		}
-		AgentMetadataHandler(mockAgentState, mockMetricsFactory)(recorder, req)
+		AgentMetadataHandler(mockAgentState, mockMetricsFactory, isManaged)(recorder, req)
 		return recorder
 	}
 
-	t.Run("happy case", func(t *testing.T) {
-		recorder := performMockRequest(t, IntrospectionTestCase[*v1.AgentMetadataResponse]{
-			Path:          V1AgentMetadataPath,
-			AgentResponse: testAgentMetadata(),
-			Err:           nil,
-		})
-		assert.Equal(t, http.StatusOK, recorder.Code)
-		testAgentMetadataJson, _ := json.Marshal(testAgentMetadata())
-		assert.Equal(t, string(testAgentMetadataJson), recorder.Body.String())
-	})
+	var emptyResponse = func() string {
+		json, _ := json.Marshal(&v1.AgentMetadataResponse{})
+		return string(json)
+	}
 
-	emptyMetadataResponse, _ := json.Marshal(v1.AgentMetadataResponse{})
+	var emptyManagedResponse = func() string {
+		json, _ := json.Marshal(&v1.ManagedAgentMetadataResponse{})
+		return string(json)
+	}
 
-	t.Run("multiple tasks found error", func(t *testing.T) {
-		recorder := performMockRequest(t, IntrospectionTestCase[*v1.AgentMetadataResponse]{
-			Path:          V1AgentMetadataPath,
-			AgentResponse: testAgentMetadata(),
-			Err:           v1.NewErrorMultipleTasksFound(internalErrorText),
-			MetricName:    metrics.IntrospectionBadRequest,
-		})
-		assert.Equal(t, http.StatusBadRequest, recorder.Code)
-		assert.Equal(t, string(emptyMetadataResponse), recorder.Body.String())
-	})
+	testCases := []agentMetadataTestCase{
+		{
+			name: "happy case",
+			testCase: IntrospectionTestCase[*v1.AgentMetadataResponse]{
+				Path:          V1AgentMetadataPath,
+				AgentResponse: testAgentMetadata(),
+				Err:           nil,
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedResponse:   testAgentMetadataJson(),
+			isManaged:          false,
+		},
+		{
+			name: "not found",
+			testCase: IntrospectionTestCase[*v1.AgentMetadataResponse]{
+				Path:          V1AgentMetadataPath,
+				AgentResponse: testAgentMetadata(),
+				Err:           v1.NewErrorNotFound(internalErrorText),
+				MetricName:    metrics.IntrospectionNotFound,
+			},
+			expectedStatusCode: http.StatusNotFound,
+			expectedResponse:   emptyResponse(),
+			isManaged:          false,
+		},
+		{
+			name: "fetch failure",
+			testCase: IntrospectionTestCase[*v1.AgentMetadataResponse]{
+				Path:          V1AgentMetadataPath,
+				AgentResponse: testAgentMetadata(),
+				Err:           v1.NewErrorFetchFailure(internalErrorText),
+				MetricName:    metrics.IntrospectionFetchFailure,
+			},
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedResponse:   emptyResponse(),
+			isManaged:          false,
+		},
+		{
+			name: "unkown error",
+			testCase: IntrospectionTestCase[*v1.AgentMetadataResponse]{
+				Path:          V1AgentMetadataPath,
+				AgentResponse: testAgentMetadata(),
+				Err:           errors.New(internalErrorText),
+				MetricName:    metrics.IntrospectionInternalServerError,
+			},
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedResponse:   emptyResponse(),
+			isManaged:          false,
+		},
+		{
+			name: "happy case managed agent",
+			testCase: IntrospectionTestCase[*v1.AgentMetadataResponse]{
+				Path:          V1AgentMetadataPath,
+				AgentResponse: testAgentMetadata(),
+				Err:           nil,
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedResponse:   testManagedAgentMetadataJson(),
+			isManaged:          true,
+		},
+		{
+			name: "not found managed agent",
+			testCase: IntrospectionTestCase[*v1.AgentMetadataResponse]{
+				Path:          V1AgentMetadataPath,
+				AgentResponse: testAgentMetadata(),
+				Err:           v1.NewErrorNotFound(internalErrorText),
+				MetricName:    metrics.IntrospectionNotFound,
+			},
+			expectedStatusCode: http.StatusNotFound,
+			expectedResponse:   emptyManagedResponse(),
+			isManaged:          true,
+		},
+		{
+			name: "fetch failure managed agent",
+			testCase: IntrospectionTestCase[*v1.AgentMetadataResponse]{
+				Path:          V1AgentMetadataPath,
+				AgentResponse: testAgentMetadata(),
+				Err:           v1.NewErrorFetchFailure(internalErrorText),
+				MetricName:    metrics.IntrospectionFetchFailure,
+			},
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedResponse:   emptyManagedResponse(),
+			isManaged:          true,
+		},
+		{
+			name: "unkown error managed agent",
+			testCase: IntrospectionTestCase[*v1.AgentMetadataResponse]{
+				Path:          V1AgentMetadataPath,
+				AgentResponse: testAgentMetadata(),
+				Err:           errors.New(internalErrorText),
+				MetricName:    metrics.IntrospectionInternalServerError,
+			},
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedResponse:   emptyManagedResponse(),
+			isManaged:          true,
+		},
+	}
 
-	t.Run("not found", func(t *testing.T) {
-		recorder := performMockRequest(t, IntrospectionTestCase[*v1.AgentMetadataResponse]{
-			Path:          V1AgentMetadataPath,
-			AgentResponse: testAgentMetadata(),
-			Err:           v1.NewErrorNotFound(internalErrorText),
-			MetricName:    metrics.IntrospectionNotFound,
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			recorder := performMockRequest(t, testCase.testCase, testCase.isManaged)
+			assert.Equal(t, testCase.expectedStatusCode, recorder.Code)
+			assert.Equal(t, testCase.expectedResponse, recorder.Body.String())
 		})
-		assert.Equal(t, http.StatusNotFound, recorder.Code)
-		assert.Equal(t, string(emptyMetadataResponse), recorder.Body.String())
-	})
-
-	t.Run("fetch failure", func(t *testing.T) {
-		recorder := performMockRequest(t, IntrospectionTestCase[*v1.AgentMetadataResponse]{
-			Path:          V1AgentMetadataPath,
-			AgentResponse: testAgentMetadata(),
-			Err:           v1.NewErrorFetchFailure(internalErrorText),
-			MetricName:    metrics.IntrospectionFetchFailure,
-		})
-		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
-		assert.Equal(t, string(emptyMetadataResponse), recorder.Body.String())
-	})
-
-	t.Run("unkown error", func(t *testing.T) {
-		recorder := performMockRequest(t, IntrospectionTestCase[*v1.AgentMetadataResponse]{
-			Path:          V1AgentMetadataPath,
-			AgentResponse: testAgentMetadata(),
-			Err:           errors.New(internalErrorText),
-			MetricName:    metrics.IntrospectionInternalServerError,
-		})
-		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
-		assert.Equal(t, string(emptyMetadataResponse), recorder.Body.String())
-	})
+	}
 }
 
 func TestTasksHandler(t *testing.T) {

--- a/ecs-agent/introspection/v1/handlers/handlers_test.go
+++ b/ecs-agent/introspection/v1/handlers/handlers_test.go
@@ -255,7 +255,7 @@ func TestAgentMetadataHandler(t *testing.T) {
 			name: "not found unversioned agent",
 			testCase: IntrospectionTestCase[*v1.AgentMetadataResponse]{
 				Path:          V1AgentMetadataPath,
-				AgentResponse: testAgentMetadata(),
+				AgentResponse: nil,
 				Err:           v1.NewErrorNotFound(internalErrorText),
 				MetricName:    metrics.IntrospectionNotFound,
 			},
@@ -267,7 +267,7 @@ func TestAgentMetadataHandler(t *testing.T) {
 			name: "fetch failure unversioned agent",
 			testCase: IntrospectionTestCase[*v1.AgentMetadataResponse]{
 				Path:          V1AgentMetadataPath,
-				AgentResponse: testAgentMetadata(),
+				AgentResponse: nil,
 				Err:           v1.NewErrorFetchFailure(internalErrorText),
 				MetricName:    metrics.IntrospectionFetchFailure,
 			},
@@ -279,7 +279,7 @@ func TestAgentMetadataHandler(t *testing.T) {
 			name: "unkown error unversioned agent",
 			testCase: IntrospectionTestCase[*v1.AgentMetadataResponse]{
 				Path:          V1AgentMetadataPath,
-				AgentResponse: testAgentMetadata(),
+				AgentResponse: nil,
 				Err:           errors.New(internalErrorText),
 				MetricName:    metrics.IntrospectionInternalServerError,
 			},

--- a/ecs-agent/introspection/v1/response.go
+++ b/ecs-agent/introspection/v1/response.go
@@ -28,6 +28,13 @@ type AgentMetadataResponse struct {
 	Version              string  `json:"Version"`
 }
 
+// ManagedAgentMetadataResponse is the schema for the metadata response JSON object for
+// the managed agent platform.
+type ManagedAgentMetadataResponse struct {
+	Cluster              string  `json:"Cluster"`
+	ContainerInstanceArn *string `json:"ContainerInstanceArn"`
+}
+
 // TaskResponse is the schema for the task response JSON object.
 type TaskResponse struct {
 	Arn           string              `json:"Arn"`

--- a/ecs-agent/introspection/v1/response.go
+++ b/ecs-agent/introspection/v1/response.go
@@ -28,9 +28,9 @@ type AgentMetadataResponse struct {
 	Version              string  `json:"Version"`
 }
 
-// ManagedAgentMetadataResponse is the schema for the metadata response JSON object for
-// the managed agent platform.
-type ManagedAgentMetadataResponse struct {
+// UnversionedAgentMetadataResponse is the schema for the metadata response JSON object
+// without the agent version.
+type UnversionedAgentMetadataResponse struct {
 	Cluster              string  `json:"Cluster"`
 	ContainerInstanceArn *string `json:"ContainerInstanceArn"`
 }


### PR DESCRIPTION
### Summary
On the Fargate platform, the agent version is managed by AWS and not externally-visible. This change allows the Fargate agent to exclude the agent version from the introspection API.

### Implementation details
This change adds an `IsManagedAgent` configuration for the shared introspection server. This option defaults to `false`. If set to `true`, the `<introspection_server>/v1/metadata` endpoint will exclude the `Version` field.

### Testing
Added new tests for this flag and tested ECS agent implementation to verify its behavior did not change.

Manual tested:
```
curl -s 127.0.0.1:51678/v1/metadata | python3 -mjson.tool
{
    "Cluster": "ecs-test",
    "ContainerInstanceArn": "arn:aws:ecs:us-west-2:337909766174:container-instance/ecs-test/43130c95daad49cf8bd38dcc25007fa5",
    "Version": "Amazon ECS Agent - v1.91.0 (*ea97869d)"
}
```

New tests cover the changes: `YES`

### Description for the changelog
Enhancement - Remove version from introspection agent metadata on Fargate

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
`NO`

**Does this PR include the addition of new environment variables in the README?**
`NO`

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
