### PR TITLE
Fix local IP address depletion by cleaning up network bridges for awsvpc tasks

### DIFF
--- a/ecs-agent/netlib/platform/common_linux.go
+++ b/ecs-agent/netlib/platform/common_linux.go
@@ -697,8 +697,10 @@ func (c *common) configureRegularENI(ctx context.Context, netNSPath string, eni 
 		cniNetConf = append(cniNetConf, createENIPluginConfigs(netNSPath, eni))
 		add = true
 	case status.NetworkDeleted:
-		// Regular ENIs are used in single-use warmpool instances, so cleanup isn't necessary.
-		cniNetConf = nil
+		if eni.IsPrimary() {
+			cniNetConf = append(cniNetConf, createBridgePluginConfig(netNSPath))
+		}
+		cniNetConf = append(cniNetConf, createENIPluginConfigs(netNSPath, eni))
 		add = false
 	}
 
@@ -735,6 +737,9 @@ func (c *common) configureBranchENI(ctx context.Context, netNSPath string, eni *
 		// We block IMDS access in awsvpc tasks.
 		cniNetConf = append(cniNetConf, createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan, blockInstanceMetadataDefault))
 	case status.NetworkDeleted:
+		if eni.IsPrimary() {
+			cniNetConf = append(cniNetConf, createBridgePluginConfig(netNSPath))
+		}
 		cniNetConf = append(cniNetConf, createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan, blockInstanceMetadataDefault))
 		add = false
 	}

--- a/ecs-agent/netlib/platform/common_linux_test.go
+++ b/ecs-agent/netlib/platform/common_linux_test.go
@@ -409,6 +409,8 @@ func testRegularENIConfiguration(t *testing.T) {
 	gomock.InOrder(
 		osWrapper.EXPECT().Setenv("ECS_CNI_LOG_FILE", ecscni.PluginLogPath).Times(1),
 		osWrapper.EXPECT().Setenv("IPAM_DB_PATH", filepath.Join(commonPlatform.stateDBDir, "eni-ipam.db")),
+		cniClient.EXPECT().Del(gomock.Any(), bridgeConfig).Return(nil).Times(1),
+		cniClient.EXPECT().Del(gomock.Any(), eniConfig).Return(nil).Times(1),
 	)
 	err = commonPlatform.configureInterface(ctx, netNSPath, eni, nil)
 	require.NoError(t, err)
@@ -448,6 +450,7 @@ func testBranchENIConfiguration(t *testing.T) {
 	// Delete workflow.
 	branchENI.DesiredStatus = status.NetworkDeleted
 	osWrapper.EXPECT().Setenv("IPAM_DB_PATH", filepath.Join(commonPlatform.stateDBDir, "eni-ipam.db"))
+	cniClient.EXPECT().Del(gomock.Any(), bridgeConfig).Return(nil).Times(1)
 	cniClient.EXPECT().Del(gomock.Any(), cniConfig).Return(nil).Times(1)
 	err = commonPlatform.configureInterface(ctx, netNSPath, branchENI, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Tasks running in awsvpc mode operate in their own network namespace with a dedicated ENI. To enable these tasks to access the Task Metadata Server (TMDS) on the host namespace, a network bridge is created. This bridge is assigned a link-local IP address to route TMDS traffic. Currently, these bridges persist after task deletion, which can lead to IP address exhaustion on long-running hosts.

### Implementation details
<!-- How are the changes implemented? -->
Fix IP address depletion by cleaning up network bridges for awsvpc tasks

Solution:
This PR implements proper cleanup of network bridges when awsvpc tasks are deleted. This prevents the accumulation of unused network bridges and their associated IP addresses.

Changes:
- Added bridge cleanup logic in task deletion flow
- updated unit tests for the cleanup functionality

Impact:
- Prevents IP address exhaustion on long-running hosts
- Reduces unnecessary network resource consumption
- No impact on running tasks or TMDS functionality

### Testing
<!-- How was this tested? -->
End to End testing. Run and Stop multiple tasks on same hosts and validated via CNI logs:
```
{
    "logstream": "cni",
    "msg": "[INFO] msg=\"Running IPAM plugin DEL\" netns=/var/run/netns/b5f5a5195469422f876318adbfec888a-0a1483b11911 ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam",
    "time": "2025-07-17T00:14:30Z"
}
```
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
fix: release network bridge IPs on task delete

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No
**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
