### PR TITLE
update additional files in agent module to aws-sdk-go-v2

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -69,9 +69,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/wsclient"
 
-	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	aws_credentials "github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/cihub/seelog"
@@ -148,7 +147,7 @@ type ecsAgent struct {
 	dockerClient                dockerapi.DockerClient
 	containerInstanceARN        string
 	credentialProvider          *aws_credentials.Credentials
-	credentialsCache            *awsv2.CredentialsCache
+	credentialsCache            *aws.CredentialsCache
 	stateManagerFactory         factory.StateManager
 	saveableOptionFactory       factory.SaveableOption
 	pauseLoader                 loader.Loader
@@ -202,7 +201,7 @@ func newAgent(blackholeEC2Metadata bool, acceptInsecureCert *bool) (agent, error
 		cancel()
 		return nil, err
 	}
-	cfg.AcceptInsecureCert = aws.BoolValue(acceptInsecureCert)
+	cfg.AcceptInsecureCert = aws.ToBool(acceptInsecureCert)
 	if cfg.AcceptInsecureCert {
 		seelog.Warn("SSL certificate verification disabled. This is not recommended.")
 	}
@@ -300,7 +299,7 @@ func (agent *ecsAgent) printECSAttributes() int {
 		return exitcodes.ExitError
 	}
 	for _, attr := range capabilities {
-		fmt.Printf("%s\t%s\n", aws.StringValue(attr.Name), aws.StringValue(attr.Value))
+		fmt.Printf("%s\t%s\n", aws.ToString(attr.Name), aws.ToString(attr.Value))
 	}
 	return exitcodes.ExitSuccess
 }
@@ -1171,11 +1170,11 @@ func mergeTags(localTags []types.Tag, ec2Tags []types.Tag) []types.Tag {
 	tagsMap := make(map[string]string)
 
 	for _, ec2Tag := range ec2Tags {
-		tagsMap[aws.StringValue(ec2Tag.Key)] = aws.StringValue(ec2Tag.Value)
+		tagsMap[aws.ToString(ec2Tag.Key)] = aws.ToString(ec2Tag.Value)
 	}
 
 	for _, localTag := range localTags {
-		tagsMap[aws.StringValue(localTag.Key)] = aws.StringValue(localTag.Value)
+		tagsMap[aws.ToString(localTag.Key)] = aws.ToString(localTag.Value)
 	}
 
 	return utils.MapToTags(tagsMap)

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -26,8 +26,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	md "github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
 )
