### PR TITLE
IPv6-only support for S3 clients

### DIFF
--- a/agent/acs/session/refresh_credentials_responder_linux.go
+++ b/agent/acs/session/refresh_credentials_responder_linux.go
@@ -19,20 +19,21 @@ package session
 import (
 	"github.com/aws/amazon-ecs-agent/agent/api/task"
 	asmfactory "github.com/aws/amazon-ecs-agent/agent/asm/factory"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
 	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/credentialspec"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 )
 
-func checkAndSetDomainlessGMSATaskExecutionRoleCredentials(iamRoleCredentials credentials.IAMRoleCredentials, task *task.Task) error {
+func checkAndSetDomainlessGMSATaskExecutionRoleCredentials(iamRoleCredentials credentials.IAMRoleCredentials, task *task.Task, ipCompatibility ipcompatibility.IPCompatibility) error {
 	// exit early if the task does not need domainless gMSA
 	if !task.RequiresDomainlessCredentialSpecResource() {
 		return nil
 	}
 	credspecContainerMapping := task.GetAllCredentialSpecRequirements()
 	credentialspecResource, err := credentialspec.NewCredentialSpecResource(task.Arn, "", task.ExecutionCredentialsID,
-		nil, ssmfactory.NewSSMClientCreator(), s3factory.NewS3ClientCreator(), asmfactory.NewClientCreator(), credspecContainerMapping)
+		nil, ssmfactory.NewSSMClientCreator(), s3factory.NewS3ClientCreator(), asmfactory.NewClientCreator(), credspecContainerMapping, ipCompatibility)
 	if err != nil {
 		return err
 	}

--- a/agent/acs/session/refresh_credentials_responder_windows.go
+++ b/agent/acs/session/refresh_credentials_responder_windows.go
@@ -18,13 +18,15 @@ package session
 
 import (
 	"github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/credentialspec"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 )
 
 // setDomainlessGMSATaskExecutionRoleCredentials sets the taskExecutionRoleCredentials to a Windows Registry Key so that
 // the domainless gMSA plugin can use these credentials to retrieve the customer Active Directory credential
-func checkAndSetDomainlessGMSATaskExecutionRoleCredentials(iamRoleCredentials credentials.IAMRoleCredentials, task *task.Task) error {
+// ipCompatibility is noop - kept it to keep consistent method signature across platforms
+func checkAndSetDomainlessGMSATaskExecutionRoleCredentials(iamRoleCredentials credentials.IAMRoleCredentials, task *task.Task, ipCompatibility ipcompatibility.IPCompatibility) error {
 	// exit early if the task does not need domainless gMSA
 	if !task.RequiresDomainlessCredentialSpecResource() {
 		return nil

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3312,13 +3312,13 @@ func (task *Task) getASMSecretsResource() ([]taskresource.TaskResource, bool) {
 // InitializeResources initializes the required field in the task on agent restart
 // Some of the fields in task isn't saved in the agent state file, agent needs
 // to initialize these fields before processing the task, eg: docker client in resource
-func (task *Task) InitializeResources(resourceFields *taskresource.ResourceFields) {
+func (task *Task) InitializeResources(config *config.Config, resourceFields *taskresource.ResourceFields) {
 	task.lock.Lock()
 	defer task.lock.Unlock()
 
 	for _, resources := range task.ResourcesMapUnsafe {
 		for _, resource := range resources {
-			resource.Initialize(resourceFields, task.KnownStatusUnsafe, task.DesiredStatusUnsafe)
+			resource.Initialize(config, resourceFields, task.KnownStatusUnsafe, task.DesiredStatusUnsafe)
 		}
 	}
 }

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -501,7 +501,7 @@ func (task *Task) initializeCredentialSpecResource(config *config.Config, creden
 	resourceFields *taskresource.ResourceFields) error {
 	credspecContainerMapping := task.GetAllCredentialSpecRequirements()
 	credentialspecResource, err := credentialspec.NewCredentialSpecResource(task.Arn, config.AWSRegion, task.ExecutionCredentialsID,
-		credentialsManager, resourceFields.SSMClientCreator, resourceFields.S3ClientCreator, resourceFields.ASMClientCreator, credspecContainerMapping, resourceFields.IPCompatibility)
+		credentialsManager, resourceFields.SSMClientCreator, resourceFields.S3ClientCreator, resourceFields.ASMClientCreator, credspecContainerMapping, config.InstanceIPCompatibility)
 	if err != nil {
 		return err
 	}

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -501,7 +501,7 @@ func (task *Task) initializeCredentialSpecResource(config *config.Config, creden
 	resourceFields *taskresource.ResourceFields) error {
 	credspecContainerMapping := task.GetAllCredentialSpecRequirements()
 	credentialspecResource, err := credentialspec.NewCredentialSpecResource(task.Arn, config.AWSRegion, task.ExecutionCredentialsID,
-		credentialsManager, resourceFields.SSMClientCreator, resourceFields.S3ClientCreator, resourceFields.ASMClientCreator, credspecContainerMapping)
+		credentialsManager, resourceFields.SSMClientCreator, resourceFields.S3ClientCreator, resourceFields.ASMClientCreator, credspecContainerMapping, resourceFields.IPCompatibility)
 	if err != nil {
 		return err
 	}
@@ -1278,7 +1278,7 @@ func (task *Task) initializeFirelensResource(config *config.Config, resourceFiel
 			}
 			firelensResource, err := firelens.NewFirelensResource(config.Cluster, task.Arn, task.Family+":"+task.Version,
 				ec2InstanceID, config.DataDir, firelensConfig.Type, config.AWSRegion, networkMode, firelensConfig.Options, containerToLogOptions,
-				credentialsManager, task.ExecutionCredentialsID, containerMemoryLimit)
+				credentialsManager, task.ExecutionCredentialsID, containerMemoryLimit, config.InstanceIPCompatibility)
 			if err != nil {
 				return errors.Wrap(err, "unable to initialize firelens resource")
 			}
@@ -3396,7 +3396,7 @@ func (task *Task) initializeEnvfilesResource(config *config.Config, credentialsM
 	for _, container := range task.Containers {
 		if container.ShouldCreateWithEnvFiles() {
 			envfileResource, err := envFiles.NewEnvironmentFileResource(config.Cluster, task.Arn, config.AWSRegion, config.DataDir,
-				container.Name, container.EnvironmentFiles, credentialsManager, task.ExecutionCredentialsID)
+				container.Name, container.EnvironmentFiles, credentialsManager, task.ExecutionCredentialsID, config.InstanceIPCompatibility)
 			if err != nil {
 				return errors.Wrapf(err, "unable to initialize envfiles resource for container %s", container.Name)
 			}

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
-	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -81,7 +80,6 @@ const (
 
 var (
 	scPauseContainerName = fmt.Sprintf(ServiceConnectPauseContainerNameFormat, scContainerName)
-	testIPCompatibility  = ipcompatibility.NewIPCompatibility(true, true)
 )
 
 func getExpectedCgroupRoot() string {

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -80,6 +81,7 @@ const (
 
 var (
 	scPauseContainerName = fmt.Sprintf(ServiceConnectPauseContainerNameFormat, scContainerName)
+	testIPCompatibility  = ipcompatibility.NewIPCompatibility(true, true)
 )
 
 func getExpectedCgroupRoot() string {
@@ -863,9 +865,10 @@ func TestGetFirelensContainer(t *testing.T) {
 
 func TestInitializeFirelensResource(t *testing.T) {
 	cfg := &config.Config{
-		DataDir:   testDataDir,
-		Cluster:   testCluster,
-		AWSRegion: testRegion,
+		DataDir:                 testDataDir,
+		Cluster:                 testCluster,
+		AWSRegion:               testRegion,
+		InstanceIPCompatibility: testIPCompatibility,
 	}
 	resourceFields := &taskresource.ResourceFields{
 		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
@@ -996,9 +999,10 @@ func TestInitializeFirelensResource(t *testing.T) {
 
 func TestInitializeFirelensResourceWithExternalConfig(t *testing.T) {
 	cfg := &config.Config{
-		DataDir:   testDataDir,
-		Cluster:   testCluster,
-		AWSRegion: testRegion,
+		DataDir:                 testDataDir,
+		Cluster:                 testCluster,
+		AWSRegion:               testRegion,
+		InstanceIPCompatibility: testIPCompatibility,
 	}
 	resourceFields := &taskresource.ResourceFields{
 		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -3983,7 +3983,8 @@ func TestInitializeAndGetEnvfilesResource(t *testing.T) {
 	defer ctrl.Finish()
 
 	cfg := &config.Config{
-		DataDir: "/ecs/data",
+		DataDir:                 "/ecs/data",
+		InstanceIPCompatibility: ipcompatibility.NewIPCompatibility(true, true),
 	}
 	credentialsManager := mock_credentials.NewMockManager(ctrl)
 
@@ -5012,6 +5013,7 @@ func TestInitializeAndGetCredentialSpecResource(t *testing.T) {
 			CredentialsManager: credentialsManager,
 			S3ClientCreator:    s3ClientCreator,
 			ASMClientCreator:   asmClientCreator,
+			IPCompatibility:    ipcompatibility.NewIPCompatibility(true, true),
 		},
 	}
 

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -85,6 +85,7 @@ var (
 	testListenerPort              = uint16(8080)
 	testBridgeDefaultListenerPort = uint16(15000)
 	testEBSReadOnly               = false
+	testIPCompatibility           = ipcompatibility.NewIPCompatibility(true, true)
 )
 
 func TestDockerConfigPortBinding(t *testing.T) {
@@ -3984,7 +3985,7 @@ func TestInitializeAndGetEnvfilesResource(t *testing.T) {
 
 	cfg := &config.Config{
 		DataDir:                 "/ecs/data",
-		InstanceIPCompatibility: ipcompatibility.NewIPCompatibility(true, true),
+		InstanceIPCompatibility: testIPCompatibility,
 	}
 	credentialsManager := mock_credentials.NewMockManager(ctrl)
 
@@ -4999,7 +5000,8 @@ func TestInitializeAndGetCredentialSpecResource(t *testing.T) {
 	defer ctrl.Finish()
 
 	cfg := &config.Config{
-		AWSRegion: "test-aws-region",
+		AWSRegion:               "test-aws-region",
+		InstanceIPCompatibility: testIPCompatibility,
 	}
 
 	credentialsManager := mock_credentials.NewMockManager(ctrl)
@@ -5013,7 +5015,6 @@ func TestInitializeAndGetCredentialSpecResource(t *testing.T) {
 			CredentialsManager: credentialsManager,
 			S3ClientCreator:    s3ClientCreator,
 			ASMClientCreator:   asmClientCreator,
-			IPCompatibility:    ipcompatibility.NewIPCompatibility(true, true),
 		},
 	}
 

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -1092,7 +1092,7 @@ func (agent *ecsAgent) startACSSession(
 
 	payloadMessageHandler := agentacs.NewPayloadMessageHandler(taskEngine, client, agent.dataClient, taskHandler,
 		credentialsManager, agent.latestSeqNumberTaskManifest)
-	credsMetadataSetter := agentacs.NewCredentialsMetadataSetter(taskEngine)
+	credsMetadataSetter := agentacs.NewCredentialsMetadataSetter(taskEngine, agent.getConfig().InstanceIPCompatibility)
 	eniHandler := agentacs.NewENIHandler(state, agent.dataClient)
 	manifestMessageIDAccessor := agentacs.NewManifestMessageIDAccessor()
 	sequenceNumberAccessor := agentacs.NewSequenceNumberAccessor(agent.latestSeqNumberTaskManifest, agent.dataClient)

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -176,6 +176,7 @@ func (agent *ecsAgent) initializeResourceFields(credentialsManager credentials.M
 			S3ClientCreator:    s3factory.NewS3ClientCreator(),
 			CredentialsManager: credentialsManager,
 			EC2InstanceID:      agent.getEC2InstanceID(),
+			IPCompatibility:    agent.getConfig().InstanceIPCompatibility,
 		},
 		Ctx:              agent.ctx,
 		DockerClient:     agent.dockerClient,

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -176,7 +176,6 @@ func (agent *ecsAgent) initializeResourceFields(credentialsManager credentials.M
 			S3ClientCreator:    s3factory.NewS3ClientCreator(),
 			CredentialsManager: credentialsManager,
 			EC2InstanceID:      agent.getEC2InstanceID(),
-			IPCompatibility:    agent.getConfig().InstanceIPCompatibility,
 		},
 		Ctx:              agent.ctx,
 		DockerClient:     agent.dockerClient,

--- a/agent/app/agent_windows.go
+++ b/agent/app/agent_windows.go
@@ -323,6 +323,7 @@ func (agent *ecsAgent) initializeResourceFields(credentialsManager credentials.M
 			FSxClientCreator:   fsxfactory.NewFSxClientCreator(),
 			S3ClientCreator:    s3factory.NewS3ClientCreator(),
 			CredentialsManager: credentialsManager,
+			IPCompatibility:    agent.getConfig().InstanceIPCompatibility,
 		},
 		Ctx:          agent.ctx,
 		DockerClient: agent.dockerClient,

--- a/agent/app/agent_windows.go
+++ b/agent/app/agent_windows.go
@@ -323,7 +323,6 @@ func (agent *ecsAgent) initializeResourceFields(credentialsManager credentials.M
 			FSxClientCreator:   fsxfactory.NewFSxClientCreator(),
 			S3ClientCreator:    s3factory.NewS3ClientCreator(),
 			CredentialsManager: credentialsManager,
-			IPCompatibility:    agent.getConfig().InstanceIPCompatibility,
 		},
 		Ctx:          agent.ctx,
 		DockerClient: agent.dockerClient,

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -192,9 +192,6 @@ var (
 
 	// isFIPSEnabled indicates whether FIPS mode is enabled on the host
 	isFIPSEnabled = false
-
-	// IsIpv6Compatible - instances are not compatible with ipv6 by default
-	IsIpv6Compatible = false
 )
 
 // Merge merges two config files, preferring the ones on the left. Any nil or

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -28,6 +28,7 @@ import (
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
 	commonutils "github.com/aws/amazon-ecs-agent/ecs-agent/utils"
+
 	"github.com/cihub/seelog"
 )
 
@@ -191,6 +192,9 @@ var (
 
 	// isFIPSEnabled indicates whether FIPS mode is enabled on the host
 	isFIPSEnabled = false
+
+	// IsIpv6Compatible - instances are not compatible with ipv6 by default
+	IsIpv6Compatible = false
 )
 
 // Merge merges two config files, preferring the ones on the left. Any nil or

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -682,7 +682,7 @@ func (engine *DockerTaskEngine) synchronizeState() {
 	engine.reconcileHostResources()
 	tasksToStart := engine.filterTasksToStartUnsafe(tasks)
 	for _, task := range tasks {
-		task.InitializeResources(engine.resourceFields)
+		task.InitializeResources(engine.cfg, engine.resourceFields)
 		engine.saveTaskData(task)
 	}
 

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -32,6 +32,7 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	mock_asm_factory "github.com/aws/amazon-ecs-agent/agent/asm/factory/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
@@ -1591,6 +1592,7 @@ func TestCredentialSpecResourceTaskFile(t *testing.T) {
 	ssmClientCreator := mock_ssm_factory.NewMockSSMClientCreator(ctrl)
 	s3ClientCreator := mock_s3_factory.NewMockS3ClientCreator(ctrl)
 	asmClientCreator := mock_asm_factory.NewMockClientCreator(ctrl)
+	testIPCompatibility := ipcompatibility.NewIPCompatibility(true, true)
 
 	credentialSpecRes, cerr := credentialspec.NewCredentialSpecResource(
 		testTask.Arn,
@@ -1600,7 +1602,9 @@ func TestCredentialSpecResourceTaskFile(t *testing.T) {
 		ssmClientCreator,
 		s3ClientCreator,
 		asmClientCreator,
-		nil)
+		nil,
+		testIPCompatibility,
+	)
 	assert.NoError(t, cerr)
 
 	credSpecdata := map[string]string{

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -2629,7 +2629,7 @@ func TestSynchronizeResource(t *testing.T) {
 	}
 	// add the task to the state to simulate the agent restored the state on restart
 	state.AddTask(testTask)
-	cgroupResource.EXPECT().Initialize(gomock.Any(), gomock.Any(), gomock.Any())
+	cgroupResource.EXPECT().Initialize(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	cgroupResource.EXPECT().SetDesiredStatus(gomock.Any()).MaxTimes(1)
 	cgroupResource.EXPECT().GetDesiredStatus().MaxTimes(2)
 	cgroupResource.EXPECT().TerminalStatus().MaxTimes(1)

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -27,6 +27,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	mock_asm_factory "github.com/aws/amazon-ecs-agent/agent/asm/factory/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
@@ -56,6 +57,8 @@ const (
 	containerNetNS           = "container:abcd"
 	ExpectedNetworkNamespace = "none"
 )
+
+var testIPCompatibility = ipcompatibility.NewIPCompatibility(true, true)
 
 func TestDeleteTask(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -148,7 +151,9 @@ func TestCredentialSpecResourceTaskFile(t *testing.T) {
 		ssmClientCreator,
 		s3ClientCreator,
 		asmClientCreator,
-		nil)
+		nil,
+		testIPCompatibility,
+	)
 	assert.NoError(t, cerr)
 
 	credSpecdata := map[string]string{
@@ -229,7 +234,9 @@ func TestCredentialSpecResourceTaskFileErr(t *testing.T) {
 		ssmClientCreator,
 		s3ClientCreator,
 		asmClientCreator,
-		nil)
+		nil,
+		testIPCompatibility,
+	)
 	assert.NoError(t, cerr)
 
 	credSpecdata := map[string]string{

--- a/agent/s3/factory/factory.go
+++ b/agent/s3/factory/factory.go
@@ -15,7 +15,6 @@ package factory
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -75,20 +74,14 @@ func createAWSConfig(region string, creds credentials.IAMRoleCredentials, useFIP
 			awscreds.NewStaticCredentials(creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken)).
 		WithRegion(region)
 
-	endpointTypeMsg := ""
 	if useDualStackEndpoint {
+		logger.Debug("Configuring S3 DualStack endpoint")
 		cfg.UseDualStackEndpoint = endpoints.DualStackEndpointStateEnabled
-		endpointTypeMsg += "DualStack "
 	}
 	if useFIPSEndpoint {
+		logger.Debug("Configuring S3 FIPS endpoint")
 		cfg.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
-		endpointTypeMsg += "FIPS-compliant "
 	}
-
-	if endpointTypeMsg == "" {
-		endpointTypeMsg = "default "
-	}
-	logger.Debug(fmt.Sprintf("Using %sS3 endpoint", endpointTypeMsg))
 
 	return cfg
 }

--- a/agent/s3/factory/factory.go
+++ b/agent/s3/factory/factory.go
@@ -15,6 +15,7 @@ package factory
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -74,20 +75,20 @@ func createAWSConfig(region string, creds credentials.IAMRoleCredentials, useFIP
 			awscreds.NewStaticCredentials(creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken)).
 		WithRegion(region)
 
-	switch {
-	case useFIPSEndpoint && useDualStackEndpoint:
-		logger.Debug("FIPS mode detected, using DualStack FIPS-compliant S3 endpoint in supported regions")
-		cfg.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+	endpointTypeMsg := ""
+	if useDualStackEndpoint {
 		cfg.UseDualStackEndpoint = endpoints.DualStackEndpointStateEnabled
-	case useFIPSEndpoint:
-		logger.Debug("FIPS mode detected, using FIPS-compliant S3 endpoint in supported regions")
-		cfg.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
-	case useDualStackEndpoint:
-		logger.Debug("Using DualStack S3 endpoint")
-		cfg.UseDualStackEndpoint = endpoints.DualStackEndpointStateEnabled
-	default:
-		logger.Debug("Using default S3 endpoint")
+		endpointTypeMsg += "DualStack "
 	}
+	if useFIPSEndpoint {
+		cfg.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+		endpointTypeMsg += "FIPS-compliant "
+	}
+
+	if endpointTypeMsg == "" {
+		endpointTypeMsg = "default "
+	}
+	logger.Debug(fmt.Sprintf("Using %sS3 endpoint", endpointTypeMsg))
 
 	return cfg
 }

--- a/agent/s3/factory/mocks/factory_mocks.go
+++ b/agent/s3/factory/mocks/factory_mocks.go
@@ -21,6 +21,7 @@ package mock_factory
 import (
 	reflect "reflect"
 
+	ipcompatibility "github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	s3 "github.com/aws/amazon-ecs-agent/agent/s3"
 	credentials "github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	gomock "github.com/golang/mock/gomock"
@@ -50,31 +51,31 @@ func (m *MockS3ClientCreator) EXPECT() *MockS3ClientCreatorMockRecorder {
 }
 
 // NewS3Client mocks base method.
-func (m *MockS3ClientCreator) NewS3Client(arg0, arg1 string, arg2 credentials.IAMRoleCredentials) (s3.S3Client, error) {
+func (m *MockS3ClientCreator) NewS3Client(arg0, arg1 string, arg2 credentials.IAMRoleCredentials, arg3 ipcompatibility.IPCompatibility) (s3.S3Client, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewS3Client", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "NewS3Client", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(s3.S3Client)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewS3Client indicates an expected call of NewS3Client.
-func (mr *MockS3ClientCreatorMockRecorder) NewS3Client(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockS3ClientCreatorMockRecorder) NewS3Client(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewS3Client", reflect.TypeOf((*MockS3ClientCreator)(nil).NewS3Client), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewS3Client", reflect.TypeOf((*MockS3ClientCreator)(nil).NewS3Client), arg0, arg1, arg2, arg3)
 }
 
 // NewS3ManagerClient mocks base method.
-func (m *MockS3ClientCreator) NewS3ManagerClient(arg0, arg1 string, arg2 credentials.IAMRoleCredentials) (s3.S3ManagerClient, error) {
+func (m *MockS3ClientCreator) NewS3ManagerClient(arg0, arg1 string, arg2 credentials.IAMRoleCredentials, arg3 ipcompatibility.IPCompatibility) (s3.S3ManagerClient, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewS3ManagerClient", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "NewS3ManagerClient", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(s3.S3ManagerClient)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewS3ManagerClient indicates an expected call of NewS3ManagerClient.
-func (mr *MockS3ClientCreatorMockRecorder) NewS3ManagerClient(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockS3ClientCreatorMockRecorder) NewS3ManagerClient(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewS3ManagerClient", reflect.TypeOf((*MockS3ClientCreator)(nil).NewS3ManagerClient), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewS3ManagerClient", reflect.TypeOf((*MockS3ClientCreator)(nil).NewS3ManagerClient), arg0, arg1, arg2, arg3)
 }

--- a/agent/taskresource/asmauth/asmauth.go
+++ b/agent/taskresource/asmauth/asmauth.go
@@ -21,6 +21,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/asm"
 	"github.com/aws/amazon-ecs-agent/agent/asm/factory"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
@@ -349,7 +350,9 @@ func (auth *ASMAuthResource) PutASMDockerAuthConfig(secretID string, authCfg reg
 	auth.dockerAuthData[secretID] = authCfg
 }
 
-func (auth *ASMAuthResource) Initialize(resourceFields *taskresource.ResourceFields,
+func (auth *ASMAuthResource) Initialize(
+	config *config.Config,
+	resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
 	auth.initStatusToTransition()

--- a/agent/taskresource/asmauth/asmauth_test.go
+++ b/agent/taskresource/asmauth/asmauth_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/asm"
 	mock_factory "github.com/aws/amazon-ecs-agent/agent/asm/factory/mocks"
 	mock_secretsmanageriface "github.com/aws/amazon-ecs-agent/agent/asm/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
@@ -157,12 +158,14 @@ func TestInitialize(t *testing.T) {
 					knownStatusUnsafe:   resourcestatus.ResourceCreated,
 					desiredStatusUnsafe: resourcestatus.ResourceCreated,
 				}
-				asmRes.Initialize(&taskresource.ResourceFields{
-					ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
-						ASMClientCreator:   asmClientCreator,
-						CredentialsManager: credentialsManager,
-					},
-				}, tc.taskKnownStatus, tc.taskDesiredStatus)
+				asmRes.Initialize(
+					&config.Config{},
+					&taskresource.ResourceFields{
+						ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
+							ASMClientCreator:   asmClientCreator,
+							CredentialsManager: credentialsManager,
+						},
+					}, tc.taskKnownStatus, tc.taskDesiredStatus)
 				if tc.expectReset {
 					assert.Equal(t, resourcestatus.ResourceStatusNone, asmRes.GetKnownStatus())
 				} else {

--- a/agent/taskresource/asmsecret/asmsecret.go
+++ b/agent/taskresource/asmsecret/asmsecret.go
@@ -26,6 +26,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/asm"
 	"github.com/aws/amazon-ecs-agent/agent/asm/factory"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
@@ -445,7 +446,9 @@ func (secret *ASMSecretResource) SetCachedSecretValue(secretKey string, secretVa
 	secret.secretData[secretKey] = secretValue
 }
 
-func (secret *ASMSecretResource) Initialize(resourceFields *taskresource.ResourceFields,
+func (secret *ASMSecretResource) Initialize(
+	config *config.Config,
+	resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
 	secret.initStatusToTransition()

--- a/agent/taskresource/asmsecret/asmsecret_test.go
+++ b/agent/taskresource/asmsecret/asmsecret_test.go
@@ -27,6 +27,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	mock_factory "github.com/aws/amazon-ecs-agent/agent/asm/factory/mocks"
 	mock_secretsmanageriface "github.com/aws/amazon-ecs-agent/agent/asm/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
@@ -238,12 +239,14 @@ func TestInitialize(t *testing.T) {
 		knownStatusUnsafe:   resourcestatus.ResourceCreated,
 		desiredStatusUnsafe: resourcestatus.ResourceCreated,
 	}
-	asmRes.Initialize(&taskresource.ResourceFields{
-		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
-			ASMClientCreator:   asmClientCreator,
-			CredentialsManager: credentialsManager,
-		},
-	}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
+	asmRes.Initialize(
+		&config.Config{},
+		&taskresource.ResourceFields{
+			ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
+				ASMClientCreator:   asmClientCreator,
+				CredentialsManager: credentialsManager,
+			},
+		}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
 	assert.Equal(t, resourcestatus.ResourceStatusNone, asmRes.GetKnownStatus())
 	assert.Equal(t, resourcestatus.ResourceCreated, asmRes.GetDesiredStatus())
 

--- a/agent/taskresource/cgroup/cgroup.go
+++ b/agent/taskresource/cgroup/cgroup.go
@@ -379,7 +379,9 @@ func (cgroup *CgroupResource) GetCgroupMountPath() string {
 }
 
 // Initialize initializes the resource fileds in cgroup
-func (cgroup *CgroupResource) Initialize(resourceFields *taskresource.ResourceFields,
+func (cgroup *CgroupResource) Initialize(
+	config *config.Config,
+	resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
 	cgroup.lock.Lock()

--- a/agent/taskresource/cgroup/cgroup_unsupported.go
+++ b/agent/taskresource/cgroup/cgroup_unsupported.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
@@ -131,7 +132,9 @@ func (c *CgroupResource) UnmarshalJSON(b []byte) error {
 }
 
 // Initialize fills the resource fileds
-func (cgroup *CgroupResource) Initialize(resourceFields *taskresource.ResourceFields,
+func (cgroup *CgroupResource) Initialize(
+	config *config.Config,
+	resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
 }

--- a/agent/taskresource/credentialspec/credentialspec.go
+++ b/agent/taskresource/credentialspec/credentialspec.go
@@ -20,6 +20,7 @@ import (
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	asmfactory "github.com/aws/amazon-ecs-agent/agent/asm/factory"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
 	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
@@ -80,7 +81,9 @@ type CredentialSpecResourceCommon struct {
 	ipCompatibility ipcompatibility.IPCompatibility
 }
 
-func (cs *CredentialSpecResource) Initialize(resourceFields *taskresource.ResourceFields,
+func (cs *CredentialSpecResource) Initialize(
+	config *config.Config,
+	resourceFields *taskresource.ResourceFields,
 	_ status.TaskStatus,
 	_ status.TaskStatus) {
 
@@ -88,7 +91,7 @@ func (cs *CredentialSpecResource) Initialize(resourceFields *taskresource.Resour
 	cs.ssmClientCreator = resourceFields.SSMClientCreator
 	cs.s3ClientCreator = resourceFields.S3ClientCreator
 	cs.secretsmanagerClientCreator = resourceFields.ASMClientCreator
-	cs.ipCompatibility = resourceFields.IPCompatibility
+	cs.ipCompatibility = config.InstanceIPCompatibility
 	cs.initStatusToTransition()
 }
 

--- a/agent/taskresource/credentialspec/credentialspec.go
+++ b/agent/taskresource/credentialspec/credentialspec.go
@@ -20,6 +20,7 @@ import (
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	asmfactory "github.com/aws/amazon-ecs-agent/agent/asm/factory"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
 	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -75,6 +76,8 @@ type CredentialSpecResourceCommon struct {
 	credentialSpecContainerMap map[string]string
 	// lock is used for fields that are accessed and updated concurrently
 	lock sync.RWMutex
+	// ipCompatibility is used to determine the eligibility to use dualstack endpoints
+	ipCompatibility ipcompatibility.IPCompatibility
 }
 
 func (cs *CredentialSpecResource) Initialize(resourceFields *taskresource.ResourceFields,
@@ -85,6 +88,7 @@ func (cs *CredentialSpecResource) Initialize(resourceFields *taskresource.Resour
 	cs.ssmClientCreator = resourceFields.SSMClientCreator
 	cs.s3ClientCreator = resourceFields.S3ClientCreator
 	cs.secretsmanagerClientCreator = resourceFields.ASMClientCreator
+	cs.ipCompatibility = resourceFields.IPCompatibility
 	cs.initStatusToTransition()
 }
 

--- a/agent/taskresource/credentialspec/credentialspec_linux.go
+++ b/agent/taskresource/credentialspec/credentialspec_linux.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/asm"
 	asmfactory "github.com/aws/amazon-ecs-agent/agent/asm/factory"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	"github.com/aws/amazon-ecs-agent/agent/s3"
 	"github.com/aws/amazon-ecs-agent/agent/ssm"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
@@ -130,7 +131,8 @@ func NewCredentialSpecResource(taskARN, region string,
 	ssmClientCreator ssmfactory.SSMClientCreator,
 	s3ClientCreator s3factory.S3ClientCreator,
 	asmClientCreator asmfactory.ClientCreator,
-	credentialSpecContainerMap map[string]string) (*CredentialSpecResource, error) {
+	credentialSpecContainerMap map[string]string,
+	ipCompatibility ipcompatibility.IPCompatibility) (*CredentialSpecResource, error) {
 	s := &CredentialSpecResource{
 		CredentialSpecResourceCommon: &CredentialSpecResourceCommon{
 			taskARN:                     taskARN,
@@ -142,6 +144,7 @@ func NewCredentialSpecResource(taskARN, region string,
 			secretsmanagerClientCreator: asmClientCreator,
 			CredSpecMap:                 make(map[string]string),
 			credentialSpecContainerMap:  credentialSpecContainerMap,
+			ipCompatibility:             ipCompatibility,
 		},
 		ServiceAccountInfoMap: make(map[string]ServiceAccountInfo),
 	}
@@ -442,7 +445,7 @@ func (cs *CredentialSpecResource) handleS3CredentialspecFile(originalCredentialS
 		return
 	}
 
-	s3Client, err := cs.s3ClientCreator.NewS3Client(bucket, cs.region, iamCredentials)
+	s3Client, err := cs.s3ClientCreator.NewS3Client(bucket, cs.region, iamCredentials, cs.ipCompatibility)
 	if err != nil {
 		cs.setTerminalReason(err.Error())
 		errorEvents <- err

--- a/agent/taskresource/credentialspec/credentialspec_linux_test.go
+++ b/agent/taskresource/credentialspec/credentialspec_linux_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	mock_asm_factory "github.com/aws/amazon-ecs-agent/agent/asm/factory/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	mock_s3_factory "github.com/aws/amazon-ecs-agent/agent/s3/factory/mocks"
 	mock_s3 "github.com/aws/amazon-ecs-agent/agent/s3/mocks"
 	mockfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory/mocks"
@@ -45,6 +46,8 @@ import (
 const (
 	taskARN = "arn:aws:ecs:us-west-2:123456789012:task/12345-678901234-56789"
 )
+
+var testIPCompatibility = ipcompatibility.NewIPCompatibility(true, true)
 
 func TestClearCredentialSpecDataHappyPath(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -93,6 +96,7 @@ func TestInitialize(t *testing.T) {
 			S3ClientCreator:    s3ClientCreator,
 			ASMClientCreator:   asmClientCreator,
 			CredentialsManager: credentialsManager,
+			IPCompatibility:    testIPCompatibility,
 		},
 	}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
 
@@ -101,6 +105,7 @@ func TestInitialize(t *testing.T) {
 	assert.NotNil(t, credspecRes.s3ClientCreator)
 	assert.NotNil(t, credspecRes.secretsmanagerClientCreator)
 	assert.NotNil(t, credspecRes.resourceStatusToTransitionFunction)
+	assert.Equal(t, testIPCompatibility, credspecRes.ipCompatibility)
 }
 
 func TestHandleSSMCredentialspecFile(t *testing.T) {
@@ -364,6 +369,7 @@ func TestHandleS3CredentialSpecFileGetS3SecretValue(t *testing.T) {
 		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
 			CredentialsManager: credentialsManager,
 			S3ClientCreator:    s3ClientCreator,
+			IPCompatibility:    testIPCompatibility,
 		},
 	}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
 
@@ -374,7 +380,7 @@ func TestHandleS3CredentialSpecFileGetS3SecretValue(t *testing.T) {
 		Body: io.NopCloser(strings.NewReader(testData)),
 	}
 	gomock.InOrder(
-		s3ClientCreator.EXPECT().NewS3Client(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockS3Client, nil),
+		s3ClientCreator.EXPECT().NewS3Client(gomock.Any(), gomock.Any(), gomock.Any(), testIPCompatibility).Return(mockS3Client, nil),
 		mockS3Client.EXPECT().GetObject(gomock.Any()).Return(s3GetObjectResponse, nil).Times(1),
 	)
 
@@ -429,6 +435,7 @@ func TestHandleS3DomainlessCredentialSpecFileGetS3SecretValue(t *testing.T) {
 		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
 			CredentialsManager: credentialsManager,
 			S3ClientCreator:    s3ClientCreator,
+			IPCompatibility:    testIPCompatibility,
 		},
 	}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
 
@@ -439,7 +446,7 @@ func TestHandleS3DomainlessCredentialSpecFileGetS3SecretValue(t *testing.T) {
 		Body: io.NopCloser(strings.NewReader(testData)),
 	}
 	gomock.InOrder(
-		s3ClientCreator.EXPECT().NewS3Client(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockS3Client, nil),
+		s3ClientCreator.EXPECT().NewS3Client(gomock.Any(), gomock.Any(), gomock.Any(), testIPCompatibility).Return(mockS3Client, nil),
 		mockS3Client.EXPECT().GetObject(gomock.Any()).Return(s3GetObjectResponse, nil).Times(1),
 	)
 
@@ -497,11 +504,12 @@ func TestHandleS3CredentialSpecFileGetS3SecretValueErr(t *testing.T) {
 		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
 			CredentialsManager: credentialsManager,
 			S3ClientCreator:    s3ClientCreator,
+			IPCompatibility:    testIPCompatibility,
 		},
 	}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
 
 	gomock.InOrder(
-		s3ClientCreator.EXPECT().NewS3Client(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockS3Client, nil),
+		s3ClientCreator.EXPECT().NewS3Client(gomock.Any(), gomock.Any(), gomock.Any(), testIPCompatibility).Return(mockS3Client, nil),
 		mockS3Client.EXPECT().GetObject(gomock.Any()).Return(nil, errors.New("test-error")).Times(1),
 	)
 

--- a/agent/taskresource/credentialspec/credentialspec_windows.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	asmfactory "github.com/aws/amazon-ecs-agent/agent/asm/factory"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	"github.com/aws/amazon-ecs-agent/agent/s3"
 	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
 	"github.com/aws/amazon-ecs-agent/agent/ssm"
@@ -92,7 +93,8 @@ func NewCredentialSpecResource(taskARN, region string,
 	ssmClientCreator ssmfactory.SSMClientCreator,
 	s3ClientCreator s3factory.S3ClientCreator,
 	asmClientCreator asmfactory.ClientCreator,
-	credentialSpecContainerMap map[string]string) (*CredentialSpecResource, error) {
+	credentialSpecContainerMap map[string]string,
+	ipCompatibility ipcompatibility.IPCompatibility) (*CredentialSpecResource, error) {
 
 	s := &CredentialSpecResource{
 		CredentialSpecResourceCommon: &CredentialSpecResourceCommon{
@@ -104,6 +106,7 @@ func NewCredentialSpecResource(taskARN, region string,
 			s3ClientCreator:            s3ClientCreator,
 			CredSpecMap:                make(map[string]string),
 			credentialSpecContainerMap: credentialSpecContainerMap,
+			ipCompatibility:            ipCompatibility,
 		},
 		ioutil:               ioutilwrapper.NewIOUtil(),
 		isDomainlessGMSATask: false,
@@ -255,7 +258,7 @@ func (cs *CredentialSpecResource) handleS3CredentialspecFile(originalCredentials
 		return err
 	}
 
-	s3Client, err := cs.s3ClientCreator.NewS3ManagerClient(bucket, cs.region, iamCredentials)
+	s3Client, err := cs.s3ClientCreator.NewS3ManagerClient(bucket, cs.region, iamCredentials, cs.ipCompatibility)
 	if err != nil {
 		cs.setTerminalReason(err.Error())
 		return err

--- a/agent/taskresource/envFiles/envfile.go
+++ b/agent/taskresource/envFiles/envfile.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	"github.com/aws/amazon-ecs-agent/agent/s3"
 	"github.com/aws/amazon-ecs-agent/agent/s3/factory"
@@ -114,7 +115,9 @@ func NewEnvironmentFileResource(cluster, taskARN, region, dataDir, containerName
 }
 
 // Initialize initializes the EnvironmentFileResource
-func (envfile *EnvironmentFileResource) Initialize(resourceFields *taskresource.ResourceFields,
+func (envfile *EnvironmentFileResource) Initialize(
+	config *config.Config,
+	resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
 	envfile.lock.Lock()
@@ -124,7 +127,7 @@ func (envfile *EnvironmentFileResource) Initialize(resourceFields *taskresource.
 	envfile.s3ClientCreator = factory.NewS3ClientCreator()
 	envfile.ioutil = ioutilwrapper.NewIOUtil()
 	envfile.bufio = bufiowrapper.NewBufio()
-	envfile.ipCompatibility = resourceFields.IPCompatibility
+	envfile.ipCompatibility = config.InstanceIPCompatibility
 	envfile.lock.Unlock()
 
 	// if task isn't in 'created' status and desired status is 'running',

--- a/agent/taskresource/envFiles/envfile.go
+++ b/agent/taskresource/envFiles/envfile.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	"github.com/aws/amazon-ecs-agent/agent/s3"
 	"github.com/aws/amazon-ecs-agent/agent/s3/factory"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -73,6 +74,7 @@ type EnvironmentFileResource struct {
 	s3ClientCreator        factory.S3ClientCreator
 	ioutil                 ioutilwrapper.IOUtil
 	bufio                  bufiowrapper.Bufio
+	ipCompatibility        ipcompatibility.IPCompatibility
 
 	// Fields for the common functionality of task resource. Access to these fields are protected by lock.
 	createdAtUnsafe      time.Time
@@ -87,7 +89,7 @@ type EnvironmentFileResource struct {
 
 // NewEnvironmentFileResource creates a new EnvironmentFileResource object
 func NewEnvironmentFileResource(cluster, taskARN, region, dataDir, containerName string, envfiles []apicontainer.EnvironmentFile,
-	credentialsManager credentials.Manager, executionCredentialsID string) (*EnvironmentFileResource, error) {
+	credentialsManager credentials.Manager, executionCredentialsID string, ipCompatibility ipcompatibility.IPCompatibility) (*EnvironmentFileResource, error) {
 	envfileResource := &EnvironmentFileResource{
 		cluster:                cluster,
 		taskARN:                taskARN,
@@ -99,6 +101,7 @@ func NewEnvironmentFileResource(cluster, taskARN, region, dataDir, containerName
 		s3ClientCreator:        factory.NewS3ClientCreator(),
 		executionCredentialsID: executionCredentialsID,
 		credentialsManager:     credentialsManager,
+		ipCompatibility:        ipCompatibility,
 	}
 
 	taskARNFields := strings.Split(taskARN, "/")
@@ -121,6 +124,7 @@ func (envfile *EnvironmentFileResource) Initialize(resourceFields *taskresource.
 	envfile.s3ClientCreator = factory.NewS3ClientCreator()
 	envfile.ioutil = ioutilwrapper.NewIOUtil()
 	envfile.bufio = bufiowrapper.NewBufio()
+	envfile.ipCompatibility = resourceFields.IPCompatibility
 	envfile.lock.Unlock()
 
 	// if task isn't in 'created' status and desired status is 'running',
@@ -354,7 +358,7 @@ func (envfile *EnvironmentFileResource) downloadEnvfileFromS3(envFilePath string
 		return
 	}
 
-	s3Client, err := envfile.s3ClientCreator.NewS3ManagerClient(bucket, envfile.region, iamCredentials)
+	s3Client, err := envfile.s3ClientCreator.NewS3ManagerClient(bucket, envfile.region, iamCredentials, envfile.ipCompatibility)
 	if err != nil {
 		errorEvents <- fmt.Errorf("unable to initialize s3 client for bucket %s, error: %v", bucket, err)
 		return

--- a/agent/taskresource/envFiles/envfile_test.go
+++ b/agent/taskresource/envFiles/envfile_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	mock_factory "github.com/aws/amazon-ecs-agent/agent/s3/factory/mocks"
 	mock_s3 "github.com/aws/amazon-ecs-agent/agent/s3/mocks/s3manager"
@@ -106,13 +107,16 @@ func TestInitializeFileEnvResource(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
+	testConfig := &config.Config{InstanceIPCompatibility: testIPCompatibility}
+
 	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, nil, nil, testIPCompatibility)
-	envfileResource.Initialize(&taskresource.ResourceFields{
-		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
-			CredentialsManager: mockCredentialsManager,
-			IPCompatibility:    testIPCompatibility,
-		},
-	}, status.TaskRunning, status.TaskRunning)
+	envfileResource.Initialize(
+		testConfig,
+		&taskresource.ResourceFields{
+			ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
+				CredentialsManager: mockCredentialsManager,
+			},
+		}, status.TaskRunning, status.TaskRunning)
 
 	assert.NotNil(t, envfileResource.statusToTransitions)
 	assert.Equal(t, 1, len(envfileResource.statusToTransitions))

--- a/agent/taskresource/envFiles/envfile_test.go
+++ b/agent/taskresource/envFiles/envfile_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	mock_factory "github.com/aws/amazon-ecs-agent/agent/s3/factory/mocks"
 	mock_s3 "github.com/aws/amazon-ecs-agent/agent/s3/mocks/s3manager"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -58,6 +59,8 @@ const (
 	tempFile               = "tmp_file"
 )
 
+var testIPCompatibility = ipcompatibility.NewIPCompatibility(true, true)
+
 func setup(t *testing.T) (oswrapper.File, *mock_ioutilwrapper.MockIOUtil,
 	*mock_credentials.MockManager, *mock_factory.MockS3ClientCreator, *mock_s3.MockS3ManagerClient, func()) {
 	ctrl := gomock.NewController(t)
@@ -73,7 +76,8 @@ func setup(t *testing.T) (oswrapper.File, *mock_ioutilwrapper.MockIOUtil,
 
 func newMockEnvfileResource(envfileLocations []container.EnvironmentFile, mockCredentialsManager *mock_credentials.MockManager,
 	mockS3ClientCreator *mock_factory.MockS3ClientCreator,
-	mockIOUtil *mock_ioutilwrapper.MockIOUtil) *EnvironmentFileResource {
+	mockIOUtil *mock_ioutilwrapper.MockIOUtil,
+	ipCompatibility ipcompatibility.IPCompatibility) *EnvironmentFileResource {
 	return &EnvironmentFileResource{
 		cluster:                cluster,
 		taskARN:                taskARN,
@@ -84,6 +88,7 @@ func newMockEnvfileResource(envfileLocations []container.EnvironmentFile, mockCr
 		credentialsManager:     mockCredentialsManager,
 		s3ClientCreator:        mockS3ClientCreator,
 		ioutil:                 mockIOUtil,
+		ipCompatibility:        ipCompatibility,
 	}
 }
 
@@ -101,10 +106,11 @@ func TestInitializeFileEnvResource(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, nil, nil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, nil, nil, testIPCompatibility)
 	envfileResource.Initialize(&taskresource.ResourceFields{
 		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
 			CredentialsManager: mockCredentialsManager,
+			IPCompatibility:    testIPCompatibility,
 		},
 	}, status.TaskRunning, status.TaskRunning)
 
@@ -113,6 +119,7 @@ func TestInitializeFileEnvResource(t *testing.T) {
 	assert.NotNil(t, envfileResource.credentialsManager)
 	assert.NotNil(t, envfileResource.s3ClientCreator)
 	assert.NotNil(t, envfileResource.ioutil)
+	assert.NotNil(t, testIPCompatibility, envfileResource.ipCompatibility)
 }
 
 func TestCreateWithEnvVarFile(t *testing.T) {
@@ -122,7 +129,7 @@ func TestCreateWithEnvVarFile(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockIOUtil, testIPCompatibility)
 	creds := credentials.TaskIAMRoleCredentials{
 		ARN: iamRoleARN,
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
@@ -140,7 +147,7 @@ func TestCreateWithEnvVarFile(t *testing.T) {
 
 	gomock.InOrder(
 		mockCredentialsManager.EXPECT().GetTaskCredentials(executionCredentialsID).Return(creds, true),
-		mockS3ClientCreator.EXPECT().NewS3ManagerClient(s3Bucket, region, creds.IAMRoleCredentials).Return(mockS3Client, nil),
+		mockS3ClientCreator.EXPECT().NewS3ManagerClient(s3Bucket, region, creds.IAMRoleCredentials, testIPCompatibility).Return(mockS3Client, nil),
 		mockIOUtil.EXPECT().TempFile(resourceDir, gomock.Any()).Return(mockFile, nil),
 		mockS3Client.EXPECT().DownloadWithContext(
 			gomock.Any(), mockFile, gomock.Any(), gomock.Any(),
@@ -161,7 +168,7 @@ func TestCreateWithInvalidS3ARN(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s", s3File), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockIOUtil, testIPCompatibility)
 	creds := credentials.TaskIAMRoleCredentials{
 		ARN: iamRoleARN,
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
@@ -185,7 +192,7 @@ func TestCreateUnableToRetrieveDataFromS3(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockIOUtil, testIPCompatibility)
 	creds := credentials.TaskIAMRoleCredentials{
 		ARN: iamRoleARN,
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
@@ -196,7 +203,7 @@ func TestCreateUnableToRetrieveDataFromS3(t *testing.T) {
 
 	gomock.InOrder(
 		mockCredentialsManager.EXPECT().GetTaskCredentials(executionCredentialsID).Return(creds, true),
-		mockS3ClientCreator.EXPECT().NewS3ManagerClient(s3Bucket, region, creds.IAMRoleCredentials).Return(mockS3Client, nil),
+		mockS3ClientCreator.EXPECT().NewS3ManagerClient(s3Bucket, region, creds.IAMRoleCredentials, testIPCompatibility).Return(mockS3Client, nil),
 		mockIOUtil.EXPECT().TempFile(resourceDir, gomock.Any()).Return(mockFile, nil),
 		mockS3Client.EXPECT().DownloadWithContext(gomock.Any(), mockFile, gomock.Any()).Return(int64(0), errors.New("error response")),
 	)
@@ -213,7 +220,7 @@ func TestCreateUnableToCreateTmpFile(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockIOUtil, testIPCompatibility)
 	creds := credentials.TaskIAMRoleCredentials{
 		ARN: iamRoleARN,
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
@@ -224,7 +231,7 @@ func TestCreateUnableToCreateTmpFile(t *testing.T) {
 
 	gomock.InOrder(
 		mockCredentialsManager.EXPECT().GetTaskCredentials(executionCredentialsID).Return(creds, true),
-		mockS3ClientCreator.EXPECT().NewS3ManagerClient(s3Bucket, region, creds.IAMRoleCredentials).Return(mockS3Client, nil),
+		mockS3ClientCreator.EXPECT().NewS3ManagerClient(s3Bucket, region, creds.IAMRoleCredentials, testIPCompatibility).Return(mockS3Client, nil),
 		mockIOUtil.EXPECT().TempFile(resourceDir, gomock.Any()).Return(nil, errors.New("error response")),
 	)
 
@@ -241,7 +248,7 @@ func TestCreateRenameFileError(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockIOUtil, testIPCompatibility)
 	creds := credentials.TaskIAMRoleCredentials{
 		ARN: iamRoleARN,
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
@@ -259,7 +266,7 @@ func TestCreateRenameFileError(t *testing.T) {
 
 	gomock.InOrder(
 		mockCredentialsManager.EXPECT().GetTaskCredentials(executionCredentialsID).Return(creds, true),
-		mockS3ClientCreator.EXPECT().NewS3ManagerClient(s3Bucket, region, creds.IAMRoleCredentials).Return(mockS3Client, nil),
+		mockS3ClientCreator.EXPECT().NewS3ManagerClient(s3Bucket, region, creds.IAMRoleCredentials, testIPCompatibility).Return(mockS3Client, nil),
 		mockIOUtil.EXPECT().TempFile(resourceDir, gomock.Any()).Return(mockFile, nil),
 		mockS3Client.EXPECT().DownloadWithContext(gomock.Any(), mockFile, gomock.Any()).Return(int64(0), nil),
 	)
@@ -277,7 +284,7 @@ func TestEnvFileCleanupSuccess(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockIOUtil, testIPCompatibility)
 
 	assert.NoError(t, envfileResource.Cleanup())
 }
@@ -290,7 +297,7 @@ func TestEnvFileCleanupResourceDirRemoveFail(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockIOUtil, testIPCompatibility)
 
 	removeAll = func(path string) error {
 		return errors.New("error response")
@@ -314,7 +321,7 @@ func TestReadEnvVarsFromEnvfiles(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, nil, nil, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, nil, nil, mockIOUtil, testIPCompatibility)
 	envfileResource.bufio = mockBufio
 
 	envfileContentLine1 := "key1=value"
@@ -363,7 +370,7 @@ func TestReadEnvVarsCommentFromEnvfiles(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, nil, nil, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, nil, nil, mockIOUtil, testIPCompatibility)
 	envfileResource.bufio = mockBufio
 
 	tempOpen := open
@@ -401,7 +408,7 @@ func TestReadEnvVarsInvalidFromEnvfiles(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, nil, nil, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, nil, nil, mockIOUtil, testIPCompatibility)
 	envfileResource.bufio = mockBufio
 
 	tempOpen := open
@@ -435,7 +442,7 @@ func TestReadEnvVarsUnableToReadEnvfile(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, nil, nil, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, nil, nil, mockIOUtil, testIPCompatibility)
 
 	tempOpen := open
 	open = func(name string) (oswrapper.File, error) {

--- a/agent/taskresource/firelens/firelens_unimplemented.go
+++ b/agent/taskresource/firelens/firelens_unimplemented.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
@@ -155,7 +156,9 @@ func (firelens *FirelensResource) UnmarshalJSON(b []byte) error {
 }
 
 // Initialize fills in the resource fields.
-func (firelens *FirelensResource) Initialize(resourceFields *taskresource.ResourceFields,
+func (firelens *FirelensResource) Initialize(
+	config *config.Config,
+	resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
 }

--- a/agent/taskresource/firelens/firelens_unimplemented.go
+++ b/agent/taskresource/firelens/firelens_unimplemented.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
@@ -53,7 +54,7 @@ type FirelensResource struct{}
 // NewFirelensResource returns a new FirelensResource.
 func NewFirelensResource(cluster, taskARN, taskDefinition, ec2InstanceID, dataDir, firelensConfigType, region, networkMode string,
 	firelensOptions map[string]string, containerToLogOptions map[string]map[string]string, credentialsManager credentials.Manager,
-	executionCredentialsID string, containerMemoryLimit int64) (*FirelensResource, error) {
+	executionCredentialsID string, containerMemoryLimit int64, ipCompatibility ipcompatibility.IPCompatibility) (*FirelensResource, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/agent/taskresource/firelens/firelens_unix.go
+++ b/agent/taskresource/firelens/firelens_unix.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
@@ -213,7 +214,9 @@ func (firelens *FirelensResource) GetExternalConfigValue() string {
 }
 
 // Initialize initializes the resource.
-func (firelens *FirelensResource) Initialize(resourceFields *taskresource.ResourceFields,
+func (firelens *FirelensResource) Initialize(
+	config *config.Config,
+	resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus, taskDesiredStatus status.TaskStatus) {
 	firelens.lock.Lock()
 	defer firelens.lock.Unlock()
@@ -223,7 +226,7 @@ func (firelens *FirelensResource) Initialize(resourceFields *taskresource.Resour
 	firelens.ioutil = ioutilwrapper.NewIOUtil()
 	firelens.s3ClientCreator = factory.NewS3ClientCreator()
 	firelens.credentialsManager = resourceFields.CredentialsManager
-	firelens.ipCompatibility = resourceFields.IPCompatibility
+	firelens.ipCompatibility = config.InstanceIPCompatibility
 }
 
 // GetNetworkMode returns the network mode of the task.

--- a/agent/taskresource/firelens/firelens_unix_test.go
+++ b/agent/taskresource/firelens/firelens_unix_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	mock_factory "github.com/aws/amazon-ecs-agent/agent/s3/factory/mocks"
 	mock_s3 "github.com/aws/amazon-ecs-agent/agent/s3/mocks/s3manager"
@@ -483,14 +484,17 @@ func TestInitializeFirelensResource(t *testing.T) {
 	_, _, mockCredentialsManager, _, _, done := setup(t)
 	defer done()
 
+	testConfig := &config.Config{InstanceIPCompatibility: testIPCompatibility}
+
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, nil, nil,
 		nil, testContainerMemoryLimit, testIPCompatibility)
-	firelensResource.Initialize(&taskresource.ResourceFields{
-		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
-			CredentialsManager: mockCredentialsManager,
-			IPCompatibility:    testIPCompatibility,
-		},
-	}, status.TaskRunning, status.TaskRunning)
+	firelensResource.Initialize(
+		testConfig,
+		&taskresource.ResourceFields{
+			ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
+				CredentialsManager: mockCredentialsManager,
+			},
+		}, status.TaskRunning, status.TaskRunning)
 
 	assert.NotNil(t, firelensResource.statusToTransitions)
 	assert.Equal(t, 1, len(firelensResource.statusToTransitions))

--- a/agent/taskresource/firelens/firelens_unix_test.go
+++ b/agent/taskresource/firelens/firelens_unix_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	mock_factory "github.com/aws/amazon-ecs-agent/agent/s3/factory/mocks"
 	mock_s3 "github.com/aws/amazon-ecs-agent/agent/s3/mocks/s3manager"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -69,6 +70,8 @@ var (
 		"config-file-type":        "s3",
 		"config-file-value":       "arn:aws:s3:::bucket/key",
 	}
+
+	testIPCompatibility = ipcompatibility.NewIPCompatibility(true, true)
 )
 
 func setup(t *testing.T) (oswrapper.File, *mock_ioutilwrapper.MockIOUtil,
@@ -106,7 +109,7 @@ func mockMkdirAllError() func() {
 
 func newMockFirelensResource(firelensConfigType, networkMode string, lopOptions map[string]string,
 	mockIOUtil *mock_ioutilwrapper.MockIOUtil, mockCredentialsManager *mock_credentials.MockManager,
-	mockS3ClientCreator *mock_factory.MockS3ClientCreator, containerMemoryReservation int64) *FirelensResource {
+	mockS3ClientCreator *mock_factory.MockS3ClientCreator, containerMemoryReservation int64, ipCompatibility ipcompatibility.IPCompatibility) *FirelensResource {
 	return &FirelensResource{
 		cluster:            testCluster,
 		taskARN:            testTaskARN,
@@ -124,6 +127,7 @@ func newMockFirelensResource(firelensConfigType, networkMode string, lopOptions 
 		ioutil:                 mockIOUtil,
 		s3ClientCreator:        mockS3ClientCreator,
 		containerMemoryLimit:   containerMemoryReservation,
+		ipCompatibility:        ipCompatibility,
 	}
 }
 
@@ -160,7 +164,7 @@ func TestCreateFirelensResourceFluentdBridgeMode(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	defer mockRename()()
 	gomock.InOrder(
@@ -175,7 +179,7 @@ func TestCreateFirelensResourceFluentdAWSVPCMode(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, awsvpcNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	defer mockRename()()
 	gomock.InOrder(
@@ -190,7 +194,7 @@ func TestCreateFirelensResourceFluentdDefaultMode(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, "", testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	defer mockRename()()
 	gomock.InOrder(
@@ -205,7 +209,7 @@ func TestCreateFirelensResourceFluentbit(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentbit, bridgeNetworkMode, testFluentbitOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	defer mockRename()()
 	gomock.InOrder(
@@ -220,7 +224,7 @@ func TestCreateFirelensResourceInvalidType(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 	firelensResource.firelensConfigType = "invalid"
 
 	assert.Error(t, firelensResource.Create())
@@ -232,7 +236,7 @@ func TestCreateFirelensResourceCreateConfigDirError(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	defer mockMkdirAllError()()
 
@@ -245,7 +249,7 @@ func TestCreateFirelensResourceCreateSocketDirError(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	defer mockMkdirAllError()()
 
@@ -258,7 +262,7 @@ func TestCreateFirelensResourceGenerateConfigError(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 	firelensResource.containerToLogOptions = map[string]map[string]string{
 		"container": {
 			"invalid": "invalid",
@@ -274,7 +278,7 @@ func TestCreateFirelensResourceCreateTempFileError(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	gomock.InOrder(
 		mockIOUtil.EXPECT().TempFile(testResourceDir, tempFile).Return(nil, errors.New("test error")),
@@ -289,7 +293,7 @@ func TestCreateFirelensResourceWriteConfigFileError(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	mockFile.(*mock_oswrapper.MockFile).WriteImpl = func(bytes []byte) (i int, e error) {
 		return 0, errors.New("test error")
@@ -308,7 +312,7 @@ func TestCreateFirelensResourceChmodError(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	mockFile.(*mock_oswrapper.MockFile).ChmodImpl = func(mode os.FileMode) error {
 		return errors.New("test error")
@@ -327,7 +331,7 @@ func TestCreateFirelensResourceRenameError(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	gomock.InOrder(
 		mockIOUtil.EXPECT().TempFile(testResourceDir, tempFile).Return(mockFile, nil),
@@ -349,7 +353,7 @@ func TestCreateFirelensResourceWithS3Config(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	err := firelensResource.parseOptions(testFirelensOptionsS3)
 	require.NoError(t, err)
@@ -366,7 +370,7 @@ func TestCreateFirelensResourceWithS3Config(t *testing.T) {
 
 	gomock.InOrder(
 		mockCredentialsManager.EXPECT().GetTaskCredentials(testExecutionCredentialsID).Return(creds, true),
-		mockS3ClientCreator.EXPECT().NewS3ManagerClient("bucket", testRegion, creds.IAMRoleCredentials).Return(mockS3Client, nil),
+		mockS3ClientCreator.EXPECT().NewS3ManagerClient("bucket", testRegion, creds.IAMRoleCredentials, testIPCompatibility).Return(mockS3Client, nil),
 		// write external config file downloaded from s3
 		mockIOUtil.EXPECT().TempFile(testResourceDir, tempFile).Return(mockFile, nil),
 		mockS3Client.EXPECT().DownloadWithContext(gomock.Any(), mockFile, gomock.Any(), gomock.Any()).Do(
@@ -387,7 +391,7 @@ func TestCreateFirelensResourceWithS3ConfigMissingCredentials(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	err := firelensResource.parseOptions(testFirelensOptionsS3)
 	require.NoError(t, err)
@@ -405,7 +409,7 @@ func TestCreateFirelensResourceWithS3ConfigInvalidS3ARN(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	err := firelensResource.parseOptions(testFirelensOptionsS3)
 	require.NoError(t, err)
@@ -424,7 +428,7 @@ func TestCreateFirelensResourceWithS3ConfigDownloadFailure(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	err := firelensResource.parseOptions(testFirelensOptionsS3)
 	require.NoError(t, err)
@@ -438,7 +442,7 @@ func TestCreateFirelensResourceWithS3ConfigDownloadFailure(t *testing.T) {
 	}
 	gomock.InOrder(
 		mockCredentialsManager.EXPECT().GetTaskCredentials(testExecutionCredentialsID).Return(creds, true),
-		mockS3ClientCreator.EXPECT().NewS3ManagerClient("bucket", testRegion, creds.IAMRoleCredentials).Return(mockS3Client, nil),
+		mockS3ClientCreator.EXPECT().NewS3ManagerClient("bucket", testRegion, creds.IAMRoleCredentials, testIPCompatibility).Return(mockS3Client, nil),
 		mockIOUtil.EXPECT().TempFile(testResourceDir, tempFile).Return(mockFile, nil),
 		mockS3Client.EXPECT().DownloadWithContext(gomock.Any(), mockFile, gomock.Any()).Return(int64(0), errors.New("test error")),
 	)
@@ -452,7 +456,7 @@ func TestCleanupFirelensResource(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	assert.NoError(t, firelensResource.Cleanup())
 }
@@ -462,7 +466,7 @@ func TestCleanupFirelensResourceError(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, mockIOUtil,
-		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit)
+		mockCredentialsManager, mockS3ClientCreator, testContainerMemoryLimit, testIPCompatibility)
 
 	removeAll = func(path string) error {
 		return errors.New("test error")
@@ -480,10 +484,11 @@ func TestInitializeFirelensResource(t *testing.T) {
 	defer done()
 
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, nil, nil,
-		nil, testContainerMemoryLimit)
+		nil, testContainerMemoryLimit, testIPCompatibility)
 	firelensResource.Initialize(&taskresource.ResourceFields{
 		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
 			CredentialsManager: mockCredentialsManager,
+			IPCompatibility:    testIPCompatibility,
 		},
 	}, status.TaskRunning, status.TaskRunning)
 
@@ -492,11 +497,12 @@ func TestInitializeFirelensResource(t *testing.T) {
 	assert.NotNil(t, firelensResource.ioutil)
 	assert.NotNil(t, firelensResource.s3ClientCreator)
 	assert.NotNil(t, firelensResource.credentialsManager)
+	assert.NotNil(t, testIPCompatibility, firelensResource.ipCompatibility)
 }
 
 func TestSetKnownStatus(t *testing.T) {
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, nil, nil,
-		nil, testContainerMemoryLimit)
+		nil, testContainerMemoryLimit, testIPCompatibility)
 	firelensResource.appliedStatusUnsafe = resourcestatus.ResourceStatus(FirelensCreated)
 
 	firelensResource.SetKnownStatus(resourcestatus.ResourceStatus(FirelensCreated))
@@ -506,7 +512,7 @@ func TestSetKnownStatus(t *testing.T) {
 
 func TestSetKnownStatusNoAppliedStatusUpdate(t *testing.T) {
 	firelensResource := newMockFirelensResource(FirelensConfigTypeFluentd, bridgeNetworkMode, testFluentdOptions, nil, nil,
-		nil, testContainerMemoryLimit)
+		nil, testContainerMemoryLimit, testIPCompatibility)
 	firelensResource.appliedStatusUnsafe = resourcestatus.ResourceStatus(FirelensCreated)
 
 	firelensResource.SetKnownStatus(resourcestatus.ResourceStatus(FirelensStatusNone))

--- a/agent/taskresource/firelens/firelensconfig_unix_test.go
+++ b/agent/taskresource/firelens/firelensconfig_unix_test.go
@@ -355,7 +355,7 @@ func TestGenerateFluentdBridgeModeConfig(t *testing.T) {
 
 	firelensResource, err := NewFirelensResource(testCluster, testTaskARN, testTaskDefinition, testEC2InstanceID,
 		testDataDir, FirelensConfigTypeFluentd, testRegion, bridgeNetworkMode, testFirelensOptionsFile, containerToLogOptions,
-		nil, testExecutionCredentialsID, testContainerMemoryLimit)
+		nil, testExecutionCredentialsID, testContainerMemoryLimit, testIPCompatibility)
 	require.NoError(t, err)
 
 	config, err := firelensResource.generateConfig()
@@ -374,7 +374,7 @@ func TestGenerateFluentdAWSVPCModeConfig(t *testing.T) {
 
 	firelensResource, err := NewFirelensResource(testCluster, testTaskARN, testTaskDefinition, testEC2InstanceID,
 		testDataDir, FirelensConfigTypeFluentd, testRegion, awsvpcNetworkMode, testFirelensOptionsFile, containerToLogOptions,
-		nil, testExecutionCredentialsID, testContainerMemoryLimit)
+		nil, testExecutionCredentialsID, testContainerMemoryLimit, testIPCompatibility)
 	require.NoError(t, err)
 
 	config, err := firelensResource.generateConfig()
@@ -393,7 +393,7 @@ func TestGenerateFluentdDefaultModeConfig(t *testing.T) {
 
 	firelensResource, err := NewFirelensResource(testCluster, testTaskARN, testTaskDefinition, testEC2InstanceID,
 		testDataDir, FirelensConfigTypeFluentd, testRegion, "", testFirelensOptionsFile, containerToLogOptions,
-		nil, testExecutionCredentialsID, testContainerMemoryLimit)
+		nil, testExecutionCredentialsID, testContainerMemoryLimit, testIPCompatibility)
 	require.NoError(t, err)
 
 	config, err := firelensResource.generateConfig()
@@ -412,7 +412,7 @@ func TestGenerateFluentbitConfig(t *testing.T) {
 
 	firelensResource, err := NewFirelensResource(testCluster, testTaskARN, testTaskDefinition, testEC2InstanceID,
 		testDataDir, FirelensConfigTypeFluentbit, testRegion, bridgeNetworkMode, testFirelensOptionsS3, containerToLogOptions,
-		nil, testExecutionCredentialsID, testContainerMemoryLimit)
+		nil, testExecutionCredentialsID, testContainerMemoryLimit, testIPCompatibility)
 	require.NoError(t, err)
 
 	config, err := firelensResource.generateConfig()
@@ -431,7 +431,7 @@ func TestGenerateFluentbitConfigWithDefaultMemBufLimit(t *testing.T) {
 
 	firelensResource, err := NewFirelensResource(testCluster, testTaskARN, testTaskDefinition, testEC2InstanceID,
 		testDataDir, FirelensConfigTypeFluentbit, testRegion, bridgeNetworkMode, testFirelensOptionsS3, containerToLogOptions,
-		nil, testExecutionCredentialsID, 0)
+		nil, testExecutionCredentialsID, 0, testIPCompatibility)
 	require.NoError(t, err)
 
 	config, err := firelensResource.generateConfig()
@@ -452,7 +452,7 @@ func TestGenerateFluentdConfigMissingOutputName(t *testing.T) {
 
 	firelensResource, err := NewFirelensResource(testCluster, testTaskARN, testTaskDefinition, testEC2InstanceID,
 		testDataDir, FirelensConfigTypeFluentd, testRegion, bridgeNetworkMode, testFirelensOptionsFile, containerToLogOptions,
-		nil, testExecutionCredentialsID, testContainerMemoryLimit)
+		nil, testExecutionCredentialsID, testContainerMemoryLimit, testIPCompatibility)
 	require.NoError(t, err)
 
 	_, err = firelensResource.generateConfig()
@@ -468,7 +468,7 @@ func TestGenerateFLuentbitConfigMissingOutputName(t *testing.T) {
 
 	firelensResource, err := NewFirelensResource(testCluster, testTaskARN, testTaskDefinition, testEC2InstanceID,
 		testDataDir, FirelensConfigTypeFluentbit, testRegion, bridgeNetworkMode, testFirelensOptionsFile, containerToLogOptions,
-		nil, testExecutionCredentialsID, testContainerMemoryLimit)
+		nil, testExecutionCredentialsID, testContainerMemoryLimit, testIPCompatibility)
 	require.NoError(t, err)
 
 	_, err = firelensResource.generateConfig()
@@ -487,7 +487,7 @@ func TestGenerateConfigWithECSMetadataDisabled(t *testing.T) {
 
 	firelensResource, err := NewFirelensResource(testCluster, testTaskARN, testTaskDefinition, testEC2InstanceID,
 		testDataDir, FirelensConfigTypeFluentd, testRegion, bridgeNetworkMode, testFirelensOptions, containerToLogOptions,
-		nil, testExecutionCredentialsID, testContainerMemoryLimit)
+		nil, testExecutionCredentialsID, testContainerMemoryLimit, testIPCompatibility)
 	require.NoError(t, err)
 
 	config, err := firelensResource.generateConfig()
@@ -509,7 +509,7 @@ func TestGenerateConfigWithoutOutputSection(t *testing.T) {
 
 	firelensResource, err := NewFirelensResource(testCluster, testTaskARN, testTaskDefinition, testEC2InstanceID,
 		testDataDir, FirelensConfigTypeFluentbit, testRegion, bridgeNetworkMode, testFirelensOptionsS3, containerToLogOptions,
-		nil, testExecutionCredentialsID, testContainerMemoryLimit)
+		nil, testExecutionCredentialsID, testContainerMemoryLimit, testIPCompatibility)
 	require.NoError(t, err)
 
 	config, err := firelensResource.generateConfig()

--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_unsupported.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_unsupported.go
@@ -21,6 +21,7 @@ import (
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	asmfactory "github.com/aws/amazon-ecs-agent/agent/asm/factory"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	fsxfactory "github.com/aws/amazon-ecs-agent/agent/fsx/factory"
 	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -55,7 +56,9 @@ func NewFSxWindowsFileServerResource(
 	return nil, errors.New("not supported")
 }
 
-func (fv *FSxWindowsFileServerResource) Initialize(resourceFields *taskresource.ResourceFields,
+func (fv *FSxWindowsFileServerResource) Initialize(
+	config *config.Config,
+	resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
 }

--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/asm"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/ssm"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -136,7 +137,9 @@ func NewFSxWindowsFileServerResource(
 	return fv, nil
 }
 
-func (fv *FSxWindowsFileServerResource) Initialize(resourceFields *taskresource.ResourceFields,
+func (fv *FSxWindowsFileServerResource) Initialize(
+	config *config.Config,
+	resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
 

--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows_test.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 
 	mock_asm_factory "github.com/aws/amazon-ecs-agent/agent/asm/factory/mocks"
@@ -79,14 +80,16 @@ func setup(t *testing.T) (
 		desiredStatusUnsafe: resourcestatus.ResourceCreated,
 		taskARN:             taskARN,
 	}
-	fv.Initialize(&taskresource.ResourceFields{
-		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
-			SSMClientCreator:   ssmClientCreator,
-			ASMClientCreator:   asmClientCreator,
-			FSxClientCreator:   fsxClientCreator,
-			CredentialsManager: credentialsManager,
-		},
-	}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
+	fv.Initialize(
+		&config.Config{},
+		&taskresource.ResourceFields{
+			ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
+				SSMClientCreator:   ssmClientCreator,
+				ASMClientCreator:   asmClientCreator,
+				FSxClientCreator:   fsxClientCreator,
+				CredentialsManager: credentialsManager,
+			},
+		}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
 	return fv, credentialsManager, ssmClientCreator, asmClientCreator, fsxClientCreator, mockSSMClient, mockASMClient, mockFSxClient
 }
 
@@ -520,14 +523,16 @@ func TestCreateUnavailableLocalPath(t *testing.T) {
 		taskARN:                taskARN,
 		executionCredentialsID: executionCredentialsID,
 	}
-	fv.Initialize(&taskresource.ResourceFields{
-		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
-			SSMClientCreator:   ssmClientCreator,
-			ASMClientCreator:   asmClientCreator,
-			FSxClientCreator:   fsxClientCreator,
-			CredentialsManager: credentialsManager,
-		},
-	}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
+	fv.Initialize(
+		&config.Config{},
+		&taskresource.ResourceFields{
+			ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
+				SSMClientCreator:   ssmClientCreator,
+				ASMClientCreator:   asmClientCreator,
+				FSxClientCreator:   fsxClientCreator,
+				CredentialsManager: credentialsManager,
+			},
+		}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
 
 	ssmTestData := "{\n\"username\": \"user\", \n\"password\": \"pass\"\n}"
 	ssmClientOutput := &ssm.GetParametersOutput{
@@ -605,14 +610,16 @@ func TestCreateSSM(t *testing.T) {
 		taskARN:                taskARN,
 		executionCredentialsID: executionCredentialsID,
 	}
-	fv.Initialize(&taskresource.ResourceFields{
-		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
-			SSMClientCreator:   ssmClientCreator,
-			ASMClientCreator:   asmClientCreator,
-			FSxClientCreator:   fsxClientCreator,
-			CredentialsManager: credentialsManager,
-		},
-	}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
+	fv.Initialize(
+		&config.Config{},
+		&taskresource.ResourceFields{
+			ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
+				SSMClientCreator:   ssmClientCreator,
+				ASMClientCreator:   asmClientCreator,
+				FSxClientCreator:   fsxClientCreator,
+				CredentialsManager: credentialsManager,
+			},
+		}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
 
 	ssmTestData := "{\n\"username\": \"user\", \n\"password\": \"pass\"\n}"
 	ssmClientOutput := &ssm.GetParametersOutput{
@@ -692,14 +699,16 @@ func TestCreateASM(t *testing.T) {
 		taskARN:                taskARN,
 		executionCredentialsID: executionCredentialsID,
 	}
-	fv.Initialize(&taskresource.ResourceFields{
-		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
-			SSMClientCreator:   ssmClientCreator,
-			ASMClientCreator:   asmClientCreator,
-			FSxClientCreator:   fsxClientCreator,
-			CredentialsManager: credentialsManager,
-		},
-	}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
+	fv.Initialize(
+		&config.Config{},
+		&taskresource.ResourceFields{
+			ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
+				SSMClientCreator:   ssmClientCreator,
+				ASMClientCreator:   asmClientCreator,
+				FSxClientCreator:   fsxClientCreator,
+				CredentialsManager: credentialsManager,
+			},
+		}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
 
 	asmTestData := "{\"username\":\"user\",\"password\":\"pass\"}"
 	asmClientOutput := &secretsmanager.GetSecretValueOutput{

--- a/agent/taskresource/interface.go
+++ b/agent/taskresource/interface.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
@@ -73,8 +74,12 @@ type TaskResource interface {
 	BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
 		dependent resourcestatus.ResourceStatus)
 	// Initialize will initialize the resource fields of the resource
-	Initialize(res *ResourceFields,
-		taskKnownStatus apitaskstatus.TaskStatus, taskDesiredStatus apitaskstatus.TaskStatus)
+	Initialize(
+		config *config.Config,
+		res *ResourceFields,
+		taskKnownStatus apitaskstatus.TaskStatus,
+		taskDesiredStatus apitaskstatus.TaskStatus,
+	)
 
 	json.Marshaler
 	json.Unmarshaler

--- a/agent/taskresource/mocks/taskresource_mocks.go
+++ b/agent/taskresource/mocks/taskresource_mocks.go
@@ -23,6 +23,7 @@ import (
 	time "time"
 
 	container "github.com/aws/amazon-ecs-agent/agent/api/container"
+	config "github.com/aws/amazon-ecs-agent/agent/config"
 	taskresource "github.com/aws/amazon-ecs-agent/agent/taskresource"
 	status "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	status0 "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
@@ -234,15 +235,15 @@ func (mr *MockTaskResourceMockRecorder) GetTerminalReason() *gomock.Call {
 }
 
 // Initialize mocks base method.
-func (m *MockTaskResource) Initialize(arg0 *taskresource.ResourceFields, arg1, arg2 status1.TaskStatus) {
+func (m *MockTaskResource) Initialize(arg0 *config.Config, arg1 *taskresource.ResourceFields, arg2, arg3 status1.TaskStatus) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Initialize", arg0, arg1, arg2)
+	m.ctrl.Call(m, "Initialize", arg0, arg1, arg2, arg3)
 }
 
 // Initialize indicates an expected call of Initialize.
-func (mr *MockTaskResourceMockRecorder) Initialize(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockTaskResourceMockRecorder) Initialize(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockTaskResource)(nil).Initialize), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockTaskResource)(nil).Initialize), arg0, arg1, arg2, arg3)
 }
 
 // KnownCreated mocks base method.

--- a/agent/taskresource/ssmsecret/ssmsecret.go
+++ b/agent/taskresource/ssmsecret/ssmsecret.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/ssm"
 	"github.com/aws/amazon-ecs-agent/agent/ssm/factory"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -406,7 +407,9 @@ func (secret *SSMSecretResource) SetCachedSecretValue(secretKey string, secretVa
 	secret.secretData[secretKey] = secretValue
 }
 
-func (secret *SSMSecretResource) Initialize(resourceFields *taskresource.ResourceFields,
+func (secret *SSMSecretResource) Initialize(
+	config *config.Config,
+	resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
 	secret.initStatusToTransition()

--- a/agent/taskresource/ssmsecret/ssmsecret_test.go
+++ b/agent/taskresource/ssmsecret/ssmsecret_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	mock_factory "github.com/aws/amazon-ecs-agent/agent/ssm/factory/mocks"
 	mock_ssm "github.com/aws/amazon-ecs-agent/agent/ssm/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -496,12 +497,14 @@ func TestInitialize(t *testing.T) {
 		knownStatusUnsafe:   resourcestatus.ResourceCreated,
 		desiredStatusUnsafe: resourcestatus.ResourceCreated,
 	}
-	ssmRes.Initialize(&taskresource.ResourceFields{
-		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
-			SSMClientCreator:   ssmClientCreator,
-			CredentialsManager: credentialsManager,
-		},
-	}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
+	ssmRes.Initialize(
+		&config.Config{},
+		&taskresource.ResourceFields{
+			ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
+				SSMClientCreator:   ssmClientCreator,
+				CredentialsManager: credentialsManager,
+			},
+		}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
 	assert.Equal(t, resourcestatus.ResourceStatusNone, ssmRes.GetKnownStatus())
 	assert.Equal(t, resourcestatus.ResourceCreated, ssmRes.GetDesiredStatus())
 

--- a/agent/taskresource/types_common.go
+++ b/agent/taskresource/types_common.go
@@ -15,6 +15,7 @@ package taskresource
 
 import (
 	asmfactory "github.com/aws/amazon-ecs-agent/agent/asm/factory"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	fsxfactory "github.com/aws/amazon-ecs-agent/agent/fsx/factory"
 	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
 	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
@@ -30,4 +31,5 @@ type ResourceFieldsCommon struct {
 	S3ClientCreator    s3factory.S3ClientCreator
 	CredentialsManager credentials.Manager
 	EC2InstanceID      string
+	IPCompatibility    ipcompatibility.IPCompatibility
 }

--- a/agent/taskresource/types_common.go
+++ b/agent/taskresource/types_common.go
@@ -15,7 +15,6 @@ package taskresource
 
 import (
 	asmfactory "github.com/aws/amazon-ecs-agent/agent/asm/factory"
-	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	fsxfactory "github.com/aws/amazon-ecs-agent/agent/fsx/factory"
 	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
 	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
@@ -31,5 +30,4 @@ type ResourceFieldsCommon struct {
 	S3ClientCreator    s3factory.S3ClientCreator
 	CredentialsManager credentials.Manager
 	EC2InstanceID      string
-	IPCompatibility    ipcompatibility.IPCompatibility
 }

--- a/agent/taskresource/volume/dockervolume.go
+++ b/agent/taskresource/volume/dockervolume.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -132,7 +133,9 @@ func NewVolumeResource(ctx context.Context,
 	return v, nil
 }
 
-func (vol *VolumeResource) Initialize(resourceFields *taskresource.ResourceFields,
+func (vol *VolumeResource) Initialize(
+	config *config.Config,
+	resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Enables S3 and S3Manager clients to automatically use dualstack endpoints when running on IPv6-only instances.

### Implementation details
1. Client Configuration Updates
    1. Modified `NewS3ManagerClient` and `NewS3Client` to accept `IPCompatibility` parameter
    2. Enhanced `createAwsConfig` to set `useDualStackEndpoint` based on IPv6 compatibility status
 3. Task Resources
     1. S3 clients are mainly used by `TaskResources` such as `EnvFiles`, `Firelens`, and `CredentialSpecs`.
     2. Added an `ipCompatibility` field to each task resource.  
           1.   Updated `New*` constructors to accept an additional `ipCompatibility` parameter. `New*` is invoked when there's a new incoming task that requires task resources.
           2. `Config.InstanceIPCompatibility` is the source of value
5. Modified Task Resources interface to pass in `*Config` to `Initialize()`.  `Initialize()` is invoked when Agent restarts and reinitialize task resouces
    1. Update all other task resources that implement this interface
7. CredentialsMetadataSetter Updates
    1. Updated `NewCredentialsMetadataSetter` to accept an `IPCompatibility` parameter
    2. Modified `checkAndSetDomainlessGMSATaskExecutionRoleCredentialsImpl` to use the `IPCompatibility` parameter when creating the `CredentialSpecResource`


### Testing
Executed functional test suite on dualstack subnet. Verified all tests passed and dualstack endpoint usage through docker container logs.
```
Host: {bucket-name}-prod.s3.dualstack.us-west-2.amazonaws.com
```
Setups done: 
- Set `IPCompatibility` to `NewIPv6OnlyCompatibility`
- Pin the functional test suite on a dualstack subnet (agent is currently connecting to control plane via IPv4).
- Set the `awsConfig` to `Debug` level and directed logs to `os.Stdout`. 

New tests cover the changes: yes
- Refactored `TestCreateAWSConfig` to remove redundant test
- Extended the test to verify correct Dualstack flag configuration in `Config`

### Description for the changelog
Enhancement: S3 and S3Manager clients resolves to dualstack endpoint on IPV6-only instances

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
