### PR TITLE
engine: add a fluentd integration test

### DIFF
--- a/agent/engine/common_unix_integ_testutil.go
+++ b/agent/engine/common_unix_integ_testutil.go
@@ -49,13 +49,13 @@ import (
 )
 
 const (
-	testRegistryImage     = "127.0.0.1:51670/amazon/amazon-ecs-netkitten:latest"
-	dockerEndpoint        = "unix:///var/run/docker.sock"
-	validTaskArnPrefix    = "arn:aws:ecs:region:account-id:task/"
-	testAppContainerImage = "public.ecr.aws/docker/library/busybox:latest"
-	testFluentBitImage    = "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
-	TestCluster           = "testCluster"
-	TestInstanceID        = "testInstanceID"
+	testRegistryImage           = "127.0.0.1:51670/amazon/amazon-ecs-netkitten:latest"
+	dockerEndpoint              = "unix:///var/run/docker.sock"
+	validTaskArnPrefix          = "arn:aws:ecs:region:account-id:task/"
+	testAppContainerImage       = "public.ecr.aws/docker/library/busybox:latest"
+	TestCluster                 = "testCluster"
+	TestInstanceID              = "testInstanceID"
+	firelensCheckLogMaxAttempts = 60
 )
 
 var (
@@ -81,6 +81,8 @@ func isDockerRunning() bool {
 
 // createFirelensLogDir creates a temporary directory where the log router container can write logs to
 func createFirelensLogDir(t *testing.T, directoryPrefix, firelensContainerUser string) string {
+	// os.MkdirTemp creates a dir with a random string appended to its name.
+	// Reference: https://pkg.go.dev/os#MkdirTemp
 	tmpDir, err := os.MkdirTemp("", directoryPrefix)
 	require.NoError(t, err)
 
@@ -175,17 +177,34 @@ func verifyFirelensTaskEvents(t *testing.T, taskEngine TaskEngine, firelensTask 
 
 // createFirelensTask creates an ECS task with 2 containers – 1) App 2) Log router container
 // The app writes the date to stdout, and the log router forwards it to a local file on disk
-func createFirelensTask(t *testing.T, testName, firelensContainerUser, tmpDir string) *apitask.Task {
-	rawHostConfigInputForApp := dockercontainer.HostConfig{
-		LogConfig: dockercontainer.LogConfig{
-			Type: logDriverTypeFirelens,
-			Config: map[string]string{
-				"Name":   "file",
-				"Path":   "/logs",
-				"File":   "app.log",
-				"Format": "plain",
+func createFirelensTask(t *testing.T, testName, firelensContainerImage, firelensContainerUser,
+	firelensType, tmpDir string) *apitask.Task {
+	// Generate the config depending on which log router is being used.
+	var rawHostConfigInputForApp dockercontainer.HostConfig
+	if firelensType == firelens.FirelensConfigTypeFluentbit {
+		rawHostConfigInputForApp = dockercontainer.HostConfig{
+			LogConfig: dockercontainer.LogConfig{
+				Type: logDriverTypeFirelens,
+				Config: map[string]string{
+					"Name":   "file",
+					"Path":   "/logs",
+					"File":   "app.log",
+					"Format": "plain",
+				},
 			},
-		},
+		}
+	} else {
+		rawHostConfigInputForApp = dockercontainer.HostConfig{
+			LogConfig: dockercontainer.LogConfig{
+				Type: logDriverTypeFirelens,
+				Config: map[string]string{
+					"@type":  "file",
+					"path":   "/logs/",
+					"format": "json",
+					"append": "true",
+				},
+			},
+		}
 	}
 	rawHostConfigForApp, err := json.Marshal(&rawHostConfigInputForApp)
 	require.NoError(t, err)
@@ -196,8 +215,10 @@ func createFirelensTask(t *testing.T, testName, firelensContainerUser, tmpDir st
 			Name:      "app",
 			Image:     testAppContainerImage,
 			Essential: true,
+			// Since the app container is essential, the app exit also immediately makes the log router container stop.
+			// Sleeping here before the exit gives the log router sometime to process the log and write to the destination.
 			Command: []string{"sh", "-c",
-				"date +%T; exit 42"},
+				"date +%T; sleep 10; exit 42"},
 			DockerConfig: apicontainer.DockerConfig{
 				HostConfig: func() *string {
 					s := string(rawHostConfigForApp)
@@ -207,10 +228,10 @@ func createFirelensTask(t *testing.T, testName, firelensContainerUser, tmpDir st
 		},
 		{
 			Name:      "log-router",
-			Image:     testFluentBitImage,
+			Image:     firelensContainerImage,
 			Essential: true,
 			FirelensConfig: &apicontainer.FirelensConfig{
-				Type: firelens.FirelensConfigTypeFluentbit,
+				Type: firelensType,
 				Options: map[string]string{
 					"enable-ecs-log-metadata": "true",
 				},
@@ -294,23 +315,47 @@ func verifyFirelensDataDir(t *testing.T, firelensDataDir, firelensContainerUser 
 }
 
 // verifyFirelensLogs verifies that the Firelens container sent app logs to a local file as expected
-func verifyFirelensLogs(t *testing.T, firelensTask *apitask.Task, tmpDir string) {
-	logFilePath := filepath.Join(tmpDir, "app.log")
+func verifyFirelensLogs(t *testing.T, firelensTask *apitask.Task, firelensType, tmpDir string) {
+	// Define the expected log file path based on the firelens type
+	var logFilePath string
+	var logFilePattern string
+	if firelensType == firelens.FirelensConfigTypeFluentbit {
+		// For Fluentbit, we expect a specific file name
+		logFilePath = filepath.Join(tmpDir, "app.log")
+		logFilePattern = logFilePath // Exact file path
+	} else {
+		// For Fluentd, we'll look for any .log file, since the file name is not deterministic
+		logFilePattern = filepath.Join(tmpDir, "*.log")
+	}
 
-	// Wait for the log file to be created and populated
+	// Wait for the log file to appear and have content
 	var logContent []byte
 	var err error
-	for i := 0; i < 30; i++ {
-		logContent, err = os.ReadFile(logFilePath)
-		if err == nil && len(logContent) > 0 {
+	var found bool
+	for i := 0; i < firelensCheckLogMaxAttempts; i++ {
+		if firelensType == firelens.FirelensConfigTypeFluentbit {
+			// For Fluentbit, check the specific file
+			logContent, err = os.ReadFile(logFilePath)
+			found = err == nil && len(logContent) > 0
+		} else {
+			// For Fluentd, find any .log file
+			matches, globErr := filepath.Glob(logFilePattern)
+			if globErr == nil && len(matches) > 0 {
+				// Use the first match
+				logFilePath = matches[0]
+				logContent, err = os.ReadFile(logFilePath)
+				found = err == nil && len(logContent) > 0
+			}
+		}
+		if found {
+			t.Logf("Found log file with content at %s", logFilePath)
 			break
 		}
 		time.Sleep(1 * time.Second)
 	}
 
-	// Check if we successfully read the log file
-	require.NoError(t, err, "Failed to read log file at %s", logFilePath)
-	require.NotEmpty(t, logContent, "Log file is empty")
+	// Verify we found a log file with content
+	require.True(t, found, "Failed to find app logs")
 
 	// Parse the JSON log object
 	jsonBlob := make(map[string]string)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR is a test-only update, targeting the feature/firelens-non-root-user branch. It adds a new fluentd integration test.

See previous similar PR for updating fluent-bit integration test: https://github.com/aws/amazon-ecs-agent/pull/4682

### Implementation details
<!-- How are the changes implemented? -->
The test is very similar to how the fluent bit test is implemented. We have 2 containers - 1) app writes to stdout 2) fluentd sidecar forwards app's stdout to local file.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

N/A

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
