### PR TITLE
Introducing AvailableMemoryProvider to allow custom calculations of a…

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
@@ -97,6 +97,7 @@ type ecsClient struct {
 	stscAttachmentCustomRetryBackoff func(func() error) error
 	metricsFactory                   metrics.EntryFactory
 	rciRetryBackoff                  *retry.ExponentialBackoff
+	availableMemoryProvider          func() int32
 }
 
 // NewECSClient creates a new ECSClient interface object.
@@ -135,6 +136,9 @@ func NewECSClient(
 	}
 	if client.rciRetryBackoff == nil {
 		client.rciRetryBackoff = retry.NewExponentialBackoff(rciMinBackoff, rciMaxBackoff, rciRetryJitter, rciRetryMultiple)
+	}
+	if client.availableMemoryProvider == nil {
+		client.availableMemoryProvider = getHostMemoryInMiB
 	}
 
 	return client, nil
@@ -432,7 +436,8 @@ func (client *ecsClient) getResources() ([]types.Resource, error) {
 	integerStr := "INTEGER"
 	stringSetStr := "STRINGSET"
 
-	cpu, mem := getCpuAndMemory()
+	cpu := getCpu()
+	mem := client.availableMemoryProvider()
 	remainingMem := mem - int32(client.configAccessor.ReservedMemory())
 	logger.Info("Remaining memory", logger.Fields{
 		"remainingMemory": remainingMem,
@@ -485,7 +490,12 @@ func (client *ecsClient) GetHostResources() (map[string]types.Resource, error) {
 	return resourceMap, nil
 }
 
-func getCpuAndMemory() (int32, int32) {
+func getCpu() int32 {
+	cpu := utils.GetNumCPU() * 1024
+	return int32(cpu)
+}
+
+func getHostMemoryInMiB() int32 {
 	memInfo, err := meminfo.Read()
 	mem := int32(0)
 	if err == nil {
@@ -496,9 +506,7 @@ func getCpuAndMemory() (int32, int32) {
 		})
 	}
 
-	cpu := utils.GetNumCPU() * 1024
-
-	return int32(cpu), mem
+	return mem
 }
 
 func validateRegisteredAttributes(expectedAttributes, actualAttributes []types.Attribute) error {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client_option.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client_option.go
@@ -106,3 +106,9 @@ func WithMetricsFactory(metricsFactory metrics.EntryFactory) ECSClientOption {
 		client.metricsFactory = metricsFactory
 	}
 }
+
+func WithAvailableMemoryProvider(availableMemoryProvider func() int32) ECSClientOption {
+	return func(client *ecsClient) {
+		client.availableMemoryProvider = availableMemoryProvider
+	}
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client_option.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client_option.go
@@ -107,6 +107,9 @@ func WithMetricsFactory(metricsFactory metrics.EntryFactory) ECSClientOption {
 	}
 }
 
+// WithAvailableMemoryProvider is an ECSClientOption that configures a
+// custom strategy for returning the default amount of available memory
+// on a container instance in MiB.
 func WithAvailableMemoryProvider(availableMemoryProvider func() int32) ECSClientOption {
 	return func(client *ecsClient) {
 		client.availableMemoryProvider = availableMemoryProvider

--- a/ecs-agent/api/ecs/client/ecs_client.go
+++ b/ecs-agent/api/ecs/client/ecs_client.go
@@ -97,6 +97,7 @@ type ecsClient struct {
 	stscAttachmentCustomRetryBackoff func(func() error) error
 	metricsFactory                   metrics.EntryFactory
 	rciRetryBackoff                  *retry.ExponentialBackoff
+	availableMemoryProvider          func() int32
 }
 
 // NewECSClient creates a new ECSClient interface object.
@@ -135,6 +136,9 @@ func NewECSClient(
 	}
 	if client.rciRetryBackoff == nil {
 		client.rciRetryBackoff = retry.NewExponentialBackoff(rciMinBackoff, rciMaxBackoff, rciRetryJitter, rciRetryMultiple)
+	}
+	if client.availableMemoryProvider == nil {
+		client.availableMemoryProvider = getHostMemoryInMiB
 	}
 
 	return client, nil
@@ -432,7 +436,8 @@ func (client *ecsClient) getResources() ([]types.Resource, error) {
 	integerStr := "INTEGER"
 	stringSetStr := "STRINGSET"
 
-	cpu, mem := getCpuAndMemory()
+	cpu := getCpu()
+	mem := client.availableMemoryProvider()
 	remainingMem := mem - int32(client.configAccessor.ReservedMemory())
 	logger.Info("Remaining memory", logger.Fields{
 		"remainingMemory": remainingMem,
@@ -485,7 +490,12 @@ func (client *ecsClient) GetHostResources() (map[string]types.Resource, error) {
 	return resourceMap, nil
 }
 
-func getCpuAndMemory() (int32, int32) {
+func getCpu() int32 {
+	cpu := utils.GetNumCPU() * 1024
+	return int32(cpu)
+}
+
+func getHostMemoryInMiB() int32 {
 	memInfo, err := meminfo.Read()
 	mem := int32(0)
 	if err == nil {
@@ -496,9 +506,7 @@ func getCpuAndMemory() (int32, int32) {
 		})
 	}
 
-	cpu := utils.GetNumCPU() * 1024
-
-	return int32(cpu), mem
+	return mem
 }
 
 func validateRegisteredAttributes(expectedAttributes, actualAttributes []types.Attribute) error {

--- a/ecs-agent/api/ecs/client/ecs_client_option.go
+++ b/ecs-agent/api/ecs/client/ecs_client_option.go
@@ -106,3 +106,9 @@ func WithMetricsFactory(metricsFactory metrics.EntryFactory) ECSClientOption {
 		client.metricsFactory = metricsFactory
 	}
 }
+
+func WithAvailableMemoryProvider(availableMemoryProvider func() int32) ECSClientOption {
+	return func(client *ecsClient) {
+		client.availableMemoryProvider = availableMemoryProvider
+	}
+}

--- a/ecs-agent/api/ecs/client/ecs_client_option.go
+++ b/ecs-agent/api/ecs/client/ecs_client_option.go
@@ -107,6 +107,9 @@ func WithMetricsFactory(metricsFactory metrics.EntryFactory) ECSClientOption {
 	}
 }
 
+// WithAvailableMemoryProvider is an ECSClientOption that configures a
+// custom strategy for returning the default amount of available memory
+// on a container instance in MiB.
 func WithAvailableMemoryProvider(availableMemoryProvider func() int32) ECSClientOption {
 	return func(client *ecsClient) {
 		client.availableMemoryProvider = availableMemoryProvider

--- a/ecs-agent/api/ecs/client/ecs_client_option_test.go
+++ b/ecs-agent/api/ecs/client/ecs_client_option_test.go
@@ -110,3 +110,12 @@ func TestWithMetricsFactory(t *testing.T) {
 	option(client)
 	assert.NotNil(t, client.metricsFactory)
 }
+
+func TestWithAvailableMemoryProvider(t *testing.T) {
+	client := &ecsClient{}
+	option := WithAvailableMemoryProvider(func() int32 {
+		return int32(1)
+	})
+	option(client)
+	assert.NotNil(t, client.availableMemoryProvider)
+}

--- a/ecs-agent/api/ecs/client/ecs_client_test.go
+++ b/ecs-agent/api/ecs/client/ecs_client_test.go
@@ -783,7 +783,7 @@ func TestRegisterContainerInstanceWithNegativeResource(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	_, mem := getCpuAndMemory()
+	mem := getHostMemoryInMiB()
 	mockEC2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
 	cfgAccessorOverrideFunc := func(cfgAccessor *mock_config.MockAgentConfigAccessor) {
 		cfgAccessor.EXPECT().ReservedMemory().Return(uint16(mem) + 1).AnyTimes()
@@ -1773,4 +1773,18 @@ func extractTagsMapFromRegisterContainerInstanceInput(req *ecsservice.RegisterCo
 		tagsMap[aws.ToString(req.Tags[i].Key)] = aws.ToString(req.Tags[i].Value)
 	}
 	return tagsMap
+}
+
+func TestAvailableMemoryProvider(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	availableMemory := int32(42)
+	tester := setup(t, ctrl, ec2.NewBlackholeEC2MetadataClient(), nil,
+		WithAvailableMemoryProvider(func() int32 {
+			return availableMemory
+		}))
+
+	client := tester.client.(*ecsClient)
+	assert.Equal(t, availableMemory, client.availableMemoryProvider())
 }


### PR DESCRIPTION
### Summary
By default the ECS Agent will read from the `MemTotal` field from `/proc/meminfo` to determine the default amount of memory available on the container instance. This PR introduces a provider for supporting custom strategies for determining the amount of available memory on the container instance.

### Implementation details
This change is implemented by introduction a new ECS Client option via `WithAvailableMemoryProvider` where ECS clients can provide their own custom AvailableMemoryProvider. If a custom provider is not provided, a provider encapsulating the existing behavior will be provided instead.

### Testing
New unit tests were introduced to test the newly added code.

New tests cover the changes: yes

### Description for the changelog
Enhancement - Add support for custom providers to determine the initial amount of available memory on a container instance. 

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No

**Does this PR include the addition of new environment variables in the README?** No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
