### PR TITLE
Migrate agent/api folder to aws-go-sdk-v2

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -30,7 +30,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
@@ -885,7 +885,7 @@ func (c *Container) GetHealthStatus() HealthStatus {
 	copyHealth := c.Health
 
 	if c.Health.Since != nil {
-		copyHealth.Since = aws.Time(aws.TimeValue(c.Health.Since))
+		copyHealth.Since = aws.Time(aws.ToTime(c.Health.Since))
 	}
 
 	return copyHealth

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -30,8 +30,8 @@ import (
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
 )
@@ -322,11 +322,11 @@ func (c *ContainerStateChange) ToECSAgent() (*ecs.ContainerStateChange, error) {
 
 	return &ecs.ContainerStateChange{
 		TaskArn:         c.TaskArn,
-		RuntimeID:       aws.StringValue(pl.RuntimeId),
+		RuntimeID:       aws.ToString(pl.RuntimeId),
 		ContainerName:   c.ContainerName,
 		Status:          c.Status,
-		ImageDigest:     aws.StringValue(pl.ImageDigest),
-		Reason:          aws.StringValue(pl.Reason),
+		ImageDigest:     aws.ToString(pl.ImageDigest),
+		Reason:          aws.ToString(pl.Reason),
 		ExitCode:        utils.Int32PtrToIntPtr(pl.ExitCode),
 		NetworkBindings: pl.NetworkBindings,
 		MetadataGetter:  newContainerMetadataGetter(c.Container),
@@ -534,7 +534,7 @@ func buildContainerStateChangePayload(change ContainerStateChange) (*types.Conta
 	statechange.Status = aws.String(stat.BackendStatusString())
 
 	if change.ExitCode != nil {
-		exitCode := int32(aws.IntValue(change.ExitCode))
+		exitCode := int32(aws.ToInt(change.ExitCode))
 		statechange.ExitCode = aws.Int32(exitCode)
 	}
 

--- a/agent/api/statechange_test.go
+++ b/agent/api/statechange_test.go
@@ -28,8 +28,8 @@ import (
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -40,7 +40,7 @@ import (
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/golang/mock/gomock"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
@@ -166,7 +166,7 @@ func TestAddNetworkResourceProvisioningDependencyWithAppMesh(t *testing.T) {
 	pauseContainer, ok := testTask.ContainerByName(NetworkPauseContainerName)
 	require.True(t, ok, "Expected to find pause container")
 	containerConfig := &dockercontainer.Config{}
-	json.Unmarshal([]byte(aws.StringValue(pauseContainer.DockerConfig.Config)), &containerConfig)
+	json.Unmarshal([]byte(aws.ToString(pauseContainer.DockerConfig.Config)), &containerConfig)
 	assert.Equal(t, "1337:35", containerConfig.User, "pause container should have correct user")
 	assert.Equal(t, apicontainer.ContainerCNIPause, pauseContainer.Type, "pause container should have correct type")
 	assert.True(t, pauseContainer.Essential, "pause container should be essential")

--- a/agent/api/testutils/container_equal_test.go
+++ b/agent/api/testutils/container_equal_test.go
@@ -22,7 +22,7 @@ import (
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
### Summary
Migrate `./agent/api` folder usage of aws-go-sdk v1 to v2 usage. This does exclude migrating `jsonutil.BuildJSON` until a later set of changes.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
Unit tests related to changed files

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
