### PR TITLE
bugfix: Fix "default" ecs cluster auto-create logic

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/errors/errors.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/errors/errors.go
@@ -58,7 +58,15 @@ func IsInstanceTypeChangedError(err error) bool {
 
 func IsClusterNotFoundError(err error) bool {
 	var notFoundErr *types.ClusterNotFoundException
-	return errors.As(err, &notFoundErr)
+	if errors.As(err, &notFoundErr) {
+		return true
+	}
+
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return strings.Contains(apiErr.ErrorMessage(), ClusterNotFoundErrorMessage)
+	}
+	return false
 }
 
 // BadVolumeError represents an error caused by bad volume

--- a/ecs-agent/api/ecs/client/ecs_client_test.go
+++ b/ecs-agent/api/ecs/client/ecs_client_test.go
@@ -783,12 +783,15 @@ func TestRegisterContainerInstanceWithNegativeResource(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mem := getHostMemoryInMiB()
+	mem := 1024
 	mockEC2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
 	cfgAccessorOverrideFunc := func(cfgAccessor *mock_config.MockAgentConfigAccessor) {
 		cfgAccessor.EXPECT().ReservedMemory().Return(uint16(mem) + 1).AnyTimes()
 	}
-	tester := setup(t, ctrl, mockEC2Metadata, cfgAccessorOverrideFunc)
+	tester := setup(t, ctrl, mockEC2Metadata, cfgAccessorOverrideFunc,
+		WithAvailableMemoryProvider(func() int32 {
+			return int32(mem)
+		}))
 
 	gomock.InOrder(
 		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).

--- a/ecs-agent/api/errors/errors.go
+++ b/ecs-agent/api/errors/errors.go
@@ -58,7 +58,15 @@ func IsInstanceTypeChangedError(err error) bool {
 
 func IsClusterNotFoundError(err error) bool {
 	var notFoundErr *types.ClusterNotFoundException
-	return errors.As(err, &notFoundErr)
+	if errors.As(err, &notFoundErr) {
+		return true
+	}
+
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return strings.Contains(apiErr.ErrorMessage(), ClusterNotFoundErrorMessage)
+	}
+	return false
 }
 
 // BadVolumeError represents an error caused by bad volume

--- a/ecs-agent/api/errors/errors_test.go
+++ b/ecs-agent/api/errors/errors_test.go
@@ -1,0 +1,133 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package errors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsInstanceTypeChangedError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "Instance type changed error",
+			err:  &smithy.GenericAPIError{Code: "Error", Message: InstanceTypeChangedErrorMessage},
+			want: true,
+		},
+		{
+			name: "Other error",
+			err:  errors.New("Some other error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsInstanceTypeChangedError(tt.err))
+		})
+	}
+}
+
+func TestIsClusterNotFoundError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "Cluster not found error",
+			err:  &types.ClusterNotFoundException{},
+			want: true,
+		},
+		{
+			name: "Cluster not found message",
+			err:  &smithy.GenericAPIError{Code: "Error", Message: ClusterNotFoundErrorMessage},
+			want: true,
+		},
+		{
+			name: "ClientException with cluster not found message",
+			err:  &types.ClientException{Message: aws.String(ClusterNotFoundErrorMessage)},
+			want: true,
+		},
+		{
+			name: "Other error",
+			err:  errors.New("Some other error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsClusterNotFoundError(tt.err))
+		})
+	}
+}
+
+func TestBadVolumeError(t *testing.T) {
+	err := &BadVolumeError{Msg: "Bad volume"}
+	assert.Equal(t, "Bad volume", err.Error())
+	assert.Equal(t, "InvalidVolumeError", err.ErrorName())
+	assert.False(t, err.Retry())
+}
+
+func TestDefaultNamedError(t *testing.T) {
+	err := &DefaultNamedError{Err: "Test error", Name: "TestError"}
+	assert.Equal(t, "TestError: Test error", err.Error())
+	assert.Equal(t, "TestError", err.ErrorName())
+
+	errNoName := &DefaultNamedError{Err: "Test error"}
+	assert.Equal(t, "UnknownError: Test error", errNoName.Error())
+}
+
+func TestNewNamedError(t *testing.T) {
+	namedErr := &BadVolumeError{Msg: "Bad volume"}
+	err := NewNamedError(namedErr)
+	assert.Equal(t, "InvalidVolumeError: Bad volume", err.Error())
+
+	plainErr := errors.New("Plain error")
+	err = NewNamedError(plainErr)
+	assert.Equal(t, "UnknownError: Plain error", err.Error())
+}
+
+func TestHostConfigError(t *testing.T) {
+	err := &HostConfigError{Msg: "Host config error"}
+	assert.Equal(t, "Host config error", err.Error())
+	assert.Equal(t, "HostConfigError", err.ErrorName())
+}
+
+func TestDockerClientConfigError(t *testing.T) {
+	err := &DockerClientConfigError{Msg: "Docker client config error"}
+	assert.Equal(t, "Docker client config error", err.Error())
+	assert.Equal(t, "DockerClientConfigError", err.ErrorName())
+}
+
+func TestResourceInitError(t *testing.T) {
+	origErr := errors.New("Original error")
+	err := NewResourceInitError("task-arn", origErr)
+	expectedMsg := "resource cannot be initialized for task task-arn: Original error"
+	assert.Equal(t, expectedMsg, err.Error())
+	assert.Equal(t, "ResourceInitializationError", err.ErrorName())
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This fixes agent's ClusterNotFound error handling, which is returned as a ClientException in the case that the agent calls RCI and the cluster does not exist.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

A new unit test file was added for testing the entire errors package, including this function.

Manual test was run to confirm that an account/region with no default cluster now has one auto-created and agent is able to register with the default cluster:

```
level=error time=2025-06-19T23:46:15Z msg="Unable to register as a container instance with ECS" error="operation error ECS: RegisterContainerInstance, https response error StatusCode: 400, RequestID: NNN, ClientException: Cluster not found."
level=error time=2025-06-19T23:46:15Z msg="Received terminal error from RegisterContainerInstance call, exiting" error="operation error ECS: RegisterContainerInstance, https response error StatusCode: 400, RequestID: NNN, ClientException: Cluster not found."
level=info time=2025-06-19T23:46:15Z msg="Successfully created a cluster" cluster="default"
```

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

bugfix: Fix "default" ecs cluster auto-create logic

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
