### PR TITLE
Dual stack EC2 client on IPv6-only instances

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -210,7 +210,11 @@ func newAgent(blackholeEC2Metadata bool, acceptInsecureCert *bool) (agent, error
 		cfg.NoIID = true
 	}
 
-	ec2Client, err := ec2.NewClientImpl(cfg.AWSRegion)
+	ec2ClientDualStackEndpointState := aws.DualStackEndpointStateDisabled
+	if cfg.InstanceIPCompatibility.IsIPv6Only() {
+		ec2ClientDualStackEndpointState = aws.DualStackEndpointStateEnabled
+	}
+	ec2Client, err := ec2.NewClientImpl(cfg.AWSRegion, ec2ClientDualStackEndpointState)
 	if err != nil {
 		logger.Critical("Error creating EC2 client", logger.Fields{
 			field.Error: err,

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/ec2/ec2_client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/ec2/ec2_client.go
@@ -54,7 +54,10 @@ type ClientImpl struct {
 	client ClientSDK
 }
 
-func NewClientImpl(awsRegion string) (Client, error) {
+func NewClientImpl(
+	awsRegion string,
+	dualStackEndpointState aws.DualStackEndpointState,
+) (Client, error) {
 	credentialsProvider := providers.NewInstanceCredentialsCache(
 		false,
 		providers.NewRotatingSharedCredentialsProviderV2(),
@@ -65,6 +68,7 @@ func NewClientImpl(awsRegion string) (Client, error) {
 		config.WithRegion(awsRegion),
 		config.WithCredentialsProvider(credentialsProvider),
 		config.WithRetryMaxAttempts(clientRetriesNum),
+		config.WithUseDualStackEndpoint(dualStackEndpointState),
 	)
 	if err != nil {
 		return nil, err

--- a/ecs-agent/ec2/ec2_client.go
+++ b/ecs-agent/ec2/ec2_client.go
@@ -54,7 +54,10 @@ type ClientImpl struct {
 	client ClientSDK
 }
 
-func NewClientImpl(awsRegion string) (Client, error) {
+func NewClientImpl(
+	awsRegion string,
+	dualStackEndpointState aws.DualStackEndpointState,
+) (Client, error) {
 	credentialsProvider := providers.NewInstanceCredentialsCache(
 		false,
 		providers.NewRotatingSharedCredentialsProviderV2(),
@@ -65,6 +68,7 @@ func NewClientImpl(awsRegion string) (Client, error) {
 		config.WithRegion(awsRegion),
 		config.WithCredentialsProvider(credentialsProvider),
 		config.WithRetryMaxAttempts(clientRetriesNum),
+		config.WithUseDualStackEndpoint(dualStackEndpointState),
 	)
 	if err != nil {
 		return nil, err

--- a/ecs-agent/ec2/ec2_client_test.go
+++ b/ecs-agent/ec2/ec2_client_test.go
@@ -34,7 +34,7 @@ func TestCreateTags(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockClientSDK := mock_ec2.NewMockClientSDK(ctrl)
-	testClient, err := ec2.NewClientImpl("us-west-2")
+	testClient, err := ec2.NewClientImpl("us-west-2", aws.DualStackEndpointStateDisabled)
 	assert.NoError(t, err)
 	testClient.(*ec2.ClientImpl).SetClientSDK(mockClientSDK)
 
@@ -54,7 +54,7 @@ func TestDescribeECSTagsForInstance(t *testing.T) {
 
 	instanceID := "iid"
 	mockClientSDK := mock_ec2.NewMockClientSDK(ctrl)
-	testClient, err := ec2.NewClientImpl("us-west-2")
+	testClient, err := ec2.NewClientImpl("us-west-2", aws.DualStackEndpointStateDisabled)
 	assert.NoError(t, err)
 	testClient.(*ec2.ClientImpl).SetClientSDK(mockClientSDK)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR makes Agent initialize its EC2 Client with dualstack endpoint usage enabled on IPv6-only instances.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Verified that `ECS_CONTAINER_INSTANCE_PROPAGATE_TAGS_FROM=ec2_instance` configuration setting that depends on EC2 Client works fine on an IPv6-only instance.

New tests cover the changes: <!-- yes|no --> No

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: Initialize EC2 Client with dualstack endpoint usage on IPv6-only instances

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
