### PR TITLE
SubnetGatewayIPV6Address and IPv6SubnetCIDRBlock metadata for IPv6-only tasks

### DIFF
--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -161,6 +161,12 @@ func newNetworkInterfaceProperties(task *apitask.Task) (tmdsv4.NetworkInterfaceP
 		attachmentIndexPtr = &vpcIndex
 	}
 
+	var subnetGatewayIPv6Address string
+	if eni.IPv6Only() {
+		// Only populate SubnetGatewayIPv6Address for IPv6-only task ENIs as we do not
+		// populate it for dual-stack ENIs for historical reasons
+		subnetGatewayIPv6Address = eni.SubnetGatewayIPV6Address
+	}
 	return tmdsv4.NetworkInterfaceProperties{
 		// TODO this is hard-coded to `0` for now. Once backend starts populating
 		// `Index` field for an ENI, we should set it as per that. Since we
@@ -173,6 +179,7 @@ func newNetworkInterfaceProperties(task *apitask.Task) (tmdsv4.NetworkInterfaceP
 		DomainNameSearchList:     eni.DomainNameSearchList,
 		PrivateDNSName:           eni.PrivateDNSName,
 		SubnetGatewayIPV4Address: eni.SubnetGatewayIPV4Address,
+		SubnetGatewayIPV6Address: subnetGatewayIPv6Address,
 	}, nil
 }
 

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface.go
@@ -296,7 +296,12 @@ func (ni *NetworkInterface) GetIPv4SubnetCIDRBlock() string {
 // GetIPv6SubnetCIDRBlock returns the IPv6 CIDR block, if any, of the NetworkInterface's subnet.
 func (ni *NetworkInterface) GetIPv6SubnetCIDRBlock() string {
 	if ni.ipv6SubnetCIDRBlock == "" && len(ni.IPV6Addresses) > 0 {
-		ipv6Addr := ni.IPV6Addresses[0].Address + "/" + IPv6SubnetPrefixLength
+		// Hardcoded prefix length is used for dual-stack ENIs for historical reasons
+		prefixLength := IPv6SubnetPrefixLength
+		if ni.IPv6Only() {
+			prefixLength = ni.GetIPv6SubnetPrefixLength()
+		}
+		ipv6Addr := ni.IPV6Addresses[0].Address + "/" + prefixLength
 		_, ipv6Net, err := net.ParseCIDR(ipv6Addr)
 		if err == nil {
 			ni.ipv6SubnetCIDRBlock = ipv6Net.String()

--- a/ecs-agent/netlib/model/networkinterface/networkinterface.go
+++ b/ecs-agent/netlib/model/networkinterface/networkinterface.go
@@ -296,7 +296,12 @@ func (ni *NetworkInterface) GetIPv4SubnetCIDRBlock() string {
 // GetIPv6SubnetCIDRBlock returns the IPv6 CIDR block, if any, of the NetworkInterface's subnet.
 func (ni *NetworkInterface) GetIPv6SubnetCIDRBlock() string {
 	if ni.ipv6SubnetCIDRBlock == "" && len(ni.IPV6Addresses) > 0 {
-		ipv6Addr := ni.IPV6Addresses[0].Address + "/" + IPv6SubnetPrefixLength
+		// Hardcoded prefix length is used for dual-stack ENIs for historical reasons
+		prefixLength := IPv6SubnetPrefixLength
+		if ni.IPv6Only() {
+			prefixLength = ni.GetIPv6SubnetPrefixLength()
+		}
+		ipv6Addr := ni.IPV6Addresses[0].Address + "/" + prefixLength
 		_, ipv6Net, err := net.ParseCIDR(ipv6Addr)
 		if err == nil {
 			ni.ipv6SubnetCIDRBlock = ipv6Net.String()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR makes the following two changes to task metadata returned for IPv6-only awsvpc mode tasks. 
1. A new `SubnetGatewayIPV6Address` field will be returned. Its value will be the subnet gateway IPv6 address used to create the default route for the task.
2. Existing `IPv6SubnetCIDRBlock` field will be computed based on the actual subnet prefix length instead of the hardcoded `/64` that is used for dual-stack tasks today.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

IPv6-only subnet with `/64` prefix -
```
ip-10-0-0-23 ❱ docker exec 6759f9efa687 sh -c 'curl -s $ECS_CONTAINER_METADATA_URI_V4' | jq '.Networks'
[
  {
    "NetworkMode": "awsvpc",
    "IPv6Addresses": [
      "2600:1f14:323a:e000:9233:2126:1e0f:ced1"
    ],
    "AttachmentIndex": 0,
    "MACAddress": "02:f2:3d:fe:5d:bb",
    "IPv6SubnetCIDRBlock": "2600:1f14:323a:e000::/64",
    "DomainNameServers": [
      "fd00:ec2::253"
    ],
    "DomainNameSearchList": [
      "us-west-2.compute.internal"
    ],
    "SubnetGatewayIPV6Address": "2600:1f14:323a:e000::1/64"
  }
]
```

IPv6-only subnet with `/60` prefix - 
```
ip-10-0-0-23 ❱ docker exec 6e086c5276d2 sh -c 'curl -s $ECS_CONTAINER_METADATA_URI_V4' | jq '.Networks'
[
  {
    "NetworkMode": "awsvpc",
    "IPv6Addresses": [
      "2600:1f14:323a:e014:588a:9986:158:b9ba"
    ],
    "AttachmentIndex": 0,
    "MACAddress": "02:5b:44:5e:c7:ef",
    "IPv6SubnetCIDRBlock": "2600:1f14:323a:e010::/60",
    "DomainNameServers": [
      "fd00:ec2::253"
    ],
    "DomainNameSearchList": [
      "us-west-2.compute.internal"
    ],
    "SubnetGatewayIPV6Address": "2600:1f14:323a:e010::1/60"
  }
]
```

Dual-stack subnet with `/60` prefix (prefix gets hardcoded as /64 and SubnetGatewayIPv6Address is not populated) - 
```
ip-10-0-0-23 ❱ docker exec 234da5144aea sh -c 'curl -s $ECS_CONTAINER_METADATA_URI_V4' | jq '.Networks'
[
  {
    "NetworkMode": "awsvpc",
    "IPv4Addresses": [
      "10.0.5.147"
    ],
    "IPv6Addresses": [
      "2600:1f14:323a:e023:170:b7b:3c6d:9a82"
    ],
    "AttachmentIndex": 0,
    "MACAddress": "02:b1:6e:6e:d3:17",
    "IPv4SubnetCIDRBlock": "10.0.5.0/24",
    "IPv6SubnetCIDRBlock": "2600:1f14:323a:e023::/64",
    "PrivateDNSName": "ip-10-0-5-147.us-west-2.compute.internal",
    "SubnetGatewayIpv4Address": "10.0.5.1/24"
  }
]
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: SubnetGatewayIPV6Address and IPv6SubnetCIDRBlock metadata for IPv6-only tasks

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
