### PR TITLE
Modify CW endpoint short term solution to include more regions

### DIFF
--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -2993,6 +2993,11 @@ func TestCreateContainerAwslogsLogDriver(t *testing.T) {
 			region:                    "us-iso-west-1",
 			expectedLogConfigEndpoint: "https://logs.us-iso-west-1.c2s.ic.gov",
 		},
+		{
+			name:                      "test container that uses awslogs log driver in FFZ",
+			region:                    "us-isob-west-1",
+			expectedLogConfigEndpoint: "https://logs.us-isob-west-1.sc2s.sgov.gov",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will clean up the [short term solution](https://github.com/aws/amazon-ecs-agent/pull/4143) of the and added one more region where we could be hitting issues with resolving the endpoints through docker. Long term solution is to not do this/remove this short term workaround altogether.

Related PR: https://github.com/aws/amazon-ecs-agent/pull/4143

### Implementation details
* Added `us-isob-west-1` to the list of regions to do the short term solution to resolve the correct endpoint for Cloudwatch
* Tidy up the code a bit by using a "set" to store all of the regions where we need to use this short term solution

### Testing
Added new unit test case

New tests cover the changes: yes

### Description for the changelog
Enhancement - Modify CW endpoint short term solution to include more regions

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
