### PR TITLE
Enable IPv6 support for SSM Client

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -416,7 +416,7 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 		return apierrors.NewResourceInitError(task.Arn, err)
 	}
 
-	task.initSecretResources(credentialsManager, resourceFields)
+	task.initSecretResources(cfg, credentialsManager, resourceFields)
 
 	task.initializeCredentialsEndpoint(credentialsManager)
 
@@ -651,14 +651,14 @@ func (task *Task) populateTaskARN() {
 	}
 }
 
-func (task *Task) initSecretResources(credentialsManager credentials.Manager,
+func (task *Task) initSecretResources(cfg *config.Config, credentialsManager credentials.Manager,
 	resourceFields *taskresource.ResourceFields) {
 	if task.requiresASMDockerAuthData() {
 		task.initializeASMAuthResource(credentialsManager, resourceFields)
 	}
 
 	if task.requiresSSMSecret() {
-		task.initializeSSMSecretResource(credentialsManager, resourceFields)
+		task.initializeSSMSecretResource(cfg, credentialsManager, resourceFields)
 	}
 
 	if task.requiresASMSecret() {
@@ -1109,10 +1109,11 @@ func (task *Task) requiresSSMSecret() bool {
 }
 
 // initializeSSMSecretResource builds the resource dependency map for the SSM ssmsecret resource
-func (task *Task) initializeSSMSecretResource(credentialsManager credentials.Manager,
+func (task *Task) initializeSSMSecretResource(cfg *config.Config,
+	credentialsManager credentials.Manager,
 	resourceFields *taskresource.ResourceFields) {
 	ssmSecretResource := ssmsecret.NewSSMSecretResource(task.Arn, task.getAllSSMSecretRequirements(),
-		task.ExecutionCredentialsID, credentialsManager, resourceFields.SSMClientCreator)
+		task.ExecutionCredentialsID, credentialsManager, resourceFields.SSMClientCreator, cfg.InstanceIPCompatibility)
 	task.AddResource(ssmsecret.ResourceName, ssmSecretResource)
 
 	// for every container that needs ssm secret vending as env, it needs to wait all secrets got retrieved

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -3037,7 +3037,7 @@ func TestInitializeAndGetSSMSecretResource(t *testing.T) {
 		},
 	}
 
-	task.initializeSSMSecretResource(credentialsManager, resFields)
+	task.initializeSSMSecretResource(&config.Config{InstanceIPCompatibility: testIPCompatibility}, credentialsManager, resFields)
 
 	resourceDep := apicontainer.ResourceDependency{
 		Name:           ssmsecret.ResourceName,

--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -203,7 +203,8 @@ func (task *Task) addFSxWindowsFileServerResource(
 		credentialsManager,
 		resourceFields.SSMClientCreator,
 		resourceFields.ASMClientCreator,
-		resourceFields.FSxClientCreator)
+		resourceFields.FSxClientCreator,
+		cfg.InstanceIPCompatibility)
 	if err != nil {
 		return err
 	}

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -2879,12 +2879,14 @@ func TestTaskSecretsEnvironmentVariables(t *testing.T) {
 				},
 			}
 
+			testIPCompatibility := ipcompatibility.NewIPCompatibility(true, true)
 			ssmSecretRes := ssmsecret.NewSSMSecretResource(
 				testTask.Arn,
 				ssmRequirements,
 				credentialsID,
 				credentialsManager,
-				ssmClientCreator)
+				ssmClientCreator,
+				testIPCompatibility)
 
 			// required for validating asm workflows
 			asmClientCreator := mock_asm_factory.NewMockClientCreator(ctrl)
@@ -2923,7 +2925,7 @@ func TestTaskSecretsEnvironmentVariables(t *testing.T) {
 			reqSecretNames := []string{ssmSecretValueFrom}
 
 			credentialsManager.EXPECT().GetTaskCredentials(credentialsID).Return(taskIAMcreds, true).Times(2)
-			ssmClientCreator.EXPECT().NewSSMClient(region, executionRoleCredentials).Return(mockSSMClient, nil)
+			ssmClientCreator.EXPECT().NewSSMClient(region, executionRoleCredentials, testIPCompatibility).Return(mockSSMClient, nil)
 			asmClientCreator.EXPECT().NewASMClient(region, executionRoleCredentials).Return(mockASMClient, nil)
 
 			mockSSMClient.EXPECT().GetParameters(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, in *ssm.GetParametersInput, optFns ...func(*ssm.Options)) {

--- a/agent/ssm/factory/mocks/factory_mocks.go
+++ b/agent/ssm/factory/mocks/factory_mocks.go
@@ -21,6 +21,7 @@ package mock_factory
 import (
 	reflect "reflect"
 
+	ipcompatibility "github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	ssm "github.com/aws/amazon-ecs-agent/agent/ssm"
 	credentials "github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	gomock "github.com/golang/mock/gomock"
@@ -50,16 +51,16 @@ func (m *MockSSMClientCreator) EXPECT() *MockSSMClientCreatorMockRecorder {
 }
 
 // NewSSMClient mocks base method.
-func (m *MockSSMClientCreator) NewSSMClient(arg0 string, arg1 credentials.IAMRoleCredentials) (ssm.SSMClient, error) {
+func (m *MockSSMClientCreator) NewSSMClient(arg0 string, arg1 credentials.IAMRoleCredentials, arg2 ipcompatibility.IPCompatibility) (ssm.SSMClient, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewSSMClient", arg0, arg1)
+	ret := m.ctrl.Call(m, "NewSSMClient", arg0, arg1, arg2)
 	ret0, _ := ret[0].(ssm.SSMClient)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewSSMClient indicates an expected call of NewSSMClient.
-func (mr *MockSSMClientCreatorMockRecorder) NewSSMClient(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSSMClientCreatorMockRecorder) NewSSMClient(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSSMClient", reflect.TypeOf((*MockSSMClientCreator)(nil).NewSSMClient), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSSMClient", reflect.TypeOf((*MockSSMClientCreator)(nil).NewSSMClient), arg0, arg1, arg2)
 }

--- a/agent/taskresource/credentialspec/credentialspec_linux.go
+++ b/agent/taskresource/credentialspec/credentialspec_linux.go
@@ -501,7 +501,7 @@ func (cs *CredentialSpecResource) handleSSMCredentialspecFile(originalCredential
 	}
 	ssmParams := []string{ssmParam[1]}
 
-	ssmClient, err := cs.ssmClientCreator.NewSSMClient(cs.region, iamCredentials)
+	ssmClient, err := cs.ssmClientCreator.NewSSMClient(cs.region, iamCredentials, cs.ipCompatibility)
 	if err != nil {
 		errorEvents <- fmt.Errorf("unable to create SSM client: %v", err)
 		return

--- a/agent/taskresource/credentialspec/credentialspec_linux_test.go
+++ b/agent/taskresource/credentialspec/credentialspec_linux_test.go
@@ -168,7 +168,7 @@ func TestHandleSSMCredentialspecFile(t *testing.T) {
 	expectedKerberosTicketPath := "/var/credentials-fetcher/krbdir/123456/webapp01"
 
 	gomock.InOrder(
-		ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any()).Return(mockSSMClient, nil),
+		ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any(), testConfig.InstanceIPCompatibility).Return(mockSSMClient, nil),
 		mockSSMClient.EXPECT().GetParameters(gomock.Any(), gomock.Any()).Return(ssmClientOutput, nil).Times(1),
 	)
 
@@ -243,7 +243,7 @@ func TestHandleSSMDomainlessCredentialspecFile(t *testing.T) {
 	expectedKerberosTicketPath := "/var/credentials-fetcher/krbdir/123456/webapp01"
 
 	gomock.InOrder(
-		ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any()).Return(mockSSMClient, nil),
+		ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any(), testConfig.InstanceIPCompatibility).Return(mockSSMClient, nil),
 		mockSSMClient.EXPECT().GetParameters(gomock.Any(), gomock.Any()).Return(ssmClientOutput, nil).Times(1),
 	)
 
@@ -333,7 +333,7 @@ func TestHandleSSMCredentialspecFileGetSSMParamErr(t *testing.T) {
 		}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
 
 	gomock.InOrder(
-		ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any()).Return(mockSSMClient, nil),
+		ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any(), testConfig.InstanceIPCompatibility).Return(mockSSMClient, nil),
 		mockSSMClient.EXPECT().GetParameters(gomock.Any(), gomock.Any()).Return(nil, errors.New("test-error")).Times(1),
 	)
 
@@ -954,7 +954,7 @@ func TestSkipCredentialFetcherInvocation(t *testing.T) {
 
 	gomock.InOrder(
 		credentialsManager.EXPECT().GetTaskCredentials(gomock.Any()).Return(taskRoleCredentials, true).Times(1),
-		ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any()).Return(mockSSMClient, nil),
+		ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any(), testConfig.InstanceIPCompatibility).Return(mockSSMClient, nil),
 		mockSSMClient.EXPECT().GetParameters(gomock.Any(), gomock.Any()).Return(ssmClientOutput, nil).Times(1),
 	)
 

--- a/agent/taskresource/credentialspec/credentialspec_windows.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows.go
@@ -305,7 +305,7 @@ func (cs *CredentialSpecResource) handleSSMCredentialspecFile(originalCredential
 		return err
 	}
 
-	ssmClient, err := cs.ssmClientCreator.NewSSMClient(cs.region, iamCredentials)
+	ssmClient, err := cs.ssmClientCreator.NewSSMClient(cs.region, iamCredentials, cs.ipCompatibility)
 	if err != nil {
 		cs.setTerminalReason(err.Error())
 		return err

--- a/agent/taskresource/credentialspec/credentialspec_windows_test.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows_test.go
@@ -492,7 +492,7 @@ func TestHandleSSMCredentialspecFile(t *testing.T) {
 			}
 
 			gomock.InOrder(
-				ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any()).Return(mockSSMClient, nil),
+				ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any(), testConfig.InstanceIPCompatibility).Return(mockSSMClient, nil),
 				mockSSMClient.EXPECT().GetParameters(gomock.Any(), gomock.Any()).Return(ssmClientOutput, nil).Times(1),
 				mockIO.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 			)
