### PR TITLE
Populate IPv6 subnet gateway address from ACS payload

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs/api.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs/api.go
@@ -993,6 +993,8 @@ type ElasticNetworkInterface struct {
 	PrivateDnsName *string `locationName:"privateDnsName" type:"string"`
 
 	SubnetGatewayIpv4Address *string `locationName:"subnetGatewayIpv4Address" type:"string"`
+
+	SubnetGatewayIpv6Address *string `locationName:"subnetGatewayIpv6Address" type:"string"`
 }
 
 // String returns the string representation.
@@ -1468,6 +1470,8 @@ type IPv6AddressAssignment struct {
 	_ struct{} `type:"structure"`
 
 	Address *string `locationName:"address" type:"string"`
+
+	Primary *bool `locationName:"primary" type:"boolean"`
 }
 
 // String returns the string representation.

--- a/ecs-agent/acs/model/api/api-2.json
+++ b/ecs-agent/acs/model/api/api-2.json
@@ -434,7 +434,8 @@
         "domainName":{"shape":"StringList"},
         "domainNameServers":{"shape":"StringList"},
         "privateDnsName":{"shape":"String"},
-        "subnetGatewayIpv4Address":{"shape":"String"}
+        "subnetGatewayIpv4Address":{"shape":"String"},
+        "subnetGatewayIpv6Address":{"shape":"String"}
       }
     },
     "ElasticNetworkInterfaceList":{
@@ -583,7 +584,8 @@
     "IPv6AddressAssignment":{
       "type":"structure",
       "members":{
-        "address":{"shape":"String"}
+        "address":{"shape":"String"},
+        "primary":{"shape":"Boolean"}
       }
     },
     "IPv6AddressList":{

--- a/ecs-agent/acs/model/ecsacs/api.go
+++ b/ecs-agent/acs/model/ecsacs/api.go
@@ -993,6 +993,8 @@ type ElasticNetworkInterface struct {
 	PrivateDnsName *string `locationName:"privateDnsName" type:"string"`
 
 	SubnetGatewayIpv4Address *string `locationName:"subnetGatewayIpv4Address" type:"string"`
+
+	SubnetGatewayIpv6Address *string `locationName:"subnetGatewayIpv6Address" type:"string"`
 }
 
 // String returns the string representation.
@@ -1468,6 +1470,8 @@ type IPv6AddressAssignment struct {
 	_ struct{} `type:"structure"`
 
 	Address *string `locationName:"address" type:"string"`
+
+	Primary *bool `locationName:"primary" type:"boolean"`
 }
 
 // String returns the string representation.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR updates the ACS task payload model so that it has two new fields - 
1. `ElasticNetworkInterface.subnetGatewayIpv6Address` - Subnet gateway address of IPv6 ENIs,
2. `IPv6AddressAssignment.primary` to signal whether an IPv6 address of an ENI is primary or not. 

`netlib/networkinterface.InterfaceFromACS` method in ecs-agent module is updated so that it validates and copies IPv6 subnet gateway address from ACS payload to the internal network interface model. Validation follows the existing validation for IPv4 subnet gateway address - i.e. the address contains one "/" and has two segments (resembles a CIDR block). 

`IPv6AddressAssignment.primary` field is unused as of this PR. It will be used in upcoming PRs. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Populate IPv6 subnet gateway address from ACS payload
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
