### PR TITLE
Enable Dualstack Support to TaskProtection Client

### DIFF
--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -73,7 +73,6 @@ func taskServerSetup(
 	containerInstanceArn string,
 	taskProtectionClientFactory tp.TaskProtectionClientFactoryInterface,
 ) (*http.Server, error) {
-
 	muxRouter := mux.NewRouter()
 
 	// Set this to false so that for request like "//v3//metadata/task"
@@ -117,7 +116,8 @@ func v2HandlersSetup(muxRouter *mux.Router,
 	credentialsManager credentials.Manager,
 	auditLogger auditinterface.AuditLogger,
 	availabilityZone string,
-	containerInstanceArn string) {
+	containerInstanceArn string,
+) {
 	muxRouter.HandleFunc(tmdsv2.CredentialsPath, tmdsv2.CredentialsHandler(credentialsManager, auditLogger))
 	muxRouter.HandleFunc(v2.ContainerMetadataPath, v2.TaskContainerMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, false))
 	muxRouter.HandleFunc(v2.TaskMetadataPath, v2.TaskContainerMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, false))
@@ -136,7 +136,8 @@ func v3HandlersSetup(muxRouter *mux.Router,
 	statsEngine stats.Engine,
 	cluster string,
 	availabilityZone string,
-	containerInstanceArn string) {
+	containerInstanceArn string,
+) {
 	muxRouter.HandleFunc(v3.ContainerMetadataPath, v3.ContainerMetadataHandler(state))
 	muxRouter.HandleFunc(v3.TaskMetadataPath, v3.TaskMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, false))
 	muxRouter.HandleFunc(v3.TaskWithTagsMetadataPath, v3.TaskMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, true))
@@ -342,7 +343,8 @@ func ServeTaskHTTPEndpoint(
 	cfg *config.Config,
 	statsEngine stats.Engine,
 	availabilityZone string,
-	vpcID string) {
+	vpcID string,
+) {
 	// Create and initialize the audit log
 	logger, err := seelog.LoggerFromConfigAsString(audit.AuditLoggerConfig(cfg))
 	if err != nil {
@@ -354,7 +356,7 @@ func ServeTaskHTTPEndpoint(
 	auditLogger := audit.NewAuditLog(containerInstanceArn, cfg, logger)
 
 	taskProtectionClientFactory := tpfactory.TaskProtectionClientFactory{
-		Region: cfg.AWSRegion, Endpoint: cfg.APIEndpoint, AcceptInsecureCert: cfg.AcceptInsecureCert,
+		Region: cfg.AWSRegion, Endpoint: cfg.APIEndpoint, AcceptInsecureCert: cfg.AcceptInsecureCert, IPCompatibility: cfg.InstanceIPCompatibility,
 	}
 	server, err := taskServerSetup(credentialsManager, auditLogger, state, ecsClient, cfg.Cluster,
 		statsEngine, cfg.TaskMetadataSteadyStateRate, cfg.TaskMetadataBurstRate,


### PR DESCRIPTION
### Summary
Enable TaskProtection Client to automatically use dualstack endpoints when running on IPv6-only instances.

### Implementation details

1. Added `IPCompatibility `field in `TaskProtectionClientFactory`
1. Created `getEndpointOptions()` method to handle endpoint configurations. Updated `NewTaskProtectionClient()` to use it.
    1. If an Endpoint is provided, set it as `BaseEndpoint` and don't use Dualstack endpoint
    2. Otherwise, if an instance is IPv6Compatible only, use Dualstack endpoint
3. Added test cases to verify the behavior above.
1. Modified `task_server_setup.go` to initialize factory with instance IP compatibility




### Testing
Executed functional test suite on dualstack subnet. Verified all tests passed and dualstack endpoint usage through docker container logs.

```
level=debug time=2025-04-30T23:30:41Z msg="Configuring TaskProtection DualStack endpoint"
```

Setups done:
* Set `IPCompatibility` to `NewIPv6OnlyCompatibility`
* Pin the functional test suite on a dualstack subnet (agent is currently connecting to control plane via IPv4).


New tests cover the changes: yes
New tests added to ensure that `UseDualStackEndpoint` flag is not set when `BaseEndpoint` is set. Also assert that custom endpoint take precedence over `UseDualStackEndpoint`


### Description for the changelog
Enhancement: TaskProtection Client resolves to dualstack endpoint on IPV6-only instances

### Additional Information


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
