### PR TITLE
Improve task network config validation in Fault Injection handlers

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -1316,8 +1316,11 @@ func validateTaskNetworkConfig(taskNetworkConfig *state.TaskNetworkConfig) error
 	}
 
 	// Device name is required to inject network faults to given ENI in the task.
-	if taskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces[0].DeviceName == "" {
-		return errors.New("no ENI device name in the network namespace within task network config")
+	// Verify all network interfaces have a non-empty DeviceName
+	for i, netInterface := range taskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces {
+		if netInterface.DeviceName == "" {
+			return fmt.Errorf("no ENI device name for network interface %d in the network namespace within task network config", i)
+		}
 	}
 
 	return nil

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -1316,8 +1316,11 @@ func validateTaskNetworkConfig(taskNetworkConfig *state.TaskNetworkConfig) error
 	}
 
 	// Device name is required to inject network faults to given ENI in the task.
-	if taskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces[0].DeviceName == "" {
-		return errors.New("no ENI device name in the network namespace within task network config")
+	// Verify all network interfaces have a non-empty DeviceName
+	for i, netInterface := range taskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces {
+		if netInterface.DeviceName == "" {
+			return fmt.Errorf("no ENI device name for network interface %d in the network namespace within task network config", i)
+		}
 	}
 
 	return nil

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_netconfig_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_netconfig_test.go
@@ -1,0 +1,138 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package handlers
+
+import (
+	"testing"
+
+	state "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateTaskNetworkConfig(t *testing.T) {
+	testCases := []struct {
+		name          string
+		config        *state.TaskNetworkConfig
+		expectedError string
+	}{
+		{
+			name:          "nil config",
+			config:        nil,
+			expectedError: "TaskNetworkConfig is empty within task metadata",
+		},
+		{
+			name:          "empty network namespaces",
+			config:        &state.TaskNetworkConfig{},
+			expectedError: "empty network namespaces within task network config",
+		},
+		{
+			name: "empty network namespace path",
+			config: &state.TaskNetworkConfig{
+				NetworkNamespaces: []*state.NetworkNamespace{{}},
+			},
+			expectedError: "no path in the network namespace within task network config",
+		},
+		{
+			name: "empty network interfaces",
+			config: &state.TaskNetworkConfig{
+				NetworkNamespaces: []*state.NetworkNamespace{
+					{
+						Path: "/proc/1234/ns/net",
+					},
+				},
+			},
+			expectedError: "empty network interfaces within task network config",
+		},
+		{
+			name: "first interface missing device name",
+			config: &state.TaskNetworkConfig{
+				NetworkNamespaces: []*state.NetworkNamespace{
+					{
+						Path: "/proc/1234/ns/net",
+						NetworkInterfaces: []*state.NetworkInterface{
+							{},
+							{
+								DeviceName: "eth1",
+							},
+						},
+					},
+				},
+			},
+			expectedError: "no ENI device name for network interface 0 in the network namespace within task network config",
+		},
+		{
+			name: "second interface missing device name",
+			config: &state.TaskNetworkConfig{
+				NetworkNamespaces: []*state.NetworkNamespace{
+					{
+						Path: "/proc/1234/ns/net",
+						NetworkInterfaces: []*state.NetworkInterface{
+							{
+								DeviceName: "eth0",
+							},
+							{},
+						},
+					},
+				},
+			},
+			expectedError: "no ENI device name for network interface 1 in the network namespace within task network config",
+		},
+		{
+			name: "valid config with single interface",
+			config: &state.TaskNetworkConfig{
+				NetworkNamespaces: []*state.NetworkNamespace{
+					{
+						Path: "/proc/1234/ns/net",
+						NetworkInterfaces: []*state.NetworkInterface{
+							{
+								DeviceName: "eth0",
+							},
+						},
+					},
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "valid config with multiple interfaces",
+			config: &state.TaskNetworkConfig{
+				NetworkNamespaces: []*state.NetworkNamespace{
+					{
+						Path: "/proc/1234/ns/net",
+						NetworkInterfaces: []*state.NetworkInterface{
+							{
+								DeviceName: "eth0",
+							},
+							{
+								DeviceName: "eth1",
+							},
+						},
+					},
+				},
+			},
+			expectedError: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTaskNetworkConfig(tc.config)
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.expectedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
