### PR TITLE
Fault Injection - Multi-ENI detection for host mode tasks & IPv6-only task detection for all tasks

### DIFF
--- a/agent/handlers/task_server_setup_linux_test.go
+++ b/agent/handlers/task_server_setup_linux_test.go
@@ -27,6 +27,8 @@ import (
 	agentV4 "github.com/aws/amazon-ecs-agent/agent/handlers/v4"
 	mock_stats "github.com/aws/amazon-ecs-agent/agent/stats/mock"
 	mock_ecs "github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/mocks"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state"
 	v4 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/utils/netconfig"
 	mock_netlinkwrapper "github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper/mocks"
@@ -37,8 +39,8 @@ import (
 )
 
 const (
-	internalError                           = "internal error"
-	defaultNetworkInterfaceNameErrorMessage = "failed to obtain default network interface name: unable to obtain default network interface name on host from endpoint ID: %s"
+	internalError                       = "internal error"
+	defaultNetworkInterfaceErrorMessage = "failed to resolve default host network interface"
 )
 
 func TestV4GetTaskMetadataWithTaskNetworkConfig(t *testing.T) {
@@ -58,6 +60,8 @@ func TestV4GetTaskMetadataWithTaskNetworkConfig(t *testing.T) {
 				task.EnableFaultInjection = true
 				task.NetworkNamespace = networkNamespace
 				task.DefaultIfname = defaultIfname
+				task.ENIs[0].IPV4Addresses = []*networkinterface.IPV4Address{{Address: "7.6.5.4"}}
+				task.ENIs[0].IPV6Addresses = []*networkinterface.IPV6Address{{Address: "9:8:9:9::"}}
 				gomock.InOrder(
 					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 					state.EXPECT().TaskByArn(taskARN).Return(task, true).Times(2),
@@ -68,10 +72,19 @@ func TestV4GetTaskMetadataWithTaskNetworkConfig(t *testing.T) {
 					state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
 				)
 			},
-			expectedTaskNetworkConfig: expectedV4TaskNetworkConfig(true, apitask.AWSVPCNetworkMode, networkNamespace, defaultIfname),
+			expectedTaskNetworkConfig: state.NewTaskNetworkConfig(apitask.AWSVPCNetworkMode,
+				networkNamespace,
+				[]*state.NetworkInterface{
+					{
+						DeviceName:    defaultIfname,
+						IPV4Addresses: []string{"7.6.5.4"},
+						IPV6Addresses: []string{"9:8:9:9::"},
+					},
+				},
+			),
 		},
 		{
-			name: "happy case with host mode",
+			name: "happy case with host mode - single default ENI",
 			setStateExpectations: func(state *mock_dockerstate.MockTaskEngineState) {
 				hostTask := standardHostTask()
 				hostTask.EnableFaultInjection = true
@@ -87,9 +100,16 @@ func TestV4GetTaskMetadataWithTaskNetworkConfig(t *testing.T) {
 				)
 			},
 			setNetLinkExpectations: func(netLink *mock_netlinkwrapper.MockNetLink) {
-				routes := []netlink.Route{
-					netlink.Route{
+				v4Routes := []netlink.Route{
+					{
 						Gw:        net.ParseIP("10.194.20.1"),
+						Dst:       nil,
+						LinkIndex: 0,
+					},
+				}
+				v6Routes := []netlink.Route{
+					{
+						Gw:        net.ParseIP("8:8:8:8::"),
 						Dst:       nil,
 						LinkIndex: 0,
 					},
@@ -100,12 +120,101 @@ func TestV4GetTaskMetadataWithTaskNetworkConfig(t *testing.T) {
 						Name:  "eth0",
 					},
 				}
+				addrs := []netlink.Addr{
+					{IPNet: &net.IPNet{IP: net.ParseIP("1.2.3.4")}},
+					{IPNet: &net.IPNet{IP: net.ParseIP("5:5:5:5::")}},
+				}
 				gomock.InOrder(
-					netLink.EXPECT().RouteList(nil, netlink.FAMILY_ALL).Return(routes, nil).AnyTimes(),
-					netLink.EXPECT().LinkByIndex(link.Attrs().Index).Return(link, nil).AnyTimes(),
+					netLink.EXPECT().RouteList(nil, netlink.FAMILY_V4).Return(v4Routes, nil),
+					netLink.EXPECT().LinkByIndex(link.Attrs().Index).Return(link, nil),
+					netLink.EXPECT().AddrList(link, netlink.FAMILY_ALL).Return(addrs, nil),
+					netLink.EXPECT().RouteList(nil, netlink.FAMILY_V6).Return(v6Routes, nil),
+					netLink.EXPECT().LinkByIndex(link.Attrs().Index).Return(link, nil),
+					netLink.EXPECT().AddrList(link, netlink.FAMILY_ALL).Return(addrs, nil),
 				)
 			},
-			expectedTaskNetworkConfig: expectedV4TaskNetworkConfig(true, apitask.HostNetworkMode, hostNetworkNamespace, defaultIfname),
+			expectedTaskNetworkConfig: state.NewTaskNetworkConfig(apitask.HostNetworkMode,
+				hostNetworkNamespace,
+				[]*state.NetworkInterface{
+					{
+						DeviceName:    "eth0",
+						IPV4Addresses: []string{"1.2.3.4"},
+						IPV6Addresses: []string{"5:5:5:5::"},
+					},
+				},
+			),
+		},
+		{
+			name: "happy case with host mode - two default ENIs",
+			setStateExpectations: func(state *mock_dockerstate.MockTaskEngineState) {
+				hostTask := standardHostTask()
+				hostTask.EnableFaultInjection = true
+				hostTask.NetworkNamespace = networkNamespace
+				hostTask.DefaultIfname = defaultIfname
+				gomock.InOrder(
+					state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
+					state.EXPECT().TaskByArn(taskARN).Return(hostTask, true).Times(2),
+					state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
+					state.EXPECT().ContainerByID(containerID).Return(nil, false).AnyTimes(),
+					state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
+					state.EXPECT().ContainerByID(containerID).Return(nil, false).AnyTimes(),
+				)
+			},
+			setNetLinkExpectations: func(netLink *mock_netlinkwrapper.MockNetLink) {
+				v4Routes := []netlink.Route{
+					{
+						Gw:        net.ParseIP("10.194.20.1"),
+						Dst:       nil,
+						LinkIndex: 0,
+					},
+				}
+				v6Routes := []netlink.Route{
+					{
+						Gw:        net.ParseIP("8:8:8:8::"),
+						Dst:       nil,
+						LinkIndex: 1,
+					},
+				}
+				v4Link := &netlink.Device{
+					LinkAttrs: netlink.LinkAttrs{
+						Index: 0,
+						Name:  "eth0",
+					},
+				}
+				v4LinkAddrs := []netlink.Addr{
+					{IPNet: &net.IPNet{IP: net.ParseIP("1.2.3.4")}},
+				}
+				v6Link := &netlink.Device{
+					LinkAttrs: netlink.LinkAttrs{
+						Index: 1,
+						Name:  "eth1",
+					},
+				}
+				v6LinkAddrs := []netlink.Addr{
+					{IPNet: &net.IPNet{IP: net.ParseIP("5:5:5:5::")}},
+				}
+				gomock.InOrder(
+					netLink.EXPECT().RouteList(nil, netlink.FAMILY_V4).Return(v4Routes, nil),
+					netLink.EXPECT().LinkByIndex(v4Link.Attrs().Index).Return(v4Link, nil),
+					netLink.EXPECT().AddrList(v4Link, netlink.FAMILY_ALL).Return(v4LinkAddrs, nil),
+					netLink.EXPECT().RouteList(nil, netlink.FAMILY_V6).Return(v6Routes, nil),
+					netLink.EXPECT().LinkByIndex(v6Link.Attrs().Index).Return(v6Link, nil),
+					netLink.EXPECT().AddrList(v6Link, netlink.FAMILY_ALL).Return(v6LinkAddrs, nil),
+				)
+			},
+			expectedTaskNetworkConfig: state.NewTaskNetworkConfig(apitask.HostNetworkMode,
+				hostNetworkNamespace,
+				[]*state.NetworkInterface{
+					{
+						DeviceName:    "eth0",
+						IPV4Addresses: []string{"1.2.3.4"},
+					},
+					{
+						DeviceName:    "eth1",
+						IPV6Addresses: []string{"5:5:5:5::"},
+					},
+				},
+			),
 		},
 		{
 			name: "happy bridge mode",
@@ -119,7 +228,7 @@ func TestV4GetTaskMetadataWithTaskNetworkConfig(t *testing.T) {
 					state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true).AnyTimes(),
 				)
 			},
-			expectedTaskNetworkConfig: expectedV4TaskNetworkConfig(true, bridgeMode, "", ""),
+			expectedTaskNetworkConfig: state.NewTaskNetworkConfig(bridgeMode, "", nil),
 		},
 		{
 			name: "unhappy case with host mode",
@@ -138,20 +247,16 @@ func TestV4GetTaskMetadataWithTaskNetworkConfig(t *testing.T) {
 				)
 			},
 			setNetLinkExpectations: func(netLink *mock_netlinkwrapper.MockNetLink) {
-				routes := []netlink.Route{
-					netlink.Route{
-						Gw:        net.ParseIP("10.194.20.1"),
-						Dst:       nil,
-						LinkIndex: 0,
-					},
-				}
 				gomock.InOrder(
-					netLink.EXPECT().RouteList(nil, netlink.FAMILY_ALL).Return(routes, errors.New(internalError)).Times(1),
+					netLink.EXPECT().RouteList(nil, netlink.FAMILY_V4).Return(nil, errors.New(internalError)).Times(1),
 				)
 			},
-			expectedTaskNetworkConfig: expectedV4TaskNetworkConfig(true, apitask.HostNetworkMode, hostNetworkNamespace, ""),
-			shouldError:               true,
-			errorMessage:              fmt.Sprintf(defaultNetworkInterfaceNameErrorMessage, v3EndpointID),
+			expectedTaskNetworkConfig: state.NewTaskNetworkConfig(
+				apitask.HostNetworkMode, hostNetworkNamespace,
+				[]*state.NetworkInterface{{DeviceName: defaultIfname}}),
+			shouldError: true,
+			errorMessage: fmt.Sprintf("%s: %s: %s",
+				defaultNetworkInterfaceErrorMessage, "failed to get routes", "internal error"),
 		},
 	}
 