@@ -582,7 +582,7 @@ func TestHandleSSMCredentialspecFileGetSSMParamErr(t *testing.T) {
 		}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
 
 	gomock.InOrder(
-		ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any()).Return(mockSSMClient, nil),
+		ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any(), testConfig.InstanceIPCompatibility).Return(mockSSMClient, nil),
 		mockSSMClient.EXPECT().GetParameters(gomock.Any(), gomock.Any()).Return(nil, errors.New("test-error")).Times(1),
 	)
 
@@ -640,7 +640,7 @@ func TestHandleSSMCredentialspecFileIOErr(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any()).Return(mockSSMClient, nil),
+		ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any(), testConfig.InstanceIPCompatibility).Return(mockSSMClient, nil),
 		mockSSMClient.EXPECT().GetParameters(gomock.Any(), gomock.Any()).Return(ssmClientOutput, nil).Times(1),
 		mockIO.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("test-error")),
 	)
@@ -995,7 +995,7 @@ func TestCreateSSM(t *testing.T) {
 
 	gomock.InOrder(
 		credentialsManager.EXPECT().GetTaskCredentials(gomock.Any()).Return(creds, true),
-		ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any()).Return(mockSSMClient, nil),
+		ssmClientCreator.EXPECT().NewSSMClient(gomock.Any(), gomock.Any(), testConfig.InstanceIPCompatibility).Return(mockSSMClient, nil),
 		mockSSMClient.EXPECT().GetParameters(gomock.Any(), gomock.Any()).Return(ssmClientOutput, nil).Times(1),
 		mockIO.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 	)

