### PR TITLE
Block off-host access to agent's introspection server via IPv6

### DIFF
--- a/ecs-init/exec/iptables/iptables.go
+++ b/ecs-init/exec/iptables/iptables.go
@@ -32,6 +32,7 @@ type iptablesAction string
 
 const (
 	iptablesExecutable            = "iptables"
+	ip6tablesExecutable           = "ip6tables"
 	credentialsProxyIpAddress     = "169.254.170.2"
 	credentialsProxyPort          = "80"
 	localhostIpAddress            = "127.0.0.1"
@@ -97,32 +98,32 @@ func NewNetfilterRoute(cmdExec exec.Exec) (*NetfilterRoute, error) {
 
 // Create creates the credentials proxy endpoint route in the netfilter table
 func (route *NetfilterRoute) Create() error {
-	err := route.modifyNetfilterEntry(iptablesTableNat, iptablesAppend, getPreroutingChainArgs)
+	err := route.modifyNetfilterEntry(iptablesTableNat, iptablesAppend, getPreroutingChainArgs, false)
 	if err != nil {
 		return err
 	}
 
 	if !skipLocalhostTrafficFilter() {
-		err = route.modifyNetfilterEntry(iptablesTableFilter, iptablesInsert, getLocalhostTrafficFilterInputChainArgs)
+		err = route.modifyNetfilterEntry(iptablesTableFilter, iptablesInsert, getLocalhostTrafficFilterInputChainArgs, false)
 		if err != nil {
 			return err
 		}
 	}
 
 	if !allowOffhostIntrospection() {
-		err = route.modifyNetfilterEntry(iptablesTableFilter, iptablesInsert, getBlockIntrospectionOffhostAccessInputChainArgs)
+		err = route.modifyNetfilterEntry(iptablesTableFilter, iptablesInsert, getBlockIntrospectionOffhostAccessInputChainArgs, true)
 		if err != nil {
 			log.Errorf("Error adding input chain entry to block offhost introspection access: %v", err)
 		}
 	}
 
-	return route.modifyNetfilterEntry(iptablesTableNat, iptablesAppend, getOutputChainArgs)
+	return route.modifyNetfilterEntry(iptablesTableNat, iptablesAppend, getOutputChainArgs, false)
 }
 
 // Remove removes the route for the credentials endpoint from the netfilter
 // table
 func (route *NetfilterRoute) Remove() error {
-	preroutingErr := route.modifyNetfilterEntry(iptablesTableNat, iptablesDelete, getPreroutingChainArgs)
+	preroutingErr := route.modifyNetfilterEntry(iptablesTableNat, iptablesDelete, getPreroutingChainArgs, false)
 	if preroutingErr != nil {
 		// Add more context for error in modifying the prerouting chain
 		preroutingErr = fmt.Errorf("error removing prerouting chain entry: %v", preroutingErr)
@@ -130,18 +131,18 @@ func (route *NetfilterRoute) Remove() error {
 
 	var localhostInputError, introspectionInputError error
 	if !skipLocalhostTrafficFilter() {
-		localhostInputError = route.modifyNetfilterEntry(iptablesTableFilter, iptablesDelete, getLocalhostTrafficFilterInputChainArgs)
+		localhostInputError = route.modifyNetfilterEntry(iptablesTableFilter, iptablesDelete, getLocalhostTrafficFilterInputChainArgs, false)
 		if localhostInputError != nil {
 			localhostInputError = fmt.Errorf("error removing input chain entry: %v", localhostInputError)
 		}
 	}
 
-	introspectionInputError = route.modifyNetfilterEntry(iptablesTableFilter, iptablesDelete, getBlockIntrospectionOffhostAccessInputChainArgs)
+	introspectionInputError = route.modifyNetfilterEntry(iptablesTableFilter, iptablesDelete, getBlockIntrospectionOffhostAccessInputChainArgs, true)
 	if introspectionInputError != nil {
 		introspectionInputError = fmt.Errorf("error removing input chain entry: %v", introspectionInputError)
 	}
 
-	outputErr := route.modifyNetfilterEntry(iptablesTableNat, iptablesDelete, getOutputChainArgs)
+	outputErr := route.modifyNetfilterEntry(iptablesTableNat, iptablesDelete, getOutputChainArgs, false)
 	if outputErr != nil {
 		// Add more context for error in modifying the output chain
 		outputErr = fmt.Errorf("error removing output chain entry: %v", outputErr)
@@ -168,16 +169,33 @@ func combinedError(errs ...error) error {
 // modifyNetfilterEntry modifies an entry in the netfilter table based on
 // the action and the function pointer to get arguments for modifying the
 // chain
-func (route *NetfilterRoute) modifyNetfilterEntry(table string, action iptablesAction, getNetfilterChainArgs getNetfilterChainArgsFunc) error {
+func (route *NetfilterRoute) modifyNetfilterEntry(table string, action iptablesAction, getNetfilterChainArgs getNetfilterChainArgsFunc, useIp6tables bool) error {
 	args := append(getTableArgs(table), string(action))
 	args = append(args, getNetfilterChainArgs()...)
 	cmd := route.cmdExec.Command(iptablesExecutable, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Errorf("Error performing action '%s' for iptables route: %v; raw output: %s", getActionName(action), err, out)
+		return err
 	}
 
-	return err
+	// Checking if we need to apply the netfilter table action for IPv6 as well.
+	if useIp6tables {
+		_, err = route.cmdExec.LookPath(ip6tablesExecutable)
+		if err != nil {
+			log.Warnf("%s unable to be found on the host. Assuming IPv6 isn't available on the host and will not apply %s.", ip6tablesExecutable, getActionName(action))
+		} else {
+			cmd = route.cmdExec.Command(ip6tablesExecutable, args...)
+			out, err = cmd.CombinedOutput()
+			if err != nil {
+				log.Errorf("Error performing action '%s' for ip6tables route: %v; raw output: %s", getActionName(action), err, out)
+				return err
+			}
+			log.Infof("Successfully blocked IPv6 off-host access for introspection server with %s.", ip6tablesExecutable)
+		}
+	}
+
+	return nil
 }
 
 func getTableArgs(table string) []string {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will block off-host access to the introspection server via IPv6 by default similar to the following [commit](https://github.com/aws/amazon-ecs-agent/commit/1394a9bedafee149f06af4387b97f8311377483b) for IPv4.

To enable off-host access using IPv6, the `ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS` environment variable can be set to `true`.

### Implementation details
* Added new function argument called `useIp6tables` for `modifyNetfilterEntry` to determine whether to also use `ip6tables` to apply the same tables modification/commands with `iptables`. As of now, it will only be set to true for blocking off-host access for introspection.
* Use `ip6tables` to run with the same arguments as `iptables` (`-A INPUT -i eth0 -p tcp --dport 51678 -j DROP`) to block off-host access with IPv6
* If `ip6tables` doesn't exist on the host then it will not block off-host access (since this is assuming IPv6 addresses aren't available on the host)

### Testing
Added new test cases and expected mocks for the use of `ip6tables` in blocking off-host access for the introspection server using an IPv6 address.

Manual testing:
1. Configured an IPV6-enabled VPC
2. Created 2 new subnets off of VPC
3. Created 2 new instances (1 for each subnets) within the same security group
4. Curl introspection endpoint from one instance over to another using the IPv6 address

Source instance
```
[ec2-user@ip-172-31-216-209 ~]$ curl -4 -v --connect-timeout 30 "172.31.100.63:51678"
*   Trying 172.31.100.63:51678...
* ipv4 connect timeout after 30000ms, move on!
* Failed to connect to 172.31.100.63 port 51678 after 30002 ms: Timeout was reached
* Closing connection
curl: (28) Failed to connect to 172.31.100.63 port 51678 after 30002 ms: Timeout was reached
[ec2-user@ip-172-31-216-209 ~]$ curl -4 -v --connect-timeout 30 http://172.31.100.63:51678
*   Trying 172.31.100.63:51678...
* ipv4 connect timeout after 30000ms, move on!
* Failed to connect to 172.31.100.63 port 51678 after 30002 ms: Timeout was reached
* Closing connection
curl: (28) Failed to connect to 172.31.100.63 port 51678 after 30002 ms: Timeout was reached
```

Target instance
```
[ec2-user@ip-172-31-100-63 amazon-ecs-agent]$ cat /var/log/ecs/ecs-init.log 
level=info time=2025-05-02T21:17:52Z msg="pre-start"
level=info time=2025-05-02T21:17:52Z msg="Successfully created docker client with API version 1.25"
level=info time=2025-05-02T21:17:52Z msg="pre-start: enabling loopback routing"
level=info time=2025-05-02T21:17:52Z msg="pre-start: disabling ipv6 router advertisements"
level=info time=2025-05-02T21:17:52Z msg="pre-start: creating credentials proxy route"
level=info time=2025-05-02T21:17:52Z msg="Successfully blocked IPv6 off-host access for introspection server with ip6tables."
level=info time=2025-05-02T21:17:52Z msg="pre-start: checking ecs agent container image loaded presence"
level=info time=2025-05-02T21:17:52Z msg="pre-start: ecs agent container image loaded presence: true"
level=info time=2025-05-02T21:17:52Z msg="pre-start: reloading agent"
level=info time=2025-05-02T21:17:53Z msg="start"
level=info time=2025-05-02T21:17:53Z msg="Successfully created docker client with API version 1.25"
level=info time=2025-05-02T21:17:53Z msg="Container name: /ecs-agent"
level=info time=2025-05-02T21:17:53Z msg="Removing existing agent container ID:<id>"
level=info time=2025-05-02T21:17:53Z msg="Starting Amazon Elastic Container Service Agent"
```

With `ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS` set to true

Source instance
```
[ec2-user@ip-172-31-216-209 ~]$ curl -6 -v --connect-timeout 15 "[2600:1f14:38e5:22ed:af92:9b4e:af76:6e7e]:51678"
*   Trying [2600:1f14:38e5:22ed:af92:9b4e:af76:6e7e]:51678...
* Connected to 2600:1f14:38e5:22ed:af92:9b4e:af76:6e7e (2600:1f14:38e5:22ed:af92:9b4e:af76:6e7e) port 51678
> GET / HTTP/1.1
> Host: [2600:1f14:38e5:22ed:af92:9b4e:af76:6e7e]:51678
> User-Agent: curl/8.5.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Mon, 05 May 2025 17:32:13 GMT
< Content-Length: 61
< Content-Type: text/plain; charset=utf-8
< 
* Connection #0 to host 2600:1f14:38e5:22ed:af92:9b4e:af76:6e7e left intact
{"AvailableCommands":["/v1/metad
[ec2-user@ip-172-31-216-209 ~]$ curl -4 -v --connect-timeout 15 172.31.100.63:51678 
*   Trying 172.31.100.63:51678...
* Connected to 172.31.100.63 (172.31.100.63) port 51678
> GET / HTTP/1.1
> Host: 172.31.100.63:51678
> User-Agent: curl/8.5.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Mon, 05 May 2025 17:32:24 GMT
< Content-Length: 61
< Content-Type: text/plain; charset=utf-8
< 
* Connection #0 to host 172.31.100.63 left intact
{"AvailableCommands":["/v1/metadata","/v1/tasks","/license"]}[ec2-user@ip-172-31-216-209 ~]$ 
```

New tests cover the changes: yes

### Description for the changelog
Bugfix - Block off-host access for introspection server using IPv6 address

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
