### PR TITLE
Register seelog log formatter before using it

### DIFF
--- a/ecs-init/logger/log.go
+++ b/ecs-init/logger/log.go
@@ -62,11 +62,14 @@ func init() {
 
 // Setup sets the custom logging config
 func Setup() {
+	// Register the custom formatter first, before any logging configuration is loaded
+	if err := seelog.RegisterCustomFormatter("InitLogfmt", logfmtFormatter); err != nil {
+		// Use fmt.Printf for error logging since seelog might not be configured yet
+		fmt.Printf("Failed to register InitLogfmt formatter: %v\n", err)
+	}
+
 	if logLevel := os.Getenv(LOGLEVEL_ENV_VAR); logLevel != "" {
 		SetLogLevel(logLevel)
-	}
-	if err := seelog.RegisterCustomFormatter("InitLogfmt", logfmtFormatter); err != nil {
-		seelog.Error(err)
 	}
 	reloadConfig()
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
The ECS init service was encountering a "format error: unrecognized formatter at 1: InitLogfmt" error during
startup. This occurred because the custom formatter InitLogfmt was being used in the seelog configuration
before it was registered with the seelog library.

### Root Cause Analysis
The issue was in the initialization sequence in the `Setup()` function in `logger/log.go`:
1. The function first checked for a log level environment variable and called `SetLogLevel()`
2. `SetLogLevel()` internally called `reloadConfig()`, which tried to use the `InitLogfmt` formatter
3. Only after this did the code register the formatter with `seelog.RegisterCustomFormatter()`
4. This timing issue caused the error message to appear during startup

### Implementation details
<!-- How are the changes implemented? -->
Reordered the initialization sequence in the `Setup()` function to:
1. Register the custom formatter first, before any logging configuration is loaded
2. Then set the log level from the environment variable if provided
3. If no log level is set, reload the configuration to apply the formatter registration

This ensures that the formatter is registered before any attempt to use it in the logging configuration.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
The fix was tested by:
1. Compiling a new binary with the changes
2. Replacing the existing binary on a running system
3. Verifying that the service starts without the error message
4. Confirming that logging works properly in both the journal and log files

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Fixed "unrecognized formatter" error by registering custom log formatter before loading seelog configuration.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
