### PR TITLE
Add Exponential/Backoff retry to GetResourceTags

### DIFF
--- a/ecs-agent/api/ecs/mocks/client/mock_errors.go
+++ b/ecs-agent/api/ecs/mocks/client/mock_errors.go
@@ -1,0 +1,80 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package mock_client provides mock error implementations for ECS client testing
+package mock_client
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
+	"github.com/aws/smithy-go"
+)
+
+// MockAPIError creates a mock error that implements smithy.APIError interface
+type MockAPIError struct {
+	code    string
+	message string
+}
+
+// MockQuotaExceededError creates a mock error that implements ratelimit.QuotaExceededError interface
+type MockQuotaExceededError struct {
+	Available uint
+	Requested uint
+}
+
+func (e *MockAPIError) Error() string {
+	return e.message
+}
+
+func (e *MockAPIError) ErrorCode() string {
+	return e.code
+}
+
+func (e *MockAPIError) ErrorMessage() string {
+	return e.message
+}
+
+func (e *MockAPIError) ErrorFault() smithy.ErrorFault {
+	return smithy.FaultUnknown
+}
+
+func (e *MockQuotaExceededError) Error() string {
+	return "retry quota exceeded"
+}
+
+func NewThrottlingException() error {
+	return &MockAPIError{code: "ThrottlingException", message: "Request was throttled"}
+}
+
+func NewServerException() error {
+	return &MockAPIError{code: "ServerException", message: "Internal server error"}
+}
+
+func NewLimitExceededException() error {
+	return &MockAPIError{code: "LimitExceededException", message: "Limit exceeded"}
+}
+
+func NewInvalidParameterException() error {
+	return &MockAPIError{code: "InvalidParameterException", message: "Invalid parameter"}
+}
+
+func NewClientException() error {
+	return &MockAPIError{code: "ClientException", message: "Client error"}
+}
+
+func NewAccessDeniedException() error {
+	return &MockAPIError{code: "AccessDeniedException", message: "Access denied"}
+}
+
+func NewQuotaExceededError() error {
+	return ratelimit.QuotaExceededError{Available: 0, Requested: 1}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR enhances the ECS Agent's GetResourceTags function by implementing exponential backoff and retry logic for resource tag retrieval. The implementation addresses potential transient failures when interacting with the ECS API, particularly focusing on handling throttling and rate limiting scenarios.
### Implementation details
<!-- How are the changes implemented? -->

The GetResourceTags function now includes an exponential backoff mechanism using `retry.NewExponentialBackoff` with configurable parameters. It implements context-aware retry logic, using `context.WithTimeout` for overall operation timeout and properly handling context cancellation. The function now differentiates between transient and non-transient errors, with special handling for throttling and rate limit exceeded cases. Structured logging has been implemented, providing detailed error information including resource ARN and attempt counts.
### Testing
<!-- How was this tested? -->
* Manual testing was performed using Apache Benchmark with concurrent requests to verify the exponential backoff and retry mechanism worked when facing throttling when calling `${ECS_CONTAINER_METADATA_URI_V4}/taskWithTags`
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
 
New tests cover the changes: yes

The `TestGetResourceTags` and `TestGetResourceTagsError functions verify successful tag retrieval and error handling respectively. The TestGetResourceTagsWithRetry function covers various retry scenarios including success after throttling, server exceptions, and mixed transient errors. It also tests non-transient error handling and multiple throttling retry scenarios. The tests verify retry behavior, error message formatting, attempt counting, and different error type handling.
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add Exponential/Backoff retry to GetResourceTags
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
