### PR TITLE
Latency and packet loss faults should apply to all network interfaces 

### DIFF
--- a/agent/handlers/v4/tmdsstate.go
+++ b/agent/handlers/v4/tmdsstate.go
@@ -13,6 +13,7 @@
 package v4
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
@@ -21,7 +22,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	tmdsv4 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -180,7 +180,7 @@ func (s *TMDSAgentState) getTaskMetadata(v3EndpointID string, includeTags bool, 
 					IPV6Addresses: taskENI.GetIPV6Addresses(),
 				}})
 		} else {
-			// For bridge mode there is no concept of task network interfaces in ECS
+			// For other network modes there is no concept of task network interfaces in ECS
 			taskNetworkConfig = tmdsv4.NewTaskNetworkConfig(
 				task.GetNetworkMode(), task.GetNetworkNamespace(), nil)
 		}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
@@ -74,4 +74,5 @@ const (
 	ExecutionStoppedAt      = "executionStoppedAt"
 	Region                  = "region"
 	DockerVersion           = "dockerVersion"
+	NetworkInterface        = "networkInterface"
 )

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -1360,16 +1360,18 @@ func (h *FaultHandler) startNetworkLatencyFaultForInterface(
 	cmdOutput, err := h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		logger.Error("Command execution failed", logger.Fields{
-			field.CommandString: tcAddQdiscRootCommandComposed,
-			field.Error:         err,
-			field.CommandOutput: string(cmdOutput[:]),
-			field.TaskARN:       taskMetadata.TaskARN,
+			field.CommandString:    tcAddQdiscRootCommandComposed,
+			field.Error:            err,
+			field.CommandOutput:    string(cmdOutput[:]),
+			field.TaskARN:          taskMetadata.TaskARN,
+			field.NetworkInterface: interfaceName,
 		})
 		return err
 	}
 	logger.Info("Command execution completed", logger.Fields{
-		field.CommandString: tcAddQdiscRootCommandComposed,
-		field.CommandOutput: string(cmdOutput[:]),
+		field.CommandString:    tcAddQdiscRootCommandComposed,
+		field.CommandOutput:    string(cmdOutput[:]),
+		field.NetworkInterface: interfaceName,
 	})
 	tcAddQdiscLossCommandComposed := nsenterPrefix + fmt.Sprintf(
 		tcAddQdiscLatencyCommandString, interfaceName, delayInMs, jitterInMs)
@@ -1377,16 +1379,18 @@ func (h *FaultHandler) startNetworkLatencyFaultForInterface(
 	cmdOutput, err = h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		logger.Error("Command execution failed", logger.Fields{
-			field.CommandString: tcAddQdiscLossCommandComposed,
-			field.Error:         err,
-			field.CommandOutput: string(cmdOutput[:]),
-			field.TaskARN:       taskMetadata.TaskARN,
+			field.CommandString:    tcAddQdiscLossCommandComposed,
+			field.Error:            err,
+			field.CommandOutput:    string(cmdOutput[:]),
+			field.TaskARN:          taskMetadata.TaskARN,
+			field.NetworkInterface: interfaceName,
 		})
 		return err
 	}
 	logger.Info("Command execution completed", logger.Fields{
-		field.CommandString: tcAddQdiscLossCommandComposed,
-		field.CommandOutput: string(cmdOutput[:]),
+		field.CommandString:    tcAddQdiscLossCommandComposed,
+		field.CommandOutput:    string(cmdOutput[:]),
+		field.NetworkInterface: interfaceName,
 	})
 	// After creating the queueing discipline, create filters to associate the IPs in the request with the handle.
 	// First redirect the allowlisted ip addresses to band 1:3 where is no network impairments.
@@ -1436,32 +1440,36 @@ func (h *FaultHandler) startNetworkPacketLossFaultForInterface(
 	cmdOutput, err := h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		logger.Error("Command execution failed", logger.Fields{
-			field.CommandString: tcAddQdiscRootCommandComposed,
-			field.Error:         err,
-			field.CommandOutput: string(cmdOutput[:]),
-			field.TaskARN:       taskMetadata.TaskARN,
+			field.CommandString:    tcAddQdiscRootCommandComposed,
+			field.Error:            err,
+			field.CommandOutput:    string(cmdOutput[:]),
+			field.TaskARN:          taskMetadata.TaskARN,
+			field.NetworkInterface: interfaceName,
 		})
 		return err
 	}
 	logger.Info("Command execution completed", logger.Fields{
-		field.CommandString: tcAddQdiscRootCommandComposed,
-		field.CommandOutput: string(cmdOutput[:]),
+		field.CommandString:    tcAddQdiscRootCommandComposed,
+		field.CommandOutput:    string(cmdOutput[:]),
+		field.NetworkInterface: interfaceName,
 	})
 	tcAddQdiscLossCommandComposed := nsenterPrefix + fmt.Sprintf(tcAddQdiscLossCommandString, interfaceName, lossPercent)
 	cmdList = strings.Split(tcAddQdiscLossCommandComposed, " ")
 	cmdOutput, err = h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		logger.Error("Command execution failed", logger.Fields{
-			field.CommandString: tcAddQdiscLossCommandComposed,
-			field.Error:         err,
-			field.CommandOutput: string(cmdOutput[:]),
-			field.TaskARN:       taskMetadata.TaskARN,
+			field.CommandString:    tcAddQdiscLossCommandComposed,
+			field.Error:            err,
+			field.CommandOutput:    string(cmdOutput[:]),
+			field.TaskARN:          taskMetadata.TaskARN,
+			field.NetworkInterface: interfaceName,
 		})
 		return err
 	}
 	logger.Info("Command execution completed", logger.Fields{
-		field.CommandString: tcAddQdiscLossCommandComposed,
-		field.CommandOutput: string(cmdOutput[:]),
+		field.CommandString:    tcAddQdiscLossCommandComposed,
+		field.CommandOutput:    string(cmdOutput[:]),
+		field.NetworkInterface: interfaceName,
 	})
 	// After creating the queueing discipline, create filters to associate the IPs in the request with the handle.
 	// First redirect the allowlisted ip addresses to band 1:3 where is no network impairments.
