### PR TITLE
Use IPv6 addresses when generating extraHosts for IPv6-only awsvpc mode tasks

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -2195,18 +2195,16 @@ func (task *Task) generateENIExtraHosts() []string {
 
 	extraHosts := []string{}
 
+	ipAddresses := eni.GetIPV4Addresses()
 	if eni.IPv6Only() {
-		// Add IPv6 addresses only if task ENI is IPv6-only.
+		// Use IPv6 addresses only if task ENI is IPv6-only.
 		// Historically, IPv6 addresses are not added for dual stack ENIs.
-		for _, ip := range eni.GetIPV6Addresses() {
-			host := fmt.Sprintf("%s:%s", hostname, ip)
-			extraHosts = append(extraHosts, host)
-		}
-	} else {
-		for _, ip := range eni.GetIPV4Addresses() {
-			host := fmt.Sprintf("%s:%s", hostname, ip)
-			extraHosts = append(extraHosts, host)
-		}
+		ipAddresses = eni.GetIPV6Addresses()
+	}
+
+	for _, ip := range ipAddresses {
+		host := fmt.Sprintf("%s:%s", hostname, ip)
+		extraHosts = append(extraHosts, host)
 	}
 
 	return extraHosts

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -2195,10 +2195,20 @@ func (task *Task) generateENIExtraHosts() []string {
 
 	extraHosts := []string{}
 
-	for _, ip := range eni.GetIPV4Addresses() {
-		host := fmt.Sprintf("%s:%s", hostname, ip)
-		extraHosts = append(extraHosts, host)
+	if eni.IPv6Only() {
+		// Add IPv6 addresses only if task ENI is IPv6-only.
+		// Historically, IPv6 addresses are not added for dual stack ENIs.
+		for _, ip := range eni.GetIPV6Addresses() {
+			host := fmt.Sprintf("%s:%s", hostname, ip)
+			extraHosts = append(extraHosts, host)
+		}
+	} else {
+		for _, ip := range eni.GetIPV4Addresses() {
+			host := fmt.Sprintf("%s:%s", hostname, ip)
+			extraHosts = append(extraHosts, host)
+		}
 	}
+
 	return extraHosts
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
For IPv6-only awsvpc tasks, we want to populate host-to-IP mappings using the task's IPv6 addresses. This change captures that change. Behavior for dual-stack awsvpc tasks is not changing and they will continue to get host-to-IP mappings for their IPv4 addresses alone.

### Implementation details
<!-- How are the changes implemented? -->
* Update `task.generateENIExtraHosts` method so that it uses IPv6 addresses for generating extraHosts if the task ENI is IPv6-only.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

Temporarily modified Agent code to populate `some.host.name` in task payload ENI's `privateDNSName` field. This is because our backend is not fully ready yet. Ran an awsvpc task and verified that `extraHosts` config of the pause container has this DNS Name in docker host config and `/etc/hosts` of the task has it too.

```
[ec2-user@ipv6only ~]$ docker inspect c26e6dd480b5 | jq '.[0].HostConfig.ExtraHosts'
[
  "some.host.name:2600:1f14:323a:e000:741b:da9c:46b1:9d1d"
]
```

```
[ec2-user@ipv6only ~]$ docker exec 2c24dc44fee7 cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
2600:1f14:323a:e000:741b:da9c:46b1:9d1d	some.host.name

[ec2-user@ipv6only ~]$ docker exec 2c24dc44fee7 ip -6 addr show eth0
25: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP group default qlen 1000
    altname enp0s6
    altname eni-030cda50d54386290
    altname device-number-1.0
    inet6 2600:1f14:323a:e000:741b:da9c:46b1:9d1d/64 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::7d:b3ff:fe74:7a6d/64 scope link proto kernel_ll
       valid_lft forever preferred_lft forever
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: Use IPv6 addresses when generating extraHosts for IPv6-only awsvpc mode tasks

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