@@ -642,7 +643,7 @@ func removeAttributesByNames(attributes []types.Attribute, names []string) []typ
 
 	var ret []types.Attribute
 	for _, attr := range attributes {
-		if _, ok := nameMap[aws.StringValue(attr.Name)]; !ok {
+		if _, ok := nameMap[aws.ToString(attr.Name)]; !ok {
 			ret = append(ret, attr)
 		}
 	}

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -36,8 +36,8 @@ import (
 	mock_mobypkgwrapper "github.com/aws/amazon-ecs-agent/agent/utils/mobypkgwrapper/mocks"
 	md "github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	aws_credentials "github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -320,7 +320,7 @@ func TestCapabilitiesECR(t *testing.T) {
 
 	capMap := make(map[string]bool)
 	for _, capability := range capabilities {
-		capMap[aws.StringValue(capability.Name)] = true
+		capMap[aws.ToString(capability.Name)] = true
 	}
 
 	_, ok := capMap["com.amazonaws.ecs.capability.ecr-auth"]
@@ -377,7 +377,7 @@ func TestCapabilitiesTaskIAMRoleForSupportedDockerVersion(t *testing.T) {
 
 	capMap := make(map[string]bool)
 	for _, capability := range capabilities {
-		capMap[aws.StringValue(capability.Name)] = true
+		capMap[aws.ToString(capability.Name)] = true
 	}
 
 	ok := capMap["com.amazonaws.ecs.capability.task-iam-role"]
@@ -431,7 +431,7 @@ func TestCapabilitiesTaskIAMRoleForUnSupportedDockerVersion(t *testing.T) {
 
 	capMap := make(map[string]bool)
 	for _, capability := range capabilities {
-		capMap[aws.StringValue(capability.Name)] = true
+		capMap[aws.ToString(capability.Name)] = true
 	}
 
 	_, ok := capMap["com.amazonaws.ecs.capability.task-iam-role"]
@@ -485,7 +485,7 @@ func TestCapabilitiesTaskIAMRoleNetworkHostForSupportedDockerVersion(t *testing.
 
 	capMap := make(map[string]bool)
 	for _, capability := range capabilities {
-		capMap[aws.StringValue(capability.Name)] = true
+		capMap[aws.ToString(capability.Name)] = true
 	}
 
 	_, ok := capMap["com.amazonaws.ecs.capability.task-iam-role-network-host"]
@@ -539,7 +539,7 @@ func TestCapabilitiesTaskIAMRoleNetworkHostForUnSupportedDockerVersion(t *testin
 
 	capMap := make(map[string]bool)
 	for _, capability := range capabilities {
-		capMap[aws.StringValue(capability.Name)] = true
+		capMap[aws.ToString(capability.Name)] = true
 	}
 
 	_, ok := capMap["com.amazonaws.ecs.capability.task-iam-role-network-host"]
@@ -621,7 +621,7 @@ func TestAWSVPCBlockInstanceMetadataWhenTaskENIIsDisabled(t *testing.T) {
 	}
 
 	for _, capability := range capabilities {
-		if aws.StringValue(capability.Name) == "ecs.capability.task-eni-block-instance-metadata" {
+		if aws.ToString(capability.Name) == "ecs.capability.task-eni-block-instance-metadata" {
 			t.Errorf("%s capability found when Task ENI is disabled in the config", taskENIBlockInstanceMetadataAttributeSuffix)
 		}
 	}
@@ -680,7 +680,7 @@ func TestCapabilitiesExecutionRoleAWSLogs(t *testing.T) {
 
 	capMap := make(map[string]bool)
 	for _, capability := range capabilities {
-		capMap[aws.StringValue(capability.Name)] = true
+		capMap[aws.ToString(capability.Name)] = true
 	}
 
 	_, ok := capMap["ecs.capability.execution-role-awslogs"]
@@ -732,7 +732,7 @@ func TestCapabilitiesTaskResourceLimit(t *testing.T) {
 
 	capMap := make(map[string]bool)
 	for _, capability := range capabilities {
-		capMap[aws.StringValue(capability.Name)] = true
+		capMap[aws.ToString(capability.Name)] = true
 	}
 
 	_, ok := capMap[expectedCapability]
@@ -784,7 +784,7 @@ func TestCapabilitesTaskResourceLimitDisabledByMissingDockerVersion(t *testing.T
 
 	capMap := make(map[string]bool)
 	for _, capability := range capabilities {
-		capMap[aws.StringValue(capability.Name)] = true
+		capMap[aws.ToString(capability.Name)] = true
 	}
 
 	_, ok := capMap[unexpectedCapability]
@@ -905,7 +905,7 @@ func TestCapabilitiesIncreasedTaskCPULimit(t *testing.T) {
 
 			capMap := make(map[string]bool)
 			for _, capability := range capabilities {
-				capMap[aws.StringValue(capability.Name)] = true
+				capMap[aws.ToString(capability.Name)] = true
 			}
 
 			_, ok := capMap[capability]
@@ -957,7 +957,7 @@ func TestCapabilitiesContainerHealth(t *testing.T) {
 
 	capMap := make(map[string]bool)
 	for _, capability := range capabilities {
-		capMap[aws.StringValue(capability.Name)] = true
+		capMap[aws.ToString(capability.Name)] = true
 	}
 
 	_, ok := capMap["ecs.capability.container-health-check"]
@@ -1007,7 +1007,7 @@ func TestCapabilitiesContainerHealthDisabled(t *testing.T) {
 
 	capMap := make(map[string]bool)
 	for _, capability := range capabilities {
-		capMap[aws.StringValue(capability.Name)] = true
+		capMap[aws.ToString(capability.Name)] = true
 	}
 
 	assert.NotContains(t, "ecs.capability.container-health-check", "Find container health check capability unexpected when it is disabled")
@@ -1054,8 +1054,8 @@ func TestCapabilitesListPluginsErrorCase(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, capability := range capabilities {
-		if strings.HasPrefix(aws.StringValue(capability.Name), "ecs.capability.docker-volume-driver") {
-			assert.Equal(t, aws.StringValue(capability.Name), "ecs.capability.docker-volume-driver.local")
+		if strings.HasPrefix(aws.ToString(capability.Name), "ecs.capability.docker-volume-driver") {
+			assert.Equal(t, aws.ToString(capability.Name), "ecs.capability.docker-volume-driver.local")
 		}
 	}
 }
@@ -1101,8 +1101,8 @@ func TestCapabilitesScanPluginsErrorCase(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, capability := range capabilities {
-		if strings.HasPrefix(aws.StringValue(capability.Name), "ecs.capability.docker-volume-driver") {
-			assert.Equal(t, aws.StringValue(capability.Name), "ecs.capability.docker-volume-driver.local")
+		if strings.HasPrefix(aws.ToString(capability.Name), "ecs.capability.docker-volume-driver") {
+			assert.Equal(t, aws.ToString(capability.Name), "ecs.capability.docker-volume-driver.local")
 		}
 	}
 }
@@ -1510,8 +1510,8 @@ func TestAppendGMSACapabilities(t *testing.T) {
 
 	assert.Equal(t, len(expectedCapabilities), len(capabilities))
 	for i, expected := range expectedCapabilities {
-		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
-		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+		assert.Equal(t, aws.ToString(expected.Name), aws.ToString(capabilities[i].Name))
+		assert.Equal(t, aws.ToString(expected.Value), aws.ToString(capabilities[i].Value))
 	}
 }
 
@@ -1536,8 +1536,8 @@ func TestAppendGMSADomainlessCapabilities(t *testing.T) {
 
 	assert.Equal(t, len(expectedCapabilities), len(capabilities))
 	for i, expected := range expectedCapabilities {
-		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
-		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+		assert.Equal(t, aws.ToString(expected.Name), aws.ToString(capabilities[i].Name))
+		assert.Equal(t, aws.ToString(expected.Value), aws.ToString(capabilities[i].Value))
 	}
 }
 
@@ -1572,7 +1572,7 @@ func TestAppendFaultInjectionCapabilities(t *testing.T) {
 		capabilities = agent.appendFaultInjectionCapabilities(capabilities)
 		// Check that the only capability is "ecs.capability.fault-injection"
 		require.Len(t, capabilities, 1)
-		assert.Equal(t, "ecs.capability.fault-injection", aws.StringValue(capabilities[0].Name))
+		assert.Equal(t, "ecs.capability.fault-injection", aws.ToString(capabilities[0].Name))
 	})
 	t.Run("Fault Injection Capability Not Available", func(t *testing.T) {
 		// Test case where required tooling is not available

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -32,8 +32,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/utils/netconfig"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/cihub/seelog"
 )
 

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/utils/netconfig"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/cihub/seelog"

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -46,8 +46,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper"
 	mock_execwrapper "github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper/mocks"
 	mock_netlinkwrapper "github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper/mocks"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	aws_credentials "github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -22,8 +22,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/ecscni"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/cihub/seelog"
 )
 

--- a/agent/app/agent_capability_windows_test.go
+++ b/agent/app/agent_capability_windows_test.go
@@ -30,8 +30,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/serviceconnect"
 	mock_mobypkgwrapper "github.com/aws/amazon-ecs-agent/agent/utils/mobypkgwrapper/mocks"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	aws_credentials "github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -263,8 +263,8 @@ func TestAppendFSxWindowsFileServerCapabilities(t *testing.T) {
 
 	assert.Equal(t, len(expectedCapabilities), len(capabilities))
 	for i, expected := range expectedCapabilities {
-		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
-		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+		assert.Equal(t, aws.ToString(expected.Name), aws.ToString(capabilities[i].Name))
+		assert.Equal(t, aws.ToString(expected.Value), aws.ToString(capabilities[i].Value))
 	}
 }
 

--- a/agent/app/agent_integ_test.go
+++ b/agent/app/agent_integ_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/agent/app/agent_integ_test.go
+++ b/agent/app/agent_integ_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 )

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -56,9 +56,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
 	md "github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon"
 
-	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
@@ -273,7 +272,7 @@ func TestDoStartRegisterContainerInstanceErrorTerminal(t *testing.T) {
 
 	gomock.InOrder(
 		client.EXPECT().GetHostResources().Return(testHostResource, nil),
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{""}, nil),
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -292,7 +291,7 @@ func TestDoStartRegisterContainerInstanceErrorTerminal(t *testing.T) {
 		ctx:               ctx,
 		cfg:               &cfg,
 		pauseLoader:       mockPauseLoader,
-		credentialsCache:  awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache:  aws.NewCredentialsCache(mockCredentialsProvider),
 		dockerClient:      dockerClient,
 		mobyPlugins:       mockMobyPlugins,
 		ec2MetadataClient: mockEC2Metadata,
@@ -335,7 +334,7 @@ func TestDoStartRegisterContainerInstanceErrorNonTerminal(t *testing.T) {
 
 	gomock.InOrder(
 		client.EXPECT().GetHostResources().Return(testHostResource, nil),
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{""}, nil),
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -354,7 +353,7 @@ func TestDoStartRegisterContainerInstanceErrorNonTerminal(t *testing.T) {
 		cfg:               &cfg,
 		dockerClient:      dockerClient,
 		pauseLoader:       mockPauseLoader,
-		credentialsCache:  awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache:  aws.NewCredentialsCache(mockCredentialsProvider),
 		mobyPlugins:       mockMobyPlugins,
 		ec2MetadataClient: mockEC2Metadata,
 		terminationHandler: func(taskEngineState dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
@@ -502,7 +501,7 @@ func testDoStartHappyPathWithConditions(t *testing.T, blackholed bool, warmPools
 
 	gomock.InOrder(
 		client.EXPECT().GetHostResources().Return(testHostResource, nil),
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{""}, nil),
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -537,7 +536,7 @@ func testDoStartHappyPathWithConditions(t *testing.T, blackholed bool, warmPools
 		dockerClient:     dockerClient,
 		dataClient:       dataClient,
 		pauseLoader:      mockPauseLoader,
-		credentialsCache: awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache: aws.NewCredentialsCache(mockCredentialsProvider),
 		mobyPlugins:      mockMobyPlugins,
 		metadataManager:  containermetadata,
 		terminationHandler: func(taskEngineState dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
@@ -1016,7 +1015,7 @@ func TestReregisterContainerInstanceHappyPath(t *testing.T) {
 	mockDaemonManager.EXPECT().LoadImage(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	gomock.InOrder(
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{""}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
@@ -1037,7 +1036,7 @@ func TestReregisterContainerInstanceHappyPath(t *testing.T) {
 		cfg:                   &cfg,
 		dockerClient:          mockDockerClient,
 		pauseLoader:           mockPauseLoader,
-		credentialsCache:      awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache:      aws.NewCredentialsCache(mockCredentialsProvider),
 		mobyPlugins:           mockMobyPlugins,
 		ec2MetadataClient:     mockEC2Metadata,
 		serviceconnectManager: mockServiceConnectManager,
@@ -1075,7 +1074,7 @@ func TestReregisterContainerInstanceInstanceTypeChanged(t *testing.T) {
 	mockDaemonManager.EXPECT().LoadImage(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	gomock.InOrder(
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{""}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
@@ -1098,7 +1097,7 @@ func TestReregisterContainerInstanceInstanceTypeChanged(t *testing.T) {
 		cfg:                   &cfg,
 		dockerClient:          mockDockerClient,
 		pauseLoader:           mockPauseLoader,
-		credentialsCache:      awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache:      aws.NewCredentialsCache(mockCredentialsProvider),
 		ec2MetadataClient:     mockEC2Metadata,
 		mobyPlugins:           mockMobyPlugins,
 		serviceconnectManager: mockServiceConnectManager,
@@ -1137,7 +1136,7 @@ func TestReregisterContainerInstanceAttributeError(t *testing.T) {
 	mockDaemonManager.EXPECT().LoadImage(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	gomock.InOrder(
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
@@ -1158,7 +1157,7 @@ func TestReregisterContainerInstanceAttributeError(t *testing.T) {
 		ec2MetadataClient:     mockEC2Metadata,
 		dockerClient:          mockDockerClient,
 		pauseLoader:           mockPauseLoader,
-		credentialsCache:      awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache:      aws.NewCredentialsCache(mockCredentialsProvider),
 		mobyPlugins:           mockMobyPlugins,
 		serviceconnectManager: mockServiceConnectManager,
 		daemonManagers:        mockDaemonManagers,
@@ -1196,7 +1195,7 @@ func TestReregisterContainerInstanceNonTerminalError(t *testing.T) {
 	mockDaemonManager.EXPECT().LoadImage(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	gomock.InOrder(
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
@@ -1217,7 +1216,7 @@ func TestReregisterContainerInstanceNonTerminalError(t *testing.T) {
 		dockerClient:          mockDockerClient,
 		ec2MetadataClient:     mockEC2Metadata,
 		pauseLoader:           mockPauseLoader,
-		credentialsCache:      awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache:      aws.NewCredentialsCache(mockCredentialsProvider),
 		mobyPlugins:           mockMobyPlugins,
 		serviceconnectManager: mockServiceConnectManager,
 		daemonManagers:        mockDaemonManagers,
@@ -1255,7 +1254,7 @@ func TestReregisterContainerInstanceTerminalError(t *testing.T) {
 	mockDaemonManager.EXPECT().LoadImage(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	gomock.InOrder(
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
@@ -1276,7 +1275,7 @@ func TestReregisterContainerInstanceTerminalError(t *testing.T) {
 		dockerClient:          mockDockerClient,
 		ec2MetadataClient:     mockEC2Metadata,
 		pauseLoader:           mockPauseLoader,
-		credentialsCache:      awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache:      aws.NewCredentialsCache(mockCredentialsProvider),
 		mobyPlugins:           mockMobyPlugins,
 		serviceconnectManager: mockServiceConnectManager,
 		daemonManagers:        mockDaemonManagers,
@@ -1315,7 +1314,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetHappyPath(t *t
 	mockDaemonManager.EXPECT().LoadImage(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	gomock.InOrder(
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
@@ -1336,7 +1335,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetHappyPath(t *t
 		dockerClient:          mockDockerClient,
 		ec2MetadataClient:     mockEC2Metadata,
 		pauseLoader:           mockPauseLoader,
-		credentialsCache:      awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache:      aws.NewCredentialsCache(mockCredentialsProvider),
 		mobyPlugins:           mockMobyPlugins,
 		serviceconnectManager: mockServiceConnectManager,
 		daemonManagers:        mockDaemonManagers,
@@ -1373,7 +1372,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetCanRetryError(
 
 	retriableError := apierrors.NewRetriableError(apierrors.NewRetriable(true), errors.New("error"))
 	gomock.InOrder(
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
@@ -1394,7 +1393,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetCanRetryError(
 		dockerClient:          mockDockerClient,
 		ec2MetadataClient:     mockEC2Metadata,
 		pauseLoader:           mockPauseLoader,
-		credentialsCache:      awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache:      aws.NewCredentialsCache(mockCredentialsProvider),
 		mobyPlugins:           mockMobyPlugins,
 		serviceconnectManager: mockServiceConnectManager,
 		daemonManagers:        mockDaemonManagers,
@@ -1431,7 +1430,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetCannotRetryErr
 
 	cannotRetryError := apierrors.NewRetriableError(apierrors.NewRetriable(false), errors.New("error"))
 	gomock.InOrder(
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
@@ -1452,7 +1451,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetCannotRetryErr
 		ec2MetadataClient:     mockEC2Metadata,
 		dockerClient:          mockDockerClient,
 		pauseLoader:           mockPauseLoader,
-		credentialsCache:      awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache:      aws.NewCredentialsCache(mockCredentialsProvider),
 		mobyPlugins:           mockMobyPlugins,
 		serviceconnectManager: mockServiceConnectManager,
 		daemonManagers:        mockDaemonManagers,
@@ -1488,7 +1487,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetAttributeError
 	mockDaemonManager.EXPECT().LoadImage(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	gomock.InOrder(
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockDockerClient.EXPECT().SupportedVersions().Return(apiVersions),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
@@ -1509,7 +1508,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetAttributeError
 		ec2MetadataClient:     mockEC2Metadata,
 		dockerClient:          mockDockerClient,
 		pauseLoader:           mockPauseLoader,
-		credentialsCache:      awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache:      aws.NewCredentialsCache(mockCredentialsProvider),
 		mobyPlugins:           mockMobyPlugins,
 		serviceconnectManager: mockServiceConnectManager,
 		daemonManagers:        mockDaemonManagers,
@@ -1550,7 +1549,7 @@ func TestRegisterContainerInstanceInvalidParameterTerminalError(t *testing.T) {
 
 	gomock.InOrder(
 		client.EXPECT().GetHostResources().Return(testHostResource, nil),
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -1568,7 +1567,7 @@ func TestRegisterContainerInstanceInvalidParameterTerminalError(t *testing.T) {
 		ec2MetadataClient: mockEC2Metadata,
 		cfg:               &cfg,
 		pauseLoader:       mockPauseLoader,
-		credentialsCache:  awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache:  aws.NewCredentialsCache(mockCredentialsProvider),
 		dockerClient:      dockerClient,
 		mobyPlugins:       mockMobyPlugins,
 		terminationHandler: func(taskEngineState dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
@@ -1639,7 +1638,7 @@ func TestRegisterContainerInstanceExceptionErrors(t *testing.T) {
 
 			gomock.InOrder(
 				client.EXPECT().GetHostResources().Return(testHostResource, nil),
-				mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+				mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 				mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
 				dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any()).AnyTimes().Return([]string{}, nil),
@@ -1661,7 +1660,7 @@ func TestRegisterContainerInstanceExceptionErrors(t *testing.T) {
 				ec2MetadataClient: mockEC2Metadata,
 				cfg:               &cfg,
 				pauseLoader:       mockPauseLoader,
-				credentialsCache:  awsv2.NewCredentialsCache(mockCredentialsProvider),
+				credentialsCache:  aws.NewCredentialsCache(mockCredentialsProvider),
 				dockerClient:      dockerClient,
 				mobyPlugins:       mockMobyPlugins,
 				terminationHandler: func(
@@ -1724,15 +1723,15 @@ func TestMergeTags(t *testing.T) {
 
 	assert.Equal(t, len(mergedTags), 3)
 	sort.Slice(mergedTags, func(i, j int) bool {
-		return aws.StringValue(mergedTags[i].Key) < aws.StringValue(mergedTags[j].Key)
+		return aws.ToString(mergedTags[i].Key) < aws.ToString(mergedTags[j].Key)
 	})
 
-	assert.Equal(t, commonKey, aws.StringValue(mergedTags[0].Key))
-	assert.Equal(t, commonKeyLocalValue, aws.StringValue(mergedTags[0].Value))
-	assert.Equal(t, ec2Key, aws.StringValue(mergedTags[1].Key))
-	assert.Equal(t, ec2Value, aws.StringValue(mergedTags[1].Value))
-	assert.Equal(t, localKey, aws.StringValue(mergedTags[2].Key))
-	assert.Equal(t, localValue, aws.StringValue(mergedTags[2].Value))
+	assert.Equal(t, commonKey, aws.ToString(mergedTags[0].Key))
+	assert.Equal(t, commonKeyLocalValue, aws.ToString(mergedTags[0].Value))
+	assert.Equal(t, ec2Key, aws.ToString(mergedTags[1].Key))
+	assert.Equal(t, ec2Value, aws.ToString(mergedTags[1].Value))
+	assert.Equal(t, localKey, aws.ToString(mergedTags[2].Key))
+	assert.Equal(t, localValue, aws.ToString(mergedTags[2].Value))
 }
 
 func TestGetContainerInstanceTagsFromEC2API(t *testing.T) {

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -46,9 +46,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
 	md "github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon"
 
-	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -134,7 +133,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 		cniClient.EXPECT().Capabilities(ecscni.ECSIPAMPluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSAppMeshPluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSBranchENIPluginName).Return(cniCapabilities, nil),
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		cniClient.EXPECT().Version(ecscni.VPCENIPluginName).Return("v1", nil),
 		cniClient.EXPECT().Version(ecscni.ECSBranchENIPluginName).Return("v2", nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
@@ -147,12 +146,12 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 				vpcFound := false
 				subnetFound := false
 				for _, attribute := range attributes {
-					if aws.StringValue(attribute.Name) == vpcIDAttributeName &&
-						aws.StringValue(attribute.Value) == vpcID {
+					if aws.ToString(attribute.Name) == vpcIDAttributeName &&
+						aws.ToString(attribute.Value) == vpcID {
 						vpcFound = true
 					}
-					if aws.StringValue(attribute.Name) == subnetIDAttributeName &&
-						aws.StringValue(attribute.Value) == subnetID {
+					if aws.ToString(attribute.Name) == subnetIDAttributeName &&
+						aws.ToString(attribute.Value) == subnetID {
 						subnetFound = true
 					}
 				}
@@ -171,7 +170,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 	agent := &ecsAgent{
 		ctx:               ctx,
 		cfg:               &cfg,
-		credentialsCache:  awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache:  aws.NewCredentialsCache(mockCredentialsProvider),
 		dataClient:        data.NewNoopClient(),
 		dockerClient:      dockerClient,
 		pauseLoader:       mockPauseLoader,
@@ -477,7 +476,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 
 	gomock.InOrder(
 		mockControl.EXPECT().Init().Return(nil),
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).Return([]string{}, nil),
@@ -510,7 +509,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 	agent := &ecsAgent{
 		ctx:              ctx,
 		cfg:              &cfg,
-		credentialsCache: awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache: aws.NewCredentialsCache(mockCredentialsProvider),
 		pauseLoader:      mockPauseLoader,
 		dockerClient:     dockerClient,
 		terminationHandler: func(state dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
@@ -579,7 +578,7 @@ func TestDoStartCgroupInitErrorPath(t *testing.T) {
 	agent := &ecsAgent{
 		ctx:              ctx,
 		cfg:              &cfg,
-		credentialsCache: awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache: aws.NewCredentialsCache(mockCredentialsProvider),
 		dockerClient:     dockerClient,
 		pauseLoader:      mockPauseLoader,
 		terminationHandler: func(state dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
@@ -653,7 +652,7 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 
 	gomock.InOrder(
 		mockGPUManager.EXPECT().Initialize().Return(nil),
-		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(awsv2.Credentials{}, nil),
+		mockCredentialsProvider.EXPECT().Retrieve(gomock.Any()).Return(aws.Credentials{}, nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).Return([]string{}, nil),
@@ -689,7 +688,7 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 	agent := &ecsAgent{
 		ctx:              ctx,
 		cfg:              &cfg,
-		credentialsCache: awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache: aws.NewCredentialsCache(mockCredentialsProvider),
 		dockerClient:     dockerClient,
 		pauseLoader:      mockPauseLoader,
 		terminationHandler: func(state dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
@@ -751,7 +750,7 @@ func TestDoStartGPUManagerInitError(t *testing.T) {
 	agent := &ecsAgent{
 		ctx:              ctx,
 		cfg:              &cfg,
-		credentialsCache: awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache: aws.NewCredentialsCache(mockCredentialsProvider),
 		dockerClient:     dockerClient,
 		pauseLoader:      mockPauseLoader,
 		terminationHandler: func(state dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
@@ -799,7 +798,7 @@ func TestDoStartTaskENIPauseError(t *testing.T) {
 	agent := &ecsAgent{
 		ctx:               ctx,
 		cfg:               &cfg,
-		credentialsCache:  awsv2.NewCredentialsCache(mockCredentialsProvider),
+		credentialsCache:  aws.NewCredentialsCache(mockCredentialsProvider),
 		dockerClient:      dockerClient,
 		pauseLoader:       mockPauseLoader,
 		cniClient:         cniClient,

--- a/agent/app/run.go
+++ b/agent/app/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
 	"github.com/aws/amazon-ecs-agent/agent/version"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	log "github.com/cihub/seelog"
 )

--- a/agent/app/run.go
+++ b/agent/app/run.go
@@ -22,7 +22,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
 	"github.com/aws/amazon-ecs-agent/agent/version"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	log "github.com/cihub/seelog"
 )
 
@@ -72,7 +72,7 @@ func Run(arguments []string) int {
 	}
 
 	// Create an Agent object
-	agent, err := newAgent(aws.BoolValue(parsedArgs.BlackholeEC2Metadata), parsedArgs.AcceptInsecureCert)
+	agent, err := newAgent(aws.ToBool(parsedArgs.BlackholeEC2Metadata), parsedArgs.AcceptInsecureCert)
 	if err != nil {
 		// Failure to initialize either the docker client or the EC2 metadata
 		// service client are non terminal errors as they could be transient

--- a/agent/engine/daemonmanager/daemon_manager.go
+++ b/agent/engine/daemonmanager/daemon_manager.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	md "github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"

--- a/agent/engine/daemonmanager/daemon_manager.go
+++ b/agent/engine/daemonmanager/daemon_manager.go
@@ -32,7 +32,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	md "github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon"
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	dockermount "github.com/docker/docker/api/types/mount"

--- a/agent/engine/daemonmanager/daemon_manager_test.go
+++ b/agent/engine/daemonmanager/daemon_manager_test.go
@@ -28,7 +28,7 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	md "github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -113,8 +113,8 @@ func TestCreateDaemonTask(t *testing.T) {
 			hostConfigRaw := resultDaemonTask.Containers[0].DockerConfig.HostConfig
 			var configMap map[string]interface{}
 			var hostConfigMap map[string]interface{}
-			json.Unmarshal([]byte(aws.StringValue(configRaw)), &configMap)
-			json.Unmarshal([]byte(aws.StringValue(hostConfigRaw)), &hostConfigMap)
+			json.Unmarshal([]byte(aws.ToString(configRaw)), &configMap)
+			json.Unmarshal([]byte(aws.ToString(hostConfigRaw)), &hostConfigMap)
 			// validate mount point count
 			if containerMounts, ok := hostConfigMap["Mounts"].([]interface{}); ok {
 				assert.Equal(t, len(containerMounts), 3, "Task should have Required container binds (2) + 1 other bind")
@@ -178,8 +178,8 @@ func TestFailCreateDaemonTask_MissingMount(t *testing.T) {
 	hostConfigRaw := resultDaemonTask.Containers[0].DockerConfig.HostConfig
 	var configMap map[string]interface{}
 	var hostConfigMap map[string]interface{}
-	json.Unmarshal([]byte(aws.StringValue(configRaw)), &configMap)
-	json.Unmarshal([]byte(aws.StringValue(hostConfigRaw)), &hostConfigMap)
+	json.Unmarshal([]byte(aws.ToString(configRaw)), &configMap)
+	json.Unmarshal([]byte(aws.ToString(hostConfigRaw)), &hostConfigMap)
 	// validate mount point count
 	if containerMounts, ok := hostConfigMap["Mounts"].([]interface{}); ok {
 		assert.Equal(t, len(containerMounts), 3, "Task should have Required container binds (2) + 1 other bind")
@@ -242,8 +242,8 @@ func TestCreateDaemonTask_PrivilegeAndMountPropagation(t *testing.T) {
 	hostConfigRaw := resultDaemonTask.Containers[0].DockerConfig.HostConfig
 	var configMap map[string]interface{}
 	var hostConfigMap map[string]interface{}
-	json.Unmarshal([]byte(aws.StringValue(configRaw)), &configMap)
-	json.Unmarshal([]byte(aws.StringValue(hostConfigRaw)), &hostConfigMap)
+	json.Unmarshal([]byte(aws.ToString(configRaw)), &configMap)
+	json.Unmarshal([]byte(aws.ToString(hostConfigRaw)), &hostConfigMap)
 	// validate mount point has One mount with Shared Propagation
 	if containerMounts, ok := hostConfigMap["Mounts"].([]interface{}); ok {
 		res := strings.Count(fmt.Sprintf("%v", containerMounts), "Propagation:shared")

--- a/agent/engine/dependencygraph/graph_test.go
+++ b/agent/engine/dependencygraph/graph_test.go
@@ -30,6 +30,7 @@ import (
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	mock_credentials "github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"

--- a/agent/engine/dependencygraph/graph_test.go
+++ b/agent/engine/dependencygraph/graph_test.go
@@ -30,7 +30,7 @@ import (
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	mock_credentials "github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks"
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -60,7 +60,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	cniTypesCurrent "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -43,7 +43,7 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/registry"

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -38,7 +38,7 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	sdkClient "github.com/docker/docker/client"

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -46,7 +46,7 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/cihub/seelog"
 	"github.com/containerd/cgroups/v3"
 	"github.com/docker/docker/api/types"

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -51,8 +51,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
 	sdkClient "github.com/docker/docker/client"

--- a/agent/engine/ordering_integ_test.go
+++ b/agent/engine/ordering_integ_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/agent/engine/serviceconnect/manager_linux.go
+++ b/agent/engine/serviceconnect/manager_linux.go
@@ -23,12 +23,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/pborman/uuid"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apiserviceconnect "github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
@@ -42,8 +36,13 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/pborman/uuid"
 )
 
 const (

--- a/agent/engine/serviceconnect/manager_linux_test_common.go
+++ b/agent/engine/serviceconnect/manager_linux_test_common.go
@@ -15,16 +15,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/amazon-ecs-agent/agent/config"
-	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
-	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
-
-	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
-	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
-	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
-
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
+	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
+	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"

--- a/agent/engine/serviceconnect/manager_linux_test_common.go
+++ b/agent/engine/serviceconnect/manager_linux_test_common.go
@@ -22,10 +22,10 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
-	"github.com/aws/aws-sdk-go/aws"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
 )

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -55,7 +55,7 @@ import (
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	mock_ttime "github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime/mocks"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )

--- a/agent/eventhandler/task_handler_test.go
+++ b/agent/eventhandler/task_handler_test.go
@@ -41,7 +41,7 @@ import (
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	mock_retry "github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry/mock"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
@@ -190,8 +190,8 @@ func TestSendsEventsContainerDifferences(t *testing.T) {
 
 	client.EXPECT().SubmitTaskStateChange(gomock.Any()).Do(func(change ecs.TaskStateChange) {
 		assert.Equal(t, taskARN, change.TaskARN)
-		assert.Equal(t, apicontainerstatus.ContainerRunning.String(), aws.StringValue(change.Containers[0].Status))
-		assert.Equal(t, apicontainerstatus.ContainerStopped.String(), aws.StringValue(change.Containers[1].Status))
+		assert.Equal(t, apicontainerstatus.ContainerRunning.String(), aws.ToString(change.Containers[0].Status))
+		assert.Equal(t, apicontainerstatus.ContainerStopped.String(), aws.ToString(change.Containers[1].Status))
 		wg.Done()
 	})
 

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -58,11 +58,10 @@ import (
 	v4 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state"
 	mock_execwrapper "github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper/mocks"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
 	smithy "github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/docker/docker/api/types"
@@ -3505,7 +3504,7 @@ func TestGetTaskProtection(t *testing.T) {
 			expectedResponseBody: tptypes.TaskProtectionResponse{
 				Error: &tptypes.ErrorResponse{
 					Arn:     taskARN,
-					Code:    request.CanceledErrorCode,
+					Code:    apierrors.ErrCodeRequestCanceled,
 					Message: "Timed out calling ECS Task Protection API",
 				},
 			},
@@ -3785,7 +3784,7 @@ func TestUpdateTaskProtection(t *testing.T) {
 		expectedResponseBody: tptypes.TaskProtectionResponse{
 			Error: &tptypes.ErrorResponse{
 				Arn:     taskARN,
-				Code:    request.CanceledErrorCode,
+				Code:    apierrors.ErrCodeRequestCanceled,
 				Message: "Timed out calling ECS Task Protection API",
 			},
 		},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR continues the migration of the agent module to aws-sdk-go-v2.

It updates additional files to use SDK v2，a few files still remain and will be migrated in follow-up PRs.

### Implementation details
<!-- How are the changes implemented? -->
Migrate agent/app, agent/engine, agent/enenthandler and agent/handler folders usage of aws-sdk-go v1 to v2 usage

- aws.StringValue, aws.Bool were replaced with aws.ToString, aws.ToBool.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: Migrated more agent files to use aws-sdk-go-v2


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
