### PR TITLE
Engine: add a fluentd integration test

### DIFF
--- a/agent/engine/common_unix_integ_testutil.go
+++ b/agent/engine/common_unix_integ_testutil.go
@@ -18,14 +18,50 @@
 package engine
 
 import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/firelens"
+	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
+	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
+
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
-	testRegistryImage = "127.0.0.1:51670/amazon/amazon-ecs-netkitten:latest"
-	dockerEndpoint    = "unix:///var/run/docker.sock"
+	testRegistryImage     = "127.0.0.1:51670/amazon/amazon-ecs-netkitten:latest"
+	dockerEndpoint        = "unix:///var/run/docker.sock"
+	validTaskArnPrefix    = "arn:aws:ecs:region:account-id:task/"
+	testAppContainerImage = "public.ecr.aws/docker/library/busybox:latest"
+	testFluentBitImage    = "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
+	TestCluster           = "testCluster"
+	TestInstanceID        = "testInstanceID"
+)
+
+var (
+	mockTaskMetadataHandler = http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Write([]byte(`{"TaskARN": "arn:aws:ecs:region:account-id:task/task-id"}`))
+	})
 )
 
 func CreateTestContainer() *apicontainer.Container {
@@ -41,4 +77,267 @@ func GetLongRunningCommand() []string {
 func isDockerRunning() bool {
 	_, err := os.Stat("/var/run/docker.sock")
 	return err == nil
+}
+
+// createFirelensLogDir creates a temporary directory where the log router container can write logs to
+func createFirelensLogDir(t *testing.T, directoryPrefix, firelensContainerUser string) string {
+	tmpDir, err := os.MkdirTemp("", directoryPrefix)
+	require.NoError(t, err)
+
+	// Change log directory ownership so that the log router can write logs to it,
+	// especially when running as non-root user
+	if firelensContainerUser != "" {
+		// Parse the user string to get UID and GID
+		parts := strings.Split(firelensContainerUser, ":")
+		if len(parts) == 2 {
+			uid, err := strconv.Atoi(parts[0])
+			require.NoError(t, err)
+
+			gid, err := strconv.Atoi(parts[1])
+			require.NoError(t, err)
+
+			// Change ownership of the directory
+			err = os.Chown(tmpDir, uid, gid)
+			require.NoError(t, err)
+		}
+	}
+	return tmpDir
+}
+
+// setupTaskMetadataServer sets up a mock TMDS that the Firelens container needs access to.
+func setupTaskMetadataServer(t *testing.T) {
+	// Note that the listener has to be overwritten here, because the default one from httptest.NewServer
+	// only listens to localhost and isn't reachable from container running in bridge network mode.
+	l, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	server := httptest.NewUnstartedServer(mockTaskMetadataHandler)
+	server.Listener = l
+	server.Start()
+	defer server.Close()
+	port := getPortFromAddr(t, server.URL)
+	ec2MetadataClient, err := ec2.NewEC2MetadataClient(nil)
+	require.NoError(t, err)
+	serverURL := fmt.Sprintf("http://%s:%s", getHostPrivateIP(t, ec2MetadataClient), port)
+	defer setV3MetadataURLFormat(serverURL + "/v3/%s")()
+}
+
+// getPortFromAddr returns the port part of an address in format "http://<addr>:<port>".
+func getPortFromAddr(t *testing.T, addr string) string {
+	u, err := url.Parse(addr)
+	require.NoErrorf(t, err, "unable to parse address: %s", addr)
+	_, port, err := net.SplitHostPort(u.Host)
+	require.NoErrorf(t, err, "unable to get port from address: %s", addr)
+	return port
+}
+
+// getHostPrivateIP returns the host's private IP.
+func getHostPrivateIP(t *testing.T, ec2MetadataClient ec2.EC2MetadataClient) string {
+	ip, err := ec2MetadataClient.PrivateIPv4Address()
+	require.NoError(t, err)
+	return ip
+}
+
+// setV3MetadataURLFormat sets the container metadata URI format and returns a function to set it back.
+func setV3MetadataURLFormat(fmt string) func() {
+	backup := apicontainer.MetadataURIFormat
+	apicontainer.MetadataURIFormat = fmt
+	return func() {
+		apicontainer.MetadataURIFormat = backup
+	}
+}
+
+// verifyFirelensTaskEvents verifies the Firelens task and container events based on the execution phase.
+func verifyFirelensTaskEvents(t *testing.T, taskEngine TaskEngine, firelensTask *apitask.Task, phase string) {
+	testEvents := InitTestEventCollection(taskEngine)
+	switch phase {
+	case "start":
+		// Verify the log-router container is running
+		VerifyContainerStatus(apicontainerstatus.ContainerRunning, firelensTask.Arn+":log-router", testEvents, t)
+
+		// Verify the app container is running
+		VerifyContainerStatus(apicontainerstatus.ContainerRunning, firelensTask.Arn+":app", testEvents, t)
+
+		// Verify the task is in running state
+		VerifyTaskStatus(apitaskstatus.TaskRunning, firelensTask.Arn, testEvents, t)
+	case "stop":
+		// Verify the app container is stopped
+		VerifyContainerStatus(apicontainerstatus.ContainerStopped, firelensTask.Arn+":app", testEvents, t)
+
+		// Verify the log-router container is stopped
+		VerifyContainerStatus(apicontainerstatus.ContainerStopped, firelensTask.Arn+":log-router", testEvents, t)
+
+		// Verify the task has stopped
+		VerifyTaskStatus(apitaskstatus.TaskStopped, firelensTask.Arn, testEvents, t)
+	default:
+		t.Errorf("Unexpected phase: %s", phase)
+	}
+}
+
+// createFirelensTask creates an ECS task with 2 containers – 1) App 2) Log router container
+// The app writes the date to stdout, and the log router forwards it to a local file on disk
+func createFirelensTask(t *testing.T, testName, firelensContainerUser, tmpDir string) *apitask.Task {
+	rawHostConfigInputForApp := dockercontainer.HostConfig{
+		LogConfig: dockercontainer.LogConfig{
+			Type: logDriverTypeFirelens,
+			Config: map[string]string{
+				"Name":   "file",
+				"Path":   "/logs",
+				"File":   "app.log",
+				"Format": "plain",
+			},
+		},
+	}
+	rawHostConfigForApp, err := json.Marshal(&rawHostConfigInputForApp)
+	require.NoError(t, err)
+
+	testTask := CreateTestTask(validTaskArnPrefix + testName + "-" + uuid.New())
+	testTask.Containers = []*apicontainer.Container{
+		{
+			Name:      "app",
+			Image:     testAppContainerImage,
+			Essential: true,
+			Command: []string{"sh", "-c",
+				"date +%T; exit 42"},
+			DockerConfig: apicontainer.DockerConfig{
+				HostConfig: func() *string {
+					s := string(rawHostConfigForApp)
+					return &s
+				}(),
+			},
+		},
+		{
+			Name:      "log-router",
+			Image:     testFluentBitImage,
+			Essential: true,
+			FirelensConfig: &apicontainer.FirelensConfig{
+				Type: firelens.FirelensConfigTypeFluentbit,
+				Options: map[string]string{
+					"enable-ecs-log-metadata": "true",
+				},
+			},
+			Environment: map[string]string{
+				"AWS_EXECUTION_ENV": "AWS_ECS_EC2",
+				"FLB_LOG_LEVEL":     "debug",
+			},
+			MountPoints: []apicontainer.MountPoint{
+				{
+					SourceVolume:  "logs",
+					ContainerPath: "/logs",
+				},
+			},
+			TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
+		},
+	}
+
+	// Set firelens container user when defined
+	if firelensContainerUser != "" {
+		rawConfigForLogRouter := fmt.Sprintf(`{"User":"%s"}`, firelensContainerUser)
+		testTask.Containers[1].DockerConfig = apicontainer.DockerConfig{
+			Config: func() *string {
+				return &rawConfigForLogRouter
+			}(),
+		}
+	}
+
+	// Initialize a task volume where the app logs will be written to
+	testTask.Volumes = []apitask.TaskVolume{
+		{
+			Name:   "logs",
+			Volume: &taskresourcevolume.FSHostVolume{FSSourcePath: tmpDir},
+		},
+	}
+	testTask.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
+	return testTask
+}
+
+// verifyFirelensDataDir verifies the configuration of the data directory, that is created for the Firelens task
+func verifyFirelensDataDir(t *testing.T, firelensDataDir, firelensContainerUser string) {
+	// Verify Firelens data directory exists
+	_, err := os.Stat(firelensDataDir)
+	require.NoError(t, err)
+
+	// Validate subdirectories - config and socket
+	firelensConfigDir := filepath.Join(firelensDataDir, "config")
+	firelensSocketDir := filepath.Join(firelensDataDir, "socket")
+
+	// Verify config directory exists
+	configDirInfo, err := os.Stat(firelensConfigDir)
+	require.NoError(t, err)
+
+	// Verify socket directory exists
+	socketDir, err := os.Stat(firelensSocketDir)
+	require.NoError(t, err)
+
+	// Helper function to get UID:GID string from FileInfo
+	getOwnership := func(info os.FileInfo) string {
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			t.Fatalf("Failed to get stat info")
+			return ""
+		}
+		return fmt.Sprintf("%d:%d", stat.Uid, stat.Gid)
+	}
+
+	// Verify the config directory is owned by the ECS agent (root)
+	expectedAgentOwnership := fmt.Sprintf("%d:%d", 0, 0)
+	assert.Equal(t, expectedAgentOwnership, getOwnership(configDirInfo),
+		"Firelens config directory has incorrect ownership")
+
+	// Verify the socket directory is owned by the firelensContainerUser when specified
+	if firelensContainerUser == "" {
+		assert.Equal(t, expectedAgentOwnership, getOwnership(configDirInfo),
+			"Firelens config directory has incorrect ownership")
+	} else {
+		assert.Equal(t, firelensContainerUser, getOwnership(socketDir),
+			"Firelens socket directory has incorrect ownership")
+	}
+}
+
+// verifyFirelensLogs verifies that the Firelens container sent app logs to a local file as expected
+func verifyFirelensLogs(t *testing.T, firelensTask *apitask.Task, tmpDir string) {
+	logFilePath := filepath.Join(tmpDir, "app.log")
+
+	// Wait for the log file to be created and populated
+	var logContent []byte
+	var err error
+	for i := 0; i < 30; i++ {
+		logContent, err = os.ReadFile(logFilePath)
+		if err == nil && len(logContent) > 0 {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	// Check if we successfully read the log file
+	require.NoError(t, err, "Failed to read log file at %s", logFilePath)
+	require.NotEmpty(t, logContent, "Log file is empty")
+
+	// Parse the JSON log object
+	jsonBlob := make(map[string]string)
+	err = json.Unmarshal(logContent, &jsonBlob)
+	require.NoError(t, err, "Failed to parse JSON log entry")
+
+	// Verify log fields
+	assert.Contains(t, jsonBlob, "container_id", "Log missing container_id field")
+	assert.Contains(t, jsonBlob, "container_name", "Log missing container_name field")
+	assert.Contains(t, jsonBlob["container_name"], "app", "Log from wrong container")
+	assert.Equal(t, "stdout", jsonBlob["source"], "Incorrect log source")
+
+	// Verify ECS metadata fields
+	assert.Equal(t, TestInstanceID, jsonBlob["ec2_instance_id"], "Incorrect EC2 instance ID")
+	assert.Equal(t, TestCluster, jsonBlob["ecs_cluster"], "Incorrect cluster name")
+	assert.Equal(t, firelensTask.Arn, jsonBlob["ecs_task_arn"], "Incorrect task ARN")
+	assert.Contains(t, jsonBlob, "ecs_task_definition", "Task definition missing")
+}
+
+// verifyFirelensResourceCleanup verifies that the Firelens task resource is cleaned up once the task stops
+func verifyFirelensResourceCleanup(t *testing.T, cfg *config.Config, firelensTask *apitask.Task, taskEngine TaskEngine,
+	firelensDataDir string) {
+	// Set sent status to trigger task cleanup
+	t.Logf("SentStatus for task %s has been marked as stopped", firelensTask.Arn)
+	firelensTask.SetSentStatus(apitaskstatus.TaskStopped)
+	waitForTaskCleanup(t, taskEngine, firelensTask.Arn, 30)
+	// Make sure the data directory is cleaned up
+	_, err := os.ReadDir(firelensDataDir)
+	assert.True(t, os.IsNotExist(err), "Firelens data directory has not been cleaned up")
 }

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -18,17 +18,11 @@ package engine
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -45,26 +39,18 @@ import (
 	engineserviceconnect "github.com/aws/amazon-ecs-agent/agent/engine/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	cgroup "github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup/control"
-	"github.com/aws/amazon-ecs-agent/agent/taskresource/firelens"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
-	cloudwatchlogs_errors "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
-	dockercontainer "github.com/docker/docker/api/types/container"
 	sdkClient "github.com/docker/docker/client"
-	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,26 +61,13 @@ var (
 )
 
 const (
-	testLogSenderImage           = "public.ecr.aws/amazonlinux/amazonlinux:2.0.20210126.0"
-	testFluentBitImage           = "public.ecr.aws/aws-observability/aws-for-fluent-bit:2.10.1"
-	testVolumeImage              = "127.0.0.1:51670/amazon/amazon-ecs-volumes-test:latest"
-	testCluster                  = "testCluster"
-	validTaskArnPrefix           = "arn:aws:ecs:region:account-id:task/"
-	testDataDir                  = "/var/lib/ecs/data/"
-	testDataDirOnHost            = "/var/lib/ecs/"
-	testInstanceID               = "testInstanceID"
-	testECSRegion                = "us-east-1"
-	testLogGroupName             = "test-fluentbit"
-	testLogGroupPrefix           = "firelens-fluentbit-"
+	testVolumeImage   = "127.0.0.1:51670/amazon/amazon-ecs-volumes-test:latest"
+	testDataDir       = "/var/lib/ecs/data/"
+	testDataDirOnHost = "/var/lib/ecs/"
+
 	testExecCommandAgentImage    = "127.0.0.1:51670/amazon/amazon-ecs-exec-command-agent-test:latest"
 	testExecCommandAgentSleepBin = "/sleep"
 	testExecCommandAgentKillBin  = "/kill"
-)
-
-var (
-	mockTaskMeatadataHandler = http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		rw.Write([]byte(`{"TaskARN": "arn:aws:ecs:region:account-id:task/task-id"}`))
-	})
 )
 
 func TestStartStopWithCgroup(t *testing.T) {
@@ -191,206 +164,84 @@ func createTestLocalVolumeMountTask() *apitask.Task {
 	return testTask
 }
 
-func TestFirelensFluentbit(t *testing.T) {
-	// Skipping the test for arm as they do not have official support for Arm images
-	if runtime.GOARCH == "arm64" {
-		t.Skip("Skipping test, unsupported image for arm64")
-	}
+// TestFirelensFluentBit integration test verifies the following:
+//
+// 1. Firelens data directory creation and ownership configuration
+// 2. Task and container state events
+// 3. Firelens container's ability to log to a destination (local file)
+// 4. Firelens resource cleanup after the task stops
+//
+// This test validates the integration of different ECS agent components. It mocks the payload received from ECS backend,
+// and does not rely on external logging destinations (like CloudWatch) for logging functionality verification.
+func TestFirelensFluentBit(t *testing.T) {
+	// Setup agent config
 	cfg := DefaultTestConfigIntegTest()
 	cfg.DataDir = testDataDir
 	cfg.DataDirOnHost = testDataDirOnHost
 	cfg.TaskCleanupWaitDuration = 1 * time.Second
-	cfg.Cluster = testCluster
+	cfg.Cluster = TestCluster
+
+	// Setup task engine
 	taskEngine, done, _, _ := SetupIntegTestTaskEngine(cfg, nil, t)
-	defer done()
-
-	// Mock task metadata server as the firelens container needs to access it.
-	// Note that the listener has to be overwritten here, because the default one from httptest.NewServer
-	// only listens to localhost and isn't reachable from container running in bridge network mode.
-	l, err := net.Listen("tcp", ":0")
-	require.NoError(t, err)
-	server := httptest.NewUnstartedServer(mockTaskMeatadataHandler)
-	server.Listener = l
-	server.Start()
-	defer server.Close()
-
-	port := getPortFromAddr(t, server.URL)
-	ec2MetadataClient, err := ec2.NewEC2MetadataClient(nil)
-	require.NoError(t, err)
-	serverURL := fmt.Sprintf("http://%s:%s", getHostPrivateIP(t, ec2MetadataClient), port)
-	defer setV3MetadataURLFormat(serverURL + "/v3/%s")()
-
-	testTask := createFirelensTask(t)
 	taskEngine.(*DockerTaskEngine).resourceFields = &taskresource.ResourceFields{
 		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
-			EC2InstanceID: testInstanceID,
+			EC2InstanceID: TestInstanceID,
 		},
 	}
-	go taskEngine.AddTask(testTask)
-	testEvents := InitTestEventCollection(taskEngine)
+	defer done()
 
-	//Verify logsender container is running
-	VerifyContainerStatus(apicontainerstatus.ContainerRunning, testTask.Arn+":logsender", testEvents, t)
+	// Setup task metadata server
+	setupTaskMetadataServer(t)
 
-	//Verify firelens container is running
-	VerifyContainerStatus(apicontainerstatus.ContainerRunning, testTask.Arn+":firelens", testEvents, t)
-
-	//Verify task is in running state
-	VerifyTaskStatus(apitaskstatus.TaskRunning, testTask.Arn, testEvents, t)
-
-	//Verify logsender container is stopped
-	VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTask.Arn+":logsender", testEvents, t)
-
-	//Verify firelens container is stopped
-	VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTask.Arn+":firelens", testEvents, t)
-
-	//Verify the task itself has stopped
-	VerifyTaskStatus(apitaskstatus.TaskStopped, testTask.Arn, testEvents, t)
-
-	taskID := testTask.GetID()
-
-	//declare a cloudwatch client
-	awsCfg, err := awsconfig.LoadDefaultConfig(context.TODO(), awsconfig.WithRegion(testECSRegion))
-	require.NoError(t, err, "Unable to load AWS config")
-	cwlClient := cloudwatchlogs.NewFromConfig(awsCfg)
-	params := &cloudwatchlogs.GetLogEventsInput{
-		LogGroupName:  aws.String(testLogGroupName),
-		LogStreamName: aws.String(fmt.Sprintf("firelens-fluentbit-logsender-firelens-%s", taskID)),
-	}
-
-	// wait for the cloud watch logs
-	resp, err := waitCloudwatchLogs(cwlClient, params)
-	require.NoError(t, err)
-	// there should only be one event as we are echoing only one thing that part of the include-filter
-	assert.Equal(t, 1, len(resp.Events))
-
-	message := aws.ToString(resp.Events[0].Message)
-	jsonBlob := make(map[string]string)
-	err = json.Unmarshal([]byte(message), &jsonBlob)
-	require.NoError(t, err)
-	assert.Equal(t, "stdout", jsonBlob["source"])
-	assert.Equal(t, "include", jsonBlob["log"])
-	assert.Contains(t, jsonBlob, "container_id")
-	assert.Contains(t, jsonBlob["container_name"], "logsender")
-	assert.Equal(t, testCluster, jsonBlob["ecs_cluster"])
-	assert.Equal(t, testTask.Arn, jsonBlob["ecs_task_arn"])
-
-	testTask.SetSentStatus(apitaskstatus.TaskStopped)
-	time.Sleep(3 * cfg.TaskCleanupWaitDuration)
-
-	for i := 0; i < 60; i++ {
-		_, ok := taskEngine.(*DockerTaskEngine).State().TaskByArn(testTask.Arn)
-		if !ok {
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
-	// Make sure all the resource is cleaned up
-	_, err = ioutil.ReadDir(filepath.Join(testDataDir, "firelens", testTask.Arn))
-	assert.Error(t, err)
-}
-
-// getPortFromAddr returns the port part of an address in format "http://<addr>:<port>".
-func getPortFromAddr(t *testing.T, addr string) string {
-	u, err := url.Parse(addr)
-	require.NoErrorf(t, err, "unable to parse address: %s", addr)
-	_, port, err := net.SplitHostPort(u.Host)
-	require.NoErrorf(t, err, "unable to get port from address: %s", addr)
-	return port
-}
-
-// getHostPrivateIP returns the host's private IP.
-func getHostPrivateIP(t *testing.T, ec2MetadataClient ec2.EC2MetadataClient) string {
-	ip, err := ec2MetadataClient.PrivateIPv4Address()
-	require.NoError(t, err)
-	return ip
-}
-
-// setV3MetadataURLFormat sets the container metadata URI format and returns a function to set it back.
-func setV3MetadataURLFormat(fmt string) func() {
-	backup := apicontainer.MetadataURIFormat
-	apicontainer.MetadataURIFormat = fmt
-	return func() {
-		apicontainer.MetadataURIFormat = backup
-	}
-}
-
-func createFirelensTask(t *testing.T) *apitask.Task {
-	testTask := CreateTestTask(validTaskArnPrefix + uuid.New())
-	rawHostConfigInputForLogSender := dockercontainer.HostConfig{
-		LogConfig: dockercontainer.LogConfig{
-			Type: logDriverTypeFirelens,
-			Config: map[string]string{
-				"Name":              "cloudwatch",
-				"exclude-pattern":   "exclude",
-				"include-pattern":   "include",
-				"log_group_name":    testLogGroupName,
-				"log_stream_prefix": testLogGroupPrefix,
-				"region":            testECSRegion,
-				"auto_create_group": "true",
-			},
-		},
-	}
-	rawHostConfigForLogSender, err := json.Marshal(&rawHostConfigInputForLogSender)
-	require.NoError(t, err)
-	testTask.Containers = []*apicontainer.Container{
+	testCases := []struct {
+		name                  string
+		firelensContainerUser string
+	}{
 		{
-			Name:      "logsender",
-			Image:     testLogSenderImage,
-			Essential: true,
-			// TODO: the firelens router occasionally failed to send logs when it's shut down very quickly after started.
-			// Let the task run for a while with a sleep helps avoid that failure, but still needs to figure out the
-			// root cause.
-			Command: []string{"sh", "-c", "echo exclude; echo include; sleep 10;"},
-			DockerConfig: apicontainer.DockerConfig{
-				HostConfig: func() *string {
-					s := string(rawHostConfigForLogSender)
-					return &s
-				}(),
-			},
-			DependsOnUnsafe: []apicontainer.DependsOn{
-				{
-					ContainerName: "firelens",
-					Condition:     "START",
-				},
-			},
+			name: "default",
 		},
 		{
-			Name:      "firelens",
-			Image:     testFluentBitImage,
-			Essential: true,
-			FirelensConfig: &apicontainer.FirelensConfig{
-				Type: firelens.FirelensConfigTypeFluentbit,
-				Options: map[string]string{
-					"enable-ecs-log-metadata": "true",
-				},
-			},
-			Environment: map[string]string{
-				"AWS_EXECUTION_ENV": "AWS_ECS_EC2",
-				"FLB_LOG_LEVEL":     "debug",
-			},
-			TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
+			name:                  "root-user",
+			firelensContainerUser: "0:1000",
+		},
+		{
+			name:                  "non-root-user",
+			firelensContainerUser: "1234:5678",
 		},
 	}
-	testTask.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
-	return testTask
-}
 
-func waitCloudwatchLogs(client *cloudwatchlogs.Client, params *cloudwatchlogs.GetLogEventsInput) (*cloudwatchlogs.GetLogEventsOutput, error) {
-	// The test could fail for timing issue, so retry for 60 seconds to make this test more stable
-	for i := 0; i < 60; i++ {
-		resp, err := client.GetLogEvents(context.TODO(), params)
-		if err != nil {
-			var notFoundErr *cloudwatchlogs_errors.ResourceNotFoundException
-			if !errors.As(err, &notFoundErr) {
-				return nil, err
-			}
-		} else if len(resp.Events) > 0 {
-			return resp, nil
-		}
-		time.Sleep(time.Second)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a temporary directory to send app logs to
+			tmpDir := createFirelensLogDir(t, tc.name, tc.firelensContainerUser)
+			defer func() {
+				err := os.RemoveAll(tmpDir)
+				require.NoError(t, err)
+			}()
+
+			// Create the Firelens task
+			firelensTask := createFirelensTask(t, tc.name, tc.firelensContainerUser, tmpDir)
+
+			// Start the Firelens task
+			go taskEngine.AddTask(firelensTask)
+
+			// Validate the Firelens task/container statuses during task start
+			verifyFirelensTaskEvents(t, taskEngine, firelensTask, "start")
+
+			// Verify Firelens data directory configuration
+			firelensDataDir := filepath.Join(testDataDir, "firelens", firelensTask.GetID())
+			verifyFirelensDataDir(t, firelensDataDir, tc.firelensContainerUser)
+
+			// Verify app logs from the destination file
+			verifyFirelensLogs(t, firelensTask, tmpDir)
+
+			// Validate the Firelens task/container statuses during task stop
+			verifyFirelensTaskEvents(t, taskEngine, firelensTask, "stop")
+
+			// Verify Firelens task resource cleanup
+			verifyFirelensResourceCleanup(t, cfg, firelensTask, taskEngine, firelensDataDir)
+		})
 	}
-	return nil, fmt.Errorf("timeout waiting for the logs to be sent to cloud watch logs")
 }
 
 // TestExecCommandAgent validates ExecCommandAgent start and monitor processes. The algorithm to test is as follows:

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -61,10 +61,11 @@ var (
 )
 
 const (
-	testVolumeImage   = "127.0.0.1:51670/amazon/amazon-ecs-volumes-test:latest"
-	testDataDir       = "/var/lib/ecs/data/"
-	testDataDirOnHost = "/var/lib/ecs/"
-
+	testVolumeImage              = "127.0.0.1:51670/amazon/amazon-ecs-volumes-test:latest"
+	testFluentBitImage           = "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
+	testFluentdImage             = "public.ecr.aws/docker/library/fluentd:v1.18-1"
+	testDataDir                  = "/var/lib/ecs/data/"
+	testDataDirOnHost            = "/var/lib/ecs/"
 	testExecCommandAgentImage    = "127.0.0.1:51670/amazon/amazon-ecs-exec-command-agent-test:latest"
 	testExecCommandAgentSleepBin = "/sleep"
 	testExecCommandAgentKillBin  = "/kill"
@@ -164,16 +165,17 @@ func createTestLocalVolumeMountTask() *apitask.Task {
 	return testTask
 }
 
-// TestFirelensFluentBit integration test verifies the following:
+// TestFirelens integration test verifies the following:
 //
 // 1. Firelens data directory creation and ownership configuration
 // 2. Task and container state events
 // 3. Firelens container's ability to log to a destination (local file)
 // 4. Firelens resource cleanup after the task stops
+// 5. Verifies all the above across both Fluentd and Fluent Bit log router options.
 //
 // This test validates the integration of different ECS agent components. It mocks the payload received from ECS backend,
 // and does not rely on external logging destinations (like CloudWatch) for logging functionality verification.
-func TestFirelensFluentBit(t *testing.T) {
+func TestFirelens(t *testing.T) {
 	// Setup agent config
 	cfg := DefaultTestConfigIntegTest()
 	cfg.DataDir = testDataDir
@@ -194,33 +196,56 @@ func TestFirelensFluentBit(t *testing.T) {
 	setupTaskMetadataServer(t)
 
 	testCases := []struct {
-		name                  string
-		firelensContainerUser string
+		name                   string
+		firelensType           string
+		firelensContainerImage string
+		firelensContainerUser  string
 	}{
 		{
-			name: "default",
+			name:                   "fluent_bit_default",
+			firelensType:           "fluentbit",
+			firelensContainerImage: testFluentBitImage,
 		},
 		{
-			name:                  "root-user",
-			firelensContainerUser: "0:1000",
+			name:                   "fluent_bit_root_user",
+			firelensType:           "fluentbit",
+			firelensContainerImage: testFluentBitImage,
+			firelensContainerUser:  "0:1000",
 		},
 		{
-			name:                  "non-root-user",
-			firelensContainerUser: "1234:5678",
+			name:                   "fluent_bit_non_root_user",
+			firelensType:           "fluentbit",
+			firelensContainerImage: testFluentBitImage,
+			firelensContainerUser:  "1234:5678",
 		},
+		{
+			name:                   "fluent_d_root_user",
+			firelensType:           "fluentd",
+			firelensContainerImage: testFluentdImage,
+			firelensContainerUser:  "0:1000",
+		},
+		{
+			name:                   "fluent_d_non_root_user",
+			firelensType:           "fluentd",
+			firelensContainerImage: testFluentdImage,
+			firelensContainerUser:  "1234:5678",
+		},
+		// No fluentd default config test case since all the available fluentd images hard-code a container user in the image.
+		// We will rely on functional test for this test case, where we build our own custom fluentd log router image.
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a temporary directory to send app logs to
-			tmpDir := createFirelensLogDir(t, tc.name, tc.firelensContainerUser)
+			tmpDir := createFirelensLogDir(t, "firelens", tc.firelensContainerUser)
 			defer func() {
 				err := os.RemoveAll(tmpDir)
 				require.NoError(t, err)
 			}()
 
 			// Create the Firelens task
-			firelensTask := createFirelensTask(t, tc.name, tc.firelensContainerUser, tmpDir)
+			firelensTask := createFirelensTask(t, tc.name, tc.firelensContainerImage, tc.firelensContainerUser,
+				tc.firelensType, tmpDir)
 
 			// Start the Firelens task
 			go taskEngine.AddTask(firelensTask)
@@ -233,7 +258,7 @@ func TestFirelensFluentBit(t *testing.T) {
 			verifyFirelensDataDir(t, firelensDataDir, tc.firelensContainerUser)
 
 			// Verify app logs from the destination file
-			verifyFirelensLogs(t, firelensTask, tmpDir)
+			verifyFirelensLogs(t, firelensTask, tc.firelensType, tmpDir)
 
 			// Validate the Firelens task/container statuses during task stop
 			verifyFirelensTaskEvents(t, taskEngine, firelensTask, "stop")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
