### PR TITLE
firelensutils: add a new unit test case for TestSetOwnership

### DIFF
--- a/ecs-agent/utils/firelens/firelens_test.go
+++ b/ecs-agent/utils/firelens/firelens_test.go
@@ -67,6 +67,13 @@ func TestSetOwnership(t *testing.T) {
 			expectedGID: testCurrGID,
 		},
 		{
+			name:        "Valid userID:groupID format",
+			input:       "100:200",
+			wantErr:     false,
+			expectedUID: 100,
+			expectedGID: 200,
+		},
+		{
 			name:        "Invalid user format, too many colons",
 			input:       "1234:dog:cat",
 			wantErr:     true,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR adds a new test case to the TestSetOwnership uni test. It helps us validate that both UID and GID are respected when setting ownership of the Firelens socket directory.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