--- a/agent/taskresource/ssmsecret/ssmsecret.go
+++ b/agent/taskresource/ssmsecret/ssmsecret.go
@@ -24,6 +24,7 @@ import (
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/config/ipcompatibility"
 	"github.com/aws/amazon-ecs-agent/agent/ssm"
 	"github.com/aws/amazon-ecs-agent/agent/ssm/factory"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -65,6 +66,7 @@ type SSMSecretResource struct {
 	// ssmClientCreator is a factory interface that creates new SSM clients. This is
 	// needed mostly for testing.
 	ssmClientCreator factory.SSMClientCreator
+	ipCompatibility  ipcompatibility.IPCompatibility
 
 	// terminalReason should be set for resource creation failures. This ensures
 	// the resource object carries some context for why provisioning failed.
@@ -80,7 +82,8 @@ func NewSSMSecretResource(taskARN string,
 	ssmSecrets map[string][]apicontainer.Secret,
 	executionCredentialsID string,
 	credentialsManager credentials.Manager,
-	ssmClientCreator factory.SSMClientCreator) *SSMSecretResource {
+	ssmClientCreator factory.SSMClientCreator,
+	ipCompatibility ipcompatibility.IPCompatibility) *SSMSecretResource {
 
 	s := &SSMSecretResource{
 		taskARN:                taskARN,
@@ -88,6 +91,7 @@ func NewSSMSecretResource(taskARN string,
 		credentialsManager:     credentialsManager,
 		executionCredentialsID: executionCredentialsID,
 		ssmClientCreator:       ssmClientCreator,
+		ipCompatibility:        ipCompatibility,
 	}
 
 	s.initStatusToTransition()
@@ -335,7 +339,7 @@ func (secret *SSMSecretResource) retrieveSSMSecretValuesByRegion(region string, 
 func (secret *SSMSecretResource) retrieveSSMSecretValues(region string, names []string, iamCredentials credentials.IAMRoleCredentials, wg *sync.WaitGroup, errorEvents chan error) {
 	defer wg.Done()
 
-	ssmClient, err := secret.ssmClientCreator.NewSSMClient(region, iamCredentials)
+	ssmClient, err := secret.ssmClientCreator.NewSSMClient(region, iamCredentials, secret.ipCompatibility)
 	if err != nil {
 		errorEvents <- fmt.Errorf("unable to create SSM client in %s: %v", region, err)
 		return
@@ -419,6 +423,7 @@ func (secret *SSMSecretResource) Initialize(
 	secret.initStatusToTransition()
 	secret.credentialsManager = resourceFields.CredentialsManager
 	secret.ssmClientCreator = resourceFields.SSMClientCreator
+	secret.ipCompatibility = config.InstanceIPCompatibility
 
 	// if task hasn't turn to 'created' status, and it's desire status is 'running'
 	// the resource status needs to be reset to 'NONE' status so the secret value


### PR DESCRIPTION
### Summary

Enable SSM client to automatically use dualstack endpoints when running on IPv6-only instances.

Ref PR: #4580 

### Implementation details
1. Client Configuration Updates
  i.  Modified `NewSSMClient` to accept `IPCompatibility` parameter
  ii. Set `useDualStackEndpoint` based on IPv6 compatibility status
2. Task Resources
     1. SSM client is mainly used by `TaskResources` such as `FSxWindowsFileServer`, `SSMSecret`, and `CredentialSpecs`.
     2. Added an `ipCompatibility` field to each task resource.  
           1.   Updated `New*` constructors to accept an additional `ipCompatibility` parameter. `New*` is invoked when there's a new incoming task that requires task resources. 
           2. `Initialize()` is invoked when Agent restarts and reinitialize task resources. Updated such that the `ipCompatibility` field is populated.
           3. `Config.InstanceIPCompatibility` is the source of value. Updated call chains so that the `ipCompatibility` is passed down correctly

### Testing

Setups done:
* Set IPCompatibility to NewIPv6OnlyCompatibility
* Pin the functional test suite to run on a dualstack subnet (agent is currently connecting to control plane via IPv4).
* Update the SSM Client to use the SSM Pre-prod endpoint for testing purpose, as the dualstack endpoint is still a work in progress. **Once the dual-stack endpoint functionality is production-ready, no additional changes will be required on top of this PR.**
    * Create SSM Parameters needed by the functional test suite on the Pre-prod


Executed functional test suite on dualstack subnet. Verified all tests passed and pre-prod endpoint usage through docker container logs.
```
level=debug time=2025-05-15T17:43:10Z msg="Test: Configuring SSM custom endpoint"
```


New tests cover the changes: no

### Description for the changelog
Enhancement: SSM Client resolves to dualstack endpoint on IPV6-only instances


### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
