### PR TITLE
[WIP] Enable IPv6 support to ASM

### DIFF
--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -2596,7 +2596,9 @@ func TestMarshalUnmarshalTaskASMResource(t *testing.T) {
 		task.getAllASMAuthDataRequirements(),
 		expectedExecutionCredentialsID,
 		credentialsManager,
-		asmClientCreator)
+		asmClientCreator,
+		testIPCompatibility,
+	)
 	res.SetKnownStatus(resourcestatus.ResourceRemoved)
 
 	// add asm auth resource to task
@@ -2708,7 +2710,8 @@ func TestPopulateASMAuthData(t *testing.T) {
 		task.getAllASMAuthDataRequirements(),
 		credentialsID,
 		credentialsManager,
-		asmClientCreator)
+		asmClientCreator,
+		testIPCompatibility)
 
 	// add asm auth resource to task
 	task.AddResource(asmauth.ResourceName, asmRes)
@@ -2719,7 +2722,7 @@ func TestPopulateASMAuthData(t *testing.T) {
 				ARN:                "",
 				IAMRoleCredentials: executionRoleCredentials,
 			}, true),
-		asmClientCreator.EXPECT().NewASMClient(region, executionRoleCredentials).Return(mockASMClient, nil),
+		asmClientCreator.EXPECT().NewASMClient(region, executionRoleCredentials, testIPCompatibility).Return(mockASMClient, nil),
 		mockASMClient.EXPECT().GetSecretValue(gomock.Any(), gomock.Any(), gomock.Any()).Return(asmSecretValue, nil),
 	)
 
@@ -2799,7 +2802,8 @@ func TestPopulateASMAuthDataNoDockerAuthConfig(t *testing.T) {
 		task.getAllASMAuthDataRequirements(),
 		credentialsID,
 		credentialsManager,
-		asmClientCreator)
+		asmClientCreator,
+		testIPCompatibility)
 
 	// add asm auth resource to task
 	task.AddResource(asmauth.ResourceName, asmRes)
@@ -3253,7 +3257,7 @@ func TestInitializeAndGetASMSecretResource(t *testing.T) {
 		},
 	}
 
-	task.initializeASMSecretResource(credentialsManager, resFields)
+	task.initializeASMSecretResource(&config.Config{InstanceIPCompatibility: testIPCompatibility}, credentialsManager, resFields)
 
 	resourceDep := apicontainer.ResourceDependency{
 		Name:           asmsecret.ResourceName,

--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -203,7 +203,8 @@ func (task *Task) addFSxWindowsFileServerResource(
 		credentialsManager,
 		resourceFields.SSMClientCreator,
 		resourceFields.ASMClientCreator,
-		resourceFields.FSxClientCreator)
+		resourceFields.FSxClientCreator,
+		cfg.InstanceIPCompatibility)
 	if err != nil {
 		return err
 	}

