### PR TITLE
Changing back TaskProtectionResponse to use pointers for nested struct fields 

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -3408,7 +3408,7 @@ func TestGetTaskProtection(t *testing.T) {
 				}, nil),
 			expectedStatusCode: http.StatusOK,
 			expectedResponseBody: tptypes.TaskProtectionResponse{
-				Failure: ecstypes.Failure{
+				Failure: &ecstypes.Failure{
 					Arn:    aws.String(taskARN),
 					Reason: aws.String("ecs failure"),
 				},
@@ -3451,7 +3451,7 @@ func TestGetTaskProtection(t *testing.T) {
 			setTaskProtectionClientFactoryExpectations: taskProtectionClientFactoryExpectations(&ecsOutput, nil),
 			expectedStatusCode:                         http.StatusOK,
 			expectedResponseBody: tptypes.TaskProtectionResponse{
-				Protection: protectedTask,
+				Protection: &protectedTask,
 			},
 		})
 	})
@@ -3684,7 +3684,7 @@ func TestUpdateTaskProtection(t *testing.T) {
 			}, nil),
 		expectedStatusCode: http.StatusOK,
 		expectedResponseBody: tptypes.TaskProtectionResponse{
-			Failure: ecstypes.Failure{
+			Failure: &ecstypes.Failure{
 				Arn:    aws.String(taskARN),
 				Reason: aws.String("ecs failure"),
 			},
@@ -3772,7 +3772,7 @@ func TestUpdateTaskProtection(t *testing.T) {
 		setTaskProtectionClientFactoryExpectations: taskProtectionClientFactoryExpectations(&ecsOutput, nil),
 		expectedStatusCode:                         http.StatusOK,
 		expectedResponseBody: tptypes.TaskProtectionResponse{
-			Protection: protectedTask,
+			Protection: &protectedTask,
 		},
 	}))
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/taskprotection/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/taskprotection/v1/handlers/handlers.go
@@ -137,7 +137,7 @@ func GetTaskProtectionHandler(
 
 		// ECS call was successful
 		utils.WriteJSONResponse(w, http.StatusOK,
-			types.NewTaskProtectionResponseProtection(responseBody.ProtectedTasks[0]), requestType)
+			types.NewTaskProtectionResponseProtection(&responseBody.ProtectedTasks[0]), requestType)
 		successMetric.WithCount(1).Done(nil)
 	}
 }
@@ -251,7 +251,7 @@ func UpdateTaskProtectionHandler(
 
 		// ECS call was successful
 		utils.WriteJSONResponse(w, http.StatusOK,
-			types.NewTaskProtectionResponseProtection(response.ProtectedTasks[0]), requestType)
+			types.NewTaskProtectionResponseProtection(&response.ProtectedTasks[0]), requestType)
 		successMetric.WithCount(1).Done(nil)
 	}
 }
@@ -351,7 +351,7 @@ func logAndValidateECSResponse(
 			return http.StatusInternalServerError, &response
 		}
 
-		response := types.NewTaskProtectionResponseFailure(failures[0])
+		response := types.NewTaskProtectionResponseFailure(&failures[0])
 		return http.StatusOK, &response
 	}
 

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/taskprotection/v1/types/types.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/taskprotection/v1/types/types.go
@@ -69,19 +69,19 @@ func (taskProtection *taskProtection) String() string {
 
 // TaskProtectionResponse is response type for all Update/GetTaskProtection requests
 type TaskProtectionResponse struct {
-	RequestID  *string             `json:"requestID,omitempty"`
-	Protection types.ProtectedTask `json:"protection,omitempty"`
-	Failure    types.Failure       `json:"failure,omitempty"`
-	Error      *ErrorResponse      `json:"error,omitempty"`
+	RequestID  *string              `json:"requestID,omitempty"`
+	Protection *types.ProtectedTask `json:"protection,omitempty"`
+	Failure    *types.Failure       `json:"failure,omitempty"`
+	Error      *ErrorResponse       `json:"error,omitempty"`
 }
 
 // NewTaskProtectionResponseProtection creates a TaskProtectionResponse when it is a successful response (has protection)
-func NewTaskProtectionResponseProtection(protection types.ProtectedTask) TaskProtectionResponse {
+func NewTaskProtectionResponseProtection(protection *types.ProtectedTask) TaskProtectionResponse {
 	return TaskProtectionResponse{Protection: protection}
 }
 
 // NewTaskProtectionResponseFailure creates a TaskProtectionResponse when there is a failed response with failure
-func NewTaskProtectionResponseFailure(failure types.Failure) TaskProtectionResponse {
+func NewTaskProtectionResponseFailure(failure *types.Failure) TaskProtectionResponse {
 	return TaskProtectionResponse{Failure: failure}
 }
 

--- a/ecs-agent/tmds/handlers/taskprotection/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/taskprotection/v1/handlers/handlers.go
@@ -137,7 +137,7 @@ func GetTaskProtectionHandler(
 
 		// ECS call was successful
 		utils.WriteJSONResponse(w, http.StatusOK,
-			types.NewTaskProtectionResponseProtection(responseBody.ProtectedTasks[0]), requestType)
+			types.NewTaskProtectionResponseProtection(&responseBody.ProtectedTasks[0]), requestType)
 		successMetric.WithCount(1).Done(nil)
 	}
 }
@@ -251,7 +251,7 @@ func UpdateTaskProtectionHandler(
 
 		// ECS call was successful
 		utils.WriteJSONResponse(w, http.StatusOK,
-			types.NewTaskProtectionResponseProtection(response.ProtectedTasks[0]), requestType)
+			types.NewTaskProtectionResponseProtection(&response.ProtectedTasks[0]), requestType)
 		successMetric.WithCount(1).Done(nil)
 	}
 }
