### PR TITLE
Migrate awserr/request to aws-go-sdk-v2

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -71,8 +71,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	aws_credentials "github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/smithy-go"
 	"github.com/cihub/seelog"
 	"github.com/pborman/uuid"
 )
@@ -1248,11 +1248,11 @@ func (agent *ecsAgent) setVPCSubnet() (error, bool) {
 	return nil, false
 }
 
-// isInstanceLaunchedInVPC returns false when the awserr returned is an EC2MetadataError
+// isInstanceLaunchedInVPC returns false when the error returned is an EC2MetadataError
 // when querying the vpc id from instance metadata
 func isInstanceLaunchedInVPC(err error) bool {
-	if aerr, ok := err.(awserr.Error); ok &&
-		aerr.Code() == "EC2MetadataError" {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "EC2MetadataError" {
 		return false
 	}
 	return true

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -58,10 +58,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
-
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -1260,7 +1258,10 @@ func TestReregisterContainerInstanceTerminalError(t *testing.T) {
 		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).AnyTimes().Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance(containerInstanceARN, gomock.Any(), gomock.Any(), gomock.Any(),
-			gomock.Any(), gomock.Any()).Return("", "", awserr.New("ClientException", "", nil)),
+			gomock.Any(), gomock.Any()).Return("", "", &smithy.GenericAPIError{
+			Code:    "ClientException",
+			Message: "",
+		}),
 	)
 	mockEC2Metadata.EXPECT().OutpostARN().Return("", nil)
 
@@ -1554,7 +1555,10 @@ func TestRegisterContainerInstanceInvalidParameterTerminalError(t *testing.T) {
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-			gomock.Any()).Return("", "", awserr.New("InvalidParameterException", "", nil)),
+			gomock.Any()).Return("", "", &smithy.GenericAPIError{
+			Code:    "InvalidParameterException",
+			Message: "",
+		}),
 	)
 	mockEC2Metadata.EXPECT().OutpostARN().Return("", nil)
 
