### PR TITLE
Consume dns server from payload

### DIFF
--- a/ecs-agent/netlib/platform/common_test.go
+++ b/ecs-agent/netlib/platform/common_test.go
@@ -78,6 +78,13 @@ func getTestIPv4OnlyInterface() *networkinterface.NetworkInterface {
 	}
 }
 
+func getTestIPv4OnlyInterfaceWithoutDNS() *networkinterface.NetworkInterface {
+	iface := getTestIPv4OnlyInterface()
+	iface.DomainNameServers = nil
+	iface.DomainNameSearchList = nil
+	return iface
+}
+
 func getTestIPv6OnlyInterface() *networkinterface.NetworkInterface {
 	return &networkinterface.NetworkInterface{
 		PrivateDNSName:    dnsName,
@@ -112,6 +119,13 @@ func getTestIPv6OnlyInterface() *networkinterface.NetworkInterface {
 		DesiredStatus:                status.NetworkReadyPull,
 		Name:                         primaryENIName,
 	}
+}
+
+func getTestIPv6OnlyInterfaceWithoutDNS() *networkinterface.NetworkInterface {
+	iface := getTestIPv6OnlyInterface()
+	iface.DomainNameServers = nil
+	iface.DomainNameSearchList = nil
+	return iface
 }
 
 func getTestDualStackInterface() *networkinterface.NetworkInterface {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR is used to consume the DNS resolver information from the ACS payload. Specifically we will use the domainNameServers and domainName fields to populate the /etc/resolv.conf for awsvpc tasks.

### Implementation details
<!-- How are the changes implemented? -->
- Parse the payload to get the domainNameServers and domainName fields and then utilize them to generate the /etc/resolv.conf.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

Yes

#### Manual testing

Launch an awsvpc task and able to confirm the /etc/resolv.conf is created based on the payload.

On the host,
```
bash-5.2# cat /run/netdog/resolv.conf 
# This is /run/systemd/resolve/resolv.conf managed by man:systemd-resolved(8).
# Do not edit.
#
# This file might be symlinked as /etc/resolv.conf. If you're looking at
# /etc/resolv.conf and seeing this text, you have followed the symlink.
#
# This is a dynamic resolv.conf file for connecting local clients directly to
# all known uplink DNS servers. This file lists all configured search domains.
#
# Third party programs should typically not access this file directly, but only
# through the symlink at /etc/resolv.conf. To manage man:resolv.conf(5) in a
# different way, replace this symlink by a static file or a different symlink.
#
# See man:systemd-resolved.service(8) for details about the supported modes of
# operation for /etc/resolv.conf.

nameserver 10.0.0.2
search us-west-2.compute.internal
bash-5.2#
```

In awsvpc task container,
```
# cat /etc/resolv.conf
nameserver fd00:ec2::253
search us-west-2.compute.internal

# ping6 2001:4860:4860::8888
PING 2001:4860:4860::8888 (2001:4860:4860::8888): 56 data bytes
64 bytes from dns.google: icmp_seq=0 ttl=117 time=7.737 ms
64 bytes from dns.google: icmp_seq=1 ttl=117 time=7.716 ms
64 bytes from dns.google: icmp_seq=2 ttl=117 time=7.620 ms
64 bytes from dns.google: icmp_seq=3 ttl=117 time=7.630 ms
^C--- 2001:4860:4860::8888 ping statistics ---
4 packets transmitted, 4 packets received, 0% packet loss
round-trip min/avg/max/stddev = 7.620/7.676/7.737/0.051 ms
# 
```


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Enhancement - Consume DNS resolver information from the payload


### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
