### PR TITLE
Use ECS_AGENT_PID_NAMESPACE_HOST to run agent container in pid host mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Additionally, the following environment variable(s) can be used to configure the
 | `ECS_OFFHOST_INTROSPECTION_INTERFACE_NAME` | `eth0` | Primary network interface name to be used for blocking offhost agent introspection port access. By default, this value is `eth0` | `eth0` |
 | `ECS_AGENT_LABELS` | `{"test.label.1":"value1","test.label.2":"value2"}` | The labels to add to the ECS Agent container. | |
 | `ECS_AGENT_APPARMOR_PROFILE` | `unconfined` | Specifies the name of the AppArmor profile to run the ecs-agent container under. This only applies to AppArmor-enabled systems, such as Ubuntu, Debian, and SUSE. If unset, defaults to the profile written out by ecs-init (ecs-agent-default). | `ecs-agent-default` |
+| `ECS_AGENT_PID_NAMESPACE_HOST` | &lt;true &#124; false&gt; | By default, the ECS agent container runs with its own PID namespace. If ECS_AGENT_PID_NAMESPACE_HOST is set to true, ecs-init will start the ECS agent container with the host's PID namespace. This is particularly useful when running on SELinux-enforcing hosts with Docker's SELinux option enabled. | false |
 
 
 ### Persistence

--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/aws/amazon-ecs-agent/ecs-init/config/awsrulesfn"
@@ -108,6 +109,10 @@ const (
 	// on AppArmor-enabled platforms (such as Ubuntu and Debian).
 	ECSAgentAppArmorProfileNameEnvVar  = "ECS_AGENT_APPARMOR_PROFILE"
 	ECSAgentAppArmorDefaultProfileName = "ecs-agent-default"
+
+	// ECSAgentPIDNamespaceHostEnvVar is the environment variable that, when set to true,
+	// configures the agent container to share the host's PID namespace (--pid=host)
+	ECSAgentPIDNamespaceHostEnvVar = "ECS_AGENT_PID_NAMESPACE_HOST"
 )
 
 // OsStat is useful for mocking in unit tests
@@ -363,4 +368,14 @@ func agentArtifactName(version string, arch string) (string, error) {
 		return "", errors.Errorf("unknown architecture %q", arch)
 	}
 	return fmt.Sprintf("ecs-agent%s-%s", interpose, version), nil
+}
+
+// IsECSAgentPIDNamespaceHostEnabled returns whether the ECS_AGENT_PID_NAMESPACE_HOST env variable is set to true
+func IsECSAgentPIDNamespaceHostEnabled() bool {
+	parsedBool, err := strconv.ParseBool(os.Getenv(ECSAgentPIDNamespaceHostEnvVar))
+	if err != nil {
+		seelog.Warnf("ECS_AGENT_PID_NAMESPACE_HOST env variable is not set to a valid boolean value, defaulting to false. Error: %v", err)
+		return false
+	}
+	return parsedBool
 }

--- a/ecs-init/config/common_test.go
+++ b/ecs-init/config/common_test.go
@@ -295,3 +295,9 @@ func TestHostCredentialsFetcherPathHostNotFound(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "/var/credentials-fetcher/socket/credentials_fetcher.sock", credentialsFetcherHost)
 }
+
+func TestAgentPIDNamespaceHost(t *testing.T) {
+	os.Setenv("ECS_AGENT_PID_NAMESPACE_HOST", "true")
+	defer os.Unsetenv("ECS_AGENT_PID_NAMESPACE_HOST")
+	assert.True(t, IsECSAgentPIDNamespaceHostEnabled())
+}

--- a/ecs-init/docker/docker_config.go
+++ b/ecs-init/docker/docker_config.go
@@ -82,6 +82,11 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 		hostConfig.Privileged = true
 	}
 
+	// Set the PID mode to host if ECS_AGENT_PID_NAMESPACE_HOST env variable is set to true
+	if config.IsECSAgentPIDNamespaceHostEnabled() {
+		hostConfig.PidMode = "host"
+	}
+
 	return hostConfig
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds a new environment variable that can be used to configure the behavior of the ecs-init service. `ECS_AGENT_PID_NAMESPACE_HOST` is a new env variable that when set to true will enable ecs-init to start the ECS Agent container in the host pid namespace. This will enable the ECS Agent container to bootstrap itself on hosts where SELinux is set to enforcing mode and also when the the docker selinux security policy is enabled.
### Implementation details
<!-- How are the changes implemented? -->
* Introduces a new env variable to ecs-init `ECS_AGENT_PID_NAMESPACE_HOST`.
* Adds a new function IsECSAgentPIDNamespaceHostEnabled(), which checks if the environment variable is set to "true".
* Modifies the host configuration setup for the ECS agent container:
    * In the function that creates the Docker HostConfig struct, a new condition is added:
```
	if config.IsECSAgentPIDNamespaceHostEnabled() {
		hostConfig.PidMode = "host"
	}
```
* This sets the PidMode to "host" when the new environment variable is enabled.
* Added unit tests to verify the environment variable is properly read and interpreted.
* Added documentation to describe the new environment variable and its purpose.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

* Set `ECS_AGENT_PID_NAMESPACE_HOST` to true in ecs.config and verified whether ECS Agent container was able to start on a host where SELinux enforcing mode was set and `selinux-enabled:true` was set in `docker/daemon.json`

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Use ECS_AGENT_PID_NAMESPACE_HOST to run agent container in pid host mode
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No
**Does this PR include the addition of new environment variables in the README?**
Yes
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
