### PR TITLE
Add support for IPv6 targets to network-latency and network-packet-loss faults

### DIFF
--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
@@ -207,9 +207,9 @@ var (
 		"SourcesToFilter": ipSourcesToFilter,
 	}
 
-	ipSources = []string{"52.95.154.1", "52.95.154.2"}
+	ipSources = []string{"52.95.154.1", "52.95.154.2", "1:2:3:4::"}
 
-	ipSourcesToFilter = []string{"8.8.8.8"}
+	ipSourcesToFilter = []string{"8.8.8.8", "5:5:5:5::"}
 
 	startNetworkBlackHolePortTestPrefix = fmt.Sprintf(startFaultRequestType, types.BlackHolePortFaultType)
 	stopNetworkBlackHolePortTestPrefix  = fmt.Sprintf(stopFaultRequestType, types.BlackHolePortFaultType)
@@ -1825,8 +1825,8 @@ func generateStartNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
 					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
 				)
-				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(5).Return(mockCMD)
-				mockCMD.EXPECT().CombinedOutput().Times(5).Return([]byte(tcCommandEmptyOutput), nil)
+				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(7).Return(mockCMD)
+				mockCMD.EXPECT().CombinedOutput().Times(7).Return([]byte(tcCommandEmptyOutput), nil)
 			},
 			expectedResponseJSON: happyFaultRunningResponse,
 		},
@@ -1886,8 +1886,8 @@ func generateStartNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
 					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
 				)
-				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(4).Return(mockCMD)
-				mockCMD.EXPECT().CombinedOutput().Times(4).Return([]byte(tcCommandEmptyOutput), nil)
+				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(5).Return(mockCMD)
+				mockCMD.EXPECT().CombinedOutput().Times(5).Return([]byte(tcCommandEmptyOutput), nil)
 			},
 			expectedResponseJSON: happyFaultRunningResponse,
 		},
@@ -2413,8 +2413,8 @@ func generateStartNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
 					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
 				)
-				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(5).Return(mockCMD)
-				mockCMD.EXPECT().CombinedOutput().Times(5).Return([]byte(tcCommandEmptyOutput), nil)
+				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(7).Return(mockCMD)
+				mockCMD.EXPECT().CombinedOutput().Times(7).Return([]byte(tcCommandEmptyOutput), nil)
 			},
 			expectedResponseJSON: happyFaultRunningResponse,
 		},
@@ -2473,8 +2473,8 @@ func generateStartNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
 					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
 				)
-				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(4).Return(mockCMD)
-				mockCMD.EXPECT().CombinedOutput().Times(4).Return([]byte(tcCommandEmptyOutput), nil)
+				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(5).Return(mockCMD)
+				mockCMD.EXPECT().CombinedOutput().Times(5).Return([]byte(tcCommandEmptyOutput), nil)
 			},
 			expectedResponseJSON: happyFaultRunningResponse,
 		},

--- a/ecs-agent/tmds/handlers/fault/v1/types/types_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/types/types_test.go
@@ -43,35 +43,6 @@ func TestNetworkBlackholePortAddSourceToFilterIfNotAlready(t *testing.T) {
 	})
 }
 
-// Tests for validateNetworkFaultRequestSource function that parses IPv4 and IPv4 CIDR blocks.
-func TestValidateNetworkFaultRequestSources(t *testing.T) {
-	tcs := []struct {
-		Name          string
-		Input         string
-		ShouldSucceed bool
-	}{
-		{"Valid IPv4", "1.2.3.4", true},
-		{"Valid IPv4 CIDR", "1.2.3.4/10", true},
-		{"Valid IPv6", "2001:db8::1", false},
-		{"Valid full IPv6", "2001:0db8:0000:0000:0000:0000:0000:0001", false},
-		{"IPv6 CIDR", "::1/128", false},
-		{"Invalid input", "invalid", false},
-		{"IPv4 with invalid CIDR", "192.168.1.0/", false},
-		{"IPv6 with invalid CIDR", "2001:db8::/129", false},
-		{"Empty input", "", false},
-	}
-	for _, tc := range tcs {
-		t.Run(tc.Name, func(t *testing.T) {
-			err := validateNetworkFaultRequestSource(tc.Input, "input")
-			if tc.ShouldSucceed {
-				require.NoError(t, err)
-			} else {
-				require.EqualError(t, err, fmt.Sprintf("invalid value %s for parameter input", tc.Input))
-			}
-		})
-	}
-}
-
 func TestRequireIPInRequestSources(t *testing.T) {
 	tcs := []struct {
 		Name          string


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This change extends support for network-latency and network-packet-loss faults to IPv6 targets. Today only IPv4 targets are accepted by these APIs but after this change IPv6 targets are accepted as well. 

### Implementation details
<!-- How are the changes implemented? -->
Request validation is changed for the APIs so that they accept IPv6 and IPv6 CIDR `Sources` (targets) and `SourcesToFilter` (protected targets). 

`tc` commands used for network-latency and network-packet-loss faults are updated so that - 
1. Protocol specified in the `filter add` commands is `all` instead of `ip`. `all` applies to all protocols whereas `ip` applies to IPv4 only. 
2. Matcher specified in the `filter add` commands uses `ip` selector for IPv4 targets and `ip6` for IPv6 targets.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Performed a variety of manual tests including the cases below. 
1. IPv6 target only with and without a target to filter (protect).
2. IPv6 CIDR target only with and without a target to filter (protect).
3. IPv4 and IPv6 targets with no targets to filter. 
4. IPv4 and IPv6 targets with an IPv4 target protected. 
5. IPv4 and IPv6 targets with an IPv6 target protected. 

In call cases above, the faults worked as expected. There was no network degradation for traffic to filtered targets but there was expected network degradation for traffic to destinations matching the targets.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: Add support for IPv6 targets to network-latency and network-packet-loss faults

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
