### PR TITLE
Migrate agent/dockerapi,gpu,stats to aws-sdk-go-v2

### DIFF
--- a/agent/dockerclient/dockerapi/types.go
+++ b/agent/dockerclient/dockerapi/types.go
@@ -20,7 +20,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/volume"
 )
@@ -128,7 +128,7 @@ func (event *DockerContainerChangeEvent) String() string {
 	res += ", health: " + event.Health.Status.String()
 
 	if event.ExitCode != nil {
-		res += fmt.Sprintf(", ExitCode: %d", aws.IntValue(event.ExitCode))
+		res += fmt.Sprintf(", ExitCode: %d", aws.ToInt(event.ExitCode))
 	}
 
 	if len(event.PortBindings) != 0 {

--- a/agent/gpu/nvidia_gpu_manager_unix.go
+++ b/agent/gpu/nvidia_gpu_manager_unix.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"sync"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
 )

--- a/agent/gpu/nvidia_gpu_manager_unix_test.go
+++ b/agent/gpu/nvidia_gpu_manager_unix_test.go
@@ -21,8 +21,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
@@ -157,8 +157,8 @@ func validateInstanceMetrics(t *testing.T, engine *DockerStatsEngine, includeSer
 	assert.Len(t, taskMetrics, 1, "incorrect number of tasks")
 
 	taskMetric := taskMetrics[0]
-	assert.Equal(t, aws.StringValue(taskMetric.TaskDefinitionFamily), taskDefinitionFamily, "unexpected task definition family")
-	assert.Equal(t, aws.StringValue(taskMetric.TaskDefinitionVersion), taskDefinitionVersion, "unexpected task definition version")
+	assert.Equal(t, aws.ToString(taskMetric.TaskDefinitionFamily), taskDefinitionFamily, "unexpected task definition family")
+	assert.Equal(t, aws.ToString(taskMetric.TaskDefinitionVersion), taskDefinitionVersion, "unexpected task definition version")
 	assert.NoError(t, validateContainerMetrics(taskMetric.ContainerMetrics, 1), "validating container metrics failed")
 	if includeServiceConnectStats {
 		assert.NoError(t, validateServiceConnectMetrics(taskMetric.ServiceConnectMetricsWrapper, 1), "validating service connect metrics failed")
@@ -172,8 +172,8 @@ func validateInstanceMetricsWithDisabledMetrics(t *testing.T, engine *DockerStat
 	assert.Len(t, taskMetrics, 1, "incorrect number of tasks")
 
 	taskMetric := taskMetrics[0]
-	assert.Equal(t, aws.StringValue(taskMetric.TaskDefinitionFamily), taskDefinitionFamily, "unexpected task definition family")
-	assert.Equal(t, aws.StringValue(taskMetric.TaskDefinitionVersion), taskDefinitionVersion, "unexpected task definition version")
+	assert.Equal(t, aws.ToString(taskMetric.TaskDefinitionFamily), taskDefinitionFamily, "unexpected task definition family")
+	assert.Equal(t, aws.ToString(taskMetric.TaskDefinitionVersion), taskDefinitionVersion, "unexpected task definition version")
 	assert.NoError(t, validateContainerMetrics(taskMetric.ContainerMetrics, 0), "validating container metrics failed")
 	if includeServiceConnectStats {
 		assert.NoError(t, validateServiceConnectMetrics(taskMetric.ServiceConnectMetricsWrapper, 1), "validating service connect metrics failed")
@@ -224,8 +224,8 @@ func validateIdleContainerMetrics(t *testing.T, engine *DockerStatsEngine) {
 	assert.NoError(t, err, "getting instance metrics failed")
 	assert.NoError(t, validateMetricsMetadata(metadata), "validating metadata failed")
 
-	assert.True(t, aws.BoolValue(metadata.Idle), "expected idle metadata to be true")
-	assert.True(t, aws.BoolValue(metadata.Fin), "fin not set to true when idle")
+	assert.True(t, aws.ToBool(metadata.Idle), "expected idle metadata to be true")
+	assert.True(t, aws.ToBool(metadata.Fin), "fin not set to true when idle")
 	assert.Len(t, taskMetrics, 0, "expected empty task metrics")
 }
 
@@ -253,16 +253,16 @@ func validateHealthMetricsMetadata(metadata *ecstcs.HealthMetadata) error {
 		return fmt.Errorf("metadata is nil")
 	}
 
-	if aws.StringValue(metadata.Cluster) != defaultCluster {
+	if aws.ToString(metadata.Cluster) != defaultCluster {
 		return fmt.Errorf("expected cluster in metadata to be: %s, got %s",
-			defaultCluster, aws.StringValue(metadata.Cluster))
+			defaultCluster, aws.ToString(metadata.Cluster))
 	}
 
-	if aws.StringValue(metadata.ContainerInstance) != defaultContainerInstance {
+	if aws.ToString(metadata.ContainerInstance) != defaultContainerInstance {
 		return fmt.Errorf("expected container instance in metadata to be %s, got %s",
-			defaultContainerInstance, aws.StringValue(metadata.ContainerInstance))
+			defaultContainerInstance, aws.ToString(metadata.ContainerInstance))
 	}
-	if len(aws.StringValue(metadata.MessageId)) == 0 {
+	if len(aws.ToString(metadata.MessageId)) == 0 {
 		return fmt.Errorf("empty MessageId")
 	}
 
@@ -275,13 +275,13 @@ func validateContainerHealthMetrics(metrics []*ecstcs.ContainerHealth, expected 
 			expected, len(metrics))
 	}
 	for _, health := range metrics {
-		if aws.StringValue(health.ContainerName) == "" {
+		if aws.ToString(health.ContainerName) == "" {
 			return fmt.Errorf("container name is empty")
 		}
-		if aws.StringValue(health.HealthStatus) == "" {
+		if aws.ToString(health.HealthStatus) == "" {
 			return fmt.Errorf("container health status is empty")
 		}
-		if aws.TimeValue(health.StatusSince).IsZero() {
+		if aws.ToTime(health.StatusSince).IsZero() {
 			return fmt.Errorf("container health status change timestamp is empty")
 		}
 	}
@@ -293,9 +293,9 @@ func validateTaskHealthMetrics(t *testing.T, engine *DockerStatsEngine) {
 	assert.NoError(t, err, "getting task health metrics failed")
 	require.Len(t, healthMetrics, 1)
 	assert.NoError(t, validateHealthMetricsMetadata(healthMetadata), "validating health metedata failed")
-	assert.Equal(t, aws.StringValue(healthMetrics[0].TaskArn), taskArn, "task arn not expected")
-	assert.Equal(t, aws.StringValue(healthMetrics[0].TaskDefinitionFamily), taskDefinitionFamily, "task definition family not expected")
-	assert.Equal(t, aws.StringValue(healthMetrics[0].TaskDefinitionVersion), taskDefinitionVersion, "task definition version not expected")
+	assert.Equal(t, aws.ToString(healthMetrics[0].TaskArn), taskArn, "task arn not expected")
+	assert.Equal(t, aws.ToString(healthMetrics[0].TaskDefinitionFamily), taskDefinitionFamily, "task definition family not expected")
+	assert.Equal(t, aws.ToString(healthMetrics[0].TaskDefinitionVersion), taskDefinitionVersion, "task definition version not expected")
 	assert.NoError(t, validateContainerHealthMetrics(healthMetrics[0].Containers, 1))
 }
 

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -44,7 +44,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/stats"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/docker/docker/api/types"
 )
 

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -38,7 +38,7 @@ import (
 	mock_csiclient "github.com/aws/amazon-ecs-agent/ecs-agent/csiclient/mocks"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -571,10 +571,10 @@ func TestGetTaskHealthMetrics(t *testing.T) {
 	metadata, taskHealth, err := engine.GetTaskHealthMetrics()
 	assert.NoError(t, err)
 
-	assert.Equal(t, aws.StringValue(metadata.ContainerInstance), "container_instance")
+	assert.Equal(t, aws.ToString(metadata.ContainerInstance), "container_instance")
 	assert.Len(t, taskHealth, 1)
 	assert.Len(t, taskHealth[0].Containers, 1)
-	assert.Equal(t, aws.StringValue(taskHealth[0].Containers[0].HealthStatus), "HEALTHY")
+	assert.Equal(t, aws.ToString(taskHealth[0].Containers[0].HealthStatus), "HEALTHY")
 }
 
 func TestGetTaskHealthMetricsStoppedContainer(t *testing.T) {

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -31,7 +31,7 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"

--- a/agent/stats/service_connect_linux_test.go
+++ b/agent/stats/service_connect_linux_test.go
@@ -32,7 +32,7 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
### Summary
Migrate ./agent/dockerapi, ./agent/gpu, and ./agent/stats folders usage of aws-sdk-go v1 to v2 usage

### Testing
Unit tests related to changed files

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