@@ -1509,32 +1517,36 @@ func (h *FaultHandler) stopTCFaultForInterface(
 	cmdOutput, err := h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		logger.Error("Command execution failed", logger.Fields{
-			field.CommandString: tcDeleteQdiscParentCommandComposed,
-			field.Error:         err,
-			field.CommandOutput: string(cmdOutput[:]),
-			field.TaskARN:       taskMetadata.TaskARN,
+			field.CommandString:    tcDeleteQdiscParentCommandComposed,
+			field.Error:            err,
+			field.CommandOutput:    string(cmdOutput[:]),
+			field.TaskARN:          taskMetadata.TaskARN,
+			field.NetworkInterface: interfaceName,
 		})
 		return err
 	}
 	logger.Info("Command execution completed", logger.Fields{
-		field.CommandString: tcDeleteQdiscParentCommandComposed,
-		field.CommandOutput: string(cmdOutput[:]),
+		field.CommandString:    tcDeleteQdiscParentCommandComposed,
+		field.CommandOutput:    string(cmdOutput[:]),
+		field.NetworkInterface: interfaceName,
 	})
 	tcDeleteQdiscRootCommandComposed := nsenterPrefix + fmt.Sprintf(tcDeleteQdiscRootCommandString, interfaceName)
 	cmdList = strings.Split(tcDeleteQdiscRootCommandComposed, " ")
 	_, err = h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		logger.Error("Command execution failed", logger.Fields{
-			field.CommandString: tcDeleteQdiscRootCommandComposed,
-			field.Error:         err,
-			field.CommandOutput: string(cmdOutput[:]),
-			field.TaskARN:       taskMetadata.TaskARN,
+			field.CommandString:    tcDeleteQdiscRootCommandComposed,
+			field.Error:            err,
+			field.CommandOutput:    string(cmdOutput[:]),
+			field.TaskARN:          taskMetadata.TaskARN,
+			field.NetworkInterface: interfaceName,
 		})
 		return err
 	}
 	logger.Info("Command execution completed", logger.Fields{
-		field.CommandString: tcDeleteQdiscRootCommandComposed,
-		field.CommandOutput: string(cmdOutput[:]),
+		field.CommandString:    tcDeleteQdiscRootCommandComposed,
+		field.CommandOutput:    string(cmdOutput[:]),
+		field.NetworkInterface: interfaceName,
 	})
 
 	return nil
@@ -1581,18 +1593,20 @@ func (h *FaultHandler) checkTCFaultForInterface(
 	cmdOutput, err := h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		logger.Error("Command execution failed", logger.Fields{
-			field.CommandString: tcCheckInjectionCommandComposed,
-			field.Error:         err,
-			field.CommandOutput: string(cmdOutput[:]),
-			field.TaskARN:       taskMetadata.TaskARN,
+			field.CommandString:    tcCheckInjectionCommandComposed,
+			field.Error:            err,
+			field.CommandOutput:    string(cmdOutput[:]),
+			field.TaskARN:          taskMetadata.TaskARN,
+			field.NetworkInterface: interfaceName,
 		})
 		return false, false, fmt.Errorf("failed to check existing network fault: '%s' command failed with the following error: '%s'. std output: '%s'. TaskArn: %s",
 			tcCheckInjectionCommandComposed, err, string(cmdOutput[:]), taskMetadata.TaskARN)
 	}
 	// Log the command output to better help us debug.
 	logger.Info("Command execution completed", logger.Fields{
-		field.CommandString: tcCheckInjectionCommandComposed,
-		field.CommandOutput: string(cmdOutput[:]),
+		field.CommandString:    tcCheckInjectionCommandComposed,
+		field.CommandOutput:    string(cmdOutput[:]),
+		field.NetworkInterface: interfaceName,
 	})
 
 	// Check whether latency fault exists and whether packet loss fault exists separately.

--- a/ecs-agent/logger/field/constants.go
+++ b/ecs-agent/logger/field/constants.go
@@ -74,4 +74,5 @@ const (
 	ExecutionStoppedAt      = "executionStoppedAt"
 	Region                  = "region"
 	DockerVersion           = "dockerVersion"
+	NetworkInterface        = "networkInterface"
 )

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -1360,16 +1360,18 @@ func (h *FaultHandler) startNetworkLatencyFaultForInterface(
 	cmdOutput, err := h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		logger.Error("Command execution failed", logger.Fields{
-			field.CommandString: tcAddQdiscRootCommandComposed,
-			field.Error:         err,
-			field.CommandOutput: string(cmdOutput[:]),
-			field.TaskARN:       taskMetadata.TaskARN,
+			field.CommandString:    tcAddQdiscRootCommandComposed,
+			field.Error:            err,
+			field.CommandOutput:    string(cmdOutput[:]),
+			field.TaskARN:          taskMetadata.TaskARN,
+			field.NetworkInterface: interfaceName,
 		})
 		return err
 	}
 	logger.Info("Command execution completed", logger.Fields{
-		field.CommandString: tcAddQdiscRootCommandComposed,
-		field.CommandOutput: string(cmdOutput[:]),
+		field.CommandString:    tcAddQdiscRootCommandComposed,
+		field.CommandOutput:    string(cmdOutput[:]),
+		field.NetworkInterface: interfaceName,
 	})
 	tcAddQdiscLossCommandComposed := nsenterPrefix + fmt.Sprintf(
 		tcAddQdiscLatencyCommandString, interfaceName, delayInMs, jitterInMs)
