### PR TITLE
Initialize OS type detailed attribute during container instance registration

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
@@ -54,6 +54,7 @@ const (
 	cpuArchAttrName             = "ecs.cpu-architecture"
 	osTypeAttrName              = "ecs.os-type"
 	osFamilyAttrName            = "ecs.os-family"
+	osTypeDetailedAttrName      = "ecs.os-type-detailed"
 	// RoundtripTimeout should only time out after dial and TLS handshake timeouts have elapsed.
 	// Add additional 2 seconds to the sum of these 2 timeouts to be extra sure of this.
 	RoundtripTimeout = httpclient.DefaultDialTimeout + httpclient.DefaultTLSHandshakeTimeout + 2*time.Second
@@ -565,6 +566,17 @@ func (client *ecsClient) getAdditionalAttributes() []types.Attribute {
 			Value: aws.String(client.configAccessor.OSFamily()),
 		})
 	}
+
+	// OSFamilyDetailed should be treated as an optional field as it is not applicable for all agents
+	// using ecs client shared library. Add a check to ensure only non-empty values are added
+	// to API call.
+	if client.configAccessor.OSFamilyDetailed() != "" {
+		attrs = append(attrs, types.Attribute{
+			Name:  aws.String(osTypeDetailedAttrName),
+			Value: aws.String(client.configAccessor.OSFamilyDetailed()),
+		})
+	}
+
 	// Send CPU arch attribute directly when running on external capacity. When running on EC2 or Fargate launch type,
 	// this is not needed since the CPU arch is reported via instance identity document in those cases.
 	if client.configAccessor.External() {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface.go
@@ -46,7 +46,7 @@ type NetworkInterface struct {
 	// SubnetGatewayIPV4Address is the IPv4 address of the subnet gateway of the NetworkInterface
 	SubnetGatewayIPV4Address string `json:",omitempty"`
 	// SubnetGatewayIPV6Address is the IPv6 address of the subnet gateway of the NetworkInterface
-	SubnetGatewayIPV6Address string `json:",omitempty`
+	SubnetGatewayIPV6Address string `json:",omitempty"`
 	// DomainNameServers specifies the nameserver IP addresses for the eni
 	DomainNameServers []string `json:",omitempty"`
 	// DomainNameSearchList specifies the search list for the domain

--- a/ecs-agent/api/ecs/client/ecs_client.go
+++ b/ecs-agent/api/ecs/client/ecs_client.go
@@ -54,6 +54,7 @@ const (
 	cpuArchAttrName             = "ecs.cpu-architecture"
 	osTypeAttrName              = "ecs.os-type"
 	osFamilyAttrName            = "ecs.os-family"
+	osTypeDetailedAttrName      = "ecs.os-type-detailed"
 	// RoundtripTimeout should only time out after dial and TLS handshake timeouts have elapsed.
 	// Add additional 2 seconds to the sum of these 2 timeouts to be extra sure of this.
 	RoundtripTimeout = httpclient.DefaultDialTimeout + httpclient.DefaultTLSHandshakeTimeout + 2*time.Second
@@ -565,6 +566,17 @@ func (client *ecsClient) getAdditionalAttributes() []types.Attribute {
 			Value: aws.String(client.configAccessor.OSFamily()),
 		})
 	}
+
+	// OSFamilyDetailed should be treated as an optional field as it is not applicable for all agents
+	// using ecs client shared library. Add a check to ensure only non-empty values are added
+	// to API call.
+	if client.configAccessor.OSFamilyDetailed() != "" {
+		attrs = append(attrs, types.Attribute{
+			Name:  aws.String(osTypeDetailedAttrName),
+			Value: aws.String(client.configAccessor.OSFamilyDetailed()),
+		})
+	}
+
 	// Send CPU arch attribute directly when running on external capacity. When running on EC2 or Fargate launch type,
 	// this is not needed since the CPU arch is reported via instance identity document in those cases.
 	if client.configAccessor.External() {

--- a/ecs-agent/api/ecs/client/ecs_client_test.go
+++ b/ecs-agent/api/ecs/client/ecs_client_test.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	ecsservice "github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,8 +46,6 @@ import (
 	mock_ec2 "github.com/aws/amazon-ecs-agent/ecs-agent/ec2/mocks"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
-	ecsservice "github.com/aws/aws-sdk-go-v2/service/ecs"
-	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 )
 
 const (
@@ -890,9 +890,9 @@ func TestRegisterBlankCluster(t *testing.T) {
 	tester := setup(t, ctrl, mockEC2Metadata, cfgAccessorOverrideFunc)
 
 	expectedAttributes := map[string]string{
-		"ecs.os-type":   tester.mockCfgAccessor.OSType(),
-		"ecs.os-family": tester.mockCfgAccessor.OSFamily(),
-		"ecs.os-type-detailed":  tester.mockCfgAccessor.OSFamilyDetailed(),
+		"ecs.os-type":          tester.mockCfgAccessor.OSType(),
+		"ecs.os-family":        tester.mockCfgAccessor.OSFamily(),
+		"ecs.os-type-detailed": tester.mockCfgAccessor.OSFamilyDetailed(),
 	}
 	defaultCluster := tester.mockCfgAccessor.DefaultClusterName()
 	gomock.InOrder(
@@ -940,9 +940,9 @@ func TestRegisterBlankClusterNotCreatingClusterWhenErrorNotClusterNotFound(t *te
 	tester := setup(t, ctrl, mockEC2Metadata, cfgAccessorOverrideFunc)
 
 	expectedAttributes := map[string]string{
-		"ecs.os-type":   tester.mockCfgAccessor.OSType(),
-		"ecs.os-family": tester.mockCfgAccessor.OSFamily(),
-		"ecs.os-type-detailed":  tester.mockCfgAccessor.OSFamilyDetailed(),
+		"ecs.os-type":          tester.mockCfgAccessor.OSType(),
+		"ecs.os-family":        tester.mockCfgAccessor.OSFamily(),
+		"ecs.os-type-detailed": tester.mockCfgAccessor.OSFamilyDetailed(),
 	}
 
 	defaultCluster := tester.mockCfgAccessor.DefaultClusterName()

--- a/ecs-agent/api/ecs/client/ecs_client_test.go
+++ b/ecs-agent/api/ecs/client/ecs_client_test.go
@@ -502,6 +502,7 @@ func TestRegisterContainerInstance(t *testing.T) {
 			expectedAttributes := map[string]string{
 				"ecs.os-type":               tester.mockCfgAccessor.OSType(),
 				"ecs.os-family":             tester.mockCfgAccessor.OSFamily(),
+				"ecs.os-type-detailed":      tester.mockCfgAccessor.OSFamilyDetailed(),
 				"my_custom_attribute":       "Custom_Value1",
 				"my_other_custom_attribute": "Custom_Value2",
 				"ecs.availability-zone":     availabilityZone,
@@ -553,12 +554,12 @@ func TestRegisterContainerInstance(t *testing.T) {
 			var expectedNumOfAttributes int
 			if !tester.mockCfgAccessor.External() {
 				// 2 capability attributes: capability1, capability2
-				// and 5 other attributes:
-				// ecs.os-type, ecs.os-family, ecs.outpost-arn, my_custom_attribute, my_other_custom_attribute.
-				expectedNumOfAttributes = 7
+				// and 6 other attributes:
+				// ecs.os-type, ecs.os-family, ecs.os-type-detailed, ecs.outpost-arn, my_custom_attribute, my_other_custom_attribute.
+				expectedNumOfAttributes = 8
 			} else {
 				// One more attribute for external case: ecs.cpu-architecture.
-				expectedNumOfAttributes = 8
+				expectedNumOfAttributes = 9
 			}
 
 			gomock.InOrder(
@@ -630,6 +631,7 @@ func TestRegisterContainerInstanceWithRetryNonTerminalError(t *testing.T) {
 	expectedAttributes := map[string]string{
 		"ecs.os-type":               tester.mockCfgAccessor.OSType(),
 		"ecs.os-family":             tester.mockCfgAccessor.OSFamily(),
+		"ecs.os-type-detailed":      tester.mockCfgAccessor.OSFamilyDetailed(),
 		"my_custom_attribute":       "Custom_Value1",
 		"my_other_custom_attribute": "Custom_Value2",
 		"ecs.availability-zone":     availabilityZone,
@@ -725,6 +727,7 @@ func TestReRegisterContainerInstance(t *testing.T) {
 	expectedAttributes := map[string]string{
 		"ecs.os-type":           tester.mockCfgAccessor.OSType(),
 		"ecs.os-family":         tester.mockCfgAccessor.OSFamily(),
+		"ecs.os-type-detailed":  tester.mockCfgAccessor.OSFamilyDetailed(),
 		"ecs.availability-zone": availabilityZone,
 		"ecs.outpost-arn":       outpostARN,
 	}
@@ -749,8 +752,8 @@ func TestReRegisterContainerInstance(t *testing.T) {
 				resource, ok := findResource(req.TotalResources, "PORTS_UDP")
 				assert.True(t, ok, `Could not find resource "PORTS_UDP"`)
 				assert.Equal(t, "STRINGSET", *resource.Type, `Wrong type for resource "PORTS_UDP"`)
-				// "ecs.os-type", ecs.os-family, ecs.outpost-arn and the 2 that we specified as additionalAttributes.
-				assert.Equal(t, 5, len(req.Attributes), "Wrong number of Attributes")
+				// "ecs.os-type", ecs.os-family, ecs.os-type-detailed, ecs.outpost-arn and the 2 that we specified as additionalAttributes.
+				assert.Equal(t, 6, len(req.Attributes), "Wrong number of Attributes")
 				reqAttributes := func() map[string]string {
 					rv := make(map[string]string, len(req.Attributes))
 					for i := range req.Attributes {
@@ -821,6 +824,7 @@ func TestRegisterContainerInstanceWithEmptyTags(t *testing.T) {
 	expectedAttributes := map[string]string{
 		"ecs.os-type":               tester.mockCfgAccessor.OSType(),
 		"ecs.os-family":             tester.mockCfgAccessor.OSFamily(),
+		"ecs.os-type-detailed":      tester.mockCfgAccessor.OSFamilyDetailed(),
 		"my_custom_attribute":       "Custom_Value1",
 		"my_other_custom_attribute": "Custom_Value2",
 	}
@@ -888,6 +892,7 @@ func TestRegisterBlankCluster(t *testing.T) {
 	expectedAttributes := map[string]string{
 		"ecs.os-type":   tester.mockCfgAccessor.OSType(),
 		"ecs.os-family": tester.mockCfgAccessor.OSFamily(),
+		"ecs.os-type-detailed":  tester.mockCfgAccessor.OSFamilyDetailed(),
 	}
 	defaultCluster := tester.mockCfgAccessor.DefaultClusterName()
 	gomock.InOrder(
@@ -937,6 +942,7 @@ func TestRegisterBlankClusterNotCreatingClusterWhenErrorNotClusterNotFound(t *te
 	expectedAttributes := map[string]string{
 		"ecs.os-type":   tester.mockCfgAccessor.OSType(),
 		"ecs.os-family": tester.mockCfgAccessor.OSFamily(),
+		"ecs.os-type-detailed":  tester.mockCfgAccessor.OSFamilyDetailed(),
 	}
 
 	defaultCluster := tester.mockCfgAccessor.DefaultClusterName()

--- a/ecs-agent/netlib/model/networkinterface/networkinterface.go
+++ b/ecs-agent/netlib/model/networkinterface/networkinterface.go
@@ -46,7 +46,7 @@ type NetworkInterface struct {
 	// SubnetGatewayIPV4Address is the IPv4 address of the subnet gateway of the NetworkInterface
 	SubnetGatewayIPV4Address string `json:",omitempty"`
 	// SubnetGatewayIPV6Address is the IPv6 address of the subnet gateway of the NetworkInterface
-	SubnetGatewayIPV6Address string `json:",omitempty`
+	SubnetGatewayIPV6Address string `json:",omitempty"`
 	// DomainNameServers specifies the nameserver IP addresses for the eni
 	DomainNameServers []string `json:",omitempty"`
 	// DomainNameSearchList specifies the search list for the domain


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR implements the `ecs.os-type-detailed` attribute for container instance registration.

### Implementation details
<!-- How are the changes implemented? -->
- Added `osTypeDetailedAttrName` constant and logic in `getAdditionalAttributes()` to include the detailed OS attribute when available
- Updated TestRegisterContainerInstance unit tests

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Ran make test, updated relevant unit tests
New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Feature: Handle `ecs.os-type-detailed` attribute container instance registration

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
