### PR TITLE
Enable DualStack ECR Image URI

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -333,7 +333,7 @@ func NewDockerGoClient(sdkclientFactory sdkclientfactory.Factory,
 	return &dockerGoClient{
 		sdkClientFactory: sdkclientFactory,
 		auth:             dockerauth.NewDockerAuthProvider(cfg.EngineAuthType, dockerAuthData),
-		ecrClientFactory: ecr.NewECRFactory(cfg.AcceptInsecureCert),
+		ecrClientFactory: ecr.NewECRFactory(cfg.AcceptInsecureCert, cfg.InstanceIPCompatibility.IsIPv6Only()),
 		ecrTokenCache:    async.NewLRUCache(tokenCacheSize, tokenCacheTTL),
 		config:           cfg,
 		context:          ctx,

--- a/agent/dockerclient/dockerauth/ecr.go
+++ b/agent/dockerclient/dockerauth/ecr.go
@@ -162,16 +162,13 @@ func (authProvider *ecrAuthProvider) getAuthConfigFromECR(image string, key cach
 		return registry.AuthConfig{}, fmt.Errorf("ecr auth: missing AuthorizationData in ECR response for %s", image)
 	}
 
-	// Verify the auth data has the correct format for ECR
-	if ecrAuthData.ProxyEndpoint != nil &&
-		strings.HasPrefix(proxyEndpointScheme+image, aws.ToString(ecrAuthData.ProxyEndpoint)) &&
-		ecrAuthData.AuthorizationToken != nil {
-
+	if ecrAuthData.AuthorizationToken != nil {
 		// Cache the new token
 		authProvider.tokenCache.Set(key.String(), ecrAuthData)
 		return extractToken(ecrAuthData)
 	}
-	return registry.AuthConfig{}, fmt.Errorf("ecr auth: AuthorizationData is malformed for %s", image)
+
+	return registry.AuthConfig{}, fmt.Errorf("ecr auth: AuthorizationData is nil for %s", image)
 }
 
 func extractToken(authData *types.AuthorizationData) (registry.AuthConfig, error) {

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -13,13 +13,13 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.72
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.3
-	github.com/aws/aws-sdk-go-v2/service/ecr v1.41.1
+	github.com/aws/aws-sdk-go-v2/service/ecr v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.47.3
 	github.com/aws/aws-sdk-go-v2/service/fsx v1.53.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.2
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.2
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.58.1
-	github.com/aws/smithy-go v1.22.2
+	github.com/aws/smithy-go v1.22.3
 	github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit v0.0.0-20210308162251-8959c62cb8f9
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
 	github.com/container-storage-interface/spec v1.8.0

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -28,8 +28,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.3 h1:3y0jkGtsaZLCg+n73
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.3/go.mod h1:uo14VBn5cNk/BPGTPz3kyLBxgpgOObgO8lmz+H7Z4Ck=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.195.0 h1:F3pFi50sK30DZ4IkkNpHwTLGeal5c3nlKuvTgv7xec4=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.195.0/go.mod h1:00zqVNJFK6UASrTnuvjJHJuaqUdkVz5tW8Ip+VhzuNg=
-github.com/aws/aws-sdk-go-v2/service/ecr v1.41.1 h1:S4zhqSS5tW7+AF5XuNFuVbx2wKzr4MgHEdRYI0+8jlY=
-github.com/aws/aws-sdk-go-v2/service/ecr v1.41.1/go.mod h1:TFp+t4IPJ8mqwe8RleaRx8tPLB0OZ2QO/LZKkCw5UEA=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.44.0 h1:E+UTVTDH6XTSjqxHWRuY8nB6s+05UllneWxnycplHFk=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.44.0/go.mod h1:iQ1skgw1XRK+6Lgkb0I9ODatAP72WoTILh0zXQ5DtbU=
 github.com/aws/aws-sdk-go-v2/service/fsx v1.53.1 h1:BGKwZSdyz4Ni72snyzYrNhjR7dwyv0up0DiAX00Mmjc=
 github.com/aws/aws-sdk-go-v2/service/fsx v1.53.1/go.mod h1:XKQ2ur+eKU8hvDvNTK7pb0VS4IVxd6YyxtV4rZ1DTtY=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 h1:eAh2A4b5IzM/lum78bZ590jy36+d/aFLgKF/4Vd1xPE=
@@ -52,8 +52,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 h1:hXmVKytPfTy5axZ+fYbR5d0c
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1/go.mod h1:MlYRNmYu/fGPoxBQVvBYr9nyr948aY/WLUvwBMBJubs=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 h1:1XuUZ8mYJw9B6lzAkXhqHlJd/XvaX32evhproijJEZY=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
-github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
-github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aws/smithy-go v1.22.3 h1:Z//5NuZCSW6R4PhQ93hShNbyBbn8BWCmCVCt+Q8Io5k=
+github.com/aws/smithy-go v1.22.3/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit v0.0.0-20210308162251-8959c62cb8f9 h1:BKngsktYtIiCpkptsC6xzc9ZqleZTofjqrjJWPIiVwA=
 github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit v0.0.0-20210308162251-8959c62cb8f9/go.mod h1:pHmn5q2flnnJgAQUoD3Hys3Fe3uoZnSwRy+Irb5Awak=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/CHANGELOG.md
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/CHANGELOG.md
@@ -1,3 +1,32 @@
+# v1.44.0 (2025-04-30)
+
+* **Feature**: Adds dualstack support for Amazon Elastic Container Registry (Amazon ECR).
+
+# v1.43.3 (2025-04-10)
+
+* No change notes available for this release.
+
+# v1.43.2 (2025-04-03)
+
+* No change notes available for this release.
+
+# v1.43.1 (2025-04-02)
+
+* **Documentation**: Fix for customer issues related to AWS account ID and size limitation for token.
+
+# v1.43.0 (2025-03-11)
+
+* **Feature**: This release adds Amazon ECR to Amazon ECR pull through cache rules support.
+
+# v1.42.1 (2025-03-04.2)
+
+* **Bug Fix**: Add assurance test for operation order.
+
+# v1.42.0 (2025-02-27)
+
+* **Feature**: Track credential providers via User-Agent Feature ids
+* **Dependency Update**: Updated to the latest SDK module versions
+
 # v1.41.1 (2025-02-18)
 
 * **Bug Fix**: Bump go version to 1.22

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_client.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_client.go
@@ -762,6 +762,37 @@ func addUserAgentRetryMode(stack *middleware.Stack, options Options) error {
 	return nil
 }
 
+type setCredentialSourceMiddleware struct {
+	ua      *awsmiddleware.RequestUserAgent
+	options Options
+}
+
+func (m setCredentialSourceMiddleware) ID() string { return "SetCredentialSourceMiddleware" }
+
+func (m setCredentialSourceMiddleware) HandleBuild(ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler) (
+	out middleware.BuildOutput, metadata middleware.Metadata, err error,
+) {
+	asProviderSource, ok := m.options.Credentials.(aws.CredentialProviderSource)
+	if !ok {
+		return next.HandleBuild(ctx, in)
+	}
+	providerSources := asProviderSource.ProviderSources()
+	for _, source := range providerSources {
+		m.ua.AddCredentialsSource(source)
+	}
+	return next.HandleBuild(ctx, in)
+}
+
+func addCredentialSource(stack *middleware.Stack, options Options) error {
+	ua, err := getOrAddRequestUserAgent(stack)
+	if err != nil {
+		return err
+	}
+
+	mw := setCredentialSourceMiddleware{ua: ua, options: options}
+	return stack.Build.Insert(&mw, "UserAgent", middleware.Before)
+}
+
 func resolveTracerProvider(options *Options) {
 	if options.TracerProvider == nil {
 		options.TracerProvider = &tracing.NopTracerProvider{}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_BatchCheckLayerAvailability.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_BatchCheckLayerAvailability.go
@@ -134,6 +134,9 @@ func (c *Client) addOperationBatchCheckLayerAvailabilityMiddlewares(stack *middl
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpBatchCheckLayerAvailabilityValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_BatchDeleteImage.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_BatchDeleteImage.go
@@ -136,6 +136,9 @@ func (c *Client) addOperationBatchDeleteImageMiddlewares(stack *middleware.Stack
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpBatchDeleteImageValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_BatchGetImage.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_BatchGetImage.go
@@ -137,6 +137,9 @@ func (c *Client) addOperationBatchGetImageMiddlewares(stack *middleware.Stack, o
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpBatchGetImageValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_BatchGetRepositoryScanningConfiguration.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_BatchGetRepositoryScanningConfiguration.go
@@ -115,6 +115,9 @@ func (c *Client) addOperationBatchGetRepositoryScanningConfigurationMiddlewares(
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpBatchGetRepositoryScanningConfigurationValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_CompleteLayerUpload.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_CompleteLayerUpload.go
@@ -144,6 +144,9 @@ func (c *Client) addOperationCompleteLayerUploadMiddlewares(stack *middleware.St
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpCompleteLayerUploadValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_CreatePullThroughCacheRule.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_CreatePullThroughCacheRule.go
@@ -37,6 +37,9 @@ type CreatePullThroughCacheRuleInput struct {
 
 	// The repository name prefix to use when caching images from the source registry.
 	//
+	// There is always an assumed / applied to the end of the prefix. If you specify
+	// ecr-public as the prefix, Amazon ECR treats that as ecr-public/ .
+	//
 	// This member is required.
 	EcrRepositoryPrefix *string
 
@@ -44,18 +47,23 @@ type CreatePullThroughCacheRuleInput struct {
 	// pull through cache rule. The following is the syntax to use for each supported
 	// upstream registry.
 	//
-	//   - Amazon ECR Public ( ecr-public ) - public.ecr.aws
+	//   - Amazon ECR ( ecr ) – dkr.ecr..amazonaws.com
 	//
-	//   - Docker Hub ( docker-hub ) - registry-1.docker.io
+	//   - Amazon ECR Public ( ecr-public ) – public.ecr.aws
 	//
-	//   - Quay ( quay ) - quay.io
+	//   - Docker Hub ( docker-hub ) – registry-1.docker.io
 	//
-	//   - Kubernetes ( k8s ) - registry.k8s.io
+	//   - GitHub Container Registry ( github-container-registry ) – ghcr.io
 	//
-	//   - GitHub Container Registry ( github-container-registry ) - ghcr.io
+	//   - GitLab Container Registry ( gitlab-container-registry ) –
+	//   registry.gitlab.com
 	//
-	//   - Microsoft Azure Container Registry ( azure-container-registry ) -
+	//   - Kubernetes ( k8s ) – registry.k8s.io
+	//
+	//   - Microsoft Azure Container Registry ( azure-container-registry ) –
 	//   .azurecr.io
+	//
+	//   - Quay ( quay ) – quay.io
 	//
 	// This member is required.
 	UpstreamRegistryUrl *string
@@ -64,6 +72,11 @@ type CreatePullThroughCacheRuleInput struct {
 	// secret that identifies the credentials to authenticate to the upstream registry.
 	CredentialArn *string
 
+	// Amazon Resource Name (ARN) of the IAM role to be assumed by Amazon ECR to
+	// authenticate to the ECR upstream registry. This role must be in the same account
+	// as the registry that you are configuring.
+	CustomRoleArn *string
+
 	// The Amazon Web Services account ID associated with the registry to create the
 	// pull through cache rule for. If you do not specify a registry, the default
 	// registry is assumed.
@@ -71,6 +84,10 @@ type CreatePullThroughCacheRuleInput struct {
 
 	// The name of the upstream registry.
 	UpstreamRegistry types.UpstreamRegistry
+
+	// The repository name prefix of the upstream registry to match with the upstream
+	// repository name. When this field isn't specified, Amazon ECR will use the ROOT .
+	UpstreamRepositoryPrefix *string
 
 	noSmithyDocumentSerde
 }
@@ -85,6 +102,9 @@ type CreatePullThroughCacheRuleOutput struct {
 	// secret associated with the pull through cache rule.
 	CredentialArn *string
 
+	// The ARN of the IAM role associated with the pull through cache rule.
+	CustomRoleArn *string
+
 	// The Amazon ECR repository prefix associated with the pull through cache rule.
 	EcrRepositoryPrefix *string
 
@@ -96,6 +116,9 @@ type CreatePullThroughCacheRuleOutput struct {
 
 	// The upstream registry URL associated with the pull through cache rule.
 	UpstreamRegistryUrl *string
+
+	// The upstream repository prefix associated with the pull through cache rule.
+	UpstreamRepositoryPrefix *string
 
 	// Metadata pertaining to the operation's result.
 	ResultMetadata middleware.Metadata
@@ -165,6 +188,9 @@ func (c *Client) addOperationCreatePullThroughCacheRuleMiddlewares(stack *middle
 		return err
 	}
 	if err = addUserAgentRetryMode(stack, options); err != nil {
+		return err
+	}
+	if err = addCredentialSource(stack, options); err != nil {
 		return err
 	}
 	if err = addOpCreatePullThroughCacheRuleValidationMiddleware(stack); err != nil {

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_CreateRepository.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_CreateRepository.go
@@ -145,6 +145,9 @@ func (c *Client) addOperationCreateRepositoryMiddlewares(stack *middleware.Stack
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpCreateRepositoryValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_CreateRepositoryCreationTemplate.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_CreateRepositoryCreationTemplate.go
@@ -172,6 +172,9 @@ func (c *Client) addOperationCreateRepositoryCreationTemplateMiddlewares(stack *
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpCreateRepositoryCreationTemplateValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DeleteLifecyclePolicy.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DeleteLifecyclePolicy.go
@@ -126,6 +126,9 @@ func (c *Client) addOperationDeleteLifecyclePolicyMiddlewares(stack *middleware.
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpDeleteLifecyclePolicyValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DeletePullThroughCacheRule.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DeletePullThroughCacheRule.go
@@ -52,6 +52,9 @@ type DeletePullThroughCacheRuleOutput struct {
 	// secret associated with the pull through cache rule.
 	CredentialArn *string
 
+	// The ARN of the IAM role associated with the pull through cache rule.
+	CustomRoleArn *string
+
 	// The Amazon ECR repository prefix associated with the request.
 	EcrRepositoryPrefix *string
 
@@ -60,6 +63,9 @@ type DeletePullThroughCacheRuleOutput struct {
 
 	// The upstream registry URL associated with the pull through cache rule.
 	UpstreamRegistryUrl *string
+
+	// The upstream repository prefix associated with the pull through cache rule.
+	UpstreamRepositoryPrefix *string
 
 	// Metadata pertaining to the operation's result.
 	ResultMetadata middleware.Metadata
@@ -129,6 +135,9 @@ func (c *Client) addOperationDeletePullThroughCacheRuleMiddlewares(stack *middle
 		return err
 	}
 	if err = addUserAgentRetryMode(stack, options); err != nil {
+		return err
+	}
+	if err = addCredentialSource(stack, options); err != nil {
 		return err
 	}
 	if err = addOpDeletePullThroughCacheRuleValidationMiddleware(stack); err != nil {

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DeleteRegistryPolicy.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DeleteRegistryPolicy.go
@@ -108,6 +108,9 @@ func (c *Client) addOperationDeleteRegistryPolicyMiddlewares(stack *middleware.S
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = stack.Initialize.Add(newServiceMetadataMiddleware_opDeleteRegistryPolicy(options.Region), middleware.Before); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DeleteRepository.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DeleteRepository.go
@@ -123,6 +123,9 @@ func (c *Client) addOperationDeleteRepositoryMiddlewares(stack *middleware.Stack
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpDeleteRepositoryValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DeleteRepositoryCreationTemplate.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DeleteRepositoryCreationTemplate.go
@@ -116,6 +116,9 @@ func (c *Client) addOperationDeleteRepositoryCreationTemplateMiddlewares(stack *
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpDeleteRepositoryCreationTemplateValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DeleteRepositoryPolicy.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DeleteRepositoryPolicy.go
@@ -123,6 +123,9 @@ func (c *Client) addOperationDeleteRepositoryPolicyMiddlewares(stack *middleware
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpDeleteRepositoryPolicyValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DescribeImageReplicationStatus.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DescribeImageReplicationStatus.go
@@ -127,6 +127,9 @@ func (c *Client) addOperationDescribeImageReplicationStatusMiddlewares(stack *mi
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpDescribeImageReplicationStatusValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DescribeImageScanFindings.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DescribeImageScanFindings.go
@@ -160,6 +160,9 @@ func (c *Client) addOperationDescribeImageScanFindingsMiddlewares(stack *middlew
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpDescribeImageScanFindingsValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DescribeImages.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DescribeImages.go
@@ -151,6 +151,9 @@ func (c *Client) addOperationDescribeImagesMiddlewares(stack *middleware.Stack, 
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpDescribeImagesValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DescribePullThroughCacheRules.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DescribePullThroughCacheRules.go
@@ -141,6 +141,9 @@ func (c *Client) addOperationDescribePullThroughCacheRulesMiddlewares(stack *mid
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = stack.Initialize.Add(newServiceMetadataMiddleware_opDescribePullThroughCacheRules(options.Region), middleware.Before); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DescribeRegistry.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DescribeRegistry.go
@@ -110,6 +110,9 @@ func (c *Client) addOperationDescribeRegistryMiddlewares(stack *middleware.Stack
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = stack.Initialize.Add(newServiceMetadataMiddleware_opDescribeRegistry(options.Region), middleware.Before); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DescribeRepositories.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DescribeRepositories.go
@@ -144,6 +144,9 @@ func (c *Client) addOperationDescribeRepositoriesMiddlewares(stack *middleware.S
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = stack.Initialize.Add(newServiceMetadataMiddleware_opDescribeRepositories(options.Region), middleware.Before); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DescribeRepositoryCreationTemplates.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_DescribeRepositoryCreationTemplates.go
@@ -144,6 +144,9 @@ func (c *Client) addOperationDescribeRepositoryCreationTemplatesMiddlewares(stac
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = stack.Initialize.Add(newServiceMetadataMiddleware_opDescribeRepositoryCreationTemplates(options.Region), middleware.Before); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetAccountSetting.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetAccountSetting.go
@@ -117,6 +117,9 @@ func (c *Client) addOperationGetAccountSettingMiddlewares(stack *middleware.Stac
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpGetAccountSettingValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetAuthorizationToken.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetAuthorizationToken.go
@@ -128,6 +128,9 @@ func (c *Client) addOperationGetAuthorizationTokenMiddlewares(stack *middleware.
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = stack.Initialize.Add(newServiceMetadataMiddleware_opGetAuthorizationToken(options.Region), middleware.Before); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetDownloadUrlForLayer.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetDownloadUrlForLayer.go
@@ -132,6 +132,9 @@ func (c *Client) addOperationGetDownloadUrlForLayerMiddlewares(stack *middleware
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpGetDownloadUrlForLayerValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetLifecyclePolicy.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetLifecyclePolicy.go
@@ -126,6 +126,9 @@ func (c *Client) addOperationGetLifecyclePolicyMiddlewares(stack *middleware.Sta
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpGetLifecyclePolicyValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetLifecyclePolicyPreview.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetLifecyclePolicyPreview.go
@@ -169,6 +169,9 @@ func (c *Client) addOperationGetLifecyclePolicyPreviewMiddlewares(stack *middlew
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpGetLifecyclePolicyPreviewValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetRegistryPolicy.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetRegistryPolicy.go
@@ -108,6 +108,9 @@ func (c *Client) addOperationGetRegistryPolicyMiddlewares(stack *middleware.Stac
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = stack.Initialize.Add(newServiceMetadataMiddleware_opGetRegistryPolicy(options.Region), middleware.Before); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetRegistryScanningConfiguration.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetRegistryScanningConfiguration.go
@@ -109,6 +109,9 @@ func (c *Client) addOperationGetRegistryScanningConfigurationMiddlewares(stack *
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = stack.Initialize.Add(newServiceMetadataMiddleware_opGetRegistryScanningConfiguration(options.Region), middleware.Before); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetRepositoryPolicy.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_GetRepositoryPolicy.go
@@ -122,6 +122,9 @@ func (c *Client) addOperationGetRepositoryPolicyMiddlewares(stack *middleware.St
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpGetRepositoryPolicyValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_InitiateLayerUpload.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_InitiateLayerUpload.go
@@ -128,6 +128,9 @@ func (c *Client) addOperationInitiateLayerUploadMiddlewares(stack *middleware.St
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpInitiateLayerUploadValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_ListImages.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_ListImages.go
@@ -150,6 +150,9 @@ func (c *Client) addOperationListImagesMiddlewares(stack *middleware.Stack, opti
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpListImagesValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_ListTagsForResource.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_ListTagsForResource.go
@@ -113,6 +113,9 @@ func (c *Client) addOperationListTagsForResourceMiddlewares(stack *middleware.St
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpListTagsForResourceValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutAccountSetting.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutAccountSetting.go
@@ -122,6 +122,9 @@ func (c *Client) addOperationPutAccountSettingMiddlewares(stack *middleware.Stac
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpPutAccountSettingValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutImage.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutImage.go
@@ -143,6 +143,9 @@ func (c *Client) addOperationPutImageMiddlewares(stack *middleware.Stack, option
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpPutImageValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutImageScanningConfiguration.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutImageScanningConfiguration.go
@@ -135,6 +135,9 @@ func (c *Client) addOperationPutImageScanningConfigurationMiddlewares(stack *mid
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpPutImageScanningConfigurationValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutImageTagMutability.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutImageTagMutability.go
@@ -133,6 +133,9 @@ func (c *Client) addOperationPutImageTagMutabilityMiddlewares(stack *middleware.
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpPutImageTagMutabilityValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutLifecyclePolicy.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutLifecyclePolicy.go
@@ -130,6 +130,9 @@ func (c *Client) addOperationPutLifecyclePolicyMiddlewares(stack *middleware.Sta
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpPutLifecyclePolicyValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutRegistryPolicy.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutRegistryPolicy.go
@@ -124,6 +124,9 @@ func (c *Client) addOperationPutRegistryPolicyMiddlewares(stack *middleware.Stac
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpPutRegistryPolicyValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutRegistryScanningConfiguration.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutRegistryScanningConfiguration.go
@@ -126,6 +126,9 @@ func (c *Client) addOperationPutRegistryScanningConfigurationMiddlewares(stack *
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpPutRegistryScanningConfigurationValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutReplicationConfiguration.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_PutReplicationConfiguration.go
@@ -124,6 +124,9 @@ func (c *Client) addOperationPutReplicationConfigurationMiddlewares(stack *middl
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpPutReplicationConfigurationValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_SetRepositoryPolicy.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_SetRepositoryPolicy.go
@@ -139,6 +139,9 @@ func (c *Client) addOperationSetRepositoryPolicyMiddlewares(stack *middleware.St
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpSetRepositoryPolicyValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_StartImageScan.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_StartImageScan.go
@@ -139,6 +139,9 @@ func (c *Client) addOperationStartImageScanMiddlewares(stack *middleware.Stack, 
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpStartImageScanValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_StartLifecyclePolicyPreview.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_StartLifecyclePolicyPreview.go
@@ -132,6 +132,9 @@ func (c *Client) addOperationStartLifecyclePolicyPreviewMiddlewares(stack *middl
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpStartLifecyclePolicyPreviewValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_TagResource.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_TagResource.go
@@ -117,6 +117,9 @@ func (c *Client) addOperationTagResourceMiddlewares(stack *middleware.Stack, opt
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpTagResourceValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_UntagResource.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_UntagResource.go
@@ -113,6 +113,9 @@ func (c *Client) addOperationUntagResourceMiddlewares(stack *middleware.Stack, o
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpUntagResourceValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_UpdatePullThroughCacheRule.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_UpdatePullThroughCacheRule.go
@@ -29,16 +29,19 @@ func (c *Client) UpdatePullThroughCacheRule(ctx context.Context, params *UpdateP
 
 type UpdatePullThroughCacheRuleInput struct {
 
-	// The Amazon Resource Name (ARN) of the Amazon Web Services Secrets Manager
-	// secret that identifies the credentials to authenticate to the upstream registry.
-	//
-	// This member is required.
-	CredentialArn *string
-
 	// The repository name prefix to use when caching images from the source registry.
 	//
 	// This member is required.
 	EcrRepositoryPrefix *string
+
+	// The Amazon Resource Name (ARN) of the Amazon Web Services Secrets Manager
+	// secret that identifies the credentials to authenticate to the upstream registry.
+	CredentialArn *string
+
+	// Amazon Resource Name (ARN) of the IAM role to be assumed by Amazon ECR to
+	// authenticate to the ECR upstream registry. This role must be in the same account
+	// as the registry that you are configuring.
+	CustomRoleArn *string
 
 	// The Amazon Web Services account ID associated with the registry associated with
 	// the pull through cache rule. If you do not specify a registry, the default
@@ -54,6 +57,9 @@ type UpdatePullThroughCacheRuleOutput struct {
 	// secret associated with the pull through cache rule.
 	CredentialArn *string
 
+	// The ARN of the IAM role associated with the pull through cache rule.
+	CustomRoleArn *string
+
 	// The Amazon ECR repository prefix associated with the pull through cache rule.
 	EcrRepositoryPrefix *string
 
@@ -63,6 +69,9 @@ type UpdatePullThroughCacheRuleOutput struct {
 	// The date and time, in JavaScript date format, when the pull through cache rule
 	// was updated.
 	UpdatedAt *time.Time
+
+	// The upstream repository prefix associated with the pull through cache rule.
+	UpstreamRepositoryPrefix *string
 
 	// Metadata pertaining to the operation's result.
 	ResultMetadata middleware.Metadata
@@ -132,6 +141,9 @@ func (c *Client) addOperationUpdatePullThroughCacheRuleMiddlewares(stack *middle
 		return err
 	}
 	if err = addUserAgentRetryMode(stack, options); err != nil {
+		return err
+	}
+	if err = addCredentialSource(stack, options); err != nil {
 		return err
 	}
 	if err = addOpUpdatePullThroughCacheRuleValidationMiddleware(stack); err != nil {

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_UpdateRepositoryCreationTemplate.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_UpdateRepositoryCreationTemplate.go
@@ -161,6 +161,9 @@ func (c *Client) addOperationUpdateRepositoryCreationTemplateMiddlewares(stack *
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpUpdateRepositoryCreationTemplateValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_UploadLayerPart.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_UploadLayerPart.go
@@ -154,6 +154,9 @@ func (c *Client) addOperationUploadLayerPartMiddlewares(stack *middleware.Stack,
 	if err = addUserAgentRetryMode(stack, options); err != nil {
 		return err
 	}
+	if err = addCredentialSource(stack, options); err != nil {
+		return err
+	}
 	if err = addOpUploadLayerPartValidationMiddleware(stack); err != nil {
 		return err
 	}

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_ValidatePullThroughCacheRule.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/api_op_ValidatePullThroughCacheRule.go
@@ -49,6 +49,9 @@ type ValidatePullThroughCacheRuleOutput struct {
 	// secret associated with the pull through cache rule.
 	CredentialArn *string
 
+	// The ARN of the IAM role associated with the pull through cache rule.
+	CustomRoleArn *string
+
 	// The Amazon ECR repository prefix associated with the pull through cache rule.
 	EcrRepositoryPrefix *string
 
@@ -69,6 +72,9 @@ type ValidatePullThroughCacheRuleOutput struct {
 
 	// The upstream registry URL associated with the pull through cache rule.
 	UpstreamRegistryUrl *string
+
+	// The upstream repository prefix associated with the pull through cache rule.
+	UpstreamRepositoryPrefix *string
 
 	// Metadata pertaining to the operation's result.
 	ResultMetadata middleware.Metadata
@@ -138,6 +144,9 @@ func (c *Client) addOperationValidatePullThroughCacheRuleMiddlewares(stack *midd
 		return err
 	}
 	if err = addUserAgentRetryMode(stack, options); err != nil {
+		return err
+	}
+	if err = addCredentialSource(stack, options); err != nil {
 		return err
 	}
 	if err = addOpValidatePullThroughCacheRuleValidationMiddleware(stack); err != nil {

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/deserializers.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/deserializers.go
@@ -10661,6 +10661,15 @@ func awsAwsjson11_deserializeDocumentPullThroughCacheRule(v **types.PullThroughC
 				sv.CredentialArn = ptr.String(jtv)
 			}
 
+		case "customRoleArn":
+			if value != nil {
+				jtv, ok := value.(string)
+				if !ok {
+					return fmt.Errorf("expected CustomRoleArn to be of type string, got %T instead", value)
+				}
+				sv.CustomRoleArn = ptr.String(jtv)
+			}
+
 		case "ecrRepositoryPrefix":
 			if value != nil {
 				jtv, ok := value.(string)
@@ -10711,6 +10720,15 @@ func awsAwsjson11_deserializeDocumentPullThroughCacheRule(v **types.PullThroughC
 					return fmt.Errorf("expected Url to be of type string, got %T instead", value)
 				}
 				sv.UpstreamRegistryUrl = ptr.String(jtv)
+			}
+
+		case "upstreamRepositoryPrefix":
+			if value != nil {
+				jtv, ok := value.(string)
+				if !ok {
+					return fmt.Errorf("expected PullThroughCacheRuleRepositoryPrefix to be of type string, got %T instead", value)
+				}
+				sv.UpstreamRepositoryPrefix = ptr.String(jtv)
 			}
 
 		default:
@@ -13525,6 +13543,15 @@ func awsAwsjson11_deserializeOpDocumentCreatePullThroughCacheRuleOutput(v **Crea
 				sv.CredentialArn = ptr.String(jtv)
 			}
 
+		case "customRoleArn":
+			if value != nil {
+				jtv, ok := value.(string)
+				if !ok {
+					return fmt.Errorf("expected CustomRoleArn to be of type string, got %T instead", value)
+				}
+				sv.CustomRoleArn = ptr.String(jtv)
+			}
+
 		case "ecrRepositoryPrefix":
 			if value != nil {
 				jtv, ok := value.(string)
@@ -13559,6 +13586,15 @@ func awsAwsjson11_deserializeOpDocumentCreatePullThroughCacheRuleOutput(v **Crea
 					return fmt.Errorf("expected Url to be of type string, got %T instead", value)
 				}
 				sv.UpstreamRegistryUrl = ptr.String(jtv)
+			}
+
+		case "upstreamRepositoryPrefix":
+			if value != nil {
+				jtv, ok := value.(string)
+				if !ok {
+					return fmt.Errorf("expected PullThroughCacheRuleRepositoryPrefix to be of type string, got %T instead", value)
+				}
+				sv.UpstreamRepositoryPrefix = ptr.String(jtv)
 			}
 
 		default:
@@ -13772,6 +13808,15 @@ func awsAwsjson11_deserializeOpDocumentDeletePullThroughCacheRuleOutput(v **Dele
 				sv.CredentialArn = ptr.String(jtv)
 			}
 
+		case "customRoleArn":
+			if value != nil {
+				jtv, ok := value.(string)
+				if !ok {
+					return fmt.Errorf("expected CustomRoleArn to be of type string, got %T instead", value)
+				}
+				sv.CustomRoleArn = ptr.String(jtv)
+			}
+
 		case "ecrRepositoryPrefix":
 			if value != nil {
 				jtv, ok := value.(string)
@@ -13797,6 +13842,15 @@ func awsAwsjson11_deserializeOpDocumentDeletePullThroughCacheRuleOutput(v **Dele
 					return fmt.Errorf("expected Url to be of type string, got %T instead", value)
 				}
 				sv.UpstreamRegistryUrl = ptr.String(jtv)
+			}
+
+		case "upstreamRepositoryPrefix":
+			if value != nil {
+				jtv, ok := value.(string)
+				if !ok {
+					return fmt.Errorf("expected PullThroughCacheRuleRepositoryPrefix to be of type string, got %T instead", value)
+				}
+				sv.UpstreamRepositoryPrefix = ptr.String(jtv)
 			}
 
 		default:
@@ -15586,6 +15640,15 @@ func awsAwsjson11_deserializeOpDocumentUpdatePullThroughCacheRuleOutput(v **Upda
 				sv.CredentialArn = ptr.String(jtv)
 			}
 
+		case "customRoleArn":
+			if value != nil {
+				jtv, ok := value.(string)
+				if !ok {
+					return fmt.Errorf("expected CustomRoleArn to be of type string, got %T instead", value)
+				}
+				sv.CustomRoleArn = ptr.String(jtv)
+			}
+
 		case "ecrRepositoryPrefix":
 			if value != nil {
 				jtv, ok := value.(string)
@@ -15618,6 +15681,15 @@ func awsAwsjson11_deserializeOpDocumentUpdatePullThroughCacheRuleOutput(v **Upda
 					return fmt.Errorf("expected UpdatedTimestamp to be a JSON Number, got %T instead", value)
 
 				}
+			}
+
+		case "upstreamRepositoryPrefix":
+			if value != nil {
+				jtv, ok := value.(string)
+				if !ok {
+					return fmt.Errorf("expected PullThroughCacheRuleRepositoryPrefix to be of type string, got %T instead", value)
+				}
+				sv.UpstreamRepositoryPrefix = ptr.String(jtv)
 			}
 
 		default:
@@ -15776,6 +15848,15 @@ func awsAwsjson11_deserializeOpDocumentValidatePullThroughCacheRuleOutput(v **Va
 				sv.CredentialArn = ptr.String(jtv)
 			}
 
+		case "customRoleArn":
+			if value != nil {
+				jtv, ok := value.(string)
+				if !ok {
+					return fmt.Errorf("expected CustomRoleArn to be of type string, got %T instead", value)
+				}
+				sv.CustomRoleArn = ptr.String(jtv)
+			}
+
 		case "ecrRepositoryPrefix":
 			if value != nil {
 				jtv, ok := value.(string)
@@ -15819,6 +15900,15 @@ func awsAwsjson11_deserializeOpDocumentValidatePullThroughCacheRuleOutput(v **Va
 					return fmt.Errorf("expected Url to be of type string, got %T instead", value)
 				}
 				sv.UpstreamRegistryUrl = ptr.String(jtv)
+			}
+
+		case "upstreamRepositoryPrefix":
+			if value != nil {
+				jtv, ok := value.(string)
+				if !ok {
+					return fmt.Errorf("expected PullThroughCacheRuleRepositoryPrefix to be of type string, got %T instead", value)
+				}
+				sv.UpstreamRepositoryPrefix = ptr.String(jtv)
 			}
 
 		default:

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/endpoints.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/endpoints.go
@@ -361,6 +361,44 @@ func (r *resolver) ResolveEndpoint(
 				if _UseDualStack == true {
 					if true == _PartitionResult.SupportsFIPS {
 						if true == _PartitionResult.SupportsDualStack {
+							if "aws" == _PartitionResult.Name {
+								uriString := func() string {
+									var out strings.Builder
+									out.WriteString("https://ecr-fips.")
+									out.WriteString(_Region)
+									out.WriteString(".api.aws")
+									return out.String()
+								}()
+
+								uri, err := url.Parse(uriString)
+								if err != nil {
+									return endpoint, fmt.Errorf("Failed to parse uri: %s", uriString)
+								}
+
+								return smithyendpoints.Endpoint{
+									URI:     *uri,
+									Headers: http.Header{},
+								}, nil
+							}
+							if "aws-us-gov" == _PartitionResult.Name {
+								uriString := func() string {
+									var out strings.Builder
+									out.WriteString("https://ecr-fips.")
+									out.WriteString(_Region)
+									out.WriteString(".api.aws")
+									return out.String()
+								}()
+
+								uri, err := url.Parse(uriString)
+								if err != nil {
+									return endpoint, fmt.Errorf("Failed to parse uri: %s", uriString)
+								}
+
+								return smithyendpoints.Endpoint{
+									URI:     *uri,
+									Headers: http.Header{},
+								}, nil
+							}
 							uriString := func() string {
 								var out strings.Builder
 								out.WriteString("https://api.ecr-fips.")
@@ -447,6 +485,63 @@ func (r *resolver) ResolveEndpoint(
 			}
 			if _UseDualStack == true {
 				if true == _PartitionResult.SupportsDualStack {
+					if "aws" == _PartitionResult.Name {
+						uriString := func() string {
+							var out strings.Builder
+							out.WriteString("https://ecr.")
+							out.WriteString(_Region)
+							out.WriteString(".api.aws")
+							return out.String()
+						}()
+
+						uri, err := url.Parse(uriString)
+						if err != nil {
+							return endpoint, fmt.Errorf("Failed to parse uri: %s", uriString)
+						}
+
+						return smithyendpoints.Endpoint{
+							URI:     *uri,
+							Headers: http.Header{},
+						}, nil
+					}
+					if "aws-cn" == _PartitionResult.Name {
+						uriString := func() string {
+							var out strings.Builder
+							out.WriteString("https://ecr.")
+							out.WriteString(_Region)
+							out.WriteString(".api.amazonwebservices.com.cn")
+							return out.String()
+						}()
+
+						uri, err := url.Parse(uriString)
+						if err != nil {
+							return endpoint, fmt.Errorf("Failed to parse uri: %s", uriString)
+						}
+
+						return smithyendpoints.Endpoint{
+							URI:     *uri,
+							Headers: http.Header{},
+						}, nil
+					}
+					if "aws-us-gov" == _PartitionResult.Name {
+						uriString := func() string {
+							var out strings.Builder
+							out.WriteString("https://ecr.")
+							out.WriteString(_Region)
+							out.WriteString(".api.aws")
+							return out.String()
+						}()
+
+						uri, err := url.Parse(uriString)
+						if err != nil {
+							return endpoint, fmt.Errorf("Failed to parse uri: %s", uriString)
+						}
+
+						return smithyendpoints.Endpoint{
+							URI:     *uri,
+							Headers: http.Header{},
+						}, nil
+					}
 					uriString := func() string {
 						var out strings.Builder
 						out.WriteString("https://api.ecr.")

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/generated.json
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/generated.json
@@ -70,6 +70,7 @@
         "protocol_test.go",
         "serializers.go",
         "snapshot_test.go",
+        "sra_operation_order_test.go",
         "types/enums.go",
         "types/errors.go",
         "types/types.go",

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/go_module_metadata.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/go_module_metadata.go
@@ -3,4 +3,4 @@
 package ecr
 
 // goModuleVersion is the tagged release for this module
-const goModuleVersion = "1.41.1"
+const goModuleVersion = "1.44.0"

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/internal/endpoints/endpoints.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/internal/endpoints/endpoints.go
@@ -87,6 +87,7 @@ func New() *Resolver {
 var partitionRegexp = struct {
 	Aws      *regexp.Regexp
 	AwsCn    *regexp.Regexp
+	AwsEusc  *regexp.Regexp
 	AwsIso   *regexp.Regexp
 	AwsIsoB  *regexp.Regexp
 	AwsIsoE  *regexp.Regexp
@@ -96,6 +97,7 @@ var partitionRegexp = struct {
 
 	Aws:      regexp.MustCompile("^(us|eu|ap|sa|ca|me|af|il|mx)\\-\\w+\\-\\d+$"),
 	AwsCn:    regexp.MustCompile("^cn\\-\\w+\\-\\d+$"),
+	AwsEusc:  regexp.MustCompile("^eusc\\-(de)\\-\\w+\\-\\d+$"),
 	AwsIso:   regexp.MustCompile("^us\\-iso\\-\\w+\\-\\d+$"),
 	AwsIsoB:  regexp.MustCompile("^us\\-isob\\-\\w+\\-\\d+$"),
 	AwsIsoE:  regexp.MustCompile("^eu\\-isoe\\-\\w+\\-\\d+$"),
@@ -973,6 +975,27 @@ var defaultPartitions = endpoints.Partitions{
 		},
 	},
 	{
+		ID: "aws-eusc",
+		Defaults: map[endpoints.DefaultKey]endpoints.Endpoint{
+			{
+				Variant: endpoints.FIPSVariant,
+			}: {
+				Hostname:          "api.ecr-fips.{region}.amazonaws.eu",
+				Protocols:         []string{"https"},
+				SignatureVersions: []string{"v4"},
+			},
+			{
+				Variant: 0,
+			}: {
+				Hostname:          "api.ecr.{region}.amazonaws.eu",
+				Protocols:         []string{"https"},
+				SignatureVersions: []string{"v4"},
+			},
+		},
+		RegionRegex:    partitionRegexp.AwsEusc,
+		IsRegionalized: true,
+	},
+	{
 		ID: "aws-iso",
 		Defaults: map[endpoints.DefaultKey]endpoints.Endpoint{
 			{
@@ -1062,6 +1085,16 @@ var defaultPartitions = endpoints.Partitions{
 		},
 		RegionRegex:    partitionRegexp.AwsIsoE,
 		IsRegionalized: true,
+		Endpoints: endpoints.Endpoints{
+			endpoints.EndpointKey{
+				Region: "eu-isoe-west-1",
+			}: endpoints.Endpoint{
+				Hostname: "api.ecr.eu-isoe-west-1.cloud.adc-e.uk",
+				CredentialScope: endpoints.CredentialScope{
+					Region: "eu-isoe-west-1",
+				},
+			},
+		},
 	},
 	{
 		ID: "aws-iso-f",

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/serializers.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/serializers.go
@@ -3557,6 +3557,11 @@ func awsAwsjson11_serializeOpDocumentCreatePullThroughCacheRuleInput(v *CreatePu
 		ok.String(*v.CredentialArn)
 	}
 
+	if v.CustomRoleArn != nil {
+		ok := object.Key("customRoleArn")
+		ok.String(*v.CustomRoleArn)
+	}
+
 	if v.EcrRepositoryPrefix != nil {
 		ok := object.Key("ecrRepositoryPrefix")
 		ok.String(*v.EcrRepositoryPrefix)
@@ -3575,6 +3580,11 @@ func awsAwsjson11_serializeOpDocumentCreatePullThroughCacheRuleInput(v *CreatePu
 	if v.UpstreamRegistryUrl != nil {
 		ok := object.Key("upstreamRegistryUrl")
 		ok.String(*v.UpstreamRegistryUrl)
+	}
+
+	if v.UpstreamRepositoryPrefix != nil {
+		ok := object.Key("upstreamRepositoryPrefix")
+		ok.String(*v.UpstreamRepositoryPrefix)
 	}
 
 	return nil
@@ -4446,6 +4456,11 @@ func awsAwsjson11_serializeOpDocumentUpdatePullThroughCacheRuleInput(v *UpdatePu
 	if v.CredentialArn != nil {
 		ok := object.Key("credentialArn")
 		ok.String(*v.CredentialArn)
+	}
+
+	if v.CustomRoleArn != nil {
+		ok := object.Key("customRoleArn")
+		ok.String(*v.CustomRoleArn)
 	}
 
 	if v.EcrRepositoryPrefix != nil {

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/types/enums.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/types/enums.go
@@ -374,6 +374,7 @@ type UpstreamRegistry string
 
 // Enum values for UpstreamRegistry
 const (
+	UpstreamRegistryEcr                     UpstreamRegistry = "ecr"
 	UpstreamRegistryEcrPublic               UpstreamRegistry = "ecr-public"
 	UpstreamRegistryQuay                    UpstreamRegistry = "quay"
 	UpstreamRegistryK8s                     UpstreamRegistry = "k8s"
@@ -389,6 +390,7 @@ const (
 // The ordering of this slice is not guaranteed to be stable across updates.
 func (UpstreamRegistry) Values() []UpstreamRegistry {
 	return []UpstreamRegistry{
+		"ecr",
 		"ecr-public",
 		"quay",
 		"k8s",

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/types/types.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/types/types.go
@@ -326,10 +326,10 @@ type ImageDetail struct {
 	// If the image is a manifest list, this will be the max size of all manifests in
 	// the list.
 	//
-	// Beginning with Docker version 1.9, the Docker client compresses image layers
+	// Starting with Docker version 1.9, the Docker client compresses image layers
 	// before pushing them to a V2 Docker registry. The output of the docker images
-	// command shows the uncompressed image size, so it may return a larger image size
-	// than the image sizes returned by DescribeImages.
+	// command shows the uncompressed image size. Therefore, Docker might return a
+	// larger image than the image sizes returned by DescribeImages.
 	ImageSizeInBytes *int64
 
 	// The list of tags associated with this image.
@@ -626,6 +626,9 @@ type PullThroughCacheRule struct {
 	// rule.
 	CredentialArn *string
 
+	// The ARN of the IAM role associated with the pull through cache rule.
+	CustomRoleArn *string
+
 	// The Amazon ECR repository prefix associated with the pull through cache rule.
 	EcrRepositoryPrefix *string
 
@@ -643,6 +646,9 @@ type PullThroughCacheRule struct {
 
 	// The upstream registry URL associated with the pull through cache rule.
 	UpstreamRegistryUrl *string
+
+	// The upstream repository prefix associated with the pull through cache rule.
+	UpstreamRepositoryPrefix *string
 
 	noSmithyDocumentSerde
 }
@@ -823,7 +829,7 @@ type RepositoryCreationTemplate struct {
 	// template.
 	Prefix *string
 
-	// he repository policy to apply to repositories created using the template. A
+	// The repository policy to apply to repositories created using the template. A
 	// repository policy is a permissions policy associated with a repository to
 	// control access permissions.
 	RepositoryPolicy *string

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/validators.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecr/validators.go
@@ -1913,9 +1913,6 @@ func validateOpUpdatePullThroughCacheRuleInput(v *UpdatePullThroughCacheRuleInpu
 	if v.EcrRepositoryPrefix == nil {
 		invalidParams.Add(smithy.NewErrParamRequired("EcrRepositoryPrefix"))
 	}
-	if v.CredentialArn == nil {
-		invalidParams.Add(smithy.NewErrParamRequired("CredentialArn"))
-	}
 	if invalidParams.Len() > 0 {
 		return invalidParams
 	} else {

--- a/agent/vendor/github.com/aws/smithy-go/CHANGELOG.md
+++ b/agent/vendor/github.com/aws/smithy-go/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Release (2025-02-17)
+
+## General Highlights
+* **Dependency Update**: Updated to the latest SDK module versions
+
+## Module Highlights
+* `github.com/aws/smithy-go`: v1.22.3
+  * **Bug Fix**: Fix HTTP metrics data race.
+  * **Bug Fix**: Replace usages of deprecated ioutil package.
+
 # Release (2025-01-21)
 
 ## General Highlights

--- a/agent/vendor/github.com/aws/smithy-go/go_module_metadata.go
+++ b/agent/vendor/github.com/aws/smithy-go/go_module_metadata.go
@@ -3,4 +3,4 @@
 package smithy
 
 // goModuleVersion is the tagged release for this module
-const goModuleVersion = "1.22.2"
+const goModuleVersion = "1.22.3"

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -198,7 +198,7 @@ github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types
 github.com/aws/aws-sdk-go-v2/service/ec2
 github.com/aws/aws-sdk-go-v2/service/ec2/internal/endpoints
 github.com/aws/aws-sdk-go-v2/service/ec2/types
-# github.com/aws/aws-sdk-go-v2/service/ecr v1.41.1
+# github.com/aws/aws-sdk-go-v2/service/ecr v1.44.0
 ## explicit; go 1.22
 github.com/aws/aws-sdk-go-v2/service/ecr
 github.com/aws/aws-sdk-go-v2/service/ecr/internal/endpoints
@@ -259,8 +259,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc/types
 github.com/aws/aws-sdk-go-v2/service/sts
 github.com/aws/aws-sdk-go-v2/service/sts/internal/endpoints
 github.com/aws/aws-sdk-go-v2/service/sts/types
-# github.com/aws/smithy-go v1.22.2
-## explicit; go 1.21
+# github.com/aws/smithy-go v1.22.3
+## explicit; go 1.22
 github.com/aws/smithy-go
 github.com/aws/smithy-go/auth
 github.com/aws/smithy-go/auth/bearer


### PR DESCRIPTION
### Summary
- Add plumbing to check IPCompatibility and set DualStack ECR when needed (IPv6)
- updated testing and introduced new testign for endpoint overrides/IPCompatibility
- Removed prefix matching (ProxyEndpoint and Image URI) that would prevent default ECR endpoint with DualStack Image URI (and reverse)
- Update aws-sdk-go-v2 ECR to 1.44.0 to add DualStack support - https://github.com/aws/aws-sdk-go-v2/blob/release-2025-04-30/service/ecr/CHANGELOG.md#v1440-2025-04-30

### Testing
`make test` and local debugging, e2e testing

New tests cover the changes: yes

### Description for the changelog
Enable DualStack ECR Image URI

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
N/A

**Does this PR include the addition of new environment variables in the README?**
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