@@ -1377,16 +1379,18 @@ func (h *FaultHandler) startNetworkLatencyFaultForInterface(
 	cmdOutput, err = h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		logger.Error("Command execution failed", logger.Fields{
-			field.CommandString: tcAddQdiscLossCommandComposed,
-			field.Error:         err,
-			field.CommandOutput: string(cmdOutput[:]),
-			field.TaskARN:       taskMetadata.TaskARN,
+			field.CommandString:    tcAddQdiscLossCommandComposed,
+			field.Error:            err,
+			field.CommandOutput:    string(cmdOutput[:]),
+			field.TaskARN:          taskMetadata.TaskARN,
+			field.NetworkInterface: interfaceName,
 		})
 		return err
 	}
 	logger.Info("Command execution completed", logger.Fields{
-		field.CommandString: tcAddQdiscLossCommandComposed,
-		field.CommandOutput: string(cmdOutput[:]),
+		field.CommandString:    tcAddQdiscLossCommandComposed,
+		field.CommandOutput:    string(cmdOutput[:]),
+		field.NetworkInterface: interfaceName,
 	})
 	// After creating the queueing discipline, create filters to associate the IPs in the request with the handle.
 	// First redirect the allowlisted ip addresses to band 1:3 where is no network impairments.
@@ -1436,32 +1440,36 @@ func (h *FaultHandler) startNetworkPacketLossFaultForInterface(
 	cmdOutput, err := h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		logger.Error("Command execution failed", logger.Fields{
-			field.CommandString: tcAddQdiscRootCommandComposed,
-			field.Error:         err,
-			field.CommandOutput: string(cmdOutput[:]),
-			field.TaskARN:       taskMetadata.TaskARN,
+			field.CommandString:    tcAddQdiscRootCommandComposed,
+			field.Error:            err,
+			field.CommandOutput:    string(cmdOutput[:]),
+			field.TaskARN:          taskMetadata.TaskARN,
+			field.NetworkInterface: interfaceName,
 		})
 		return err
 	}
 	logger.Info("Command execution completed", logger.Fields{
-		field.CommandString: tcAddQdiscRootCommandComposed,
-		field.CommandOutput: string(cmdOutput[:]),
+		field.CommandString:    tcAddQdiscRootCommandComposed,
+		field.CommandOutput:    string(cmdOutput[:]),
+		field.NetworkInterface: interfaceName,
 	})
 	tcAddQdiscLossCommandComposed := nsenterPrefix + fmt.Sprintf(tcAddQdiscLossCommandString, interfaceName, lossPercent)
 	cmdList = strings.Split(tcAddQdiscLossCommandComposed, " ")
 	cmdOutput, err = h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		logger.Error("Command execution failed", logger.Fields{
-			field.CommandString: tcAddQdiscLossCommandComposed,
-			field.Error:         err,
-			field.CommandOutput: string(cmdOutput[:]),
-			field.TaskARN:       taskMetadata.TaskARN,
+			field.CommandString:    tcAddQdiscLossCommandComposed,
+			field.Error:            err,
+			field.CommandOutput:    string(cmdOutput[:]),
+			field.TaskARN:          taskMetadata.TaskARN,
+			field.NetworkInterface: interfaceName,
 		})
 		return err
 	}
 	logger.Info("Command execution completed", logger.Fields{
-		field.CommandString: tcAddQdiscLossCommandComposed,
-		field.CommandOutput: string(cmdOutput[:]),
+		field.CommandString:    tcAddQdiscLossCommandComposed,
+		field.CommandOutput:    string(cmdOutput[:]),
+		field.NetworkInterface: interfaceName,
 	})
 	// After creating the queueing discipline, create filters to associate the IPs in the request with the handle.
 	// First redirect the allowlisted ip addresses to band 1:3 where is no network impairments.
@@ -1509,32 +1517,36 @@ func (h *FaultHandler) stopTCFaultForInterface(
 	cmdOutput, err := h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		logger.Error("Command execution failed", logger.Fields{
-			field.CommandString: tcDeleteQdiscParentCommandComposed,
-			field.Error:         err,
-			field.CommandOutput: string(cmdOutput[:]),
-			field.TaskARN:       taskMetadata.TaskARN,
+			field.CommandString:    tcDeleteQdiscParentCommandComposed,
+			field.Error:            err,
+			field.CommandOutput:    string(cmdOutput[:]),
+			field.TaskARN:          taskMetadata.TaskARN,
+			field.NetworkInterface: interfaceName,
 		})
 		return err
 	}
 	logger.Info("Command execution completed", logger.Fields{
-		field.CommandString: tcDeleteQdiscParentCommandComposed,
-		field.CommandOutput: string(cmdOutput[:]),
+		field.CommandString:    tcDeleteQdiscParentCommandComposed,
+		field.CommandOutput:    string(cmdOutput[:]),
+		field.NetworkInterface: interfaceName,
 	})
 	tcDeleteQdiscRootCommandComposed := nsenterPrefix + fmt.Sprintf(tcDeleteQdiscRootCommandString, interfaceName)
 	cmdList = strings.Split(tcDeleteQdiscRootCommandComposed, " ")
 	_, err = h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		logger.Error("Command execution failed", logger.Fields{
-			field.CommandString: tcDeleteQdiscRootCommandComposed,
-			field.Error:         err,
-			field.CommandOutput: string(cmdOutput[:]),
-			field.TaskARN:       taskMetadata.TaskARN,
+			field.CommandString:    tcDeleteQdiscRootCommandComposed,
+			field.Error:            err,
+			field.CommandOutput:    string(cmdOutput[:]),
+			field.TaskARN:          taskMetadata.TaskARN,
+			field.NetworkInterface: interfaceName,
 		})
 		return err
 	}
 	logger.Info("Command execution completed", logger.Fields{
-		field.CommandString: tcDeleteQdiscRootCommandComposed,
-		field.CommandOutput: string(cmdOutput[:]),
+		field.CommandString:    tcDeleteQdiscRootCommandComposed,
+		field.CommandOutput:    string(cmdOutput[:]),
+		field.NetworkInterface: interfaceName,
 	})
 
 	return nil
