### PR TITLE
feat(ipv6): dual stack endpoint option in ecs client

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client_option.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client_option.go
@@ -31,6 +31,14 @@ func WithFIPSDetected(val bool) ECSClientOption {
 	}
 }
 
+// WithDualStackEnabled is an ECSClientOption that configures the
+// ecsClient.isDualStackEnabled with the value passed as a parameter.
+func WithDualStackEnabled(val bool) ECSClientOption {
+	return func(client *ecsClient) {
+		client.isDualStackEnabled = val
+	}
+}
+
 // WithDiscoverPollEndpointCacheTTL is an ECSClientOption that configures the
 // ecsClient.pollEndpointCache.ttl with the value passed as a parameter.
 func WithDiscoverPollEndpointCacheTTL(t *async.TTL) ECSClientOption {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
@@ -130,6 +130,8 @@ type NetworkInterfaceProperties struct {
 	PrivateDNSName string `json:"PrivateDNSName,omitempty"`
 	// SubnetGatewayIPV4Address is the IPv4 gateway address for the network interface.
 	SubnetGatewayIPV4Address string `json:"SubnetGatewayIpv4Address,omitempty"`
+	// SubnetGatewayIPV6Address is the IPv6 gateway address for the network interface.
+	SubnetGatewayIPV6Address string `json:"SubnetGatewayIPV6Address,omitempty"`
 }
 
 // StatsResponse is the v4 Stats response for a container.

--- a/ecs-agent/api/ecs/client/ecs_client_option.go
+++ b/ecs-agent/api/ecs/client/ecs_client_option.go
@@ -31,6 +31,14 @@ func WithFIPSDetected(val bool) ECSClientOption {
 	}
 }
 
+// WithDualStackEnabled is an ECSClientOption that configures the
+// ecsClient.isDualStackEnabled with the value passed as a parameter.
+func WithDualStackEnabled(val bool) ECSClientOption {
+	return func(client *ecsClient) {
+		client.isDualStackEnabled = val
+	}
+}
+
 // WithDiscoverPollEndpointCacheTTL is an ECSClientOption that configures the
 // ecsClient.pollEndpointCache.ttl with the value passed as a parameter.
 func WithDiscoverPollEndpointCacheTTL(t *async.TTL) ECSClientOption {

--- a/ecs-agent/tmds/handlers/v4/handlers_test.go
+++ b/ecs-agent/tmds/handlers/v4/handlers_test.go
@@ -63,6 +63,7 @@ const (
 	macAddress               = "06:96:9a:ce:a6:ce"
 	privateDNSName           = "ip-172-31-47-69.us-west-2.compute.internal"
 	subnetGatewayIpv4Address = "172.31.32.1/20"
+	subnetGatewayIpv6Address = "2600:1f14:30ab:6901::/64"
 	externalReason           = "external reason"
 	containerArn             = "arn:aws:ecs:ap-northnorth-1:NNN:container/NNNNNNNN-aaaa-4444-bbbb-00000000000"
 	timestamp                = "2025-04-29T16:56:17.446028948Z"
@@ -81,7 +82,7 @@ const (
 	containerResponseJSON = `{"DockerId":"%s","Name":"%s","DockerName":"%s","Image":"%s","ImageID":"%s",` +
 		`"Ports":[{"ContainerPort":%d,"Protocol":"%s","HostPort":%d}],"Labels":{"foo":"bar"},"DesiredStatus":"%s",` +
 		`"KnownStatus":"%s","Limits":{"CPU":%d,"Memory":%d},"Type":"%s","ContainerARN":"%s","Networks":[{"NetworkMode":"%s",` +
-		`"IPv4Addresses":["%s"],"AttachmentIndex":0,"MACAddress":"%s","IPv4SubnetCIDRBlock":"%s","PrivateDNSName":"%s","SubnetGatewayIpv4Address":"%s"}]}`
+		`"IPv4Addresses":["%s"],"AttachmentIndex":0,"MACAddress":"%s","IPv4SubnetCIDRBlock":"%s","PrivateDNSName":"%s","SubnetGatewayIpv4Address":"%s","SubnetGatewayIPV6Address":"%s"}]}`
 	taskResponseJSON = `{"Cluster":"%s","TaskARN":"%s","Family":"%s","Revision":"%s","DesiredStatus":"%s",` +
 		`"KnownStatus":"%s","Limits":{"CPU":%d,"Memory":%d},"PullStartedAt":"%s","PullStoppedAt":"%s","ExecutionStoppedAt":"%s",` +
 		`"AvailabilityZone":"%s","LaunchType":"%s","Containers":[%s],"VPCID":"%s","ClockDrift":{"ClockErrorBound":%d,` +
@@ -139,6 +140,7 @@ var (
 				MACAddress:               macAddress,
 				PrivateDNSName:           privateDNSName,
 				SubnetGatewayIPV4Address: subnetGatewayIpv4Address,
+				SubnetGatewayIPV6Address: subnetGatewayIpv6Address,
 			}},
 		},
 	}
@@ -180,6 +182,7 @@ var (
 		iPv4SubnetCIDRBlock,
 		privateDNSName,
 		subnetGatewayIpv4Address,
+		subnetGatewayIpv6Address,
 	)
 	happyContainerStatsResponseJSON = fmt.Sprintf(containerStatsResponseJSON,
 		numProcs,

--- a/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/ecs-agent/tmds/handlers/v4/state/response.go
@@ -130,6 +130,8 @@ type NetworkInterfaceProperties struct {
 	PrivateDNSName string `json:"PrivateDNSName,omitempty"`
 	// SubnetGatewayIPV4Address is the IPv4 gateway address for the network interface.
 	SubnetGatewayIPV4Address string `json:"SubnetGatewayIpv4Address,omitempty"`
+	// SubnetGatewayIPV6Address is the IPv6 gateway address for the network interface.
+	SubnetGatewayIPV6Address string `json:"SubnetGatewayIPV6Address,omitempty"`
 }
 
 // StatsResponse is the v4 Stats response for a container.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
ECS client option WithDualStackEnabled and SubnetGatewayIPV6Address field under NetworkInterfaceProperties

### Implementation details
This change adds support for dual stack endpoint configured ECS client.

### Testing
Tested with new unit tests

```
go test -tags=unit -v ./api/ecs/client
go test -tags=unit -v ./tmds/handlers/v4/
```

### Description for the changelog
* Enhancement - Add a DualStackEnabled ECS client option
* Enhancement - Add a SubnetGatewayIPV6Address field under NetworkInterfaceProperties

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No

**Does this PR include the addition of new environment variables in the README?** No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
