### PR TITLE
Determine instance IP compatibility using all ENIs 

### DIFF
--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -180,23 +180,8 @@ func getConfigFileName() (string, error) {
 //
 //lint:ignore U1000 Function will be used in the future
 func (c *Config) determineIPCompatibility(ec2client ec2.EC2MetadataClient) {
-	// Load primary ENI's MAC address on EC2 Launch Type
-	var primaryENIMAC string
-	if !c.External.Enabled() {
-		logger.Info("Calling IMDS to fetch mac address of the primary ENI")
-		var eniMACFetchErr error
-		primaryENIMAC, eniMACFetchErr = ec2client.PrimaryENIMAC()
-		if eniMACFetchErr != nil {
-			logger.Warn("Failed to fetch primary ENI's mac address from IMDS."+
-				" Failing back instance IP compatibility to IPv4-only.",
-				logger.Fields{field.Error: eniMACFetchErr})
-			c.InstanceIPCompatibility = ipcompatibility.NewIPv4OnlyCompatibility()
-			return
-		}
-	}
-
 	var err error
-	c.InstanceIPCompatibility, err = netutils.DetermineIPCompatibility(nlWrapper, primaryENIMAC)
+	c.InstanceIPCompatibility, err = netutils.DetermineIPCompatibility(nlWrapper, "")
 	if err != nil {
 		logger.Warn("Failed to determine instance IP compatibility."+
 			" Failing back instance IP compatibility to IPv4-only.",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
For EC2 Launch Type, currently the `config.determineIPCompatibility` function that is used to determine instance IP compatibility only considers the primary ENI of the instance. However, instances could be set up with multiple ENIs so Agent should consider all network interfaces to correctly determine the IP compatibility of the instance. The function already considers all network interfaces when determining the IP compatibility in EXTERNAL mode, so this changes unifies the logic for EC2 and EXTERNAL modes. 

### Implementation details
<!-- How are the changes implemented? -->
* Remove the dependency on primary ENI from `config.determineIPCompatibility` function. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Launched an EC2 instance with two ENIs - one IPv4-only primary ENI and one IPv6-only secondary ENI. Commented-out the default IPv4 route and updated `/etc/resolv.conf` so that it only has an IPv6 DNS Server. Verified that Agent correctly determined the instance's compatibility to be IPv6-only based on the IPv6 default routes via the secondary ENI. Tasks were successfully placed on the instance. 

```
[ec2-user@ip-10-0-1-250 ~]$ ip route show default

[ec2-user@ip-10-0-1-250 ~]$ cat /etc/resolv.conf
# This is /run/systemd/resolve/resolv.conf managed by man:systemd-resolved(8).
# Do not edit.
#
# This file might be symlinked as /etc/resolv.conf. If you're looking at
# /etc/resolv.conf and seeing this text, you have followed the symlink.
#
# This is a dynamic resolv.conf file for connecting local clients directly to
# all known uplink DNS servers. This file lists all configured search domains.
#
# Third party programs should typically not access this file directly, but only
# through the symlink at /etc/resolv.conf. To manage man:resolv.conf(5) in a
# different way, replace this symlink by a static file or a different symlink.
#
# See man:systemd-resolved.service(8) for details about the supported modes of
# operation for /etc/resolv.conf.

#nameserver 10.0.0.2
#nameserver 169.254.169.253
nameserver fd00:ec2::253
search us-west-2.compute.internal

[ec2-user@ip-10-0-1-250 ~]$ grep -i 'compat' /var/log/ecs/ecs-agent.log
level=info time=2025-06-05T19:00:27Z msg="Successfully determined IP compatibilty of the container instance" IPv4=false IPv6=true

[ec2-user@ip-10-0-1-250 ~]$ docker ps
CONTAINER ID   IMAGE                                        COMMAND        CREATED          STATUS                   PORTS                                                                                    NAMES
63258d04f587   ecr-public.aws.com/amazonlinux/amazonlinux   "sleep 7200"   10 seconds ago   Up 8 seconds             0.0.0.0:8081->8081/tcp, :::8081->8081/tcp, 0.0.0.0:32770->8080/tcp, :::32770->8080/tcp   ecs-ipv6-bridge-3-amazonlinux-948293b2b1d5958b2e00
8006ec476488   amazon/amazon-ecs-agent:latest               "/agent"       8 minutes ago    Up 8 minutes (healthy)                                                                                            ecs-agent
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
bugfix: Determine IP compatibility of the instance using all ENIS and not just the primary ENI

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
no

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
