### PR TITLE
Adds RestartPolicy for ServiceConnect Relay Instance Task

### DIFF
--- a/agent/engine/serviceconnect/manager_linux.go
+++ b/agent/engine/serviceconnect/manager_linux.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/utils/loader"
+	apicontainerrestart "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
@@ -360,12 +361,6 @@ func (m *manager) CreateInstanceTask(cfg *config.Config) (*apitask.Task, error) 
 	containerRunning := apicontainerstatus.ContainerRunning
 	dockerHostConfig := dockercontainer.HostConfig{
 		NetworkMode: apitask.HostNetworkMode,
-		// do not restart relay if it's stopped manually.
-		// the default value of 0 for MaximumRetryCount means that we will not enforce a maximum count
-		RestartPolicy: dockercontainer.RestartPolicy{
-			Name:              "on-failure",
-			MaximumRetryCount: 0,
-		},
 	}
 	rawHostConfig, err := json.Marshal(&dockerHostConfig)
 	if err != nil {
@@ -402,6 +397,12 @@ func (m *manager) CreateInstanceTask(cfg *config.Config) (*apitask.Task, error) 
 			TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 			Essential:                 true,
 			SteadyStateStatusUnsafe:   &containerRunning,
+			// Restart Relay if it exits or crashes
+			// RestartAttemptPeriod value 60 ensures it has run for atleast 60 seconds and prevents a crash/restart loop
+			RestartPolicy: &apicontainerrestart.RestartPolicy{
+				Enabled:              true,
+				RestartAttemptPeriod: 60,
+			},
 			DockerConfig: apicontainer.DockerConfig{
 				Config:     aws.String(rawConfig),
 				HostConfig: aws.String(string(rawHostConfig)),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Addresses https://github.com/aws/amazon-ecs-agent/issues/4459.
Adds a RestartPolicy for the Relay Instance Task to always restart it even if it crashes due to failure.

### Implementation details
<!-- How are the changes implemented? -->
- Removed the docker restart policy altogether from the relay container as it wasn't working as expected since relay is an instance task and ECS agent didn't account for it's containers to be restarted. Here's the error seen in docker logs:
```
Apr 24 22:00:16 ip-10-0-11-122.us-west-2.compute.internal dockerd[3840]: time="2025-04-24T22:00:16.343334735Z" level=warning msg="ShouldRestart failed, container will not be restarted" container=f3347cb63b4a9f468171c98496c5f5971dcf3cb997acaf029b769057f20d7e17 daemonShuttingDown=false error="restart canceled" execDuration=11m32.320561113s exitStatus="{137 2025-04-24 22:00:16.327669004 +0000 UTC}" hasBeenManuallyStopped=true restartCount=0
``` 
- Added New Task RestartPolicy for the Relay Instance Task. Changes in `serviceconnect/manager_linux.go`.

### Testing
<!-- How was this tested? -->

Tested by generating a generic rpm and installing it on a personal instance and ran a ServiceConnect service.

#### Task RestartPolicy Testing
- Ran a SC task on an instance to allow Relay to start
- Manually stopped the Envoy process within the Relay container by issuing SigKill 4 times. This ensured that we exhaust the relay internal restarts and cause the container to exit (with a exit code 0).
- Observed the relay container be restarted again by ECS Agent
- Checked task sidecar SC agent logs to ensure it's able to connect to SC control plane

**ECS Agent logs**
```
level=debug time=2025-04-28T12:47:49Z msg="DockerGoClient: got event from docker daemon: &{die a2fbcf1f75d45af875dd09ce1e58841ee478fcdff706dd873c54533d1dc688ce ecs-service-connect-agent:interface-v1 container die {a2fbcf1f75d45af875dd09ce1e58841ee478fcdff706dd873c54533d1dc688ce map[com.amazonaws.ecs.cluster:cluster-onhutevt-rsmkuoqh com.amazonaws.ecs.container-name:instance-service-connect-relay com.amazonaws.ecs.task-arn:arn:::::/service-connect-relay-cc2bf646-2385-11f0-9b92-06b47b7463a3 com.amazonaws.ecs.task-definition-family: com.amazonaws.ecs.task-definition-version: execDuration:86 exitCode:0 image:ecs-service-connect-agent:interface-v1 name:ecs---instance-service-connect-relay-8a86aab1a8bea4a98801]} local 1745844469 1745844469163350754}" module=docker_client.go
level=debug time=2025-04-28T12:47:49Z msg="Handling a docker event" exitCode=0 labels=map[com.amazonaws.ecs.cluster:cluster-onhutevt-rsmkuoqh com.amazonaws.ecs.container-name:instance-service-connect-relay com.amazonaws.ecs.task-arn:arn:::::/service-connect-relay-cc2bf646-2385-11f0-9b92-06b47b7463a3 com.amazonaws.ecs.task-definition-family: com.amazonaws.ecs.task-definition-version:] createdAt="2025-04-27 16:36:41.203064231 +0000 UTC" dockerId="a2fbcf1f75d45af875dd09ce1e58841ee478fcdff706dd873c54533d1dc688ce" health="UNHEALTHY" volumes=[{Type:bind Name: Source:/var/run/ecs/service_connect/relay Destination:/var/run/ecs Driver: Mode: RW:true Propagation:rprivate} {Type:bind Name: Source:/var/run/ecs/service_connect/relay Destination:/var/run/ecs/relay Driver: Mode: RW:true Propagation:rprivate} {Type:bind Name: Source:/var/log/ecs/service_connect/relay Destination:/var/log Driver: Mode: RW:true Propagation:rprivate}] startedAt="2025-04-28 12:46:22.910656939 +0000 UTC" finishedAt="2025-04-28 12:47:49.083179264 +0000 UTC" status="STOPPED"
level=debug time=2025-04-28T12:47:49Z msg="Writing docker event to the task" task="service-connect-relay-cc2bf646-2385-11f0-9b92-06b47b7463a3" dockerId="a2fbcf1f75d45af875dd09ce1e58841ee478fcdff706dd873c54533d1dc688ce" exitCode=0 labels=map[com.amazonaws.ecs.cluster:cluster-onhutevt-rsmkuoqh com.amazonaws.ecs.container-name:instance-service-connect-relay com.amazonaws.ecs.task-arn:arn:::::/service-connect-relay-cc2bf646-2385-11f0-9b92-06b47b7463a3 com.amazonaws.ecs.task-definition-family: com.amazonaws.ecs.task-definition-version:] createdAt="2025-04-27 16:36:41.203064231 +0000 UTC" finishedAt="2025-04-28 12:47:49.083179264 +0000 UTC" status="STOPPED" health="UNHEALTHY" volumes=[{Type:bind Name: Source:/var/run/ecs/service_connect/relay Destination:/var/run/ecs Driver: Mode: RW:true Propagation:rprivate} {Type:bind Name: Source:/var/run/ecs/service_connect/relay Destination:/var/run/ecs/relay Driver: Mode: RW:true Propagation:rprivate} {Type:bind Name: Source:/var/log/ecs/service_connect/relay Destination:/var/log Driver: Mode: RW:true Propagation:rprivate}] startedAt="2025-04-28 12:46:22.910656939 +0000 UTC"
level=debug time=2025-04-28T12:47:49Z msg="Wrote docker event to the task" task="service-connect-relay-cc2bf646-2385-11f0-9b92-06b47b7463a3" dockerId="a2fbcf1f75d45af875dd09ce1e58841ee478fcdff706dd873c54533d1dc688ce" exitCode=0 labels=map[com.amazonaws.ecs.cluster:cluster-onhutevt-rsmkuoqh com.amazonaws.ecs.container-name:instance-service-connect-relay com.amazonaws.ecs.task-arn:arn:::::/service-connect-relay-cc2bf646-2385-11f0-9b92-06b47b7463a3 com.amazonaws.ecs.task-definition-family: com.amazonaws.ecs.task-definition-version:] createdAt="2025-04-27 16:36:41.203064231 +0000 UTC" status="STOPPED" health="UNHEALTHY" volumes=[{Type:bind Name: Source:/var/run/ecs/service_connect/relay Destination:/var/run/ecs Driver: Mode: RW:true Propagation:rprivate} {Type:bind Name: Source:/var/run/ecs/service_connect/relay Destination:/var/run/ecs/relay Driver: Mode: RW:true Propagation:rprivate} {Type:bind Name: Source:/var/log/ecs/service_connect/relay Destination:/var/log Driver: Mode: RW:true Propagation:rprivate}] startedAt="2025-04-28 12:46:22.910656939 +0000 UTC" finishedAt="2025-04-28 12:47:49.083179264 +0000 UTC"
level=info time=2025-04-28T12:47:49Z msg="Handling container change event" task="service-connect-relay-cc2bf646-2385-11f0-9b92-06b47b7463a3" container="instance-service-connect-relay" runtimeID="a2fbcf1f75d45af875dd09ce1e58841ee478fcdff706dd873c54533d1dc688ce" changeEventStatus="STOPPED" knownStatus="RUNNING" desiredStatus="RUNNING"
level=info time=2025-04-28T12:47:49Z msg="Starting container" task="service-connect-relay-cc2bf646-2385-11f0-9b92-06b47b7463a3" container="instance-service-connect-relay" runtimeID="a2fbcf1f75d45af875dd09ce1e58841ee478fcdff706dd873c54533d1dc688ce"
level=debug time=2025-04-28T12:47:49Z msg="DockerGoClient: got event from docker daemon: &{start a2fbcf1f75d45af875dd09ce1e58841ee478fcdff706dd873c54533d1dc688ce ecs-service-connect-agent:interface-v1 container start {a2fbcf1f75d45af875dd09ce1e58841ee478fcdff706dd873c54533d1dc688ce map[com.amazonaws.ecs.cluster:cluster-onhutevt-rsmkuoqh com.amazonaws.ecs.container-name:instance-service-connect-relay com.amazonaws.ecs.task-arn:arn:::::/service-connect-relay-cc2bf646-2385-11f0-9b92-06b47b7463a3 com.amazonaws.ecs.task-definition-family: com.amazonaws.ecs.task-definition-version: image:ecs-service-connect-agent:interface-v1 name:ecs---instance-service-connect-relay-8a86aab1a8bea4a98801]} local 1745844469 1745844469314481019}" module=docker_client.go
level=info time=2025-04-28T12:47:49Z msg="Started container" task="service-connect-relay-cc2bf646-2385-11f0-9b92-06b47b7463a3" container="instance-service-connect-relay" runtimeID="a2fbcf1f75d45af875dd09ce1e58841ee478fcdff706dd873c54533d1dc688ce" elapsed=151.142873ms
level=debug time=2025-04-28T12:47:49Z msg="Handling a docker event" status="RUNNING" health="UNKNOWN" volumes=[{Type:bind Name: Source:/var/run/ecs/service_connect/relay Destination:/var/run/ecs Driver: Mode: RW:true Propagation:rprivate} {Type:bind Name: Source:/var/run/ecs/service_connect/relay Destination:/var/run/ecs/relay Driver: Mode: RW:true Propagation:rprivate} {Type:bind Name: Source:/var/log/ecs/service_connect/relay Destination:/var/log Driver: Mode: RW:true Propagation:rprivate}] labels=map[com.amazonaws.ecs.cluster:cluster-onhutevt-rsmkuoqh com.amazonaws.ecs.container-name:instance-service-connect-relay com.amazonaws.ecs.task-arn:arn:::::/service-connect-relay-cc2bf646-2385-11f0-9b92-06b47b7463a3 com.amazonaws.ecs.task-definition-family: com.amazonaws.ecs.task-definition-version:] createdAt="2025-04-27 16:36:41.203064231 +0000 UTC" startedAt="2025-04-28 12:47:49.310153034 +0000 UTC" finishedAt="2025-04-28 12:47:49.083179264 +0000 UTC" dockerId="a2fbcf1f75d45af875dd09ce1e58841ee478fcdff706dd873c54533d1dc688ce"
level=debug time=2025-04-28T12:47:49Z msg="Writing docker event to the task" task="service-connect-relay-cc2bf646-2385-11f0-9b92-06b47b7463a3" labels=map[com.amazonaws.ecs.cluster:cluster-onhutevt-rsmkuoqh com.amazonaws.ecs.container-name:instance-service-connect-relay com.amazonaws.ecs.task-arn:arn:::::/service-connect-relay-cc2bf646-2385-11f0-9b92-06b47b7463a3 com.amazonaws.ecs.task-definition-family: com.amazonaws.ecs.task-definition-version:] createdAt="2025-04-27 16:36:41.203064231 +0000 UTC" startedAt="2025-04-28 12:47:49.310153034 +0000 UTC" finishedAt="2025-04-28 12:47:49.083179264 +0000 UTC" dockerId="a2fbcf1f75d45af875dd09ce1e58841ee478fcdff706dd873c54533d1dc688ce" status="RUNNING" health="UNKNOWN" volumes=[{Type:bind Name: Source:/var/run/ecs/service_connect/relay Destination:/var/run/ecs Driver: Mode: RW:true Propagation:rprivate} {Type:bind Name: Source:/var/run/ecs/service_connect/relay Destination:/var/run/ecs/relay Driver: Mode: RW:true Propagation:rprivate} {Type:bind Name: Source:/var/log/ecs/service_connect/relay Destination:/var/log Driver: Mode: RW:true Propagation:rprivate}]
level=info time=2025-04-28T12:47:49Z msg="Restarted container" knownStatus="RUNNING" desiredStatus="RUNNING" task="service-connect-relay-cc2bf646-2385-11f0-9b92-06b47b7463a3" container="instance-service-connect-relay" runtimeID="a2fbcf1f75d45af875dd09ce1e58841ee478fcdff706dd873c54533d1dc688ce" changeEventStatus="STOPPED" restartCount=3 lastRestartAt="2025-04-28T12:47:49Z"
```
**SC Relay Agent Logs**
```
[2025-04-28 12:46:22.628][7][warning] [AppNet Agent] [Envoy process 24119] Exited with code [-1]
[2025-04-28 12:46:22.628][7][warning] [AppNet Agent] [Envoy process 24119] was terminated by signal: [killed] with Core Dump: [false]
tail: appnet_envoy.log: file truncated
[2025-04-28 12:46:22.919][7][info] [AppNet Agent] Server started, /var/run/ecs/appnet_admin.sock
[2025-04-28 12:46:22.919][7][info] [AppNet Agent] Executing command: [/usr/bin/envoy -c /tmp/envoy-config-1885498610.yaml -l info --concurrency 1 --drain-time-s 20 --disable-hot-restart]
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Adds automatic restart for service connect relay upon exit or crashes.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No
**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
