### PR TITLE
Determine the fluentd async option based on Docker server version

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -1300,6 +1300,7 @@ func (dg *dockerGoClient) Version(ctx context.Context, timeout time.Duration) (s
 	}
 
 	version = info.Version
+	seelog.Debugf("Determined the Docker server version: %s", version)
 	dg.setDaemonVersion(version)
 	return version, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Docker's fluentd log driver supports passing an async option. The `fluentd-async-connect` option was deprecated in Docker v20.10.0 and removed completely in v28.0.0, in favor of `fluentd-async`. See: https://docs.docker.com/engine/deprecated/#fluentd-async-connect-log-opt. Functionally, both options are equivalent, see: https://github.com/moby/moby/pull/39086.

This PR makes ECS agent support the new `fluentd-async` option, while maintaining backwards-compatibility with older Docker server versions.

### Implementation details
<!-- How are the changes implemented? -->

1. Added the new `fluentd-async`option alongside the old `fluentd-async-connect` option. in the Docker task engine.

2. In order to be backwards compatible with Docker versions older than 20.10.0, ECS agent will continue using the legacy `fluentd-async-connect` option for old versions. The new `fluentd-async` option will be used on instances with Docker version 20.10.0 and above.

Since the refactor on Docker's side isn't versioned and affects all client API versions, the ECS agent will determine which option to use, using the Docker server version. This is already available to the Docker task engine. 

https://github.com/aws/amazon-ecs-agent/blob/006c1e88ec11e47a5522ed52e264485632cff093/agent/engine/docker_task_engine.go#L2882-L2885

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> Yes

1. Updated existing unit tests and added new unit tests.
2. Ran Firelens functional tests against this PR on a container instance that has Docker v25 (version shipped in the ECS AMIs), the tests passed.
3. Ran Firelens functional tests against this PR on a container instance that has Docker v28 installed, the tests passed.
4. Ran Firelens functional tests against this PR on a container instance that has Docker v19, the tests passed.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement: Determine the fluentd log driver's async option based on Docker server version

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** no
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** no
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
