### PR TITLE
Add testing for test ULongStatsSet, EphemeralStorageMetrics

### DIFF
--- a/ecs-agent/tcs/model/ecstcs/api_test.go
+++ b/ecs-agent/tcs/model/ecstcs/api_test.go
@@ -18,7 +18,6 @@ package ecstcs
 import (
 	"testing"
 
-	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
@@ -27,9 +26,9 @@ import (
 )
 
 // Populate a ULongStatsSet with dummy value
-func getDummyULongStatsSet() *ecstcs.ULongStatsSet {
+func getDummyULongStatsSet() *ULongStatsSet {
 	dummy := aws.Int64(0)
-	return &ecstcs.ULongStatsSet{
+	return &ULongStatsSet{
 		Max:         dummy,
 		OverflowMax: dummy,
 		Min:         dummy,
@@ -50,7 +49,7 @@ const sampleCountField = "sampleCount"
 const sumField = "sum"
 
 /*
-Tests cases of TestULongStatsSet that do not raise an error during validate():
+Tests cases of ULongStatsSet that do not raise an error during validate():
  1. Non-nil StatsSet
  3. Non-nil StatsSet with "some" nil values
     a. Nil OverflowMax
@@ -60,7 +59,7 @@ Tests cases of TestULongStatsSet that do not raise an error during validate():
 func TestULongStatsSet(t *testing.T) {
 	cases := []struct {
 		Name     string
-		StatsSet *ecstcs.ULongStatsSet
+		StatsSet *ULongStatsSet
 	}{
 		{
 			Name:     "happy case",
@@ -68,7 +67,7 @@ func TestULongStatsSet(t *testing.T) {
 		},
 		{
 			Name: "nil OverflowMax",
-			StatsSet: func() *ecstcs.ULongStatsSet {
+			StatsSet: func() *ULongStatsSet {
 				s := getDummyULongStatsSet()
 				s.OverflowMax = nil
 				return s
@@ -76,7 +75,7 @@ func TestULongStatsSet(t *testing.T) {
 		},
 		{
 			Name: "nil OverflowMin",
-			StatsSet: func() *ecstcs.ULongStatsSet {
+			StatsSet: func() *ULongStatsSet {
 				s := getDummyULongStatsSet()
 				s.OverflowMin = nil
 				return s
@@ -84,7 +83,7 @@ func TestULongStatsSet(t *testing.T) {
 		},
 		{
 			Name: "nil OverflowSum",
-			StatsSet: func() *ecstcs.ULongStatsSet {
+			StatsSet: func() *ULongStatsSet {
 				s := getDummyULongStatsSet()
 				s.OverflowSum = nil
 				return s
@@ -136,12 +135,12 @@ func TestULongStatsSetNilValues(t *testing.T) {
 	cases := []struct {
 		Name     string
 		Field    string
-		StatsSet *ecstcs.ULongStatsSet
+		StatsSet *ULongStatsSet
 	}{
 		{
 			Name:  "nil Max",
 			Field: "Max",
-			StatsSet: func() *ecstcs.ULongStatsSet {
+			StatsSet: func() *ULongStatsSet {
 				s := getDummyULongStatsSet()
 				s.Max = nil
 				return s
@@ -150,7 +149,7 @@ func TestULongStatsSetNilValues(t *testing.T) {
 		{
 			Name:  "nil Min",
 			Field: "Min",
-			StatsSet: func() *ecstcs.ULongStatsSet {
+			StatsSet: func() *ULongStatsSet {
 				s := getDummyULongStatsSet()
 				s.Min = nil
 				return s
@@ -159,7 +158,7 @@ func TestULongStatsSetNilValues(t *testing.T) {
 		{
 			Name:  "nil SampleCount",
 			Field: "SampleCount",
-			StatsSet: func() *ecstcs.ULongStatsSet {
+			StatsSet: func() *ULongStatsSet {
 				s := getDummyULongStatsSet()
 				s.SampleCount = nil
 				return s
@@ -168,7 +167,7 @@ func TestULongStatsSetNilValues(t *testing.T) {
 		{
 			Name:  "nil Sum",
 			Field: "Sum",
-			StatsSet: func() *ecstcs.ULongStatsSet {
+			StatsSet: func() *ULongStatsSet {
 				s := getDummyULongStatsSet()
 				s.Sum = nil
 				return s
@@ -197,7 +196,7 @@ Tests cases of EphemeralStorageMetrics that do not raise an error during validat
 func TestEphemeralStorageMetrics(t *testing.T) {
 	cases := []struct {
 		Name     string
-		StatsSet *ecstcs.ULongStatsSet
+		StatsSet *ULongStatsSet
 	}{
 		{
 			Name:     "happy case",
@@ -212,7 +211,7 @@ func TestEphemeralStorageMetrics(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.Name, func(t *testing.T) {
 			// Construct EphemeralStorageMetrics
-			metrics := ecstcs.EphemeralStorageMetrics{
+			metrics := EphemeralStorageMetrics{
 				BytesUtilized: test.StatsSet,
 			}
 			// Marshal to JSON (bytes)
@@ -245,11 +244,11 @@ Tests cases of EphemeralStorageMetrics that do raise an error during validate():
 func TestEphemeralStorageMetricsNilValues(t *testing.T) {
 	cases := []struct {
 		Name     string
-		StatsSet *ecstcs.ULongStatsSet
+		StatsSet *ULongStatsSet
 	}{
 		{
 			Name: "nil Max",
-			StatsSet: func() *ecstcs.ULongStatsSet {
+			StatsSet: func() *ULongStatsSet {
 				s := getDummyULongStatsSet()
 				s.Max = nil
 				return s
@@ -257,7 +256,7 @@ func TestEphemeralStorageMetricsNilValues(t *testing.T) {
 		},
 		{
 			Name: "nil Min",
-			StatsSet: func() *ecstcs.ULongStatsSet {
+			StatsSet: func() *ULongStatsSet {
 				s := getDummyULongStatsSet()
 				s.Min = nil
 				return s
@@ -265,7 +264,7 @@ func TestEphemeralStorageMetricsNilValues(t *testing.T) {
 		},
 		{
 			Name: "nil SampleCount",
-			StatsSet: func() *ecstcs.ULongStatsSet {
+			StatsSet: func() *ULongStatsSet {
 				s := getDummyULongStatsSet()
 				s.SampleCount = nil
 				return s
@@ -273,7 +272,7 @@ func TestEphemeralStorageMetricsNilValues(t *testing.T) {
 		},
 		{
 			Name: "nil Sum",
-			StatsSet: func() *ecstcs.ULongStatsSet {
+			StatsSet: func() *ULongStatsSet {
 				s := getDummyULongStatsSet()
 				s.Sum = nil
 				return s
@@ -284,7 +283,7 @@ func TestEphemeralStorageMetricsNilValues(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.Name, func(t *testing.T) {
 			// Construct EphemeralStorageMetrics
-			metrics := ecstcs.EphemeralStorageMetrics{
+			metrics := EphemeralStorageMetrics{
 				BytesUtilized: test.StatsSet,
 			}
 			// Build error object for comparison

--- a/ecs-agent/tcs/model/ecstcs/api_test.go
+++ b/ecs-agent/tcs/model/ecstcs/api_test.go
@@ -1,0 +1,300 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package ecstcs
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Populate a ULongStatsSet with dummy value
+func getDummyULongStatsSet() *ecstcs.ULongStatsSet {
+	dummy := aws.Int64(0)
+	return &ecstcs.ULongStatsSet{
+		Max:         dummy,
+		OverflowMax: dummy,
+		Min:         dummy,
+		OverflowMin: dummy,
+		SampleCount: dummy,
+		Sum:         dummy,
+		OverflowSum: dummy,
+	}
+}
+
+const bytesUtilizedField = "bytesUtilized"
+const maxField = "max"
+const minField = "min"
+const overflowMaxField = "overflowMax"
+const overflowMinField = "overflowMin"
+const overflowSumField = "overflowSum"
+const sampleCountField = "sampleCount"
+const sumField = "sum"
+
+/*
+Tests cases of TestULongStatsSet that do not raise an error during validate():
+ 1. Non-nil StatsSet
+ 3. Non-nil StatsSet with "some" nil values
+    a. Nil OverflowMax
+    b. Nil OverflowMin
+    c. Nil OverflowSum
+*/
+func TestULongStatsSet(t *testing.T) {
+	cases := []struct {
+		Name     string
+		StatsSet *ecstcs.ULongStatsSet
+	}{
+		{
+			Name:     "happy case",
+			StatsSet: getDummyULongStatsSet(),
+		},
+		{
+			Name: "nil OverflowMax",
+			StatsSet: func() *ecstcs.ULongStatsSet {
+				s := getDummyULongStatsSet()
+				s.OverflowMax = nil
+				return s
+			}(),
+		},
+		{
+			Name: "nil OverflowMin",
+			StatsSet: func() *ecstcs.ULongStatsSet {
+				s := getDummyULongStatsSet()
+				s.OverflowMin = nil
+				return s
+			}(),
+		},
+		{
+			Name: "nil OverflowSum",
+			StatsSet: func() *ecstcs.ULongStatsSet {
+				s := getDummyULongStatsSet()
+				s.OverflowSum = nil
+				return s
+			}(),
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.Name, func(t *testing.T) {
+			// Marshal to JSON (bytes)
+			bytes, err := jsonutil.BuildJSON(test.StatsSet)
+			require.NoError(t, err)
+
+			// convert bytes to JSON (string)
+			jsonString := string(bytes)
+
+			// test required keys are present
+			assert.Contains(t, jsonString, maxField)
+			assert.Contains(t, jsonString, minField)
+			assert.Contains(t, jsonString, sampleCountField)
+			assert.Contains(t, jsonString, sumField)
+			// test optional keys if non-nil
+			if test.StatsSet.OverflowMax != nil {
+				assert.Contains(t, jsonString, overflowMaxField)
+			}
+			if test.StatsSet.OverflowMin != nil {
+				assert.Contains(t, jsonString, overflowMinField)
+			}
+			if test.StatsSet.OverflowSum != nil {
+				assert.Contains(t, jsonString, overflowSumField)
+			}
+
+			// validate no errors
+			errors := test.StatsSet.Validate()
+			require.NoError(t, errors)
+		})
+	}
+}
+
+/*
+Tests cases of ULongStatsSet that do raise an error during validate():
+ 1. Non-nil StatsSet with "some" nil values
+    a. Nil Max
+    b. Nil Min
+    c. Nil SampleCount
+    d. Nil Sum
+*/
+func TestULongStatsSetNilValues(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Field    string
+		StatsSet *ecstcs.ULongStatsSet
+	}{
+		{
+			Name:  "nil Max",
+			Field: "Max",
+			StatsSet: func() *ecstcs.ULongStatsSet {
+				s := getDummyULongStatsSet()
+				s.Max = nil
+				return s
+			}(),
+		},
+		{
+			Name:  "nil Min",
+			Field: "Min",
+			StatsSet: func() *ecstcs.ULongStatsSet {
+				s := getDummyULongStatsSet()
+				s.Min = nil
+				return s
+			}(),
+		},
+		{
+			Name:  "nil SampleCount",
+			Field: "SampleCount",
+			StatsSet: func() *ecstcs.ULongStatsSet {
+				s := getDummyULongStatsSet()
+				s.SampleCount = nil
+				return s
+			}(),
+		},
+		{
+			Name:  "nil Sum",
+			Field: "Sum",
+			StatsSet: func() *ecstcs.ULongStatsSet {
+				s := getDummyULongStatsSet()
+				s.Sum = nil
+				return s
+			}(),
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.Name, func(t *testing.T) {
+			// Build error object for comparison
+			invalidParams := request.ErrInvalidParams{Context: "ULongStatsSet"}
+			invalidParams.Add(request.NewErrParamRequired(test.Field))
+
+			// validate specific error
+			errors := test.StatsSet.Validate()
+			assert.Equal(t, invalidParams, errors)
+		})
+	}
+}
+
+/*
+Tests cases of EphemeralStorageMetrics that do not raise an error during validate():
+ 1. Non-nil BytesUtilized
+ 2. Nil BytesUtilized
+*/
+func TestEphemeralStorageMetrics(t *testing.T) {
+	cases := []struct {
+		Name     string
+		StatsSet *ecstcs.ULongStatsSet
+	}{
+		{
+			Name:     "happy case",
+			StatsSet: getDummyULongStatsSet(),
+		},
+		{
+			Name:     "nil StatsSet",
+			StatsSet: nil,
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.Name, func(t *testing.T) {
+			// Construct EphemeralStorageMetrics
+			metrics := ecstcs.EphemeralStorageMetrics{
+				BytesUtilized: test.StatsSet,
+			}
+			// Marshal to JSON (bytes)
+			bytes, err := jsonutil.BuildJSON(&metrics)
+			require.NoError(t, err)
+
+			// convert bytes to JSON (string)
+			jsonString := string(bytes)
+
+			// test optional keys if non-nil
+			if test.StatsSet != nil {
+				assert.Contains(t, jsonString, bytesUtilizedField)
+			}
+
+			// validate no errors
+			errors := metrics.Validate()
+			require.NoError(t, errors)
+		})
+	}
+}
+
+/*
+Tests cases of EphemeralStorageMetrics that do raise an error during validate():
+ 1. Non-nil StatsSet with "some" nil values
+    a. Nil Max
+    b. Nil Min
+    c. Nil SampleCount
+    d. Nil Sum
+*/
+func TestEphemeralStorageMetricsNilValues(t *testing.T) {
+	cases := []struct {
+		Name     string
+		StatsSet *ecstcs.ULongStatsSet
+	}{
+		{
+			Name: "nil Max",
+			StatsSet: func() *ecstcs.ULongStatsSet {
+				s := getDummyULongStatsSet()
+				s.Max = nil
+				return s
+			}(),
+		},
+		{
+			Name: "nil Min",
+			StatsSet: func() *ecstcs.ULongStatsSet {
+				s := getDummyULongStatsSet()
+				s.Min = nil
+				return s
+			}(),
+		},
+		{
+			Name: "nil SampleCount",
+			StatsSet: func() *ecstcs.ULongStatsSet {
+				s := getDummyULongStatsSet()
+				s.SampleCount = nil
+				return s
+			}(),
+		},
+		{
+			Name: "nil Sum",
+			StatsSet: func() *ecstcs.ULongStatsSet {
+				s := getDummyULongStatsSet()
+				s.Sum = nil
+				return s
+			}(),
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.Name, func(t *testing.T) {
+			// Construct EphemeralStorageMetrics
+			metrics := ecstcs.EphemeralStorageMetrics{
+				BytesUtilized: test.StatsSet,
+			}
+			// Build error object for comparison
+			err := test.StatsSet.Validate()
+			invalidParams := request.ErrInvalidParams{Context: "EphemeralStorageMetrics"}
+			invalidParams.AddNested("BytesUtilized", err.(request.ErrInvalidParams))
+
+			// validate specific error
+			errors := metrics.Validate()
+			assert.Equal(t, invalidParams, errors)
+		})
+	}
+}


### PR DESCRIPTION
Add testing for test ULongStatsSet, EphemeralStorageMetrics
    
Context:
    
Missing testing on fields/validation for ULongStatsSet, EphemeralStorageMetrics.
    
Fix:
    
- Add happy-cases (non-null, null struct)
- Add nil fields in struct testing errors
    
Related to #4471
    
Testing:
    
- New tests run locally
- make test/make run-integ-tests
   
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
