### PR TITLE
Modify amazon linux codebuild and spec file to include baking in the CSI driver tar file

### DIFF
--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -24,6 +24,7 @@
 %global no_exec_perm 644
 %global debug_package %{nil}
 %global agent_image ecs-agent-v%{version}.tar
+%global ebs_csi_driver_dir /var/lib/ecs/deps/daemons/ebs-csi-driver
 
 Name:           ecs-init
 Version:        1.91.0
@@ -38,6 +39,8 @@ Source2:        ecs.service
 Source3:        amazon-ecs-volume-plugin.service
 Source4:        amazon-ecs-volume-plugin.socket
 Source5:        amazon-ecs-volume-plugin.conf
+Source6:        ebs-csi-driver-arm64-v%{version}.tar
+Source7:        ebs-csi-driver-v%{version}.tar
 
 BuildRequires:  golang >= 1.22.0
 %if %{with systemd}
@@ -171,6 +174,13 @@ mkdir -p %{buildroot}%{_sysconfdir}/ecs
 touch %{buildroot}%{_sysconfdir}/ecs/ecs.config
 touch %{buildroot}%{_sysconfdir}/ecs/ecs.config.json
 
+mkdir -p %{buildroot}%{ebs_csi_driver_dir}
+%ifarch aarch64
+install -m %{no_exec_perm} -D %{SOURCE6} %{buildroot}%{ebs_csi_driver_dir}/ebs-csi-driver.tar
+%else
+install -m %{no_exec_perm} -D %{SOURCE7} %{buildroot}%{ebs_csi_driver_dir}/ebs-csi-driver.tar
+%endif
+
 # Configure ecs-init to reload the bundled ECS container agent image.
 mkdir -p %{buildroot}%{_cachedir}/ecs
 echo 2 > %{buildroot}%{_cachedir}/ecs/state
@@ -198,6 +208,8 @@ install -m %{no_exec_perm} -D %{SOURCE5} %{buildroot}%{_sysconfdir}/init/amazon-
 %{_cachedir}/ecs/%{basename:%{agent_image}}
 %{_cachedir}/ecs/state
 %dir %{_sharedstatedir}/ecs/data
+%dir %{ebs_csi_driver_dir}
+%{ebs_csi_driver_dir}/ebs-csi-driver.tar
 
 %if %{with systemd}
 %{_unitdir}/ecs.service


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will introduce baking in the EBS CSI driver image tar file as part of the ECS Init RPM builds for Amazon Linux platforms. This essentially should have no functional changes/impact to ECS. Now merging changes from feature branch into dev.


Original feature branch PR: https://github.com/aws/amazon-ecs-agent/pull/4521

### Description for the changelog
enhancement: Modify amazon linux codebuil and spec file to include baking in the CSI driver tar file

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
