### PR TITLE
Pass IPv6 subnet gateway to CNI plugins for IPv6 only tasks

### DIFF
--- a/agent/ecscni/plugin_linux_test.go
+++ b/agent/ecscni/plugin_linux_test.go
@@ -537,7 +537,7 @@ func TestConstructVPCENINetworkConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "IPv6 only",
+			name: "IPv6 only - no subnet gateway prefix",
 			iface: &ni.NetworkInterface{
 				ID:                       eniID,
 				IPV6Addresses:            []*ni.IPV6Address{{Address: ipv6Address}},
@@ -547,6 +547,22 @@ func TestConstructVPCENINetworkConfig(t *testing.T) {
 			expected: VPCENIPluginConfig{
 				Type:               "vpc-eni",
 				ENIIPAddresses:     []string{eniIPV6AddressWithBlockSize},
+				ENIMACAddress:      eniMACAddress,
+				BlockIMDS:          true,
+				GatewayIPAddresses: []string{"1:2:3:4::1"},
+			},
+		},
+		{
+			name: "IPv6 only - non empty subnet gateway prefix",
+			iface: &ni.NetworkInterface{
+				ID:                       eniID,
+				IPV6Addresses:            []*ni.IPV6Address{{Address: ipv6Address}},
+				MacAddress:               eniMACAddress,
+				SubnetGatewayIPV6Address: "1:2:3:4::1/60",
+			},
+			expected: VPCENIPluginConfig{
+				Type:               "vpc-eni",
+				ENIIPAddresses:     []string{ipv6Address + "/60"},
 				ENIMACAddress:      eniMACAddress,
 				BlockIMDS:          true,
 				GatewayIPAddresses: []string{"1:2:3:4::1"},

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface.go
@@ -248,8 +248,16 @@ func (ni *NetworkInterface) GetIPAddressesWithPrefixLength() []string {
 	for _, addr := range ni.IPV4Addresses {
 		addresses = append(addresses, addr.Address+"/"+ni.GetIPv4SubnetPrefixLength())
 	}
-	for _, addr := range ni.IPV6Addresses {
-		addresses = append(addresses, addr.Address+"/"+IPv6SubnetPrefixLength)
+
+	if ni.IPv6Only() {
+		for _, addr := range ni.IPV6Addresses {
+			addresses = append(addresses, addr.Address+"/"+ni.GetIPv6SubnetPrefixLength())
+		}
+	} else {
+		// To be backwards compatible, we should use this for dual stack tasks.
+		for _, addr := range ni.IPV6Addresses {
+			addresses = append(addresses, addr.Address+"/"+IPv6SubnetPrefixLength)
+		}
 	}
 
 	return addresses
@@ -262,6 +270,15 @@ func (ni *NetworkInterface) GetIPv4SubnetPrefixLength() string {
 	}
 
 	return ni.ipv4SubnetPrefixLength
+}
+
+// GetIPv6SubnetPrefixLength returns the IPv6 prefix length of the NetworkInterface's subnet.
+func (ni *NetworkInterface) GetIPv6SubnetPrefixLength() string {
+	prefixLen := IPv6SubnetPrefixLength
+	if strings.Contains(ni.SubnetGatewayIPV6Address, "/") {
+		prefixLen = strings.Split(ni.SubnetGatewayIPV6Address, "/")[1]
+	}
+	return prefixLen
 }
 
 // GetIPv4SubnetCIDRBlock returns the IPv4 CIDR block, if any, of the NetworkInterface's subnet.

--- a/ecs-agent/netlib/model/ecscni/eni_config.go
+++ b/ecs-agent/netlib/model/ecscni/eni_config.go
@@ -49,17 +49,24 @@ func NewENIConfig(
 	stayDown bool,
 	mtu int,
 ) *ENIConfig {
-	return &ENIConfig{
+	eniConfig := &ENIConfig{
 		CNIConfig:             cniConfig,
 		ENIID:                 eni.ID,
 		MACAddress:            eni.MacAddress,
 		IPAddresses:           eni.GetIPAddressesWithPrefixLength(),
-		GatewayIPAddresses:    []string{eni.GetSubnetGatewayIPv4Address()},
+		GatewayIPAddresses:    []string{},
 		BlockInstanceMetadata: blockInstanceMetadata,
 		StayDown:              stayDown,
 		DeviceName:            eni.DeviceName,
 		MTU:                   mtu,
 	}
+
+	if eni.IPv6Only() {
+		eniConfig.GatewayIPAddresses = []string{eni.GetSubnetGatewayIPv6Address()}
+	} else {
+		eniConfig.GatewayIPAddresses = []string{eni.GetSubnetGatewayIPv4Address()}
+	}
+	return eniConfig
 }
 
 func (ec *ENIConfig) String() string {

--- a/ecs-agent/netlib/model/networkinterface/networkinterface.go
+++ b/ecs-agent/netlib/model/networkinterface/networkinterface.go
@@ -248,8 +248,16 @@ func (ni *NetworkInterface) GetIPAddressesWithPrefixLength() []string {
 	for _, addr := range ni.IPV4Addresses {
 		addresses = append(addresses, addr.Address+"/"+ni.GetIPv4SubnetPrefixLength())
 	}
-	for _, addr := range ni.IPV6Addresses {
-		addresses = append(addresses, addr.Address+"/"+IPv6SubnetPrefixLength)
+
+	if ni.IPv6Only() {
+		for _, addr := range ni.IPV6Addresses {
+			addresses = append(addresses, addr.Address+"/"+ni.GetIPv6SubnetPrefixLength())
+		}
+	} else {
+		// To be backwards compatible, we should use this for dual stack tasks.
+		for _, addr := range ni.IPV6Addresses {
+			addresses = append(addresses, addr.Address+"/"+IPv6SubnetPrefixLength)
+		}
 	}
 
 	return addresses
@@ -262,6 +270,15 @@ func (ni *NetworkInterface) GetIPv4SubnetPrefixLength() string {
 	}
 
 	return ni.ipv4SubnetPrefixLength
+}
+
+// GetIPv6SubnetPrefixLength returns the IPv6 prefix length of the NetworkInterface's subnet.
+func (ni *NetworkInterface) GetIPv6SubnetPrefixLength() string {
+	prefixLen := IPv6SubnetPrefixLength
+	if strings.Contains(ni.SubnetGatewayIPV6Address, "/") {
+		prefixLen = strings.Split(ni.SubnetGatewayIPV6Address, "/")[1]
+	}
+	return prefixLen
 }
 
 // GetIPv4SubnetCIDRBlock returns the IPv4 CIDR block, if any, of the NetworkInterface's subnet.

--- a/ecs-agent/netlib/platform/cniconf_linux.go
+++ b/ecs-agent/netlib/platform/cniconf_linux.go
@@ -156,13 +156,13 @@ func createBranchENIConfig(
 		ifName = fmt.Sprintf("eth%d", iface.Index)
 	}
 
-	return &ecscni.VPCBranchENIConfig{
+	eniConfig := &ecscni.VPCBranchENIConfig{
 		CNIConfig:          cniConfig,
 		TrunkMACAddress:    iface.InterfaceVlanProperties.TrunkInterfaceMacAddress,
 		BranchVlanID:       iface.InterfaceVlanProperties.VlanID,
 		BranchMACAddress:   iface.MacAddress,
 		IPAddresses:        iface.GetIPAddressesWithPrefixLength(),
-		GatewayIPAddresses: []string{iface.GetSubnetGatewayIPv4Address()},
+		GatewayIPAddresses: []string{},
 		BlockIMDS:          blockInstanceMetadata,
 		InterfaceType:      ifType,
 		UID:                strconv.Itoa(int(iface.UserID)),
@@ -172,6 +172,12 @@ func createBranchENIConfig(
 		// This is used by vpc-branch-eni plugin for the name of the VLAN/TAP interface.
 		IfName: ifName,
 	}
+	if iface.IPv6Only() {
+		eniConfig.GatewayIPAddresses = []string{iface.GetSubnetGatewayIPv6Address()}
+	} else {
+		eniConfig.GatewayIPAddresses = []string{iface.GetSubnetGatewayIPv4Address()}
+	}
+	return eniConfig
 }
 
 // NewTunnelConfig creates a new vpc-tunnel CNI plugin configuration.

--- a/ecs-agent/netlib/platform/common_linux_test.go
+++ b/ecs-agent/netlib/platform/common_linux_test.go
@@ -327,7 +327,7 @@ func testRegularENIConfiguration(t *testing.T) {
 		stateDBDir: "dummy-db-dir",
 	}
 
-	eni := getTestRegularENI()
+	eni := getTestRegularV4ENI()
 
 	// When the ENI is the primary ENI.
 	eniConfig := createENIPluginConfigs(netNSPath, eni)
@@ -377,7 +377,7 @@ func testBranchENIConfiguration(t *testing.T) {
 		stateDBDir: "dummy-db-dir",
 	}
 
-	branchENI := getTestBranchENI()
+	branchENI := getTestBranchV4ENI()
 	branchENI.DesiredStatus = status.NetworkReadyPull
 	bridgeConfig := createBridgePluginConfig(netNSPath)
 	cniConfig := createBranchENIConfig(netNSPath, branchENI, VPCBranchENIInterfaceTypeVlan, blockInstanceMetadataDefault)

--- a/ecs-agent/netlib/platform/common_test.go
+++ b/ecs-agent/netlib/platform/common_test.go
@@ -37,7 +37,7 @@ const (
 	deviceName            = "eth1"
 	eniMAC                = "f0:5c:89:a3:ab:01"
 	subnetGatewayIPv4CIDR = "10.1.0.1/24"
-	subnetGatewayIPv6CIDR = "2600:1f14:30ab:6902::/64"
+	subnetGatewayIPv6CIDR = "2600:1f14:30ab:6902::/60"
 	primaryENIName        = "primary-eni"
 	secondaryENIName      = "secondary-eni"
 )

--- a/ecs-agent/netlib/platform/firecracker_linux_test.go
+++ b/ecs-agent/netlib/platform/firecracker_linux_test.go
@@ -159,7 +159,7 @@ func TestFirecracker_BranchENIConfiguration(t *testing.T) {
 		common: commonPlatform,
 	}
 
-	branchENI := getTestBranchENI()
+	branchENI := getTestBranchV4ENI()
 
 	cniConfig := createBranchENIConfig(netNSPath, branchENI, VPCBranchENIInterfaceTypeVlan, false)
 	cniClient.EXPECT().Add(gomock.Any(), cniConfig).Return(nil, nil).Times(1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This change is to pass IPv6 subnet gateway to CNI plugins (ecs-cni & vpc-cni) to setup the task ENI for IPv6 only tasks.

### Implementation details
<!-- How are the changes implemented? -->
1. Use the IPv6 subnet gateway value from control plane in CNI plugins
2. For IPv6 only tasks, use the IPv6 subnet prefix of associated IPv6 CIDR to generate the IPv6 with block size, instead of the hardcoded value of /64. This IPv6 address with block size will be passed to CNI plugins as well.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

Yes

### manual testing
1. Able to launch one IPv6 only task on EC2 mode with the custom AMI which has this change. The task uses one IPv6 subnet whose CIDR prefix is 60.
```
[root@ip-10-0-135-124 ecs]# cat ecs-cni-warmpool.log 
2025-05-15T22:45:57Z [INFO] version: {"version":"2020.09.0","dirty":false,"gitShortHash":"50a9a47e"}
2025-05-15T22:46:40Z [DEBUG] Loaded config: {{0.3.0 network-name ecs-bridge map[] {ecs-ipam} {[]  [] []}} fargate-bridge 1500}
2025-05-15T22:46:40Z [INFO] msg="Creating the bridge" 
...
2025-05-15T22:46:40Z [DEBUG] Loaded config: {{0.3.0 network-name ecs-eni map[] {} {[]  [] []}} eni-02776c7e29acaa546 06:46:37:d6:7d:09 [2600:1f14:30ab:6914:ba:3f09:8a87:507e/60] [2600:1f14:30ab:6910::1] true false 9001}
2025-05-15T22:46:40Z [INFO] Found network device for the ENI (mac address=06:46:37:d6:7d:09): eth1
2025-05-15T22:46:40Z [INFO] ENI 06:46:37:d6:7d:09 (device name=eth1) has been assigned to the container's namespace
[root@ip-10-0-135-124 ecs]#
```
2. Able to launch one IPv6 only task on EC2 mode with the custom AMI 
```
...
2025-05-15T22:51:06Z [DEBUG] Loaded config: {{0.3.0 network-name ecs-eni map[] {} {[]  [] []}} eni-0ac687efa5d3dd49f 06:7d:8d:49:c0:ef [2600:1f14:30ab:6904:6e40:c74e:6626:c2cc/64] [2600:1f14:30ab:6904::1] true false 9001}
2025-05-15T22:51:06Z [INFO] Found network device for the ENI (mac address=06:7d:8d:49:c0:ef): eth1
2025-05-15T22:51:06Z [INFO] ENI 06:7d:8d:49:c0:ef (device name=eth1) has been assigned to the container's namespace
```
3. Able to launch one IPv4 task on EC2 mode with custom AMI via vpc cni
```
bash-5.2# cat ecs-cni-warmpool.log 
2025-05-16T01:01:42Z [INFO] version: {"version":"2020.09.0","dirty":false,"gitShortHash":"50a9a47e"}
2025-05-16T01:13:00Z [DEBUG] Loaded config: {{0.3.0 network-name ecs-bridge map[] {ecs-ipam} {[]  [] []}} fargate-bridge 1500}
2025-05-16T01:13:00Z [INFO] msg="Creating the bridge" netns=/var/run/netns/cf4d28c8d2a64749872c47856d6d0293-06f72a14cf5f ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam
2025-05-16T01:13:00Z [INFO] msg="Creating veth pair for namespace" netns=/var/run/netns/cf4d28c8d2a64749872c47856d6d0293-06f72a14cf5f ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam
2025-05-16T01:13:00Z [INFO] msg="Attaching veth pair to bridge" netns=/var/run/netns/cf4d28c8d2a64749872c47856d6d0293-06f72a14cf5f ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam hostVethName=vethe850e9e6
2025-05-16T01:13:00Z [INFO] msg="Running IPAM plugin ADD" netns=/var/run/netns/cf4d28c8d2a64749872c47856d6d0293-06f72a14cf5f ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam hostVethName=vethe850e9e6
2025-05-16T01:13:00Z [INFO] msg="Configuring container's interface" netns=/var/run/netns/cf4d28c8d2a64749872c47856d6d0293-06f72a14cf5f ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam hostVethName=vethe850e9e6
2025-05-16T01:13:00Z [INFO] msg="Configuring bridge" netns=/var/run/netns/cf4d28c8d2a64749872c47856d6d0293-06f72a14cf5f ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam hostVethName=vethe850e9e6
bash-5.2#
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Feature: support task ENI setup for IPv6 only tasks

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
