### PR TITLE
Disable instance IP compatibility initialization for now

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -239,7 +239,7 @@ func NewConfig(ec2client ec2.EC2MetadataClient) (*Config, error) {
 		ec2client = ec2.NewBlackholeEC2MetadataClient()
 	}
 
-	// TODO - Enable when launching IPv6-only support
+	// TODO feat:IPv6-only - Enable when launching IPv6-only support
 	// config.determineIPCompatibility(ec2client)
 
 	if config.complete() {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -239,7 +239,8 @@ func NewConfig(ec2client ec2.EC2MetadataClient) (*Config, error) {
 		ec2client = ec2.NewBlackholeEC2MetadataClient()
 	}
 
-	config.determineIPCompatibility(ec2client)
+	// TODO - Enable when launching IPv6-only support
+	// config.determineIPCompatibility(ec2client)
 
 	if config.complete() {
 		// No need to do file / network IO

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -171,7 +171,7 @@ func getConfigFileName() (string, error) {
 // This is a fallback to help with graceful adoption of Agent in IPv6-only environments
 // without disrupting existing environments.
 //
-// # TODO Remove lint rule below
+// TODO feat:IPv6-only - Remove lint rule below
 //
 //lint:ignore U1000 Function will be used in the future
 func (c *Config) determineIPCompatibility(ec2client ec2.EC2MetadataClient) {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -170,6 +170,10 @@ func getConfigFileName() (string, error) {
 // determining the IP compatibility of the container instance.
 // This is a fallback to help with graceful adoption of Agent in IPv6-only environments
 // without disrupting existing environments.
+//
+// # TODO Remove lint rule below
+//
+//lint:ignore U1000 Function will be used in the future
 func (c *Config) determineIPCompatibility(ec2client ec2.EC2MetadataClient) {
 	// Load primary ENI's MAC address on EC2 Launch Type
 	var primaryENIMAC string

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -384,6 +384,8 @@ func TestDetermineIPCompatibility(t *testing.T) {
 // Tests that IPCompatibility defaults to IPv4-only when determining IP compatibility of
 // the container instance fails due to some error.
 func TestIPCompatibilityFallback(t *testing.T) {
+	// TODO: Remove skip
+	t.Skip("Enable when launching IPv6-only support")
 	defer setTestRegion()()
 	ctrl := gomock.NewController(t)
 	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -384,7 +384,7 @@ func TestDetermineIPCompatibility(t *testing.T) {
 // Tests that IPCompatibility defaults to IPv4-only when determining IP compatibility of
 // the container instance fails due to some error.
 func TestIPCompatibilityFallback(t *testing.T) {
-	// TODO: Remove skip
+	// TODO feat:IPv6-only - Remove skip
 	t.Skip("Enable when launching IPv6-only support")
 	defer setTestRegion()()
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Disabling instance IP compatibility determination for now. It is to be used for IPv6-only support in Agent and we will enable it later when all the other changes for IPv6-only support are ready. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Disable instance IP compatibility detemination for now

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
