### PR TITLE
Fault Injection - Add a general error case for default network interface resolution errors

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -1238,13 +1238,23 @@ func getTaskMetadataErrorResponse(endpointContainerID, requestType string, err e
 		return http.StatusInternalServerError, errors.New(errFailedToGetContainerMetadata.ExternalReason())
 	}
 
+	// TODO: remove when all usage of ErrorDefaultNetworkInterfaceName are removed from Agents
 	var errDefaultNetworkInterfaceName *state.ErrorDefaultNetworkInterfaceName
 	if errors.As(err, &errDefaultNetworkInterfaceName) {
-		logger.Error("Unable to obtain default network interface on host", logger.Fields{
+		logger.Error("Unable to obtain default network interface name on host", logger.Fields{
 			field.Error:                   errDefaultNetworkInterfaceName.ExternalReason(),
 			field.TMDSEndpointContainerID: endpointContainerID,
 		})
 		return http.StatusInternalServerError, errors.New(errDefaultNetworkInterfaceName.ExternalReason())
+	}
+
+	var errDefaultNetworkInterface *state.ErrorDefaultNetworkInterface
+	if errors.As(err, &errDefaultNetworkInterface) {
+		logger.Error("Unable to obtain default network interface on host", logger.Fields{
+			field.Error:                   errDefaultNetworkInterface,
+			field.TMDSEndpointContainerID: endpointContainerID,
+		})
+		return http.StatusInternalServerError, errors.New(errDefaultNetworkInterface.ExternalReason())
 	}
 
 	logger.Error("Unknown error encountered when handling task metadata fetch failure", logger.Fields{

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/state.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/state.go
@@ -95,6 +95,8 @@ func (e *ErrorStatsFetchFailure) Unwrap() error {
 }
 
 // Error to be returned when we're unable to obtain the default network interface name on the host namespace for a task
+//
+// Deprecated: Use the more general ErrorDefaultNetworkInterface type
 type ErrorDefaultNetworkInterfaceName struct {
 	externalReason string // Reason to be returned in TMDS response
 }
@@ -109,6 +111,35 @@ func (e *ErrorDefaultNetworkInterfaceName) ExternalReason() string {
 
 func (e *ErrorDefaultNetworkInterfaceName) Error() string {
 	return fmt.Sprintf("failed to obtain default network interface name: %s", e.externalReason)
+}
+
+// Error to be returned when we're unable to obtain the default network interface
+// on the host namespace for a task.
+type ErrorDefaultNetworkInterface struct {
+	internalError error
+}
+
+func NewErrorDefaultNetworkInterface(internalError error) *ErrorDefaultNetworkInterface {
+	return &ErrorDefaultNetworkInterface{internalError: internalError}
+}
+
+func (e *ErrorDefaultNetworkInterface) ExternalReason() string {
+	return "failed to resolve default host network interface"
+}
+
+func (e *ErrorDefaultNetworkInterface) Error() string {
+	return fmt.Sprintf("failed to resolve default host network interface: %v", e.internalError)
+}
+
+// Unwrap implements the errors.Unwrap interface
+func (e *ErrorDefaultNetworkInterface) Unwrap() error {
+	return e.internalError
+}
+
+// Is implements the errors.Is interface
+func (e *ErrorDefaultNetworkInterface) Is(target error) bool {
+	_, ok := target.(*ErrorDefaultNetworkInterface)
+	return ok
 }
 
 // Interface for interacting with Agent State relevant to TMDS

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -1238,13 +1238,23 @@ func getTaskMetadataErrorResponse(endpointContainerID, requestType string, err e
 		return http.StatusInternalServerError, errors.New(errFailedToGetContainerMetadata.ExternalReason())
 	}
 
+	// TODO: remove when all usage of ErrorDefaultNetworkInterfaceName are removed from Agents
 	var errDefaultNetworkInterfaceName *state.ErrorDefaultNetworkInterfaceName
 	if errors.As(err, &errDefaultNetworkInterfaceName) {
-		logger.Error("Unable to obtain default network interface on host", logger.Fields{
+		logger.Error("Unable to obtain default network interface name on host", logger.Fields{
 			field.Error:                   errDefaultNetworkInterfaceName.ExternalReason(),
 			field.TMDSEndpointContainerID: endpointContainerID,
 		})
 		return http.StatusInternalServerError, errors.New(errDefaultNetworkInterfaceName.ExternalReason())
+	}
+
+	var errDefaultNetworkInterface *state.ErrorDefaultNetworkInterface
+	if errors.As(err, &errDefaultNetworkInterface) {
+		logger.Error("Unable to obtain default network interface on host", logger.Fields{
+			field.Error:                   errDefaultNetworkInterface,
+			field.TMDSEndpointContainerID: endpointContainerID,
+		})
+		return http.StatusInternalServerError, errors.New(errDefaultNetworkInterface.ExternalReason())
 	}
 
 	logger.Error("Unknown error encountered when handling task metadata fetch failure", logger.Fields{

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
@@ -72,6 +72,7 @@ const (
 	missingHostInterfaceError    = "unable to obtain default network interface name on host"
 	jsonStringMarshalError       = "json: cannot unmarshal string into Go struct field %s of type %s"
 	jsonIntMarshalError          = "json: cannot unmarshal number %s into Go struct field %s of type %s"
+	defaultIfaceResolveErr       = "failed to resolve default host network interface"
 )
 
 var (
@@ -571,6 +572,18 @@ func generateCommonNetworkBlackHolePortTestCases(name string) []networkFaultInje
 			expectedResponseJSON: fmt.Sprintf(errorResponse, taskMetdataUnknownFailureError),
 		},
 		{
+			name:                 "Agent failed to resolve default host network interface",
+			expectedStatusCode:   500,
+			requestBody:          happyBlackHolePortReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(defaultIfaceResolveErr),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).
+					Return(state.TaskResponse{}, state.NewErrorDefaultNetworkInterface(nil)).
+					Times(1)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, defaultIfaceResolveErr),
+		},
+		{
 			name:                 fmt.Sprintf("%s request timed out", name),
 			expectedStatusCode:   500,
 			requestBody:          happyBlackHolePortReqBody,
@@ -811,12 +824,6 @@ func generateStartBlackHolePortFaultTestCases() []networkFaultInjectionTestCase 
 					// Create the chain in IPv6 table
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
 					cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte(internalError), errors.New("fail the ipv6 table update")),
-					// Insert the rule to drop packets
-					//exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
-					//cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
-					// Insert the chain
-					//exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(cmdExec),
-					//cmdExec.EXPECT().CombinedOutput().Times(1).Return([]byte{}, nil),
 				)
 			},
 			expectedResponseJSON: fmt.Sprintf(errorResponse, internalError),
@@ -1747,6 +1754,18 @@ func generateCommonNetworkLatencyTestCases(name string) []networkFaultInjectionT
 			expectedResponseJSON: fmt.Sprintf(errorResponse, taskMetdataUnknownFailureError),
 		},
 		{
+			name:                 "Agent failed to resolve host default network interface",
+			expectedStatusCode:   500,
+			requestBody:          happyNetworkLatencyReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(defaultIfaceResolveErr),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).
+					Return(state.TaskResponse{}, state.NewErrorDefaultNetworkInterface(nil)).
+					Times(1)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, defaultIfaceResolveErr),
+		},
+		{
 			name:               "failed-to-unmarshal-json",
 			expectedStatusCode: 500,
 			requestBody: map[string]interface{}{
@@ -2355,6 +2374,18 @@ func generateCommonNetworkPacketLossTestCases(name string) []networkFaultInjecti
 				mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte("["), nil)
 			},
 			expectedResponseJSON: fmt.Sprintf(errorResponse, internalError),
+		},
+		{
+			name:                 "Agent failed to resolve host default network interface",
+			expectedStatusCode:   500,
+			requestBody:          happyNetworkPacketLossReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(defaultIfaceResolveErr),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).
+					Return(state.TaskResponse{}, state.NewErrorDefaultNetworkInterface(nil)).
+					Times(1)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, defaultIfaceResolveErr),
 		},
 		{
 			name:                 "request timed out",

--- a/ecs-agent/tmds/handlers/v4/state/state.go
+++ b/ecs-agent/tmds/handlers/v4/state/state.go
@@ -95,6 +95,8 @@ func (e *ErrorStatsFetchFailure) Unwrap() error {
 }
 
 // Error to be returned when we're unable to obtain the default network interface name on the host namespace for a task
+//
+// Deprecated: Use the more general ErrorDefaultNetworkInterface type
 type ErrorDefaultNetworkInterfaceName struct {
 	externalReason string // Reason to be returned in TMDS response
 }
@@ -109,6 +111,35 @@ func (e *ErrorDefaultNetworkInterfaceName) ExternalReason() string {
 
 func (e *ErrorDefaultNetworkInterfaceName) Error() string {
 	return fmt.Sprintf("failed to obtain default network interface name: %s", e.externalReason)
+}
+
+// Error to be returned when we're unable to obtain the default network interface
+// on the host namespace for a task.
+type ErrorDefaultNetworkInterface struct {
+	internalError error
+}
+
+func NewErrorDefaultNetworkInterface(internalError error) *ErrorDefaultNetworkInterface {
+	return &ErrorDefaultNetworkInterface{internalError: internalError}
+}
+
+func (e *ErrorDefaultNetworkInterface) ExternalReason() string {
+	return "failed to resolve default host network interface"
+}
+
+func (e *ErrorDefaultNetworkInterface) Error() string {
+	return fmt.Sprintf("failed to resolve default host network interface: %v", e.internalError)
+}
+
+// Unwrap implements the errors.Unwrap interface
+func (e *ErrorDefaultNetworkInterface) Unwrap() error {
+	return e.internalError
+}
+
+// Is implements the errors.Is interface
+func (e *ErrorDefaultNetworkInterface) Is(target error) bool {
+	_, ok := target.(*ErrorDefaultNetworkInterface)
+	return ok
 }
 
 // Interface for interacting with Agent State relevant to TMDS


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adding a new error type `ErrorDefaultNetworkInterface` that may be returned by Agents to signal any errors that occurred during resolution of default network interface for host mode tasks. The existing error type `ErrorDefaultNetworkInterfaceName` is specific to issues with resolving the name of the default network interface and has been deprecated in favor of this new error type. 

The new error type is being added because upcoming changes to fault handlers will require resolution of IP addresses of default interfaces in addition to just their names. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
NA (Changes are not consumed yet)

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