@@ -1588,18 +1592,27 @@ func TestRegisterContainerInstanceExceptionErrors(t *testing.T) {
 		exitCode int
 	}{
 		{
-			name:     "InvalidParameterException",
-			regError: awserr.New("InvalidParameterException", "", nil),
+			name: "InvalidParameterException",
+			regError: &smithy.GenericAPIError{
+				Code:    "InvalidParameterException",
+				Message: "",
+			},
 			exitCode: exitcodes.ExitTerminal,
 		},
 		{
-			name:     "ClientException",
-			regError: awserr.New("ClientException", "", nil),
+			name: "ClientException",
+			regError: &smithy.GenericAPIError{
+				Code:    "ClientException",
+				Message: "",
+			},
 			exitCode: exitcodes.ExitTerminal,
 		},
 		{
-			name:     "ThrottlingException",
-			regError: awserr.New("ThrottlingException", "", nil),
+			name: "ThrottlingException",
+			regError: &smithy.GenericAPIError{
+				Code:    "ThrottlingException",
+				Message: "",
+			},
 			exitCode: exitcodes.ExitError,
 		},
 	}

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -48,7 +48,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/smithy-go"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -229,7 +229,10 @@ func TestSetVPCSubnetClassicEC2(t *testing.T) {
 	mockMetadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
 	gomock.InOrder(
 		mockMetadata.EXPECT().PrimaryENIMAC().Return(mac, nil),
-		mockMetadata.EXPECT().VPCID(mac).Return("", awserr.New("EC2MetadataError", "failed to make EC2Metadata request", nil)),
+		mockMetadata.EXPECT().VPCID(mac).Return("", &smithy.GenericAPIError{
+			Code:    "EC2MetadataError",
+			Message: "failed to make EC2Metadata request",
+		}),
 	)
 	agent := &ecsAgent{ec2MetadataClient: mockMetadata}
 	err, ok := agent.setVPCSubnet()

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -58,8 +58,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cloudwatchlogs_errors "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
@@ -381,8 +381,8 @@ func waitCloudwatchLogs(client *cloudwatchlogs.Client, params *cloudwatchlogs.Ge
 	for i := 0; i < 60; i++ {
 		resp, err := client.GetLogEvents(context.TODO(), params)
 		if err != nil {
-			awsError, ok := err.(awserr.Error)
-			if !ok || awsError.Code() != "ResourceNotFoundException" {
+			var notFoundErr *cloudwatchlogs_errors.ResourceNotFoundException
+			if !errors.As(err, &notFoundErr) {
 				return nil, err
 			}
 		} else if len(resp.Events) > 0 {

--- a/agent/eventhandler/task_handler_test.go
+++ b/agent/eventhandler/task_handler_test.go
@@ -42,7 +42,7 @@ import (
 	mock_retry "github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry/mock"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/smithy-go"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -122,7 +122,10 @@ func TestSendsEventsInvalidParametersEventsRemoved(t *testing.T) {
 	client.EXPECT().SubmitTaskStateChange(gomock.Any()).Do(func(interface{}) {
 		assert.Equal(t, 1, handler.tasksToEvents[taskARN].events.Len())
 		wg.Done()
-	}).Return(awserr.New(apierrors.ErrCodeInvalidParameterException, "", nil))
+	}).Return(&smithy.GenericAPIError{
+		Code:    apierrors.ErrCodeInvalidParameterException,
+		Message: "",
+	})
 
 	handler.AddStateChangeEvent(taskEvent, client)
 

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/smithy-go"
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
@@ -271,15 +270,6 @@ func newErrorResponse(err error, field, resourceARN string) *tmdsv2.ErrorRespons
 		ErrorField:   field,
 		ErrorMessage: err.Error(),
 		ResourceARN:  resourceARN,
-	}
-	// v1 error handling will be removed once v2 migraiton is complete.
-	if awsErr, ok := err.(awserr.Error); ok {
-		errResp.ErrorCode = awsErr.Code()
-		errResp.ErrorMessage = awsErr.Message()
-		if reqErr, ok := err.(awserr.RequestFailure); ok {
-			errResp.StatusCode = reqErr.StatusCode()
-			errResp.RequestId = reqErr.RequestID()
-		}
 	}
 
 	var apiErr smithy.APIError

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -33,10 +33,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
-
 	"github.com/pkg/errors"
 )
 
@@ -142,12 +140,6 @@ func Remove(slice []string, s int) []string {
 // interface of awserr and it has the same error code as
 // the passed in error code.
 func IsAWSErrorCodeEqual(err error, code string) bool {
-	// v1 error handling will be removed once v2 migraiton is complete.
-	awsErr, ok := err.(awserr.Error)
-	if ok {
-		return awsErr.Code() == code
-	}
-
 	var apiErr smithy.APIError
 	if errors.As(err, &apiErr) {
 		return apiErr.ErrorCode() == code

--- a/agent/utils/utils_test.go
+++ b/agent/utils/utils_test.go
@@ -28,7 +28,6 @@ import (
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stretchr/testify/assert"
@@ -114,16 +113,6 @@ func TestIsAWSErrorCodeEqual(t *testing.T) {
 		err  error
 		res  bool
 	}{
-		{
-			name: "Happy Path",
-			err:  awserr.New(apierrors.ErrCodeInvalidParameterException, "errMsg", errors.New("err")),
-			res:  true,
-		},
-		{
-			name: "Wrong Error Code",
-			err:  awserr.New("errCode", "errMsg", errors.New("err")),
-			res:  false,
-		},
 		{
 			name: "Happy Path SDKv2",
 			err:  &smithy.GenericAPIError{Code: apierrors.ErrCodeInvalidParameterException},

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/errors/errors.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/errors/errors.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/smithy-go"
 )
 
@@ -49,11 +48,6 @@ const (
 // registering the container instance is because of instance type being
 // changed
 func IsInstanceTypeChangedError(err error) bool {
-	// v1 error handling will be removed after all clients have been migrated to aws-sdk-go-v2
-	if awserr, ok := err.(awserr.Error); ok {
-		return strings.Contains(awserr.Message(), InstanceTypeChangedErrorMessage)
-	}
-
 	var apiErr smithy.APIError
 	if errors.As(err, &apiErr) {
 		return strings.Contains(apiErr.ErrorMessage(), InstanceTypeChangedErrorMessage)
@@ -63,11 +57,6 @@ func IsInstanceTypeChangedError(err error) bool {
 }
 
 func IsClusterNotFoundError(err error) bool {
-	// v1 error handling will be removed after all clients have been migrated to aws-sdk-go-v2
-	if awserr, ok := err.(awserr.Error); ok {
-		return strings.Contains(awserr.Message(), ClusterNotFoundErrorMessage)
-	}
-
 	var notFoundErr *types.ClusterNotFoundException
 	return errors.As(err, &notFoundErr)
 }

--- a/ecs-agent/api/errors/errors.go
+++ b/ecs-agent/api/errors/errors.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/smithy-go"
 )
 
@@ -49,11 +48,6 @@ const (
 // registering the container instance is because of instance type being
 // changed
 func IsInstanceTypeChangedError(err error) bool {
-	// v1 error handling will be removed after all clients have been migrated to aws-sdk-go-v2
-	if awserr, ok := err.(awserr.Error); ok {
-		return strings.Contains(awserr.Message(), InstanceTypeChangedErrorMessage)
-	}
-
 	var apiErr smithy.APIError
 	if errors.As(err, &apiErr) {
 		return strings.Contains(apiErr.ErrorMessage(), InstanceTypeChangedErrorMessage)
@@ -63,11 +57,6 @@ func IsInstanceTypeChangedError(err error) bool {
 }
 
 func IsClusterNotFoundError(err error) bool {
-	// v1 error handling will be removed after all clients have been migrated to aws-sdk-go-v2
-	if awserr, ok := err.(awserr.Error); ok {
-		return strings.Contains(awserr.Message(), ClusterNotFoundErrorMessage)
-	}
-
 	var notFoundErr *types.ClusterNotFoundException
 	return errors.As(err, &notFoundErr)
 }

--- a/ecs-agent/tmds/handlers/taskprotection/v1/handlers/handlers_test.go
+++ b/ecs-agent/tmds/handlers/taskprotection/v1/handlers/handlers_test.go
@@ -39,7 +39,6 @@ import (
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/aws/request"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 
 	"github.com/golang/mock/gomock"
@@ -229,7 +228,7 @@ func TestGetTaskProtection(t *testing.T) {
 			expectedResponseBody: types.TaskProtectionResponse{
 				Error: &types.ErrorResponse{
 					Arn:     taskARN,
-					Code:    request.CanceledErrorCode,
+					Code:    requestCanceled,
 					Message: "Timed out calling ECS Task Protection API",
 				},
 			},
@@ -463,7 +462,7 @@ func TestUpdateTaskProtection(t *testing.T) {
 			expectedResponseBody: types.TaskProtectionResponse{
 				Error: &types.ErrorResponse{
 					Arn:     taskARN,
-					Code:    request.CanceledErrorCode,
+					Code:    requestCanceled,
 					Message: "Timed out calling ECS Task Protection API",
 				},
 			},


### PR DESCRIPTION


### Summary
Migrate usage of awserr/request to aws-go-sdk-v2

### Implementation details
Following details from https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/handle-errors.html and moving to checking smithy-go errors, we are able to remove imports for `"github.com/aws/aws-sdk-go/aws/awserr"` and `"github.com/aws/aws-sdk-go/aws/request"`.

### Testing
- Locally testing
- `make test` and `make run-sudo-tests`

New tests cover the changes: N/A (existing tests)

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