@@ -351,7 +351,7 @@ func logAndValidateECSResponse(
 			return http.StatusInternalServerError, &response
 		}
 
-		response := types.NewTaskProtectionResponseFailure(failures[0])
+		response := types.NewTaskProtectionResponseFailure(&failures[0])
 		return http.StatusOK, &response
 	}
 

--- a/ecs-agent/tmds/handlers/taskprotection/v1/types/types.go
+++ b/ecs-agent/tmds/handlers/taskprotection/v1/types/types.go
@@ -69,19 +69,19 @@ func (taskProtection *taskProtection) String() string {
 
 // TaskProtectionResponse is response type for all Update/GetTaskProtection requests
 type TaskProtectionResponse struct {
-	RequestID  *string             `json:"requestID,omitempty"`
-	Protection types.ProtectedTask `json:"protection,omitempty"`
-	Failure    types.Failure       `json:"failure,omitempty"`
-	Error      *ErrorResponse      `json:"error,omitempty"`
+	RequestID  *string              `json:"requestID,omitempty"`
+	Protection *types.ProtectedTask `json:"protection,omitempty"`
+	Failure    *types.Failure       `json:"failure,omitempty"`
+	Error      *ErrorResponse       `json:"error,omitempty"`
 }
 
 // NewTaskProtectionResponseProtection creates a TaskProtectionResponse when it is a successful response (has protection)
-func NewTaskProtectionResponseProtection(protection types.ProtectedTask) TaskProtectionResponse {
+func NewTaskProtectionResponseProtection(protection *types.ProtectedTask) TaskProtectionResponse {
 	return TaskProtectionResponse{Protection: protection}
 }
 
 // NewTaskProtectionResponseFailure creates a TaskProtectionResponse when there is a failed response with failure
-func NewTaskProtectionResponseFailure(failure types.Failure) TaskProtectionResponse {
+func NewTaskProtectionResponseFailure(failure *types.Failure) TaskProtectionResponse {
 	return TaskProtectionResponse{Failure: failure}
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will change back the `TaskProtectionResponse` struct to have pointers to its struct fields (e.g. `ProtectionTask` and `Failure`) so that the response body will respect the `omitempty`.

### Implementation details
* Changed back `types.*` to `*types.*` for the struct fields of `TaskProtectionResponse`

### Testing
* Modified the unit tests to also test that the response JSON string is what we intend it to be
* Manual testing

Before this change:
```
root@e71d43e2b5e5:/# curl --request GET ${ECS_AGENT_URI}/task-protection/v1/state
{"protection":{"ExpirationDate":null,"ProtectionEnabled":false,"TaskArn":"arn:aws:ecs:us-west-2:*:task/963adc2fcf1d4095bff50879c2840d01"},"failure":{"Arn":null,"Detail":null,"Reason":null}}
```

After:
```
root@c811d7572190:/# curl --request GET ${ECS_AGENT_URI}/task-protection/v1/state
{"protection":{"ExpirationDate":null,"ProtectionEnabled":false,"TaskArn":"arn:aws:ecs:us-west-2:*:task/b513ca611b3f48efabc0d753978ed91a"}}
```

New tests cover the changes: yes

### Description for the changelog
Bugfix - Change back to having struct field pointers within TaskProtectionResponse

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
