### PR TITLE
Include IPv6 addresses in container metadata file  for bridge mode 

### DIFF
--- a/agent/containermetadata/parse_metadata.go
+++ b/agent/containermetadata/parse_metadata.go
@@ -139,6 +139,7 @@ func parseNetworkMetadata(settings *types.NetworkSettings, hostConfig *dockercon
 	// We get the NetworkMode (Network interface name) from the HostConfig because this
 	// this is the network with which the container is created
 	ipv4AddressFromSettings := settings.IPAddress
+	ipv6AddressFromSettings := settings.GlobalIPv6Address
 	networkModeFromHostConfig := string(hostConfig.NetworkMode)
 
 	// Extensive Network information is not available for Docker API versions 1.17-1.20
@@ -148,12 +149,28 @@ func parseNetworkMetadata(settings *types.NetworkSettings, hostConfig *dockercon
 		for modeFromSettings, containerNetwork := range settings.Networks {
 			networkMode := modeFromSettings
 			ipv4Addresses := []string{containerNetwork.IPAddress}
-			network := tmdsresponse.Network{NetworkMode: networkMode, IPv4Addresses: ipv4Addresses}
+			var ipv6Addresses []string
+			if containerNetwork.GlobalIPv6Address != "" {
+				ipv6Addresses = []string{containerNetwork.GlobalIPv6Address}
+			}
+			network := tmdsresponse.Network{
+				NetworkMode:   networkMode,
+				IPv4Addresses: ipv4Addresses,
+				IPv6Addresses: ipv6Addresses,
+			}
 			networkList = append(networkList, network)
 		}
 	} else {
 		ipv4Addresses := []string{ipv4AddressFromSettings}
-		network := tmdsresponse.Network{NetworkMode: networkModeFromHostConfig, IPv4Addresses: ipv4Addresses}
+		var ipv6Addresses []string
+		if ipv6AddressFromSettings != "" {
+			ipv6Addresses = []string{ipv6AddressFromSettings}
+		}
+		network := tmdsresponse.Network{
+			NetworkMode:   networkModeFromHostConfig,
+			IPv4Addresses: ipv4Addresses,
+			IPv6Addresses: ipv6Addresses,
+		}
 		networkList = append(networkList, network)
 	}
 

--- a/agent/containermetadata/parse_metadata_test.go
+++ b/agent/containermetadata/parse_metadata_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
@@ -220,9 +221,18 @@ func TestParseHasNetworkSettingsNetworksNonEmpty(t *testing.T) {
 	// Networks assertions
 	networks := metadata.dockerContainerMetadata.networkInfo.networks
 	assert.Equal(t, len(networks), 2, "Expected two networks")
-	assert.Equal(t, "bridge", networks[0].NetworkMode)
-	assert.Equal(t, "1.2.3.4", networks[0].IPv4Addresses[0])
-	assert.Equal(t, "5:6:7:8::", networks[0].IPv6Addresses[0])
+
+	// Find the bridge network and verify its properties
+	var bridgeNetwork *response.Network
+	for i := range networks {
+		if networks[i].NetworkMode == "bridge" {
+			bridgeNetwork = &networks[i]
+			break
+		}
+	}
+	assert.NotNil(t, bridgeNetwork, "Bridge network not found")
+	assert.Equal(t, "1.2.3.4", bridgeNetwork.IPv4Addresses[0])
+	assert.Equal(t, "5:6:7:8::", bridgeNetwork.IPv6Addresses[0])
 }
 
 func TestParseHasNetworkSettingsNetworksNonEmptyWithIPv4Only(t *testing.T) {
@@ -236,9 +246,16 @@ func TestParseHasNetworkSettingsNetworksNonEmptyWithIPv4Only(t *testing.T) {
 	validateBasicMetadata(t, &metadata, fixture)
 	// Networks assertions
 	networks := metadata.dockerContainerMetadata.networkInfo.networks
-	assert.Equal(t, len(networks), 2, "Expected two networks")
-	assert.Equal(t, "bridge", networks[0].NetworkMode)
-	assert.Equal(t, "1.2.3.4", networks[0].IPv4Addresses[0])
+	// Find the bridge network and verify its properties
+	var bridgeNetwork *response.Network
+	for i := range networks {
+		if networks[i].NetworkMode == "bridge" {
+			bridgeNetwork = &networks[i]
+			break
+		}
+	}
+	assert.NotNil(t, bridgeNetwork, "Bridge network not found")
+	assert.Equal(t, "1.2.3.4", bridgeNetwork.IPv4Addresses[0])
 }
 
 func TestParseHasNoContainerJSONBase(t *testing.T) {

--- a/agent/containermetadata/parse_metadata_test.go
+++ b/agent/containermetadata/parse_metadata_test.go
@@ -218,7 +218,8 @@ func TestParseHasNetworkSettingsNetworksEmpty(t *testing.T) {
 	mockHostConfig := &dockercontainer.HostConfig{NetworkMode: "bridge"}
 	mockNetworkSettings := &types.NetworkSettings{
 		DefaultNetworkSettings: types.DefaultNetworkSettings{
-			IPAddress: "0.0.0.0",
+			IPAddress:         "1.2.3.4",
+			GlobalIPv6Address: "5:6:7:8::",
 		}}
 	mockContainer := &types.ContainerJSON{
 		ContainerJSONBase: &types.ContainerJSONBase{
@@ -246,7 +247,13 @@ func TestParseHasNetworkSettingsNetworksEmpty(t *testing.T) {
 	assert.Equal(t, metadata.hostPrivateIPv4Address, mockHostPrivateIPv4Address, "Expected hostPrivateIPv4Address "+hostPrivateIPv4Address)
 	assert.Equal(t, metadata.hostPublicIPv4Address, mockHostPublicIPv4Address, "Expected hostPublicIPv4Address "+hostPublicIPv4Address)
 	assert.Equal(t, string(metadata.metadataStatus), expectedStatus, "Expected status "+expectedStatus)
-	assert.Equal(t, len(metadata.dockerContainerMetadata.networkInfo.networks), 1, "Expected one network")
+
+	// Networks assertions
+	networks := metadata.dockerContainerMetadata.networkInfo.networks
+	assert.Equal(t, len(networks), 1, "Expected one networks")
+	assert.Equal(t, "bridge", networks[0].NetworkMode)
+	assert.Equal(t, "1.2.3.4", networks[0].IPv4Addresses[0])
+	assert.Equal(t, "5:6:7:8::", networks[0].IPv6Addresses[0])
 }
 
 func TestParseHasNetworkSettingsNetworksNonEmpty(t *testing.T) {
@@ -261,7 +268,7 @@ func TestParseHasNetworkSettingsNetworksNonEmpty(t *testing.T) {
 
 	mockHostConfig := &dockercontainer.HostConfig{NetworkMode: dockercontainer.NetworkMode("bridge")}
 	mockNetworks := map[string]*network.EndpointSettings{}
-	mockNetworks["bridge"] = &network.EndpointSettings{}
+	mockNetworks["bridge"] = &network.EndpointSettings{IPAddress: "1.2.3.4", GlobalIPv6Address: "5:6:7:8::"}
 	mockNetworks["network0"] = &network.EndpointSettings{}
 	mockNetworkSettings := &types.NetworkSettings{
 		Networks: mockNetworks,
@@ -292,7 +299,13 @@ func TestParseHasNetworkSettingsNetworksNonEmpty(t *testing.T) {
 	assert.Equal(t, metadata.hostPrivateIPv4Address, mockHostPrivateIPv4Address, "Expected hostPrivateIPv4Address "+hostPrivateIPv4Address)
 	assert.Equal(t, metadata.hostPublicIPv4Address, mockHostPublicIPv4Address, "Expected hostPublicIPv4Address "+hostPublicIPv4Address)
 	assert.Equal(t, string(metadata.metadataStatus), expectedStatus, "Expected status "+expectedStatus)
-	assert.Equal(t, len(metadata.dockerContainerMetadata.networkInfo.networks), 2, "Expected two networks")
+
+	// Networks assertions
+	networks := metadata.dockerContainerMetadata.networkInfo.networks
+	assert.Equal(t, len(networks), 2, "Expected two networks")
+	assert.Equal(t, "bridge", networks[0].NetworkMode)
+	assert.Equal(t, "1.2.3.4", networks[0].IPv4Addresses[0])
+	assert.Equal(t, "5:6:7:8::", networks[0].IPv6Addresses[0])
 }
 
 func TestParseHasNoContainerJSONBase(t *testing.T) {

--- a/agent/containermetadata/parse_metadata_test.go
+++ b/agent/containermetadata/parse_metadata_test.go
@@ -196,6 +196,18 @@ func TestParseHasNetworkSettingsNetworksEmpty(t *testing.T) {
 	assert.Equal(t, "5:6:7:8::", networks[0].IPv6Addresses[0])
 }
 
+func TestParseHasNetworkSettingsNetworksEmptyWithIPv4Only(t *testing.T) {
+	fixture := newBasicFixture().withDefaultNetworkSettings("1.2.3.4", "")
+	metadata := fixture.manager.parseMetadata(fixture.container, fixture.task, containerName)
+
+	validateBasicMetadata(t, &metadata, fixture)
+	// Networks assertions
+	networks := metadata.dockerContainerMetadata.networkInfo.networks
+	assert.Equal(t, len(networks), 1, "Expected one networks")
+	assert.Equal(t, "bridge", networks[0].NetworkMode)
+	assert.Equal(t, "1.2.3.4", networks[0].IPv4Addresses[0])
+}
+
 func TestParseHasNetworkSettingsNetworksNonEmpty(t *testing.T) {
 	mockNetworks := map[string]*network.EndpointSettings{}
 	mockNetworks["bridge"] = &network.EndpointSettings{IPAddress: "1.2.3.4", GlobalIPv6Address: "5:6:7:8::"}
@@ -211,6 +223,22 @@ func TestParseHasNetworkSettingsNetworksNonEmpty(t *testing.T) {
 	assert.Equal(t, "bridge", networks[0].NetworkMode)
 	assert.Equal(t, "1.2.3.4", networks[0].IPv4Addresses[0])
 	assert.Equal(t, "5:6:7:8::", networks[0].IPv6Addresses[0])
+}
+
+func TestParseHasNetworkSettingsNetworksNonEmptyWithIPv4Only(t *testing.T) {
+	mockNetworks := map[string]*network.EndpointSettings{}
+	mockNetworks["bridge"] = &network.EndpointSettings{IPAddress: "1.2.3.4", GlobalIPv6Address: ""}
+	mockNetworks["network0"] = &network.EndpointSettings{}
+
+	fixture := newBasicFixture().withNetworks(mockNetworks)
+	metadata := fixture.manager.parseMetadata(fixture.container, fixture.task, containerName)
+
+	validateBasicMetadata(t, &metadata, fixture)
+	// Networks assertions
+	networks := metadata.dockerContainerMetadata.networkInfo.networks
+	assert.Equal(t, len(networks), 2, "Expected two networks")
+	assert.Equal(t, "bridge", networks[0].NetworkMode)
+	assert.Equal(t, "1.2.3.4", networks[0].IPv4Addresses[0])
 }
 
 func TestParseHasNoContainerJSONBase(t *testing.T) {

--- a/agent/containermetadata/parse_metadata_test.go
+++ b/agent/containermetadata/parse_metadata_test.go
@@ -32,222 +32,162 @@ const (
 	cluster = "us-west2"
 )
 
-// TestParseContainerCreate checks case when parsing is done at metadata creation
-func TestParseContainerCreate(t *testing.T) {
-	mockTaskARN := validTaskARN
-	mockTaskDefinitionFamily := taskDefinitionFamily
-	mockTaskDefinitionRevision := taskDefinitionRevision
-	mockTask := &apitask.Task{Arn: mockTaskARN, Family: mockTaskDefinitionFamily, Version: mockTaskDefinitionRevision}
-	mockContainerName := containerName
-	mockCluster := cluster
-	mockContainerInstanceARN := containerInstanceARN
-	mockAvailabilityZone := availabilityZone
-	mockHostPrivateIPv4Address := hostPrivateIPv4Address
-	mockHostPublicIPv4Address := hostPublicIPv4Address
+type testFixture struct {
+	task           *apitask.Task
+	container      *types.ContainerJSON
+	manager        *metadataManager
+	expectedStatus string
+}
 
-	expectedStatus := string(MetadataInitial)
+func newBasicFixture() *testFixture {
+	mockTask := &apitask.Task{Arn: validTaskARN}
 
-	newManager := &metadataManager{
-		cluster:                mockCluster,
-		containerInstanceARN:   mockContainerInstanceARN,
-		availabilityZone:       mockAvailabilityZone,
-		hostPrivateIPv4Address: mockHostPrivateIPv4Address,
-		hostPublicIPv4Address:  mockHostPublicIPv4Address,
+	manager := &metadataManager{
+		cluster:                cluster,
+		containerInstanceARN:   containerInstanceARN,
+		availabilityZone:       availabilityZone,
+		hostPrivateIPv4Address: hostPrivateIPv4Address,
+		hostPublicIPv4Address:  hostPublicIPv4Address,
 	}
 
-	metadata := newManager.parseMetadataAtContainerCreate(mockTask, mockContainerName)
-	assert.Equal(t, metadata.cluster, mockCluster, "Expected cluster "+mockCluster)
-	assert.Equal(t, metadata.taskMetadata.containerName, mockContainerName, "Expected container name "+mockContainerName)
-	assert.Equal(t, metadata.taskMetadata.taskARN, mockTaskARN, "Expected task ARN "+mockTaskARN)
-	assert.Equal(t, metadata.containerInstanceARN, mockContainerInstanceARN, "Expected container instance ARN "+mockContainerInstanceARN)
-	assert.Equal(t, metadata.availabilityZone, mockAvailabilityZone, "Expected availabilityZone "+mockAvailabilityZone)
-	assert.Equal(t, metadata.hostPrivateIPv4Address, mockHostPrivateIPv4Address, "Expected hostPrivateIPv4Address "+hostPrivateIPv4Address)
-	assert.Equal(t, metadata.hostPublicIPv4Address, mockHostPublicIPv4Address, "Expected hostPublicIPv4Address "+hostPublicIPv4Address)
-	assert.Equal(t, metadata.taskMetadata.taskDefinitionFamily, mockTaskDefinitionFamily, "Expected task definition family "+mockTaskDefinitionFamily)
-	assert.Equal(t, metadata.taskMetadata.taskDefinitionRevision, mockTaskDefinitionRevision, "Expected task definition revision "+mockTaskDefinitionRevision)
-	assert.Equal(t, string(metadata.metadataStatus), expectedStatus, "Expected status "+expectedStatus)
+	return &testFixture{
+		task:           mockTask,
+		manager:        manager,
+		expectedStatus: string(MetadataReady),
+	}
+}
+
+// adds a container with a basic Config and an empty NetworkingSettings
+func (f *testFixture) withContainer() *testFixture {
+	f.container = &types.ContainerJSON{
+		Config:          &dockercontainer.Config{Image: "image"},
+		NetworkSettings: &types.NetworkSettings{},
+	}
+	return f
+}
+
+// adds a host config to the container
+func (f *testFixture) withHostConfig() *testFixture {
+	if f.container == nil {
+		f.withContainer()
+	}
+	f.container.ContainerJSONBase = &types.ContainerJSONBase{HostConfig: &dockercontainer.HostConfig{NetworkMode: "bridge"}}
+	return f
+}
+
+// ensures container and host config are properly initialized
+func (f *testFixture) initContainerAndHostConfig() *testFixture {
+	if f.container == nil {
+		f.withContainer()
+	}
+
+	if f.container.ContainerJSONBase == nil {
+		f.withHostConfig()
+	}
+
+	return f
+}
+
+// adds default network settings to the container NetworkSettings
+func (f *testFixture) withDefaultNetworkSettings(ipv4 string, ipv6 string) *testFixture {
+	f.initContainerAndHostConfig()
+	f.container.NetworkSettings.DefaultNetworkSettings = types.DefaultNetworkSettings{
+		IPAddress:         ipv4,
+		GlobalIPv6Address: ipv6,
+	}
+
+	return f
+}
+
+// adds specified networks to the container NetworkSettings
+func (f *testFixture) withNetworks(networks map[string]*network.EndpointSettings) *testFixture {
+	f.initContainerAndHostConfig()
+	f.container.NetworkSettings.Networks = networks
+	return f
+}
+
+// withPorts adds port bindings to the container NetworkSettings
+func (f *testFixture) withPorts(ports nat.PortMap) *testFixture {
+	f.initContainerAndHostConfig()
+	f.container.NetworkSettings.Ports = ports
+	return f
+}
+
+// Helper function for standard validations
+func validateBasicMetadata(t *testing.T, metadata *Metadata, fixture *testFixture) {
+	assert.Equal(t, fixture.manager.cluster, metadata.cluster, "Expected cluster "+fixture.manager.cluster)
+	assert.Equal(t, containerName, metadata.taskMetadata.containerName, "Expected container name "+containerName)
+	assert.Equal(t, fixture.task.Arn, metadata.taskMetadata.taskARN, "Expected task ARN "+fixture.task.Arn)
+	assert.Equal(t, fixture.manager.containerInstanceARN, metadata.containerInstanceARN, "Expected container instance ARN "+fixture.manager.containerInstanceARN)
+	assert.Equal(t, fixture.manager.availabilityZone, metadata.availabilityZone, "Expected availabilityZone "+fixture.manager.availabilityZone)
+	assert.Equal(t, fixture.manager.hostPrivateIPv4Address, metadata.hostPrivateIPv4Address, "Expected hostPrivateIPv4Address "+fixture.manager.hostPrivateIPv4Address)
+	assert.Equal(t, fixture.manager.hostPublicIPv4Address, metadata.hostPublicIPv4Address, "Expected hostPublicIPv4Address "+fixture.manager.hostPublicIPv4Address)
+	assert.Equal(t, fixture.expectedStatus, string(metadata.metadataStatus), "Expected status "+fixture.expectedStatus)
+}
+
+// TestParseContainerCreate checks case when parsing is done at metadata creation
+func TestParseContainerCreate(t *testing.T) {
+	fixture := newBasicFixture()
+	fixture.task = &apitask.Task{
+		Arn:     validTaskARN,
+		Family:  taskDefinitionFamily,
+		Version: taskDefinitionRevision,
+	}
+	fixture.expectedStatus = string(MetadataInitial)
+	metadata := fixture.manager.parseMetadataAtContainerCreate(fixture.task, containerName)
+
+	validateBasicMetadata(t, &metadata, fixture)
+	assert.Equal(t, taskDefinitionFamily, metadata.taskMetadata.taskDefinitionFamily, "Expected task definition family "+taskDefinitionFamily)
+	assert.Equal(t, taskDefinitionRevision, metadata.taskMetadata.taskDefinitionRevision, "Expected task definition revision "+taskDefinitionRevision)
 }
 
 func TestParseHasNoContainer(t *testing.T) {
-	mockTaskARN := validTaskARN
-	mockTask := &apitask.Task{Arn: mockTaskARN}
-	mockContainerName := containerName
-	mockCluster := cluster
-	mockContainerInstanceARN := containerInstanceARN
-	mockAvailabilityZone := availabilityZone
-	mockHostPrivateIPv4Address := hostPrivateIPv4Address
-	mockHostPublicIPv4Address := hostPublicIPv4Address
+	fixture := newBasicFixture()
+	metadata := fixture.manager.parseMetadata(nil, fixture.task, containerName)
 
-	expectedStatus := string(MetadataReady)
-
-	newManager := &metadataManager{
-		cluster:                mockCluster,
-		containerInstanceARN:   mockContainerInstanceARN,
-		availabilityZone:       mockAvailabilityZone,
-		hostPrivateIPv4Address: mockHostPrivateIPv4Address,
-		hostPublicIPv4Address:  mockHostPublicIPv4Address,
-	}
-
-	metadata := newManager.parseMetadata(nil, mockTask, mockContainerName)
-	assert.Equal(t, metadata.cluster, mockCluster, "Expected cluster "+mockCluster)
-	assert.Equal(t, metadata.taskMetadata.containerName, mockContainerName, "Expected container name "+mockContainerName)
-	assert.Equal(t, metadata.taskMetadata.taskARN, mockTaskARN, "Expected task ARN "+mockTaskARN)
-	assert.Equal(t, metadata.containerInstanceARN, mockContainerInstanceARN, "Expected container instance ARN "+mockContainerInstanceARN)
-	assert.Equal(t, metadata.availabilityZone, mockAvailabilityZone, "Expected availabilityZone "+mockAvailabilityZone)
-	assert.Equal(t, metadata.hostPrivateIPv4Address, mockHostPrivateIPv4Address, "Expected hostPrivateIPv4Address "+hostPrivateIPv4Address)
-	assert.Equal(t, metadata.hostPublicIPv4Address, mockHostPublicIPv4Address, "Expected hostPublicIPv4Address "+hostPublicIPv4Address)
-	assert.Equal(t, string(metadata.metadataStatus), expectedStatus, "Expected status "+expectedStatus)
-	assert.Equal(t, metadata.dockerContainerMetadata.containerID, "", "Expected empty container metadata")
-	assert.Equal(t, metadata.dockerContainerMetadata.dockerContainerName, "", "Expected empty container metadata")
-	assert.Equal(t, metadata.dockerContainerMetadata.imageID, "", "Expected empty container metadata")
-	assert.Equal(t, metadata.dockerContainerMetadata.imageName, "", "Expected empty container metadata")
+	validateBasicMetadata(t, &metadata, fixture)
+	assert.Equal(t, "", metadata.dockerContainerMetadata.containerID, "Expected empty container metadata")
+	assert.Equal(t, "", metadata.dockerContainerMetadata.dockerContainerName, "Expected empty container metadata")
+	assert.Equal(t, "", metadata.dockerContainerMetadata.imageID, "Expected empty container metadata")
+	assert.Equal(t, "", metadata.dockerContainerMetadata.imageName, "Expected empty container metadata")
 }
 
 func TestParseHasConfig(t *testing.T) {
-	mockTaskARN := validTaskARN
-	mockTask := &apitask.Task{Arn: mockTaskARN}
-	mockContainerName := containerName
-	mockCluster := cluster
-	mockContainerInstanceARN := containerInstanceARN
-	mockAvailabilityZone := availabilityZone
-	mockHostPrivateIPv4Address := hostPrivateIPv4Address
-	mockHostPublicIPv4Address := hostPublicIPv4Address
-
-	mockConfig := &dockercontainer.Config{Image: "image"}
-
 	mockNetworks := map[string]*network.EndpointSettings{}
-	mockNetworkSettings := &types.NetworkSettings{Networks: mockNetworks}
 
-	mockContainer := &types.ContainerJSON{
-		Config:          mockConfig,
-		NetworkSettings: mockNetworkSettings,
-	}
+	fixture := newBasicFixture().withContainer().withNetworks(mockNetworks)
+	metadata := fixture.manager.parseMetadata(fixture.container, fixture.task, containerName)
 
-	expectedStatus := string(MetadataReady)
-
-	newManager := &metadataManager{
-		cluster:                mockCluster,
-		containerInstanceARN:   mockContainerInstanceARN,
-		availabilityZone:       mockAvailabilityZone,
-		hostPrivateIPv4Address: mockHostPrivateIPv4Address,
-		hostPublicIPv4Address:  mockHostPublicIPv4Address,
-	}
-
-	metadata := newManager.parseMetadata(mockContainer, mockTask, mockContainerName)
-
-	assert.Equal(t, metadata.cluster, mockCluster, "Expected cluster "+mockCluster)
-	assert.Equal(t, metadata.taskMetadata.containerName, mockContainerName, "Expected container name "+mockContainerName)
-	assert.Equal(t, metadata.taskMetadata.taskARN, mockTaskARN, "Expected task ARN "+mockTaskARN)
-	assert.Equal(t, metadata.containerInstanceARN, mockContainerInstanceARN, "Expected container instance ARN "+mockContainerInstanceARN)
-	assert.Equal(t, metadata.availabilityZone, mockAvailabilityZone, "Expected availabilityZone "+mockAvailabilityZone)
-	assert.Equal(t, metadata.hostPrivateIPv4Address, mockHostPrivateIPv4Address, "Expected hostPrivateIPv4Address "+hostPrivateIPv4Address)
-	assert.Equal(t, metadata.hostPublicIPv4Address, mockHostPublicIPv4Address, "Expected hostPublicIPv4Address "+hostPublicIPv4Address)
-	assert.Equal(t, string(metadata.metadataStatus), expectedStatus, "Expected status "+expectedStatus)
-	assert.Equal(t, metadata.dockerContainerMetadata.imageName, "image", "Expected nonempty imageID")
+	validateBasicMetadata(t, &metadata, fixture)
+	assert.Equal(t, "image", metadata.dockerContainerMetadata.imageName, "Expected nonempty imageID")
 }
 
 func TestParseHasNetworkSettingsPortBindings(t *testing.T) {
-	mockTaskARN := validTaskARN
-	mockTask := &apitask.Task{Arn: mockTaskARN}
-	mockContainerName := containerName
-	mockCluster := cluster
-	mockContainerInstanceARN := containerInstanceARN
-	mockAvailabilityZone := availabilityZone
-	mockHostPrivateIPv4Address := hostPrivateIPv4Address
-	mockHostPublicIPv4Address := hostPublicIPv4Address
+	mockNetworks := map[string]*network.EndpointSettings{}
+	mockNetworks["bridge"] = &network.EndpointSettings{}
+	mockNetworks["network0"] = &network.EndpointSettings{}
 
 	mockPorts := nat.PortMap{}
 	mockPortBinding := make([]nat.PortBinding, 0)
 	mockPortBinding = append(mockPortBinding, nat.PortBinding{HostIP: "0.0.0.0", HostPort: "8080"})
 	mockPorts["80/tcp"] = mockPortBinding
 
-	mockHostConfig := &dockercontainer.HostConfig{NetworkMode: "bridge"}
-	mockNetworks := map[string]*network.EndpointSettings{}
-	mockNetworks["bridge"] = &network.EndpointSettings{}
-	mockNetworks["network0"] = &network.EndpointSettings{}
-	mockNetworkSettings := &types.NetworkSettings{
-		NetworkSettingsBase: types.NetworkSettingsBase{
-			Ports: mockPorts,
-		},
-		Networks: mockNetworks,
-	}
-	mockContainer := &types.ContainerJSON{
-		ContainerJSONBase: &types.ContainerJSONBase{
-			HostConfig: mockHostConfig,
-		},
-		NetworkSettings: mockNetworkSettings,
-	}
+	fixture := newBasicFixture().withNetworks(mockNetworks).withPorts(mockPorts)
+	metadata := fixture.manager.parseMetadata(fixture.container, fixture.task, containerName)
 
-	expectedStatus := string(MetadataReady)
-
-	newManager := &metadataManager{
-		cluster:                mockCluster,
-		containerInstanceARN:   mockContainerInstanceARN,
-		availabilityZone:       mockAvailabilityZone,
-		hostPrivateIPv4Address: mockHostPrivateIPv4Address,
-		hostPublicIPv4Address:  mockHostPublicIPv4Address,
-	}
-
-	metadata := newManager.parseMetadata(mockContainer, mockTask, mockContainerName)
-	assert.Equal(t, metadata.cluster, mockCluster, "Expected cluster "+mockCluster)
-	assert.Equal(t, metadata.taskMetadata.containerName, mockContainerName, "Expected container name "+mockContainerName)
-	assert.Equal(t, metadata.taskMetadata.taskARN, mockTaskARN, "Expected task ARN "+mockTaskARN)
-	assert.Equal(t, metadata.containerInstanceARN, mockContainerInstanceARN, "Expected container instance ARN "+mockContainerInstanceARN)
-	assert.Equal(t, metadata.availabilityZone, mockAvailabilityZone, "Expected availabilityZone "+mockAvailabilityZone)
-	assert.Equal(t, metadata.hostPrivateIPv4Address, mockHostPrivateIPv4Address, "Expected hostPrivateIPv4Address "+hostPrivateIPv4Address)
-	assert.Equal(t, metadata.hostPublicIPv4Address, mockHostPublicIPv4Address, "Expected hostPublicIPv4Address "+hostPublicIPv4Address)
-	assert.Equal(t, string(metadata.metadataStatus), expectedStatus, "Expected status "+expectedStatus)
-	assert.Equal(t, len(metadata.dockerContainerMetadata.networkInfo.networks), 2, "Expected two networks")
-
-	assert.Equal(t, len(metadata.dockerContainerMetadata.ports), 1, "Expected nonempty list of ports")
+	validateBasicMetadata(t, &metadata, fixture)
+	assert.Equal(t, 2, len(metadata.dockerContainerMetadata.networkInfo.networks), "Expected two networks")
+	assert.Equal(t, 1, len(metadata.dockerContainerMetadata.ports), "Expected nonempty list of ports")
 	assert.Equal(t, uint16(80), metadata.dockerContainerMetadata.ports[0].ContainerPort, "Expected nonempty ContainerPort field")
 	assert.Equal(t, uint16(8080), metadata.dockerContainerMetadata.ports[0].HostPort, "Expected nonempty HostPort field")
 	assert.Equal(t, "0.0.0.0", metadata.dockerContainerMetadata.ports[0].BindIP, "Expected nonempty HostIP field")
 }
 
 func TestParseHasNetworkSettingsNetworksEmpty(t *testing.T) {
-	mockTaskARN := validTaskARN
-	mockTask := &apitask.Task{Arn: mockTaskARN}
-	mockContainerName := containerName
-	mockCluster := cluster
-	mockContainerInstanceARN := containerInstanceARN
-	mockAvailabilityZone := availabilityZone
-	mockHostPrivateIPv4Address := hostPrivateIPv4Address
-	mockHostPublicIPv4Address := hostPublicIPv4Address
+	fixture := newBasicFixture().withDefaultNetworkSettings("1.2.3.4", "5:6:7:8::")
+	metadata := fixture.manager.parseMetadata(fixture.container, fixture.task, containerName)
 
-	mockHostConfig := &dockercontainer.HostConfig{NetworkMode: "bridge"}
-	mockNetworkSettings := &types.NetworkSettings{
-		DefaultNetworkSettings: types.DefaultNetworkSettings{
-			IPAddress:         "1.2.3.4",
-			GlobalIPv6Address: "5:6:7:8::",
-		}}
-	mockContainer := &types.ContainerJSON{
-		ContainerJSONBase: &types.ContainerJSONBase{
-			HostConfig: mockHostConfig,
-		},
-		NetworkSettings: mockNetworkSettings,
-	}
-
-	expectedStatus := string(MetadataReady)
-
-	newManager := &metadataManager{
-		cluster:                mockCluster,
-		containerInstanceARN:   mockContainerInstanceARN,
-		availabilityZone:       mockAvailabilityZone,
-		hostPrivateIPv4Address: mockHostPrivateIPv4Address,
-		hostPublicIPv4Address:  mockHostPublicIPv4Address,
-	}
-
-	metadata := newManager.parseMetadata(mockContainer, mockTask, mockContainerName)
-	assert.Equal(t, metadata.cluster, mockCluster, "Expected cluster "+mockCluster)
-	assert.Equal(t, metadata.taskMetadata.containerName, mockContainerName, "Expected container name "+mockContainerName)
-	assert.Equal(t, metadata.taskMetadata.taskARN, mockTaskARN, "Expected task ARN "+mockTaskARN)
-	assert.Equal(t, metadata.containerInstanceARN, mockContainerInstanceARN, "Expected container instance ARN "+mockContainerInstanceARN)
-	assert.Equal(t, metadata.availabilityZone, mockAvailabilityZone, "Expected availabilityZone "+mockAvailabilityZone)
-	assert.Equal(t, metadata.hostPrivateIPv4Address, mockHostPrivateIPv4Address, "Expected hostPrivateIPv4Address "+hostPrivateIPv4Address)
-	assert.Equal(t, metadata.hostPublicIPv4Address, mockHostPublicIPv4Address, "Expected hostPublicIPv4Address "+hostPublicIPv4Address)
-	assert.Equal(t, string(metadata.metadataStatus), expectedStatus, "Expected status "+expectedStatus)
-
+	validateBasicMetadata(t, &metadata, fixture)
 	// Networks assertions
 	networks := metadata.dockerContainerMetadata.networkInfo.networks
 	assert.Equal(t, len(networks), 1, "Expected one networks")
@@ -257,49 +197,14 @@ func TestParseHasNetworkSettingsNetworksEmpty(t *testing.T) {
 }
 
 func TestParseHasNetworkSettingsNetworksNonEmpty(t *testing.T) {
-	mockTaskARN := validTaskARN
-	mockTask := &apitask.Task{Arn: mockTaskARN}
-	mockContainerName := containerName
-	mockCluster := cluster
-	mockContainerInstanceARN := containerInstanceARN
-	mockAvailabilityZone := availabilityZone
-	mockHostPrivateIPv4Address := hostPrivateIPv4Address
-	mockHostPublicIPv4Address := hostPublicIPv4Address
-
-	mockHostConfig := &dockercontainer.HostConfig{NetworkMode: dockercontainer.NetworkMode("bridge")}
 	mockNetworks := map[string]*network.EndpointSettings{}
 	mockNetworks["bridge"] = &network.EndpointSettings{IPAddress: "1.2.3.4", GlobalIPv6Address: "5:6:7:8::"}
 	mockNetworks["network0"] = &network.EndpointSettings{}
-	mockNetworkSettings := &types.NetworkSettings{
-		Networks: mockNetworks,
-	}
-	mockContainer := &types.ContainerJSON{
-		ContainerJSONBase: &types.ContainerJSONBase{
-			HostConfig: mockHostConfig,
-		},
-		NetworkSettings: mockNetworkSettings,
-	}
 
-	expectedStatus := string(MetadataReady)
+	fixture := newBasicFixture().withNetworks(mockNetworks)
+	metadata := fixture.manager.parseMetadata(fixture.container, fixture.task, containerName)
 
-	newManager := &metadataManager{
-		cluster:                mockCluster,
-		containerInstanceARN:   mockContainerInstanceARN,
-		availabilityZone:       mockAvailabilityZone,
-		hostPrivateIPv4Address: mockHostPrivateIPv4Address,
-		hostPublicIPv4Address:  mockHostPublicIPv4Address,
-	}
-
-	metadata := newManager.parseMetadata(mockContainer, mockTask, mockContainerName)
-	assert.Equal(t, metadata.cluster, mockCluster, "Expected cluster "+mockCluster)
-	assert.Equal(t, metadata.taskMetadata.containerName, mockContainerName, "Expected container name "+mockContainerName)
-	assert.Equal(t, metadata.taskMetadata.taskARN, mockTaskARN, "Expected task ARN "+mockTaskARN)
-	assert.Equal(t, metadata.containerInstanceARN, mockContainerInstanceARN, "Expected container instance ARN "+mockContainerInstanceARN)
-	assert.Equal(t, metadata.availabilityZone, mockAvailabilityZone, "Expected AvailabilityZone"+mockAvailabilityZone)
-	assert.Equal(t, metadata.hostPrivateIPv4Address, mockHostPrivateIPv4Address, "Expected hostPrivateIPv4Address "+hostPrivateIPv4Address)
-	assert.Equal(t, metadata.hostPublicIPv4Address, mockHostPublicIPv4Address, "Expected hostPublicIPv4Address "+hostPublicIPv4Address)
-	assert.Equal(t, string(metadata.metadataStatus), expectedStatus, "Expected status "+expectedStatus)
-
+	validateBasicMetadata(t, &metadata, fixture)
 	// Networks assertions
 	networks := metadata.dockerContainerMetadata.networkInfo.networks
 	assert.Equal(t, len(networks), 2, "Expected two networks")
@@ -309,91 +214,34 @@ func TestParseHasNetworkSettingsNetworksNonEmpty(t *testing.T) {
 }
 
 func TestParseHasNoContainerJSONBase(t *testing.T) {
-	mockTaskARN := validTaskARN
-	mockTask := &apitask.Task{Arn: mockTaskARN}
-	mockContainerName := containerName
-	mockCluster := cluster
-	mockContainerInstanceARN := containerInstanceARN
+	fixture := newBasicFixture().withDefaultNetworkSettings("0.0.0.0", "")
+	fixture.container.ContainerJSONBase = nil
+	metadata := fixture.manager.parseMetadata(fixture.container, fixture.task, containerName)
 
-	mockConfig := &dockercontainer.Config{Image: "image"}
-	mockNetworkSettings := &types.NetworkSettings{
-		DefaultNetworkSettings: types.DefaultNetworkSettings{
-			IPAddress: "0.0.0.0",
-		}}
-	mockContainer := &types.ContainerJSON{
-		NetworkSettings: mockNetworkSettings,
-		Config:          mockConfig,
-	}
-
-	expectedStatus := string(MetadataReady)
-
-	newManager := &metadataManager{
-		cluster:              mockCluster,
-		containerInstanceARN: mockContainerInstanceARN,
-	}
-
-	metadata := newManager.parseMetadata(mockContainer, mockTask, mockContainerName)
-	assert.Equal(t, metadata.cluster, mockCluster, "Expected cluster "+mockCluster)
-	assert.Equal(t, metadata.taskMetadata.containerName, mockContainerName, "Expected container name "+mockContainerName)
-	assert.Equal(t, metadata.taskMetadata.taskARN, mockTaskARN, "Expected task ARN "+mockTaskARN)
-	assert.Equal(t, metadata.containerInstanceARN, mockContainerInstanceARN, "Expected container instance ARN "+mockContainerInstanceARN)
-	assert.Equal(t, string(metadata.metadataStatus), expectedStatus, "Expected status "+expectedStatus)
-	assert.Equal(t, len(metadata.dockerContainerMetadata.networkInfo.networks), 0, "Expected one network")
-	assert.Equal(t, metadata.dockerContainerMetadata.imageName, "image")
+	validateBasicMetadata(t, &metadata, fixture)
+	// nil ContainerJSONBase means that hostConfig will be nil too; thus expect no networks
+	assert.Equal(t, 0, len(metadata.dockerContainerMetadata.networkInfo.networks), "Expected zero networks")
+	assert.Equal(t, "image", metadata.dockerContainerMetadata.imageName)
 }
 
 func TestParseTaskDefinitionSettings(t *testing.T) {
-	mockTaskARN := validTaskARN
-	mockTask := &apitask.Task{Arn: mockTaskARN}
-	mockContainerName := containerName
-	mockCluster := cluster
-	mockContainerInstanceARN := containerInstanceARN
-	mockAvailabilityZone := availabilityZone
-	mockHostPrivateIPv4Address := hostPrivateIPv4Address
-	mockHostPublicIPv4Address := hostPublicIPv4Address
-
-	mockHostConfig := &dockercontainer.HostConfig{NetworkMode: dockercontainer.NetworkMode("bridge")}
-	mockConfig := &dockercontainer.Config{Image: "image"}
 	mockNetworkSettings := &types.NetworkSettings{
 		NetworkSettingsBase: types.NetworkSettingsBase{
 			LinkLocalIPv6Address: "0.0.0.0",
 		},
 	}
-	mockContainer := &types.ContainerJSON{
-		ContainerJSONBase: &types.ContainerJSONBase{
-			HostConfig: mockHostConfig,
-		},
-		Config:          mockConfig,
-		NetworkSettings: mockNetworkSettings,
-	}
 
-	expectedStatus := string(MetadataReady)
+	fixture := newBasicFixture().withHostConfig()
+	fixture.container.NetworkSettings = mockNetworkSettings
+	metadata := fixture.manager.parseMetadata(fixture.container, fixture.task, containerName)
 
-	newManager := &metadataManager{
-		cluster:                mockCluster,
-		containerInstanceARN:   mockContainerInstanceARN,
-		availabilityZone:       mockAvailabilityZone,
-		hostPrivateIPv4Address: mockHostPrivateIPv4Address,
-		hostPublicIPv4Address:  mockHostPublicIPv4Address,
-	}
-
-	metadata := newManager.parseMetadata(mockContainer, mockTask, mockContainerName)
-	assert.Equal(t, metadata.cluster, mockCluster, "Expected cluster "+mockCluster)
-	assert.Equal(t, metadata.taskMetadata.containerName, mockContainerName, "Expected container name "+mockContainerName)
-	assert.Equal(t, metadata.taskMetadata.taskARN, mockTaskARN, "Expected task ARN "+mockTaskARN)
-	assert.Equal(t, metadata.taskMetadata.taskDefinitionFamily, "", "Expected no task definition family")
-	assert.Equal(t, metadata.taskMetadata.taskDefinitionRevision, "", "Expected no task definition revision")
-	assert.Equal(t, metadata.containerInstanceARN, mockContainerInstanceARN, "Expected container instance ARN "+mockContainerInstanceARN)
-	assert.Equal(t, metadata.availabilityZone, mockAvailabilityZone, "Expected availabilityZone "+mockAvailabilityZone)
-	assert.Equal(t, metadata.hostPrivateIPv4Address, mockHostPrivateIPv4Address, "Expected hostPrivateIPv4Address "+hostPrivateIPv4Address)
-	assert.Equal(t, metadata.hostPublicIPv4Address, mockHostPublicIPv4Address, "Expected hostPublicIPv4Address "+hostPublicIPv4Address)
-	assert.Equal(t, string(metadata.metadataStatus), expectedStatus, "Expected status "+expectedStatus)
+	validateBasicMetadata(t, &metadata, fixture)
+	assert.Equal(t, "", metadata.taskMetadata.taskDefinitionFamily, "Expected no task definition family")
+	assert.Equal(t, "", metadata.taskMetadata.taskDefinitionRevision, "Expected no task definition revision")
 
 	// now add the task definition details
-	mockTaskDefinitionFamily := taskDefinitionFamily
-	mockTaskDefinitionRevision := taskDefinitionRevision
-	mockTask = &apitask.Task{Arn: mockTaskARN, Family: mockTaskDefinitionFamily, Version: mockTaskDefinitionRevision}
-	metadata = newManager.parseMetadata(nil, mockTask, mockContainerName)
-	assert.Equal(t, metadata.taskMetadata.taskDefinitionFamily, mockTaskDefinitionFamily, "Expected task definition family "+mockTaskDefinitionFamily)
-	assert.Equal(t, metadata.taskMetadata.taskDefinitionRevision, mockTaskDefinitionRevision, "Expected task definition revision "+mockTaskDefinitionRevision)
+	mockTask := &apitask.Task{Arn: validTaskARN, Family: taskDefinitionFamily, Version: taskDefinitionRevision}
+	metadata = fixture.manager.parseMetadata(fixture.container, mockTask, containerName)
+	assert.Equal(t, taskDefinitionFamily, metadata.taskMetadata.taskDefinitionFamily, "Expected task definition family")
+	assert.Equal(t, taskDefinitionRevision, metadata.taskMetadata.taskDefinitionRevision, "Expected task definition revision")
 }


### PR DESCRIPTION
### Summary
Modify Container Metadata File to include IPv6 container addresses for bridge mode tasks.   
No IP addresses are returned for `host` mode containers as they don’t have dedicated IPs and just use the host’s network.
No IP addresses are returned for `awsvpc` mode containers in general, so it is out of scope.

### Implementation details
Reference PR https://github.com/aws/amazon-ecs-agent/pull/4581
Also refactored test cases to allow cleaner way of adding tests

### Testing

New tests cover the changes: Yes. Extended existing tests to check that IP addresses is populated correctly when provided

Manual tests were conducted:
1. `host`- Ensured that container metadata file remains the same before/after code changes
1. `bridge` - Ensured that IPv6 address is seen in container metadata file when launching a task on an instance with IPv6 enabled on the bridge network. Steps:
      1. Launch an EC2 instance with ECS Optimized AMI on a Dualstack subnet. Build a custom Agent with this PR code changes, and replace the official ECS Agent that comes with the AMI
      1. Modify Docker daemon configuration file (/etc/docker/daemon.json) to enables and configure IPv6 networking 
      ```
      {
          "ipv6": true,
          "fixed-cidr-v6": "fd00::/80",
          "experimental": true,
          "ip6tables": true
      }
      ```
      3. Launch a task with `bridge` network mode.
      4. Read the container metadata file
      ```
      sudo docker exec 3651a9290e9b sh -c 'cat $ECS_CONTAINER_METADATA_FILE' | jq "."
      {
        "Cluster": "default",
        "ContainerInstanceARN": "arn:aws:ecs:us-west-2:767397926813:container-instance/default/2dbb35327962415786b0c914ff2102fc",
        "TaskARN": "arn:aws:ecs:us-west-2:767397926813:task/default/db67c3c468b64dd2970cfe5987b4132b",
        "TaskDefinitionFamily": "test-bridge",
        "TaskDefinitionRevision": "1",
        "ContainerID": "3651a9290e9bd64f4627d8a8eeb52b0d35958f88369e1ad1795caca84f246687",
        "ContainerName": "container",
        "DockerContainerName": "/ecs-test-bridge-1-container-b8cde1d686968d83da01",
        "ImageID": "sha256:52edd22441d417ba74ef11d2a208582177ff470e7cd0456592708a7e671c6e13",
        "ImageName": "public.ecr.aws/amazonlinux/amazonlinux:2",
        "Networks": [
          {
            "NetworkMode": "bridge",
            "IPv4Addresses": [
              "172.17.0.2"
            ],
            "IPv6Addresses": [
              "fd00::242:ac11:2"
            ]
          }
        ],
        "MetadataFileStatus": "READY",
        "AvailabilityZone": "us-west-2c",
        "HostPrivateIPv4Address": "10.0.2.106",
        "HostPublicIPv4Address": "34.221.78.5"
      ```



### Description for the changelog
Enhancement: Include container IPv6 addresses (if available) in container metadata file for bridge mode tasks.



### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