@@ -180,7 +285,7 @@ func TestV4GetTaskMetadataWithTaskNetworkConfig(t *testing.T) {
 			actualTaskResponse, err := tmdsAgentState.GetTaskMetadataWithTaskNetworkConfig(v3EndpointID, netConfigClient)
 
 			if tc.shouldError {
-				var errDefaultNetworkInterfaceName *v4.ErrorDefaultNetworkInterfaceName
+				var errDefaultNetworkInterfaceName *v4.ErrorDefaultNetworkInterface
 				assert.Error(t, err)
 				assert.ErrorAs(t, err, &errDefaultNetworkInterfaceName)
 				assert.Equal(t, tc.errorMessage, err.Error())

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -735,10 +735,6 @@ func expectedV4TaskResponse() v4.TaskResponse {
 	)
 }
 
-func expectedV4TaskNetworkConfig(enableFaultInjection bool, networkMode, path, deviceName string) *v4.TaskNetworkConfig {
-	return v4.NewTaskNetworkConfig(networkMode, path, deviceName)
-}
-
 // expectedV4TaskResponseHostModeWithFaultInjectionEnabled returns a standard v4 task response with
 // FaultInjection enabled.
 func expectedV4TaskResponseHostModeWithFaultInjectionEnabled() v4.TaskResponse {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -1213,9 +1213,16 @@ func validateTaskMetadata(w http.ResponseWriter, agentState state.AgentState, re
 	return &taskMetadata, nil
 }
 
+// isIPv6OnlyTask determines if a task is IPv6-only by examining its network interfaces.
+// A task is considered IPv6-only if it has exactly one network interface with no IPv4
+// addresses and at least one IPv6 address. This is because IPv6-only tasks can only
+// have a single interface - multi-interface tasks must be either IPv4+IPv6 or IPv6+IPv4.
 func isIPv6OnlyTask(taskMetadata *state.TaskResponse) bool {
-	return len(taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces[0].IPV4Addresses) == 0 &&
-		len(taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces[0].IPV6Addresses) >= 1
+	interfaces := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces
+	if len(interfaces) != 1 {
+		return false
+	}
+	return len(interfaces[0].IPV4Addresses) == 0 && len(interfaces[0].IPV6Addresses) > 0
 }
 
 // getTaskMetadataErrorResponse will be used to classify certain errors that was returned from a GetTaskMetadata function call.

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
@@ -47,20 +47,17 @@ type TaskNetworkConfig struct {
 	NetworkNamespaces []*NetworkNamespace
 }
 
-func NewTaskNetworkConfig(networkMode, path, deviceName string) *TaskNetworkConfig {
-	return &TaskNetworkConfig{
+func NewTaskNetworkConfig(networkMode, path string, networkInterfaces []*NetworkInterface) *TaskNetworkConfig {
+	cfg := &TaskNetworkConfig{
 		NetworkMode: networkMode,
 		NetworkNamespaces: []*NetworkNamespace{
 			{
-				Path: path,
-				NetworkInterfaces: []*NetworkInterface{
-					{
-						DeviceName: deviceName,
-					},
-				},
+				Path:              path,
+				NetworkInterfaces: networkInterfaces,
 			},
 		},
 	}
+	return cfg
 }
 
 type NetworkNamespace struct {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils.go
@@ -149,3 +149,12 @@ func (t *Timestamp) UnmarshalJSON(data []byte) error {
 	*t = Timestamp(timestamp)
 	return err
 }
+
+// ToPtrSlice converts a slices of values to a slice of pointers to those values.
+func ToPtrSlice[V any](xs []V) []*V {
+	var result []*V
+	for _, x := range xs {
+		result = append(result, &x)
+	}
+	return result
+}

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -1213,9 +1213,16 @@ func validateTaskMetadata(w http.ResponseWriter, agentState state.AgentState, re
 	return &taskMetadata, nil
 }
 
+// isIPv6OnlyTask determines if a task is IPv6-only by examining its network interfaces.
+// A task is considered IPv6-only if it has exactly one network interface with no IPv4
+// addresses and at least one IPv6 address. This is because IPv6-only tasks can only
+// have a single interface - multi-interface tasks must be either IPv4+IPv6 or IPv6+IPv4.
 func isIPv6OnlyTask(taskMetadata *state.TaskResponse) bool {
-	return len(taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces[0].IPV4Addresses) == 0 &&
-		len(taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces[0].IPV6Addresses) >= 1
+	interfaces := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces
+	if len(interfaces) != 1 {
+		return false
+	}
+	return len(interfaces[0].IPV4Addresses) == 0 && len(interfaces[0].IPV6Addresses) > 0
 }
 
 // getTaskMetadataErrorResponse will be used to classify certain errors that was returned from a GetTaskMetadata function call.

--- a/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/ecs-agent/tmds/handlers/v4/state/response.go
@@ -47,20 +47,17 @@ type TaskNetworkConfig struct {
 	NetworkNamespaces []*NetworkNamespace
 }
 
-func NewTaskNetworkConfig(networkMode, path, deviceName string) *TaskNetworkConfig {
-	return &TaskNetworkConfig{
+func NewTaskNetworkConfig(networkMode, path string, networkInterfaces []*NetworkInterface) *TaskNetworkConfig {
+	cfg := &TaskNetworkConfig{
 		NetworkMode: networkMode,
 		NetworkNamespaces: []*NetworkNamespace{
 			{
-				Path: path,
-				NetworkInterfaces: []*NetworkInterface{
-					{
-						DeviceName: deviceName,
-					},
-				},
+				Path:              path,
+				NetworkInterfaces: networkInterfaces,
 			},
 		},
 	}
+	return cfg
 }
 
 type NetworkNamespace struct {

--- a/ecs-agent/utils/utils.go
+++ b/ecs-agent/utils/utils.go
@@ -149,3 +149,12 @@ func (t *Timestamp) UnmarshalJSON(data []byte) error {
 	*t = Timestamp(timestamp)
 	return err
 }
+
+// ToPtrSlice converts a slices of values to a slice of pointers to those values.
+func ToPtrSlice[V any](xs []V) []*V {
+	var result []*V
+	for _, x := range xs {
+		result = append(result, &x)
+	}
+	return result
+}

--- a/ecs-agent/utils/utils_test.go
+++ b/ecs-agent/utils/utils_test.go
@@ -345,3 +345,44 @@ func TestUnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestToPtrSlice(t *testing.T) {
+	t.Run("Empty slice", func(t *testing.T) {
+		input := []int{}
+		result := ToPtrSlice(input)
+		assert.Empty(t, result, "Result should be an empty slice")
+	})
+
+	t.Run("Slice of ints", func(t *testing.T) {
+		input := []int{1, 2, 3}
+		result := ToPtrSlice(input)
+		assert.Len(t, result, 3, "Result should have the same length as input")
+		for i, ptr := range result {
+			assert.NotNil(t, ptr, "Pointer should not be nil")
+			assert.Equal(t, input[i], *ptr, "Pointed value should match input")
+		}
+	})
+
+	t.Run("Slice of strings", func(t *testing.T) {
+		input := []string{"a", "b", "c"}
+		result := ToPtrSlice(input)
+		assert.Len(t, result, 3, "Result should have the same length as input")
+		for i, ptr := range result {
+			assert.NotNil(t, ptr, "Pointer should not be nil")
+			assert.Equal(t, input[i], *ptr, "Pointed value should match input")
+		}
+	})
+
+	t.Run("Slice of structs", func(t *testing.T) {
+		type TestStruct struct {
+			Value int
+		}
+		input := []TestStruct{{1}, {2}, {3}}
+		result := ToPtrSlice(input)
+		assert.Len(t, result, 3, "Result should have the same length as input")
+		for i, ptr := range result {
+			assert.NotNil(t, ptr, "Pointer should not be nil")
+			assert.Equal(t, input[i], *ptr, "Pointed value should match input")
+		}
+	})
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR modifies the behavior of the `GetTaskMetadataWithTaskNetworkConfig` method of `TMDSAgentState` implementation to:
1. Return task ENI's IPv4 and IPv6 addresses for awsvpc mode tasks
2. Look up and return default IPv4 and IPv6 network interfaces and their IP addresses in the host network namespace for host mode tasks

The definition of IPv6-only tasks in the context of Fault Injection handlers has been updated accordingly. The new definition states that an IPv6-only task has a single network interface with no IPv4 addresses and at least one IPv6 address. This updated definition correctly identifies host mode tasks with separate default network interfaces for IPv4 and IPv6 as not IPv6-only. The `isIPv6OnlyTask` function has been updated to reflect this change.

### Implementation details
<!-- How are the changes implemented? -->
1. `TMDSAgentState.getTaskMetadata` method that's responsible for populating task network configuration for all tasks on all platforms is updated so that it populates IP addresses for awsvpc tasks. 
2. `TMDSAgentState.GetTaskMetadataWithTaskNetworkConfig` method for Linux specifically is updated so that for host mode tasks it looks up default network interfaces for IPv4 and IPv6 using the `GetDefaultNetworkInterfaces` utility function that was introduced in #4665. 
3. `isIPv6OnlyTask` function in `ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go` is updated as per the new definition mentioned above. 
4. Unit test updates. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Launched two instances, one IPv6-only and another one with two ENIs - IPv4-only and IPv6-only (we will call this v4v6 instance). On both instances I temporarily renamed `ip6tables` utility so that it is not found by Agent.

On v4v6 instance, verified that start blackhole port fault request do not fail but the fault is not injected for IPv6 traffic.
```
bash-5.2# curl -XPOST --data '{"Port": 80, "Protocol": "tcp", "TrafficType": "egress"}' ${ECS_AGENT_URI}/fault/v1/network-blackhole-port/start
{"Status":"running"}bash-5.2#
bash-5.2# curl -4 --connect-timeout 2 -w "IP: %{remote_ip}\nHTTP: %{response_code}\n" -s example.com -o /dev/null
IP:
HTTP: 000
bash-5.2# curl -6 --connect-timeout 2 -w "IP: %{remote_ip}\nHTTP: %{response_code}\n" -s example.com -o /dev/null
IP: 2600:1406:bc00:53::b81e:94c8
HTTP: 200
```

On the IPv6-only instance this causes an internal server error. 
```
bash-5.2# curl -XPOST --data '{"Port": 80, "Protocol": "tcp", "TrafficType": "egress"}' ${ECS_AGENT_URI}/fault/v1/network-blackhole-port/start
{"Error":"internal error"}bash-5.2#
bash-5.2# curl -XPOST --data '{"Port": 80, "Protocol": "tcp", "TrafficType": "egress"}' ${ECS_AGENT_URI}/fault/v1/network-blackhole-port/stop
{"Error":"internal error"}bash-5.2# exit
```

Logs on IPv6-only instance -

```
[ec2-user@ipv6only ~]$ grep -i ip6tables /var/log/ecs/ecs-agent.log
level=error time=2025-06-03T23:07:28Z msg="Unable to execute the command" command="ip6tables -w 5 -N egress-tcp-80" output="" taskArn="arn:aws:ecs:us-west-2:979604884904:task/sc-test/9fa2dec442f34773b1e467eb7e607fba" error="exec: \"ip6tables\": executable file not found in $PATH" netns="host"
level=error time=2025-06-03T23:07:53Z msg="Unable to execute the command" netns="host" command="ip6tables -w 5 -F egress-tcp-80" output="" taskArn="arn:aws:ecs:us-west-2:979604884904:task/sc-test/9fa2dec442f34773b1e467eb7e607fba" error="exec: \"ip6tables\": executable file not found in $PATH"
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
enhancement: [TMDS Fault Injection] Improve network interface detection to handle multiple default interfaces in host mode and update IPv6-only task identification

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
