### PR TITLE
Fix a bug in Service Connect error handling

### DIFF
--- a/agent/engine/serviceconnect/manager_linux.go
+++ b/agent/engine/serviceconnect/manager_linux.go
@@ -348,9 +348,12 @@ func (m *manager) AugmentTaskContainer(
 			DNSConfigToDockerExtraHostsFormat(task.ServiceConnectConfig.DNSConfig)...)
 	}
 	if container == task.GetServiceConnectContainer() {
-		m.augmentAgentContainer(task, container, hostConfig, instanceIPCompatibility)
+		err = m.augmentAgentContainer(task, container, hostConfig, instanceIPCompatibility)
 	}
-	return err
+	if err != nil {
+		return dockerapi.CannotCreateContainerError{FromError: err}
+	}
+	return nil
 }
 
 func (m *manager) CreateInstanceTask(cfg *config.Config) (*apitask.Task, error) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Service connect tasks go through an "augmenting" phase handled by `serviceconnect.Manager`'s `AugmentTaskContainer` method. This method makes some changes to tasks such as populating `APPNET_CONTAINER_IP_MAPPING` environment variable in service connect sidecar container. However, the method implementation currently swallows any errors that happen during the augmentation process. This PR fixes this bug by surfacing any such errors as `CannotCreateContainer` errors.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Ran a Service Connect bridge mode service task on an instance faked to have IPv6-only compatibility and without IPv6 enabled on docker bridge network. This causes task augmentation to fail because an IPv6 address is expected for each task container but it is not found. Verified the task stop error in DescribeTasks response that is reproduced below. 

```
$ aws ecs describe-tasks --cluster tutorial --task a2eafcdda65348178cc6e0da96cb2cdc | jq '.tasks[0].containers'
[
  {
    "containerArn": "arn:aws:ecs:us-west-2:979604884904:container/tutorial/a2eafcdda65348178cc6e0da96cb2cdc/27ff7458-2088-4ae0-8cbe-a8e38ab01a45",
    "taskArn": "arn:aws:ecs:us-west-2:979604884904:task/tutorial/a2eafcdda65348178cc6e0da96cb2cdc",
    "name": "webserver",
    "image": "public.ecr.aws/docker/library/nginx:latest",
    "imageDigest": "sha256:5ed8fcc66f4ed123c1b2560ed708dc148755b6e4cbd8b943fab094f2c6bfa91e",
    "lastStatus": "STOPPED",
    "networkInterfaces": [],
    "healthStatus": "UNKNOWN",
    "managedAgents": [
      {
        "name": "ExecuteCommandAgent",
        "reason": "Received Container Stopped event",
        "lastStatus": "STOPPED"
      }
    ],
    "cpu": "100"
  },
  {
    "containerArn": "arn:aws:ecs:us-west-2:979604884904:container/tutorial/a2eafcdda65348178cc6e0da96cb2cdc/fb80fa71-e919-48bd-8070-33561163435f",
    "taskArn": "arn:aws:ecs:us-west-2:979604884904:task/tutorial/a2eafcdda65348178cc6e0da96cb2cdc",
    "name": "ecs-service-connect-dVSKI",
    "lastStatus": "STOPPED",
    "reason": "CannotCreateContainerError: CannotCreateContainerError: instance is IPv6-only but no IPv6 address found for container 'webserver'",
    "networkInterfaces": [],
    "healthStatus": "UNKNOWN",
    "managedAgents": [
      {
        "name": "ExecuteCommandAgent",
        "reason": "Received Container Stopped event",
        "lastStatus": "STOPPED"
      }
    ]
  }
]
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bugfix: Surface task augmentation errors for Service Connect tasks

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
