### PR TITLE
Require ip6tables for fault injection capabilty on IPv6-only instances

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -551,7 +551,7 @@ func (agent *ecsAgent) appendFaultInjectionCapabilities(capabilities []types.Att
 		return capabilities
 	}
 
-	if isFaultInjectionToolingAvailable() {
+	if isFaultInjectionToolingAvailable(agent.cfg) {
 		capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFaultInjection)
 		seelog.Debug("Fault injection capability is enabled.")
 	} else {

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -1564,7 +1564,7 @@ func TestAppendFaultInjectionCapabilities(t *testing.T) {
 	defer func() { isFaultInjectionToolingAvailable = originalIsFaultInjectionToolingAvailable }()
 	t.Run("Fault Injection Capability Available", func(t *testing.T) {
 		// Test case where required tooling is available
-		isFaultInjectionToolingAvailable = func() bool { return true }
+		isFaultInjectionToolingAvailable = func(cfg *config.Config) bool { return true }
 		capabilities := []types.Attribute{}
 		agent := &ecsAgent{
 			cfg: &config.Config{},
@@ -1576,7 +1576,7 @@ func TestAppendFaultInjectionCapabilities(t *testing.T) {
 	})
 	t.Run("Fault Injection Capability Not Available", func(t *testing.T) {
 		// Test case where required tooling is not available
-		isFaultInjectionToolingAvailable = func() bool { return false }
+		isFaultInjectionToolingAvailable = func(cfg *config.Config) bool { return false }
 		capabilities := []types.Attribute{}
 		agent := &ecsAgent{
 			cfg: &config.Config{},
@@ -1588,7 +1588,7 @@ func TestAppendFaultInjectionCapabilities(t *testing.T) {
 
 	t.Run("Fault Injection Capability Not Available for EXTERNAL Launch Type", func(t *testing.T) {
 		// Test case where required tooling is available but EXTERNAL Launch Type
-		isFaultInjectionToolingAvailable = func() bool { return true }
+		isFaultInjectionToolingAvailable = func(cfg *config.Config) bool { return true }
 		capabilities := []types.Attribute{}
 		agent := &ecsAgent{
 			cfg: &config.Config{

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -258,8 +258,13 @@ var networkConfigClient = netconfig.NewNetworkConfigClient()
 
 // checkFaultInjectionTooling checks for the required network packages like iptables, tc
 // to be available on the host before ecs.capability.fault-injection can be advertised
-func checkFaultInjectionTooling() bool {
+func checkFaultInjectionTooling(cfg *config.Config) bool {
 	tools := []string{"iptables", "tc", "nsenter"}
+	if cfg.InstanceIPCompatibility.IsIPv6Only() {
+		// ip6tables is a required dependency on IPv6-only instances.
+		// TODO: Consider making ip6tables a required dependency for all instances (ned to consider backwards compatibility)
+		tools = append(tools, "ip6tables")
+	}
 	for _, tool := range tools {
 		if _, err := lookPathFunc(tool); err != nil {
 			seelog.Warnf(

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -262,7 +262,7 @@ func checkFaultInjectionTooling(cfg *config.Config) bool {
 	tools := []string{"iptables", "tc", "nsenter"}
 	if cfg.InstanceIPCompatibility.IsIPv6Only() {
 		// ip6tables is a required dependency on IPv6-only instances.
-		// TODO: Consider making ip6tables a required dependency for all instances (ned to consider backwards compatibility)
+		// TODO: Consider making ip6tables a required dependency for all instances (need to consider backwards compatibility)
 		tools = append(tools, "ip6tables")
 	}
 	for _, tool := range tools {

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -1041,7 +1041,7 @@ func TestCheckFaultInjectionTooling(t *testing.T) {
 		)
 		osExecWrapper = mockExec
 		assert.True(t,
-			checkFaultInjectionTooling(),
+			checkFaultInjectionTooling(&config.Config{}),
 			"Expected checkFaultInjectionTooling to return true when all tools are available")
 	})
 
@@ -1059,7 +1059,7 @@ func TestCheckFaultInjectionTooling(t *testing.T) {
 		)
 		osExecWrapper = mockExec
 		assert.False(t,
-			checkFaultInjectionTooling(),
+			checkFaultInjectionTooling(&config.Config{}),
 			"Expected checkFaultInjectionTooling to return false when kernel modules are not available")
 	})
 
@@ -1083,7 +1083,7 @@ func TestCheckFaultInjectionTooling(t *testing.T) {
 		)
 		osExecWrapper = mockExec
 		assert.False(t,
-			checkFaultInjectionTooling(),
+			checkFaultInjectionTooling(&config.Config{}),
 			"Expected checkFaultInjectionTooling to return false when unable to find default host interface name")
 	})
 
@@ -1112,7 +1112,7 @@ func TestCheckFaultInjectionTooling(t *testing.T) {
 		)
 		osExecWrapper = mockExec
 		assert.False(t,
-			checkFaultInjectionTooling(),
+			checkFaultInjectionTooling(&config.Config{}),
 			"Expected checkFaultInjectionTooling to return false when required tc show command failed")
 	})
 
@@ -1126,10 +1126,24 @@ func TestCheckFaultInjectionTooling(t *testing.T) {
 				return "/usr/bin/" + file, nil
 			}
 			assert.False(t,
-				checkFaultInjectionTooling(),
+				checkFaultInjectionTooling(&config.Config{}),
 				"Expected checkFaultInjectionTooling to return false when a tool is missing")
 		})
 	}
+
+	t.Run("missing ip6tables on IPv6-only instance", func(t *testing.T) {
+		lookPathFunc = func(file string) (string, error) {
+			if file == "ip6tables" {
+				return "", exec.ErrNotFound
+			}
+			return "/usr/bin/" + file, nil
+		}
+		assert.False(t,
+			checkFaultInjectionTooling(&config.Config{
+				InstanceIPCompatibility: ipcompatibility.NewIPv6OnlyCompatibility(),
+			}),
+			"Expected checkFaultInjectionTooling to return false when ip6tables is missing on IPv6-only instance")
+	})
 }
 
 func convertToInterfaceList(strings []string) []interface{} {

--- a/agent/app/agent_capability_unspecified.go
+++ b/agent/app/agent_capability_unspecified.go
@@ -151,6 +151,6 @@ var isFaultInjectionToolingAvailable = checkFaultInjectionTooling
 
 // checkFaultInjectionTooling checks for the required network packages like iptables, tc
 // to be available on the host before ecs.capability.fault-injection can be advertised
-func checkFaultInjectionTooling() bool {
+func checkFaultInjectionTooling(_ *config.Config) bool {
 	return false
 }

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -149,7 +149,7 @@ var isFaultInjectionToolingAvailable = checkFaultInjectionTooling
 
 // checkFaultInjectionTooling checks for the required network packages like iptables, tc
 // to be available on the host before ecs.capability.fault-injection can be advertised
-func checkFaultInjectionTooling() bool {
+func checkFaultInjectionTooling(_ *config.Config) bool {
 	seelog.Warnf("Fault injection tooling is not supported on windows")
 	return false
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This change makes `ip6tables` a required dependency for fault injection capability on IPv6-only instances. While the Agent already uses `ip6tables` to apply network-blackhole-port fault to IPv6 traffic (as implemented in [PR #4629](https://github.com/aws/amazon-ecs-agent/pull/4629)), this requirement is currently only enforced for IPv6-only tasks, remaining best-effort for other tasks.

By making this change, the Agent will detect missing `ip6tables` dependency during instance registration for IPv6-only instances, preventing failures during fault injection. While we plan to consider enforcing IPv6 fault injection across all instance types in the future, this requires careful backwards-compatibility considerations. Since IPv6-only support is an upcoming feature, we can safely enforce this requirement for IPv6-only instances now without breaking existing functionality.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Temporarily renamed `ip6tables` on an IPv6-only and a dual-stack instance and ran Agent. 

IPv6-only instance - 
```
[ec2-user@ipv6only ~]$ which ip6tables
/usr/bin/which: no ip6tables in (/home/ec2-user/.local/bin:/home/ec2-user/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin)
[ec2-user@ipv6only ~]$ grep -i fault /var/log/ecs/ecs-agent.log
level=warn time=2025-06-05T22:14:09Z msg="Failed to find network tool ip6tables that is needed for fault-injection feature: exec: \"ip6tables\": executable file not found in $PATH" module=agent_capability_unix.go
level=warn time=2025-06-05T22:14:09Z msg="Fault injection capability not enabled: Required network tools are missing" module=agent_capability.go
level=debug time=2025-06-05T22:14:09Z msg="Successfully set up Fault TMDS handlers" module=task_server_setup.go
[ec2-user@ipv6only ~]$ grep -i 'starting amazon ecs' /var/log/ecs/ecs-agent.log
level=info time=2025-06-05T22:14:08Z msg="Starting Amazon ECS Agent" version="1.94.0" commit="07357f54"
```

Dual-stack instance - 
```
ip-10-0-0-23 ❱ which ip6tables
ip6tables not found
ip-10-0-0-23 ❱ grep -i fault /var/log/ecs/ecs-agent.log
level=debug time=2025-06-05T22:12:34Z msg="Fault injection capability is enabled." module=agent_capability.go
level=debug time=2025-06-05T22:12:35Z msg="Successfully set up Fault TMDS handlers" module=task_server_setup.go
ip-10-0-0-23 ❱ grep -i 'starting amazon ecs' /var/log/ecs/ecs-agent.log
level=info time=2025-06-05T22:12:34Z msg="Starting Amazon ECS Agent" version="1.94.0" commit="07357f54"
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: require `ip6tables` for fault injection capability on IPv6-only instances

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
no

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