--- a/agent/asm/factory/mocks/factory_mocks.go
+++ b/agent/asm/factory/mocks/factory_mocks.go
@@ -22,6 +22,7 @@ import (
 	reflect "reflect"
 
 	asm "github.com/aws/amazon-ecs-agent/agent/asm"
+	ipcompatibility "github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	credentials "github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -50,16 +51,16 @@ func (m *MockClientCreator) EXPECT() *MockClientCreatorMockRecorder {
 }
 
 // NewASMClient mocks base method.
-func (m *MockClientCreator) NewASMClient(arg0 string, arg1 credentials.IAMRoleCredentials) (asm.SecretsManagerAPI, error) {
+func (m *MockClientCreator) NewASMClient(arg0 string, arg1 credentials.IAMRoleCredentials, arg2 ipcompatibility.IPCompatibility) (asm.SecretsManagerAPI, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewASMClient", arg0, arg1)
+	ret := m.ctrl.Call(m, "NewASMClient", arg0, arg1, arg2)
 	ret0, _ := ret[0].(asm.SecretsManagerAPI)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewASMClient indicates an expected call of NewASMClient.
-func (mr *MockClientCreatorMockRecorder) NewASMClient(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientCreatorMockRecorder) NewASMClient(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewASMClient", reflect.TypeOf((*MockClientCreator)(nil).NewASMClient), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewASMClient", reflect.TypeOf((*MockClientCreator)(nil).NewASMClient), arg0, arg1, arg2)
 }

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -27,7 +27,6 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	mock_asm_factory "github.com/aws/amazon-ecs-agent/agent/asm/factory/mocks"
-	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
@@ -57,8 +56,6 @@ const (
 	containerNetNS           = "container:abcd"
 	ExpectedNetworkNamespace = "none"
 )
-
-var testIPCompatibility = ipcompatibility.NewIPCompatibility(true, true)
 
 func TestDeleteTask(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/agent/taskresource/credentialspec/credentialspec_linux.go
+++ b/agent/taskresource/credentialspec/credentialspec_linux.go
@@ -268,7 +268,7 @@ func (cs *CredentialSpecResource) handleDomainlessKerberosTicketCreation() error
 				iamCredentials = executionCredentials.GetIAMRoleCredentials()
 			}
 
-			asmClient, err := cs.secretsmanagerClientCreator.NewASMClient(cs.region, iamCredentials)
+			asmClient, err := cs.secretsmanagerClientCreator.NewASMClient(cs.region, iamCredentials, cs.ipCompatibility)
 			if err != nil {
 				return fmt.Errorf("unable to create ASM client: %v", err)
 			}
@@ -324,7 +324,7 @@ func (cs *CredentialSpecResource) HandleDomainlessKerberosTicketRenewal(iamCrede
 				visitedDomainlessUser[v.domainlessGmsaUserArn] = true
 
 				// get domain-user credentials from secrets manager
-				asmClient, err := cs.secretsmanagerClientCreator.NewASMClient(cs.region, iamCredentials)
+				asmClient, err := cs.secretsmanagerClientCreator.NewASMClient(cs.region, iamCredentials, cs.ipCompatibility)
 				if err != nil {
 					return fmt.Errorf("unable to create ASM client: %v", err)
 				}

--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_unsupported.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_unsupported.go
@@ -22,6 +22,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	asmfactory "github.com/aws/amazon-ecs-agent/agent/asm/factory"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	fsxfactory "github.com/aws/amazon-ecs-agent/agent/fsx/factory"
 	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -52,7 +53,8 @@ func NewFSxWindowsFileServerResource(
 	credentialsManager credentials.Manager,
 	ssmClientCreator ssmfactory.SSMClientCreator,
 	asmClientCreator asmfactory.ClientCreator,
-	fsxClientCreator fsxfactory.FSxClientCreator) (*FSxWindowsFileServerResource, error) {
+	fsxClientCreator fsxfactory.FSxClientCreator,
+	ipCompatibility ipcompatibility.IPCompatibility) (*FSxWindowsFileServerResource, error) {
 	return nil, errors.New("not supported")
 }
 

--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows_test.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 
 	mock_asm_factory "github.com/aws/amazon-ecs-agent/agent/asm/factory/mocks"
@@ -59,6 +60,8 @@ const (
 	hostPath               = `Z:\`
 )
 
+var testIPCompatibility = ipcompatibility.NewIPCompatibility(true, true)
+
 func setup(t *testing.T) (
 	*FSxWindowsFileServerResource, *mock_credentials.MockManager, *mock_ssm_factory.MockSSMClientCreator,
 	*mock_asm_factory.MockClientCreator, *mock_fsx_factory.MockFSxClientCreator, *mock_ssmiface.MockSSMClient,
@@ -81,7 +84,7 @@ func setup(t *testing.T) (
 		taskARN:             taskARN,
 	}
 	fv.Initialize(
-		&config.Config{},
+		&config.Config{InstanceIPCompatibility: testIPCompatibility},
 		&taskresource.ResourceFields{
 			ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
 				SSMClientCreator:   ssmClientCreator,
@@ -252,7 +255,7 @@ func TestRetrieveASMCredentials(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		asmClientCreator.EXPECT().NewASMClient(gomock.Any(), gomock.Any()).Return(mockASMClient, nil),
+		asmClientCreator.EXPECT().NewASMClient(gomock.Any(), gomock.Any(), testIPCompatibility).Return(mockASMClient, nil),
 		mockASMClient.EXPECT().GetSecretValue(
 			gomock.Any(),
 			gomock.Any(),
@@ -700,7 +703,7 @@ func TestCreateASM(t *testing.T) {
 		executionCredentialsID: executionCredentialsID,
 	}
 	fv.Initialize(
-		&config.Config{},
+		&config.Config{InstanceIPCompatibility: testIPCompatibility},
 		&taskresource.ResourceFields{
 			ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
 				SSMClientCreator:   ssmClientCreator,
@@ -734,7 +737,7 @@ func TestCreateASM(t *testing.T) {
 
 	gomock.InOrder(
 		credentialsManager.EXPECT().GetTaskCredentials(gomock.Any()).Return(creds, true),
-		asmClientCreator.EXPECT().NewASMClient(gomock.Any(), gomock.Any()).Return(mockASMClient, nil),
+		asmClientCreator.EXPECT().NewASMClient(gomock.Any(), gomock.Any(), testIPCompatibility).Return(mockASMClient, nil),
 		mockASMClient.EXPECT().GetSecretValue(
 			gomock.Any(),
 			gomock.Any(),


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
Executed functional test suite on dualstack subnet. Verified all tests passed and dualstack endpoint usage through docker container logs.
```
Host: {bucket-name}-prod.s3.dualstack.us-west-2.amazonaws.com
```
Setups done: 
- Set `IPCompatibility` to `NewIPv6OnlyCompatibility`
- Pin the functional test suite on a dualstack subnet (agent is currently connecting to control plane via IPv4).
- Set the `awsConfig` to `Debug` level and directed logs to `os.Stdout`. 

New tests cover the changes: no

### Description for the changelog
Enhancement: ASM client resolves to dualstack endpoint on IPV6-only instances

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
