### PR TITLE
IPv6-only capability and config initialization

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -84,6 +84,7 @@ const (
 	capabilityEBSTaskAttach                                = "storage.ebs-task-volume-attach"
 	capabilityContainerRestartPolicy                       = "container-restart-policy"
 	capabilityFaultInjection                               = "fault-injection"
+	capabilityIPv6Only                                     = "ipv6-only"
 
 	// network capabilities, going forward, please append "network." prefix to any new networking capability we introduce
 	networkCapabilityPrefix      = "network."
@@ -317,6 +318,9 @@ func (agent *ecsAgent) capabilities() ([]types.Attribute, error) {
 	}
 
 	capabilities = agent.appendFaultInjectionCapabilities(capabilities)
+
+	// IPv6-only cap
+	capabilities = appendIPv6OnlyCapability(capabilities)
 
 	return capabilities, nil
 }

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -301,3 +301,9 @@ func checkTCShowTooling() bool {
 	}
 	return true
 }
+
+// appendIPv6OnlyCapability appends ecs.capability.ipv6-only to passed capabilities and returns
+// the updated capabilities slice.
+func appendIPv6OnlyCapability(capabilities []types.Attribute) []types.Attribute {
+	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityIPv6Only)
+}

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -1139,3 +1139,18 @@ func convertToInterfaceList(strings []string) []interface{} {
 	}
 	return interfaces
 }
+
+func TestAppendIPv6OnlyCapability(t *testing.T) {
+	capabilities := []types.Attribute{
+		types.Attribute{Name: aws.String("cap1")},
+		types.Attribute{Name: aws.String("cap2")},
+	}
+	capabilities = appendIPv6OnlyCapability(capabilities)
+	assert.Equal(t,
+		[]types.Attribute{
+			types.Attribute{Name: aws.String("cap1")},
+			types.Attribute{Name: aws.String("cap2")},
+			types.Attribute{Name: aws.String("ecs.capability.ipv6-only")},
+		},
+		capabilities)
+}

--- a/agent/app/agent_capability_unspecified.go
+++ b/agent/app/agent_capability_unspecified.go
@@ -154,3 +154,8 @@ var isFaultInjectionToolingAvailable = checkFaultInjectionTooling
 func checkFaultInjectionTooling() bool {
 	return false
 }
+
+// appendIPv6OnlyCapability is a no-op.
+func appendIPv6OnlyCapability(capabilities []types.Attribute) []types.Attribute {
+	return capabilities
+}

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -153,3 +153,8 @@ func checkFaultInjectionTooling() bool {
 	seelog.Warnf("Fault injection tooling is not supported on windows")
 	return false
 }
+
+// appendIPv6OnlyCapability is a no-op as IPv6-only capability is not supported on Windows.
+func appendIPv6OnlyCapability(capabilities []types.Attribute) []types.Attribute {
+	return capabilities
+}

--- a/agent/app/agent_capability_windows_test.go
+++ b/agent/app/agent_capability_windows_test.go
@@ -345,3 +345,17 @@ func TestAppendExecCapabilities(t *testing.T) {
 		})
 	}
 }
+
+func TestAppendIPv6OnlyCapability(t *testing.T) {
+	capabilities := []types.Attribute{
+		types.Attribute{Name: aws.String("cap1")},
+		types.Attribute{Name: aws.String("cap2")},
+	}
+	capabilities = appendIPv6OnlyCapability(capabilities)
+	assert.Equal(t,
+		[]types.Attribute{
+			types.Attribute{Name: aws.String("cap1")},
+			types.Attribute{Name: aws.String("cap2")},
+		},
+		capabilities)
+}

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -240,8 +240,7 @@ func NewConfig(ec2client ec2.EC2MetadataClient) (*Config, error) {
 		ec2client = ec2.NewBlackholeEC2MetadataClient()
 	}
 
-	// TODO feat:IPv6-only - Enable when launching IPv6-only support
-	// config.determineIPCompatibility(ec2client)
+	config.determineIPCompatibility(ec2client)
 
 	if config.complete() {
 		// No need to do file / network IO

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -175,10 +175,6 @@ func getConfigFileName() (string, error) {
 // determining the IP compatibility of the container instance.
 // This is a fallback to help with graceful adoption of Agent in IPv6-only environments
 // without disrupting existing environments.
-//
-// TODO feat:IPv6-only - Remove lint rule below
-//
-//lint:ignore U1000 Function will be used in the future
 func (c *Config) determineIPCompatibility(ec2client ec2.EC2MetadataClient) {
 	// Load primary ENI's MAC address on EC2 Launch Type
 	var primaryENIMAC string

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -384,8 +384,6 @@ func TestDetermineIPCompatibility(t *testing.T) {
 // Tests that IPCompatibility defaults to IPv4-only when determining IP compatibility of
 // the container instance fails due to some error.
 func TestIPCompatibilityFallback(t *testing.T) {
-	// TODO feat:IPv6-only - Remove skip
-	t.Skip("Enable when launching IPv6-only support")
 	defer setTestRegion()()
 	ctrl := gomock.NewController(t)
 	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
_This change is being merged to a feature branch_

This PR contains two changes - 
1. Agent will advertise `ecs.capability.ipv6-only` capability to signal Agent's capability to handle IPv6-only tasks. 
2. Instance's IP compatibility will be determined and initialized during Agent startup.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Verified that Agent advertises the new capability and IPv6-only awsvpc tasks can be placed on the instance. 

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
NA - Merging to feature branch.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