@@ -1581,18 +1593,20 @@ func (h *FaultHandler) checkTCFaultForInterface(
 	cmdOutput, err := h.runExecCommand(ctx, cmdList)
 	if err != nil {
 		logger.Error("Command execution failed", logger.Fields{
-			field.CommandString: tcCheckInjectionCommandComposed,
-			field.Error:         err,
-			field.CommandOutput: string(cmdOutput[:]),
-			field.TaskARN:       taskMetadata.TaskARN,
+			field.CommandString:    tcCheckInjectionCommandComposed,
+			field.Error:            err,
+			field.CommandOutput:    string(cmdOutput[:]),
+			field.TaskARN:          taskMetadata.TaskARN,
+			field.NetworkInterface: interfaceName,
 		})
 		return false, false, fmt.Errorf("failed to check existing network fault: '%s' command failed with the following error: '%s'. std output: '%s'. TaskArn: %s",
 			tcCheckInjectionCommandComposed, err, string(cmdOutput[:]), taskMetadata.TaskARN)
 	}
 	// Log the command output to better help us debug.
 	logger.Info("Command execution completed", logger.Fields{
-		field.CommandString: tcCheckInjectionCommandComposed,
-		field.CommandOutput: string(cmdOutput[:]),
+		field.CommandString:    tcCheckInjectionCommandComposed,
+		field.CommandOutput:    string(cmdOutput[:]),
+		field.NetworkInterface: interfaceName,
 	})
 
 	// Check whether latency fault exists and whether packet loss fault exists separately.

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
@@ -261,6 +261,300 @@ var (
 	taskMetdataUnknownFailureError = fmt.Sprintf("failed to get task metadata due to internal server error for container: %s", endpointId)
 )
 
+// setStartLatencyFaultExpectations sets up all mock expectations for start network latency fault
+func setStartLatencyFaultExpectations(
+	exec *mock_execwrapper.MockExec,
+	ctrl *gomock.Controller,
+	interfaces []string,
+	delayMs uint64,
+	jitterMs uint64,
+	sourcesToFilter []string,
+	sources []string,
+) {
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+	mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+
+	// Set up context expectations
+	expectations := []*gomock.Call{
+		exec.EXPECT().
+			NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).
+			Return(ctx, cancel),
+	}
+
+	// Check existing faults for each interface
+	for _, interfaceName := range interfaces {
+		expectations = append(expectations,
+			exec.EXPECT().
+				CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", interfaceName, "parent", "1:1"}).
+				Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil),
+		)
+	}
+
+	// Apply latency fault to each interface
+	for _, interfaceName := range interfaces {
+		expectations = append(expectations,
+			// Create root qdisc
+			exec.EXPECT().
+				CommandContext(gomock.Any(), "tc",
+					[]string{
+						"qdisc", "add", "dev", interfaceName, "root",
+						"handle", "1:", "prio", "priomap",
+						"2", "2", "2", "2",
+						"2", "2", "2", "2",
+						"2", "2", "2", "2",
+						"2", "2", "2", "2",
+					}).
+				Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil),
+
+			// Add latency qdisc
+			exec.EXPECT().
+				CommandContext(gomock.Any(), "tc",
+					[]string{
+						"qdisc", "add", "dev", interfaceName, "parent", "1:1",
+						"handle", "10:", "netem", "delay",
+						fmt.Sprintf("%dms", delayMs),
+						fmt.Sprintf("%dms", jitterMs),
+					}).
+				Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil),
+		)
+
+		// Set up SourcesToFilter expectations
+		for _, source := range sourcesToFilter {
+			if isIPv4(source) {
+				expectations = append(expectations,
+					exec.EXPECT().
+						CommandContext(gomock.Any(), "tc",
+							[]string{
+								"filter", "add", "dev", interfaceName,
+								"protocol", "all", "parent", "1:0", "prio", "1",
+								"u32", "match", "ip", "dst", source, "flowid", "1:3",
+							}).
+						Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil),
+				)
+			} else {
+				expectations = append(expectations,
+					exec.EXPECT().
+						CommandContext(gomock.Any(), "tc",
+							[]string{
+								"filter", "add", "dev", interfaceName,
+								"protocol", "all", "parent", "1:0", "prio", "1",
+								"u32", "match", "ip6", "dst", source, "flowid", "1:3",
+							}).
+						Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil),
+				)
+			}
+		}
+
+		// Set up Sources expectations
+		for _, source := range sources {
+			if isIPv4(source) {
+				expectations = append(expectations,
+					exec.EXPECT().
+						CommandContext(gomock.Any(), "tc",
+							[]string{
+								"filter", "add", "dev", interfaceName,
+								"protocol", "all", "parent", "1:0", "prio", "2",
+								"u32", "match", "ip", "dst", source, "flowid", "1:1",
+							}).
+						Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil),
+				)
+			} else {
+				expectations = append(expectations,
+					exec.EXPECT().
+						CommandContext(gomock.Any(), "tc",
+							[]string{
+								"filter", "add", "dev", interfaceName,
+								"protocol", "all", "parent", "1:0", "prio", "2",
+								"u32", "match", "ip6", "dst", source, "flowid", "1:1",
+							}).
+						Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil),
+				)
+			}
+		}
+	}
+	gomock.InOrder(expectations...)
+}
+
+// setStartPacketLossFaultExpectations sets up mock expectations for applying network packet loss fault to network interfaces
+func setStartPacketLossFaultExpectations(
+	exec *mock_execwrapper.MockExec,
+	ctrl *gomock.Controller,
+	interfaces []string,
+	lossPercent uint64,
+	sourcesToFilter []string,
+	sources []string,
+) {
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+	mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+
+	// Set up context expectations
+	expectations := []*gomock.Call{
+		exec.EXPECT().
+			NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).
+			Return(ctx, cancel),
+	}
+
+	// Check existing faults for each interface
+	for _, iface := range interfaces {
+		expectations = append(expectations,
+			exec.EXPECT().
+				CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", iface, "parent", "1:1"}).
+				Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil),
+		)
+	}
+
+	// Apply packet loss fault to each interface
+	for _, iface := range interfaces {
+		expectations = append(expectations,
+			// Create root qdisc
+			exec.EXPECT().
+				CommandContext(gomock.Any(), "tc",
+					[]string{
+						"qdisc", "add", "dev", iface, "root",
+						"handle", "1:", "prio", "priomap",
+						"2", "2", "2", "2",
+						"2", "2", "2", "2",
+						"2", "2", "2", "2",
+						"2", "2", "2", "2",
+					}).
+				Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil),
+
+			// Add packet loss qdisc
+			exec.EXPECT().
+				CommandContext(gomock.Any(), "tc",
+					[]string{
+						"qdisc", "add", "dev", iface, "parent", "1:1",
+						"handle", "10:", "netem", "loss",
+						fmt.Sprintf("%d%%", lossPercent),
+					}).
+				Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil),
+		)
+
+		// Set up SourcesToFilter expectations
+		for _, source := range sourcesToFilter {
+			if isIPv4(source) {
+				expectations = append(expectations,
+					exec.EXPECT().
+						CommandContext(gomock.Any(), "tc",
+							[]string{
+								"filter", "add", "dev", iface,
+								"protocol", "all", "parent", "1:0", "prio", "1",
+								"u32", "match", "ip", "dst", source, "flowid", "1:3",
+							}).
+						Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil),
+				)
+			} else {
+				expectations = append(expectations,
+					exec.EXPECT().
+						CommandContext(gomock.Any(), "tc",
+							[]string{
+								"filter", "add", "dev", iface,
+								"protocol", "all", "parent", "1:0", "prio", "1",
+								"u32", "match", "ip6", "dst", source, "flowid", "1:3",
+							}).
+						Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil),
+				)
+			}
+		}
+
+		// Set up Sources expectations
+		for _, source := range sources {
+			if isIPv4(source) {
+				expectations = append(expectations,
+					exec.EXPECT().
+						CommandContext(gomock.Any(), "tc",
+							[]string{
+								"filter", "add", "dev", iface,
+								"protocol", "all", "parent", "1:0", "prio", "2",
+								"u32", "match", "ip", "dst", source, "flowid", "1:1",
+							}).
+						Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil),
+				)
+			} else {
+				expectations = append(expectations,
+					exec.EXPECT().
+						CommandContext(gomock.Any(), "tc",
+							[]string{
+								"filter", "add", "dev", iface,
+								"protocol", "all", "parent", "1:0", "prio", "2",
+								"u32", "match", "ip6", "dst", source, "flowid", "1:1",
+							}).
+						Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil),
+				)
+			}
+		}
+	}
+
+	gomock.InOrder(expectations...)
+}
+
+// setStopTCFaultExpectations sets up all mock expectations for stopping
+// tc based faults - latency and packet loss
+func setStopTCFaultExpectations(
+	exec *mock_execwrapper.MockExec,
+	ctrl *gomock.Controller,
+	interfaces []string,
+	lossExistsCommandOutput string,
+) {
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+	mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+
+	// Set up context expectations
+	exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel)
+
+	// Check existing fault on each interface
+	expectations := []*gomock.Call{}
+	for _, iface := range interfaces {
+		expectations = append(expectations,
+			exec.EXPECT().
+				CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", iface, "parent", "1:1"}).
+				Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Return([]byte(lossExistsCommandOutput), nil),
+		)
+	}
+	for _, iface := range interfaces {
+		expectations = append(expectations,
+			// Delete netem qdisc
+			exec.EXPECT().
+				CommandContext(gomock.Any(), "tc", []string{"qdisc", "del", "dev", iface, "parent", "1:1", "handle", "10:"}).
+				Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Return([]byte(""), nil),
+
+			// Delete root qdisc
+			exec.EXPECT().
+				CommandContext(gomock.Any(), "tc", []string{"qdisc", "del", "dev", iface, "root", "handle", "1:", "prio"}).
+				Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Return([]byte(""), nil),
+		)
+	}
+	gomock.InOrder(expectations...)
+}
+
+// Helper function to check if an IP address is IPv4
+func isIPv4(ip string) bool {
+	// Simple check - if it contains ':', it's IPv6
+	for i := 0; i < len(ip); i++ {
+		if ip[i] == ':' {
+			return false
+		}
+	}
+	return true
+}
+
 type networkFaultInjectionTestCase struct {
 	name                      string
 	expectedStatusCode        int
@@ -1882,6 +2176,29 @@ func generateStartNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 			expectedResponseJSON: happyFaultRunningResponse,
 		},
 		{
+			name:                 "no-existing-fault - two interfaces",
+			expectedStatusCode:   200,
+			requestBody:          happyNetworkLatencyReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().
+					GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).
+					Return(happyTaskResponseTwoInterfaces, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				setStartLatencyFaultExpectations(
+					exec,
+					ctrl,
+					[]string{"eth0", "eth1"},
+					delayMilliseconds,
+					jitterMilliseconds,
+					ipSourcesToFilter,
+					ipSources,
+				)
+			},
+			expectedResponseJSON: happyFaultRunningResponse,
+		},
+		{
 			name:                 "existing-network-latency-fault",
 			expectedStatusCode:   409,
 			requestBody:          happyNetworkLatencyReqBody,
@@ -2142,6 +2459,20 @@ func generateStopNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 			expectedResponseJSON: happyFaultStoppedResponse,
 		},
 		{
+			name:                 "existing-network-latency-fault-empty-request-payload-two-interfaces",
+			expectedStatusCode:   200,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("stopped"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().
+					GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).
+					Return(happyTaskResponseTwoInterfaces, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				setStopTCFaultExpectations(exec, ctrl, []string{"eth0", "eth1"}, tcLatencyFaultExistsCommandOutput)
+			},
+			expectedResponseJSON: happyFaultStoppedResponse,
+		},
+		{
 			name:                 "existing-network-latency-fault-happy-request-payload",
 			expectedStatusCode:   200,
 			requestBody:          happyNetworkLatencyReqBody,
@@ -2209,6 +2540,38 @@ func generateStopNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 func generateCheckNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 	commonTcs := generateCommonNetworkLatencyTestCases(checkNetworkLatencyTestPrefix)
 	tcs := []networkFaultInjectionTestCase{
+		{
+			name:                 "existing-network-latency-fault-two-interfaces",
+			expectedStatusCode:   200,
+			requestBody:          happyNetworkLatencyReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().
+					GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).
+					Return(happyTaskResponseTwoInterfaces, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+				expectations := []*gomock.Call{
+					exec.EXPECT().
+						NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).
+						Return(ctx, cancel),
+				}
+
+				// Check existing fault on each interface
+				for _, iface := range []string{"eth0", "eth1"} {
+					expectations = append(expectations,
+						exec.EXPECT().
+							CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", iface, "parent", "1:1"}).
+							Return(mockCMD),
+						mockCMD.EXPECT().CombinedOutput().Return([]byte(tcLatencyFaultExistsCommandOutput), nil),
+					)
+				}
+				gomock.InOrder(expectations...)
+			},
+			expectedResponseJSON: happyFaultRunningResponse,
+		},
 		{
 			name:                 "no-existing-fault-empty-request-payload",
 			expectedStatusCode:   200,
@@ -2460,6 +2823,28 @@ func generateCommonNetworkPacketLossTestCases(name string) []networkFaultInjecti
 func generateStartNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 	commonTcs := generateCommonNetworkPacketLossTestCases(startNetworkPacketLossTestPrefix)
 	tcs := []networkFaultInjectionTestCase{
+		{
+			name:                 "no-existing-fault - two interfaces",
+			expectedStatusCode:   200,
+			requestBody:          happyNetworkPacketLossReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().
+					GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).
+					Return(happyTaskResponseTwoInterfaces, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				setStartPacketLossFaultExpectations(
+					exec,
+					ctrl,
+					[]string{"eth0", "eth1"},
+					lossPercent,
+					ipSourcesToFilter,
+					ipSources,
+				)
+			},
+			expectedResponseJSON: happyFaultRunningResponse,
+		},
 		{
 			name:                 "no-existing-fault",
 			expectedStatusCode:   200,
@@ -2782,6 +3167,20 @@ func generateStopNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 			expectedResponseJSON: happyFaultStoppedResponse,
 		},
 		{
+			name:                 "existing-network-packet-loss-fault-empty-request-payload-two-interfaces",
+			expectedStatusCode:   200,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("stopped"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().
+					GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).
+					Return(happyTaskResponseTwoInterfaces, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				setStopTCFaultExpectations(exec, ctrl, []string{"eth0", "eth1"}, tcLossFaultExistsCommandOutput)
+			},
+			expectedResponseJSON: happyFaultStoppedResponse,
+		},
+		{
 			name:               "unknown-request-body-no-existing-fault-invalid-request-payload",
 			expectedStatusCode: 200,
 			requestBody: map[string]interface{}{
@@ -2811,6 +3210,38 @@ func generateStopNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 func generateCheckNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 	commonTcs := generateCommonNetworkPacketLossTestCases(checkNetworkPacketLossTestPrefix)
 	tcs := []networkFaultInjectionTestCase{
+		{
+			name:                 "existing-network-packet-loss-fault-two-interfaces",
+			expectedStatusCode:   200,
+			requestBody:          happyNetworkPacketLossReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().
+					GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).
+					Return(happyTaskResponseTwoInterfaces, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+				expectations := []*gomock.Call{
+					exec.EXPECT().
+						NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).
+						Return(ctx, cancel),
+				}
+
+				// Check existing fault on each interface
+				for _, iface := range []string{"eth0", "eth1"} {
+					expectations = append(expectations,
+						exec.EXPECT().
+							CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", iface, "parent", "1:1"}).
+							Return(mockCMD),
+						mockCMD.EXPECT().CombinedOutput().Return([]byte(tcLossFaultExistsCommandOutput), nil),
+					)
+				}
+				gomock.InOrder(expectations...)
+			},
+			expectedResponseJSON: happyFaultRunningResponse,
+		},
 		{
 			name:                 "no-existing-fault-empty-request-payload",
 			expectedStatusCode:   200,
@@ -2962,6 +3393,172 @@ func TestIsIPv6OnlyTask(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := isIPv6OnlyTask(tc.task)
 			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// TestCheckTCFault does focused testing for CheckTCFault function.
+func TestCheckTCFault(t *testing.T) {
+	createTestTaskMetadata := func(deviceNames []string) *state.TaskResponse {
+		interfaces := make([]*state.NetworkInterface, len(deviceNames))
+		for i, name := range deviceNames {
+			interfaces[i] = &state.NetworkInterface{
+				DeviceName: name,
+			}
+		}
+
+		return &state.TaskResponse{
+			TaskResponse: &v2.TaskResponse{TaskARN: "test-task"},
+			TaskNetworkConfig: &state.TaskNetworkConfig{
+				NetworkMode: "host",
+				NetworkNamespaces: []*state.NetworkNamespace{
+					{
+						Path:              "host",
+						NetworkInterfaces: interfaces,
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                string
+		deviceNames         []string
+		expectedLatency     bool
+		expectedPacketLoss  bool
+		expectedError       error
+		commandExpectations func(*mock_execwrapper.MockExec, *mock_execwrapper.MockCmd)
+	}{
+		{
+			name:               "No faults exist",
+			deviceNames:        []string{"eth0"},
+			expectedLatency:    false,
+			expectedPacketLoss: false,
+			expectedError:      nil,
+			commandExpectations: func(exec *mock_execwrapper.MockExec, cmd *mock_execwrapper.MockCmd) {
+				exec.EXPECT().CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", "eth0", "parent", "1:1"}).Return(cmd)
+				cmd.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil)
+			},
+		},
+		{
+			name:               "Latency fault exists",
+			deviceNames:        []string{"eth0"},
+			expectedLatency:    true,
+			expectedPacketLoss: false,
+			expectedError:      nil,
+			commandExpectations: func(exec *mock_execwrapper.MockExec, cmd *mock_execwrapper.MockCmd) {
+				exec.EXPECT().CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", "eth0", "parent", "1:1"}).Return(cmd)
+				cmd.EXPECT().CombinedOutput().Return([]byte(tcLatencyFaultExistsCommandOutput), nil)
+			},
+		},
+		{
+			name:               "Packet loss fault exists",
+			deviceNames:        []string{"eth0"},
+			expectedLatency:    false,
+			expectedPacketLoss: true,
+			expectedError:      nil,
+			commandExpectations: func(exec *mock_execwrapper.MockExec, cmd *mock_execwrapper.MockCmd) {
+				exec.EXPECT().CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", "eth0", "parent", "1:1"}).Return(cmd)
+				cmd.EXPECT().CombinedOutput().Return([]byte(tcLossFaultExistsCommandOutput), nil)
+			},
+		},
+		{
+			name:               "Command execution error",
+			deviceNames:        []string{"eth0"},
+			expectedLatency:    false,
+			expectedPacketLoss: false,
+			expectedError:      errors.New("failed to check existing network fault: 'tc -j q show dev eth0 parent 1:1' command failed with the following error: 'command failed'. std output: ''. TaskArn: test-task"),
+			commandExpectations: func(exec *mock_execwrapper.MockExec, cmd *mock_execwrapper.MockCmd) {
+				exec.EXPECT().CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", "eth0", "parent", "1:1"}).Return(cmd)
+				cmd.EXPECT().CombinedOutput().Return([]byte(""), errors.New("command failed"))
+			},
+		},
+		{
+			name:               "Invalid JSON output",
+			deviceNames:        []string{"eth0"},
+			expectedLatency:    false,
+			expectedPacketLoss: false,
+			expectedError:      errors.New("failed to check existing network fault: failed to unmarshal tc command output: invalid character 'i' looking for beginning of value. TaskArn: test-task"),
+			commandExpectations: func(exec *mock_execwrapper.MockExec, cmd *mock_execwrapper.MockCmd) {
+				exec.EXPECT().CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", "eth0", "parent", "1:1"}).Return(cmd)
+				cmd.EXPECT().CombinedOutput().Return([]byte("invalid json"), nil)
+			},
+		},
+		{
+			name:               "Multiple network interfaces - no faults",
+			deviceNames:        []string{"eth0", "eth1"},
+			expectedLatency:    false,
+			expectedPacketLoss: false,
+			expectedError:      nil,
+			commandExpectations: func(exec *mock_execwrapper.MockExec, cmd *mock_execwrapper.MockCmd) {
+				// First interface check
+				exec.EXPECT().CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", "eth0", "parent", "1:1"}).Return(cmd)
+				cmd.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil)
+
+				// Second interface check
+				exec.EXPECT().CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", "eth1", "parent", "1:1"}).Return(cmd)
+				cmd.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil)
+			},
+		},
+		{
+			name:               "Multiple network interfaces - latency fault on second interface",
+			deviceNames:        []string{"eth0", "eth1"},
+			expectedLatency:    true,
+			expectedPacketLoss: false,
+			expectedError:      nil,
+			commandExpectations: func(exec *mock_execwrapper.MockExec, cmd *mock_execwrapper.MockCmd) {
+				// First interface check - no fault
+				exec.EXPECT().CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", "eth0", "parent", "1:1"}).Return(cmd)
+				cmd.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil)
+
+				// Second interface check - has fault
+				exec.EXPECT().CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", "eth1", "parent", "1:1"}).Return(cmd)
+				cmd.EXPECT().CombinedOutput().Return([]byte(tcLatencyFaultExistsCommandOutput), nil)
+			},
+		},
+		{
+			name:               "Multiple network interfaces - packet loss fault on second interface",
+			deviceNames:        []string{"eth0", "eth1"},
+			expectedLatency:    false,
+			expectedPacketLoss: true,
+			expectedError:      nil,
+			commandExpectations: func(exec *mock_execwrapper.MockExec, cmd *mock_execwrapper.MockCmd) {
+				// First interface check - no fault
+				exec.EXPECT().CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", "eth0", "parent", "1:1"}).Return(cmd)
+				cmd.EXPECT().CombinedOutput().Return([]byte(tcCommandEmptyOutput), nil)
+
+				// Second interface check - has fault
+				exec.EXPECT().CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", "eth1", "parent", "1:1"}).Return(cmd)
+				cmd.EXPECT().CombinedOutput().Return([]byte(tcLossFaultExistsCommandOutput), nil)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockExec := mock_execwrapper.NewMockExec(ctrl)
+			mockCmd := mock_execwrapper.NewMockCmd(ctrl)
+
+			handler := &FaultHandler{
+				osExecWrapper: mockExec,
+			}
+
+			tc.commandExpectations(mockExec, mockCmd)
+
+			taskMetadata := createTestTaskMetadata(tc.deviceNames)
+			latencyExists, packetLossExists, err := handler.checkTCFault(context.Background(), taskMetadata)
+
+			if tc.expectedError != nil {
+				assert.EqualError(t, err, tc.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectedLatency, latencyExists)
+			assert.Equal(t, tc.expectedPacketLoss, packetLossExists)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR changes network latency and packet loss Fault Injection handlers so that they apply to all network interfaces of the task instead of just the first one. This is relevant for host mode task on hosts with different default network interfaces for IPv4 and IPv6. 

### Implementation details
<!-- How are the changes implemented? -->
Fault injection handlers now loop through all network interfaces instead of looking at just the first one.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Launched an instance with two ENIs - one IPv4-only and one IPv6-only. So, this instance has different IPv4 and IPv6 default network interfaces.

Latency fault worked on both IPv4 and IPv6 targets as expected -
```
bash-5.2# curl -XPOST --data '{"DelayMilliseconds": 500, "JitterMilliseconds": 0, "Sources": ["23.215.0.138/24", "2600:1406:bc00:53::b81e:94ce/64"], "SourcesToFilter": ["2600:1406:bc00:53::b81e:94c8"]}' ${ECS_AGENT_URI}/fault/v1/network-latency/start
{"Status":"running"}bash-5.2#
bash-5.2# ping -c3 23.215.0.138
PING 23.215.0.138 (23.215.0.138) 56(84) bytes of data.
64 bytes from 23.215.0.138: icmp_seq=1 ttl=48 time=564 ms
64 bytes from 23.215.0.138: icmp_seq=2 ttl=48 time=564 ms
64 bytes from 23.215.0.138: icmp_seq=3 ttl=48 time=564 ms

--- 23.215.0.138 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2003ms
rtt min/avg/max/mdev = 563.583/563.612/563.662/0.035 ms
bash-5.2# ping -c3 23.215.0.136
PING 23.215.0.136 (23.215.0.136) 56(84) bytes of data.
64 bytes from 23.215.0.136: icmp_seq=1 ttl=48 time=566 ms
64 bytes from 23.215.0.136: icmp_seq=2 ttl=48 time=566 ms
64 bytes from 23.215.0.136: icmp_seq=3 ttl=48 time=566 ms

--- 23.215.0.136 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2000ms
rtt min/avg/max/mdev = 565.607/565.616/565.627/0.008 ms
bash-5.2# ping -c3 2600:1406:bc00:53::b81e:94ce
PING 2600:1406:bc00:53::b81e:94ce(2600:1406:bc00:53::b81e:94ce) 56 data bytes
64 bytes from 2600:1406:bc00:53::b81e:94ce: icmp_seq=1 ttl=50 time=533 ms
64 bytes from 2600:1406:bc00:53::b81e:94ce: icmp_seq=2 ttl=50 time=533 ms
64 bytes from 2600:1406:bc00:53::b81e:94ce: icmp_seq=3 ttl=50 time=533 ms

--- 2600:1406:bc00:53::b81e:94ce ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2000ms
rtt min/avg/max/mdev = 533.428/533.433/533.436/0.003 ms
bash-5.2# ping -c3 2600:1406:bc00:53::b81e:94c8
PING 2600:1406:bc00:53::b81e:94c8(2600:1406:bc00:53::b81e:94c8) 56 data bytes
64 bytes from 2600:1406:bc00:53::b81e:94c8: icmp_seq=1 ttl=50 time=31.6 ms
64 bytes from 2600:1406:bc00:53::b81e:94c8: icmp_seq=2 ttl=50 time=31.6 ms
64 bytes from 2600:1406:bc00:53::b81e:94c8: icmp_seq=3 ttl=50 time=31.6 ms

--- 2600:1406:bc00:53::b81e:94c8 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2004ms
rtt min/avg/max/mdev = 31.610/31.622/31.647/0.017 ms
```

State of tc configuration with latency fault applied - 
```
[ec2-user@ip-10-0-1-50 ~]$ tc q show dev ens5
qdisc prio 1: root refcnt 3 bands 3 priomap 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
qdisc netem 10: parent 1:1 limit 1000 delay 500ms
[ec2-user@ip-10-0-1-50 ~]$ tc q show dev ens6
qdisc prio 1: root refcnt 3 bands 3 priomap 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
qdisc netem 10: parent 1:1 limit 1000 delay 500ms
```

Packet loss fault worked on both IPv4 and IPv6 targets as expected - 
```
bash-5.2# curl -XPOST --data '{"LossPercent": 33, "Sources": ["23.215.0.138/24", "2600:1406:bc00:53::b81e:94ce/64"], "SourcesToFilter": ["23.215.0.136"]}' ${ECS_AGENT_URI}/fault/v1/network-packet-loss/start
{"Status":"running"}bash-5.2#
bash-5.2# ping -i0.01 -c1000 23.215.0.138 | grep -A3 "ping statistics"
--- 23.215.0.138 ping statistics ---
1000 packets transmitted, 674 received, 32.6% packet loss, time 15925ms
rtt min/avg/max/mdev = 64.908/65.037/84.045/0.770 ms, pipe 5
bash-5.2# ping -i0.01 -c1000 23.215.0.136 | grep -A3 "ping statistics"
--- 23.215.0.136 ping statistics ---
1000 packets transmitted, 1000 received, 0% packet loss, time 15416ms
rtt min/avg/max/mdev = 63.741/63.903/90.693/1.220 ms, pipe 6
bash-5.2# ping -i0.01 -c1000 2600:1406:bc00:53::b81e:94ce | grep -A3 "ping statistics"
--- 2600:1406:bc00:53::b81e:94ce ping statistics ---
1000 packets transmitted, 669 received, 33.1% packet loss, time 15184ms
rtt min/avg/max/mdev = 33.346/33.402/35.425/0.114 ms, pipe 3
```

State of tc configuration with packet loss fault applied - 
```
[ec2-user@ip-10-0-1-50 ~]$ tc q show dev ens5
qdisc prio 1: root refcnt 3 bands 3 priomap 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
qdisc netem 10: parent 1:1 limit 1000 loss 33%
[ec2-user@ip-10-0-1-50 ~]$ tc q show dev ens6
qdisc prio 1: root refcnt 3 bands 3 priomap 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
qdisc netem 10: parent 1:1 limit 1000 loss 33%
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
bugfix: Network latency and packet loss faults should apply to all default network interfaces in host mode

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
