### PR TITLE
IPv6 default route for IPv6-only awsvpc tasks

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface.go
@@ -45,6 +45,8 @@ type NetworkInterface struct {
 	IPV6Addresses []*IPV6Address
 	// SubnetGatewayIPV4Address is the IPv4 address of the subnet gateway of the NetworkInterface
 	SubnetGatewayIPV4Address string `json:",omitempty"`
+	// SubnetGatewayIPV6Address is the IPv6 address of the subnet gateway of the NetworkInterface
+	SubnetGatewayIPV6Address string `json:",omitempty`
 	// DomainNameServers specifies the nameserver IP addresses for the eni
 	DomainNameServers []string `json:",omitempty"`
 	// DomainNameSearchList specifies the search list for the domain
@@ -297,6 +299,16 @@ func (ni *NetworkInterface) GetSubnetGatewayIPv4Address() string {
 	return gwAddr
 }
 
+// GetSubnetGatewayIPv6Address returns the subnet gateway IPv6 address for the NetworkInterface.
+func (ni *NetworkInterface) GetSubnetGatewayIPv6Address() string {
+	var gwAddr string
+	if ni.SubnetGatewayIPV6Address != "" {
+		gwAddr = strings.Split(ni.SubnetGatewayIPV6Address, "/")[0]
+	}
+
+	return gwAddr
+}
+
 // GetHostname returns the hostname assigned to the NetworkInterface
 func (ni *NetworkInterface) GetHostname() string {
 	return ni.PrivateDNSName
@@ -374,9 +386,10 @@ func (ni *NetworkInterface) String() string {
 
 	return fmt.Sprintf(
 		"eni id:%s, mac: %s, hostname: %s, ipv4addresses: [%s], ipv6addresses: [%s], dns: [%s], dns search: [%s],"+
-			" gateway ipv4: [%s][%s]", ni.ID, ni.MacAddress, ni.GetHostname(), strings.Join(ipv4Addresses, ","),
+			" gateway ipv4: [%s], gateway ipv6: [%s][%s]", ni.ID, ni.MacAddress, ni.GetHostname(), strings.Join(ipv4Addresses, ","),
 		strings.Join(ipv6Addresses, ","), strings.Join(ni.DomainNameServers, ","),
-		strings.Join(ni.DomainNameSearchList, ","), ni.SubnetGatewayIPV4Address, eniString)
+		strings.Join(ni.DomainNameSearchList, ","), ni.SubnetGatewayIPV4Address,
+		ni.SubnetGatewayIPV6Address, eniString)
 }
 
 // IPV4Address is the ipv4 information of the eni

--- a/ecs-agent/netlib/model/networkinterface/networkinterface.go
+++ b/ecs-agent/netlib/model/networkinterface/networkinterface.go
@@ -45,6 +45,8 @@ type NetworkInterface struct {
 	IPV6Addresses []*IPV6Address
 	// SubnetGatewayIPV4Address is the IPv4 address of the subnet gateway of the NetworkInterface
 	SubnetGatewayIPV4Address string `json:",omitempty"`
+	// SubnetGatewayIPV6Address is the IPv6 address of the subnet gateway of the NetworkInterface
+	SubnetGatewayIPV6Address string `json:",omitempty`
 	// DomainNameServers specifies the nameserver IP addresses for the eni
 	DomainNameServers []string `json:",omitempty"`
 	// DomainNameSearchList specifies the search list for the domain
@@ -297,6 +299,16 @@ func (ni *NetworkInterface) GetSubnetGatewayIPv4Address() string {
 	return gwAddr
 }
 
+// GetSubnetGatewayIPv6Address returns the subnet gateway IPv6 address for the NetworkInterface.
+func (ni *NetworkInterface) GetSubnetGatewayIPv6Address() string {
+	var gwAddr string
+	if ni.SubnetGatewayIPV6Address != "" {
+		gwAddr = strings.Split(ni.SubnetGatewayIPV6Address, "/")[0]
+	}
+
+	return gwAddr
+}
+
 // GetHostname returns the hostname assigned to the NetworkInterface
 func (ni *NetworkInterface) GetHostname() string {
 	return ni.PrivateDNSName
@@ -374,9 +386,10 @@ func (ni *NetworkInterface) String() string {
 
 	return fmt.Sprintf(
 		"eni id:%s, mac: %s, hostname: %s, ipv4addresses: [%s], ipv6addresses: [%s], dns: [%s], dns search: [%s],"+
-			" gateway ipv4: [%s][%s]", ni.ID, ni.MacAddress, ni.GetHostname(), strings.Join(ipv4Addresses, ","),
+			" gateway ipv4: [%s], gateway ipv6: [%s][%s]", ni.ID, ni.MacAddress, ni.GetHostname(), strings.Join(ipv4Addresses, ","),
 		strings.Join(ipv6Addresses, ","), strings.Join(ni.DomainNameServers, ","),
-		strings.Join(ni.DomainNameSearchList, ","), ni.SubnetGatewayIPV4Address, eniString)
+		strings.Join(ni.DomainNameSearchList, ","), ni.SubnetGatewayIPV4Address,
+		ni.SubnetGatewayIPV6Address, eniString)
 }
 
 // IPV4Address is the ipv4 information of the eni

--- a/ecs-agent/netlib/model/networkinterface/networkinterface_test.go
+++ b/ecs-agent/netlib/model/networkinterface/networkinterface_test.go
@@ -1,0 +1,53 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package networkinterface
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSubnetGatewayIPv6Address(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty address",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "ipv6 address with prefix",
+			input:    "2001:db8:85a3::8a2e:370:7334/64",
+			expected: "2001:db8:85a3::8a2e:370:7334",
+		},
+		{
+			name:     "ipv6 address without prefix",
+			input:    "2001:db8:85a3::8a2e:370:7334",
+			expected: "2001:db8:85a3::8a2e:370:7334",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ni := &NetworkInterface{SubnetGatewayIPV6Address: tt.input}
+			assert.Equal(t, tt.expected, ni.GetSubnetGatewayIPv6Address())
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This change makes Agent create an IPv6 default route in task network namespace of awsvpc tasks whose task ENIs are IPv6-only. The default route is via the task subnet's gateway address which will be passed to Agent by ECS backend. Changes to update ECS backend model to include IPv6 subnet gateway address are not a part of this change and will be made separately in the near future. 

This change is applicable only to IPv6-only task ENIs. Dual stack task ENIs continue to work as before (without an explicitly created default IPv6 route). 

The default routes are created by vpc-eni (for standard awsvpc mode) and vpc-branch-eni (for awsvpc mode with ENI trunking enabled) CNI plugins. The plugins themselves already support creating default IPv6 routes, so we just need Agent to pass the IPv6 subnet gateway address to the plugins. 

### Implementation details
<!-- How are the changes implemented? -->
1. Add `SubnetGatewayIPV6Address` field to `NetworkInterface` type in ecs-agent module. Also add a `GetSubnetGatewayIPv6Address` method to get it. This struct is Agent's representation of ENIs. 
2. Update CNI configs generated for vpc-eni and vpc-branch-eni plugins so that they include IPv6 subnet gateway address for IPv6-only task ENIs. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

Made temporary changes to the code so that task ENIs as seen by task engine only have IPv6 addresses (they are already passed by ECS backend) and an IPv6 subnet gateway address. Ran an awsvpc task in dual-stack subnet and verified that the task's network has an IPv6 default route via the subnet gateway and no IPv4 default route. 

```
ipv6dev ❱ docker exec -it a2b914a4f4f1 bash
bash-5.2# ip -6 route show default
default via 2600:1f14:323a:e001::1 dev eth0 metric 1024 pref medium
default via fe80::5f:3cff:fe81:2ef dev eth0 proto ra metric 1024 expires 1799sec hoplimit 255 pref medium
bash-5.2# ip route show default
bash-5.2#
```

There are two IPv6 default routes because a default route is automatically configured for IPv6 task ENIs by EC2. However, ECS will be adding an explicit route that will be via the default subnet gateway address and will take priority (as it has no metric).

Did the same testing on an instance enabled for ENI trunking also. Observed the same results. 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
