### PR TITLE
Update network latency fault check

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -1376,6 +1376,7 @@ func (h *FaultHandler) startNetworkLatencyFaultForInterface(
 		field.CommandOutput:    string(cmdOutput[:]),
 		field.NetworkInterface: interfaceName,
 	})
+
 	tcAddQdiscLossCommandComposed := nsenterPrefix + fmt.Sprintf(
 		tcAddQdiscLatencyCommandString, interfaceName, delayInMs, jitterInMs)
 	cmdList = strings.Split(tcAddQdiscLossCommandComposed, " ")
@@ -1631,14 +1632,23 @@ func (h *FaultHandler) checkTCFaultForInterface(
 
 // checkLatencyFault parses the tc command output and checks if there's existing network-latency fault running.
 func checkLatencyFault(outputUnmarshalled []map[string]interface{}) (bool, error) {
+	packetLossFaultExist, err := checkPacketLossFault(outputUnmarshalled)
+	if err != nil {
+		return false, err
+	}
+
+	// Make sure no existing packet loss fault because only one tc fault is allowed.
+	if packetLossFaultExist {
+		return false, nil
+	}
+
 	for _, line := range outputUnmarshalled {
 		// Check if field "kind":"netem" exists.
 		if line["kind"] == "netem" {
-			// Now check if network packet loss fault exists.
 			if options := line["options"]; options != nil {
-				if delay := options.(map[string]interface{})["delay"]; delay != nil {
-					return true, nil
-				}
+				// We don't check the "delay" field in the output of "options" intentionally because
+				// it is not present if the delay is zero and the jitter is non-zero.
+				return true, nil
 			}
 		}
 	}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/utils"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -34,6 +35,7 @@ const (
 	// Request Payload Errors
 	MissingRequiredFieldError = "required parameter %s is missing"
 	MissingRequestBodyError   = "required request body is missing"
+	ZeroDelayAndJitterError   = "required either DelayMilliseconds or JitterMilliseconds to be non-zero"
 	InvalidValueError         = "invalid value %s for parameter %s"
 )
 
@@ -129,6 +131,11 @@ func (request NetworkLatencyRequest) ValidateRequest() error {
 	if request.JitterMilliseconds == nil {
 		return fmt.Errorf(MissingRequiredFieldError, "JitterMilliseconds")
 	}
+
+	if aws.ToUint64(request.DelayMilliseconds) == 0 && aws.ToUint64(request.JitterMilliseconds) == 0 {
+		return errors.New(ZeroDelayAndJitterError)
+	}
+
 	if len(request.Sources) == 0 {
 		return fmt.Errorf(MissingRequiredFieldError, "Sources")
 	}

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -1376,6 +1376,7 @@ func (h *FaultHandler) startNetworkLatencyFaultForInterface(
 		field.CommandOutput:    string(cmdOutput[:]),
 		field.NetworkInterface: interfaceName,
 	})
+
 	tcAddQdiscLossCommandComposed := nsenterPrefix + fmt.Sprintf(
 		tcAddQdiscLatencyCommandString, interfaceName, delayInMs, jitterInMs)
 	cmdList = strings.Split(tcAddQdiscLossCommandComposed, " ")
@@ -1631,14 +1632,23 @@ func (h *FaultHandler) checkTCFaultForInterface(
 
 // checkLatencyFault parses the tc command output and checks if there's existing network-latency fault running.
 func checkLatencyFault(outputUnmarshalled []map[string]interface{}) (bool, error) {
+	packetLossFaultExist, err := checkPacketLossFault(outputUnmarshalled)
+	if err != nil {
+		return false, err
+	}
+
+	// Make sure no existing packet loss fault because only one tc fault is allowed.
+	if packetLossFaultExist {
+		return false, nil
+	}
+
 	for _, line := range outputUnmarshalled {
 		// Check if field "kind":"netem" exists.
 		if line["kind"] == "netem" {
-			// Now check if network packet loss fault exists.
 			if options := line["options"]; options != nil {
-				if delay := options.(map[string]interface{})["delay"]; delay != nil {
-					return true, nil
-				}
+				// We don't check the "delay" field in the output of "options" intentionally because
+				// it is not present if the delay is zero and the jitter is non-zero.
+				return true, nil
 			}
 		}
 	}

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -62,10 +63,11 @@ const (
 	nspath             = "/some/path"
 	nspathHost         = "host"
 	// Fault injection tooling errors output
-	iptablesChainNotFoundError        = "iptables: Bad rule (does a matching rule exist in that chain?)."
-	tcLatencyFaultExistsCommandOutput = `[{"kind":"netem","handle":"10:","parent":"1:1","options":{"limit":1000,"delay":{"delay":123456789,"jitter":4567,"correlation":0},"ecn":false,"gap":0}}]`
-	tcLossFaultExistsCommandOutput    = `[{"kind":"netem","handle":"10:","dev":"eth0","parent":"1:1","options":{"limit":1000,"loss-random":{"loss":0.06,"correlation":0},"ecn":false,"gap":0}}]`
-	tcCommandEmptyOutput              = `[]`
+	iptablesChainNotFoundError                     = "iptables: Bad rule (does a matching rule exist in that chain?)."
+	tcLatencyFaultExistsCommandOutput              = `[{"kind":"netem","handle":"10:","parent":"1:1","options":{"limit":1000,"delay":{"delay":123456789,"jitter":4567,"correlation":0},"ecn":false,"gap":0}}]`
+	tcLatencyFaultWithZeroDelayExistsCommandOutput = `[{"kind":"netem","handle":"10:","parent":"1:1","options":{"limit":1000,"ecn":false,"gap":0}}]`
+	tcLossFaultExistsCommandOutput                 = `[{"kind":"netem","handle":"10:","dev":"eth0","parent":"1:1","options":{"limit":1000,"loss-random":{"loss":0.06,"correlation":0},"ecn":false,"gap":0}}]`
+	tcCommandEmptyOutput                           = `[]`
 	// Common Fault injection JSON responses
 	happyFaultRunningResponse    = `{"Status":"running"}`
 	happyFaultStoppedResponse    = `{"Status":"stopped"}`
@@ -229,6 +231,13 @@ var (
 
 	happyNetworkLatencyReqBody = map[string]interface{}{
 		"DelayMilliseconds":  delayMilliseconds,
+		"JitterMilliseconds": jitterMilliseconds,
+		"Sources":            ipSources,
+		"SourcesToFilter":    ipSourcesToFilter,
+	}
+
+	happyNetworkLatencyReqBodyWithZeroDelay = map[string]interface{}{
+		"DelayMilliseconds":  0,
 		"JitterMilliseconds": jitterMilliseconds,
 		"Sources":            ipSources,
 		"SourcesToFilter":    ipSourcesToFilter,
@@ -2176,6 +2185,39 @@ func generateStartNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 			expectedResponseJSON: happyFaultRunningResponse,
 		},
 		{
+			name:                 "zero-delay",
+			expectedStatusCode:   200,
+			requestBody:          happyNetworkLatencyReqBodyWithZeroDelay,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+
+				commandList := strings.Split(
+					fmt.Sprintf("nsenter --net=/some/path "+tcAddQdiscLatencyCommandString, "eth0", 0, jitterMilliseconds),
+					" ")
+				gomock.InOrder(
+					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+					// Check existing fault
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
+				)
+				// Add root handler
+				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD)
+				mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil)
+				// Add lantecy handler
+				exec.EXPECT().CommandContext(gomock.Any(), commandList[0], commandList[1:]).Times(1).Return(mockCMD)
+				mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil)
+				// Add targets to the handler
+				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(5).Return(mockCMD)
+				mockCMD.EXPECT().CombinedOutput().Times(5).Return([]byte(tcCommandEmptyOutput), nil)
+			},
+			expectedResponseJSON: happyFaultRunningResponse,
+		},
+		{
 			name:                 "no-existing-fault - two interfaces",
 			expectedStatusCode:   200,
 			requestBody:          happyNetworkLatencyReqBody,
@@ -2212,6 +2254,23 @@ func generateStartNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 				exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel)
 				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD)
 				mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLatencyFaultExistsCommandOutput), nil)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, latencyFaultAlreadyRunningError),
+		},
+		{
+			name:                 "existing-network-latency-fault-with-0-delay",
+			expectedStatusCode:   409,
+			requestBody:          happyNetworkLatencyReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(latencyFaultAlreadyRunningError),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+				exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel)
+				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD)
+				mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLatencyFaultWithZeroDelayExistsCommandOutput), nil)
 			},
 			expectedResponseJSON: fmt.Sprintf(errorResponse, latencyFaultAlreadyRunningError),
 		},
@@ -2358,6 +2417,21 @@ func generateStartNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 			expectedResponseJSON: fmt.Sprintf(errorResponse, fmt.Sprintf(types.MissingRequiredFieldError, "JitterMilliseconds")),
 		},
 		{
+			name:               fmt.Sprintf("%s invalid delay and jitter", startNetworkLatencyTestPrefix),
+			expectedStatusCode: 400,
+			requestBody: map[string]interface{}{
+				"DelayMilliseconds":  0,
+				"JitterMilliseconds": 0,
+				"Sources":            ipSources,
+				"SourcesToFilter":    ipSourcesToFilter,
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(types.ZeroDelayAndJitterError),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(state.TaskResponse{}, nil).Times(0)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, types.ZeroDelayAndJitterError),
+		},
+		{
 			name:               fmt.Sprintf("%s invalid DelayMilliseconds in the request body 1", startNetworkLatencyTestPrefix),
 			expectedStatusCode: 400,
 			requestBody: map[string]interface{}{
@@ -2494,6 +2568,27 @@ func generateStopNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 			expectedResponseJSON: happyFaultStoppedResponse,
 		},
 		{
+			name:                 "existing-network-latency-fault-with-0-delay-happy-request-payload",
+			expectedStatusCode:   200,
+			requestBody:          happyNetworkLatencyReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("stopped"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+				gomock.InOrder(
+					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLatencyFaultWithZeroDelayExistsCommandOutput), nil),
+				)
+				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(mockCMD)
+				mockCMD.EXPECT().CombinedOutput().Times(2).Return([]byte(""), nil)
+			},
+			expectedResponseJSON: happyFaultStoppedResponse,
+		},
+		{
 			name:                 "existing-network-packet-loss-fault-empty-request-payload",
 			expectedStatusCode:   200,
 			requestBody:          nil,
@@ -2606,6 +2701,25 @@ func generateCheckNetworkLatencyTestCases() []networkFaultInjectionTestCase {
 					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
 					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
 					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLatencyFaultExistsCommandOutput), nil),
+				)
+			},
+			expectedResponseJSON: happyFaultRunningResponse,
+		},
+		{
+			name:                 "existing-network-latency-fault-with-0-delay-happy-request-payload",
+			expectedStatusCode:   200,
+			requestBody:          happyNetworkLatencyReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+				gomock.InOrder(
+					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLatencyFaultWithZeroDelayExistsCommandOutput), nil),
 				)
 			},
 			expectedResponseJSON: happyFaultRunningResponse,
@@ -2880,6 +2994,23 @@ func generateStartNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 				exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel)
 				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD)
 				mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLatencyFaultExistsCommandOutput), nil)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, latencyFaultAlreadyRunningError),
+		},
+		{
+			name:                 "existing-network-latency-fault-with-0-delay",
+			expectedStatusCode:   409,
+			requestBody:          happyNetworkPacketLossReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(latencyFaultAlreadyRunningError),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+				exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel)
+				exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD)
+				mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLatencyFaultWithZeroDelayExistsCommandOutput), nil)
 			},
 			expectedResponseJSON: fmt.Sprintf(errorResponse, latencyFaultAlreadyRunningError),
 		},
@@ -3281,6 +3412,25 @@ func generateCheckNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
 			expectedResponseJSON: happyFaultNotRunningResponse,
 		},
 		{
+			name:                 "existing-network-latency-fault-with-0-delay-happy-request-payload",
+			expectedStatusCode:   200,
+			requestBody:          happyNetworkPacketLossReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("not-running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+				gomock.InOrder(
+					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLatencyFaultWithZeroDelayExistsCommandOutput), nil),
+				)
+			},
+			expectedResponseJSON: happyFaultNotRunningResponse,
+		},
+		{
 			name:                 "existing-network-packet-loss-fault-empty-request-payload",
 			expectedStatusCode:   200,
 			requestBody:          nil,
@@ -3449,6 +3599,17 @@ func TestCheckTCFault(t *testing.T) {
 			commandExpectations: func(exec *mock_execwrapper.MockExec, cmd *mock_execwrapper.MockCmd) {
 				exec.EXPECT().CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", "eth0", "parent", "1:1"}).Return(cmd)
 				cmd.EXPECT().CombinedOutput().Return([]byte(tcLatencyFaultExistsCommandOutput), nil)
+			},
+		},
+		{
+			name:               "Latency fault with 0 delay exists",
+			deviceNames:        []string{"eth0"},
+			expectedLatency:    true,
+			expectedPacketLoss: false,
+			expectedError:      nil,
+			commandExpectations: func(exec *mock_execwrapper.MockExec, cmd *mock_execwrapper.MockCmd) {
+				exec.EXPECT().CommandContext(gomock.Any(), "tc", []string{"-j", "q", "show", "dev", "eth0", "parent", "1:1"}).Return(cmd)
+				cmd.EXPECT().CombinedOutput().Return([]byte(tcLatencyFaultWithZeroDelayExistsCommandOutput), nil)
 			},
 		},
 		{

--- a/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/utils"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -34,6 +35,7 @@ const (
 	// Request Payload Errors
 	MissingRequiredFieldError = "required parameter %s is missing"
 	MissingRequestBodyError   = "required request body is missing"
+	ZeroDelayAndJitterError   = "required either DelayMilliseconds or JitterMilliseconds to be non-zero"
 	InvalidValueError         = "invalid value %s for parameter %s"
 )
 
@@ -129,6 +131,11 @@ func (request NetworkLatencyRequest) ValidateRequest() error {
 	if request.JitterMilliseconds == nil {
 		return fmt.Errorf(MissingRequiredFieldError, "JitterMilliseconds")
 	}
+
+	if aws.ToUint64(request.DelayMilliseconds) == 0 && aws.ToUint64(request.JitterMilliseconds) == 0 {
+		return errors.New(ZeroDelayAndJitterError)
+	}
+
 	if len(request.Sources) == 0 {
 		return fmt.Errorf(MissingRequiredFieldError, "Sources")
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR is to 1) update the logic for checking if any network latency fault exist and 2) disallow requests with zero delay and zero jitter for network latency faults.

Currently when a network latency request with delay 0 is sent to TMDS, the network latency fault can be created successfully. But the status check of the fault won't work. Because the underlying implementation relies on `tc`'s output to tell if any existing such fault. In this case of delay 0 + non-zero jitter, the output of this fault check is 
```
[{"kind":"netem","handle":"10:","parent":"1:1","options":{"limit":1000,"ecn":false,"gap":0}}]
```
The output above doesn't have `delay` field present in the `options` which fails the existing latency fault check. Normally the output will look similar to this below
```
[{"kind":"netem","handle":"10:","parent":"1:1","options":{"limit":1000,"delay":{"delay":1e-06,"jitter":1,"correlation":0},"ecn":false,"gap":0}}]
```

To work around this issue, we will remove the `delay` check for network latency fault. This works because we only allow one tc fault (either network latency fault or network packet loss fault) at any time.

### Implementation details
<!-- How are the changes implemented? -->
Unit tested. Please check below manual test result.

```
// Start a new task with a custom AMI that has the change

// Not able to start the network latency fault with delay 0 + jitter 0
sh-4.2# curl http://169.254.170.2/api/ac440d03e4ba486f918488190b87ca71-3147973833/fault/v1/network-latency/start  -d '{"DelayMilliseconds":0,"JitterMilliseconds":0,"Sources":["0.0.0.0/0"],"SourcesToFilter":["169.254.170.2","209.54.181.198","52.119.199.54","67.220.242.18","67.220.251.145"]}' -v
...
< HTTP/1.1 400 Bad Request
...
{"Error":"required either DelayMilliseconds or JitterMilliseconds to be non-zero"}sh-4.2# 


// Able to inject the fault with delay 0 + jitter 1000ms
sh-4.2# curl http://169.254.170.2/api/ac440d03e4ba486f918488190b87ca71-3147973833/fault/v1/network-latency/start  -d '{"DelayMilliseconds":0,"JitterMilliseconds":1000,"Sources":["0.0.0.0/0"],"SourcesToFilter":["169.254.170.2","209.54.181.198","52.119.199.54","67.220.242.18","67.220.251.145"]}' -v
...
{"Status":"running"}sh-4.2#

// Able to see the fault is running
sh-4.2# curl http://169.254.170.2/api/ac440d03e4ba486f918488190b87ca71-3147973833/fault/v1/network-latency/status  -d '{"DelayMilliseconds":0,"JitterMilliseconds":1000,"Sources":["0.0.0.0/0"],"SourcesToFilter":["169.254.170.2","209.54.181.198","52.119.199.54","67.220.242.18","67.220.251.145"]}'
{"Status":"running"}sh-4.2# 

// We can see this IP is impacted by the fault
sh-4.2# ping -c 10 3.5.76.1
PING 3.5.76.1 (3.5.76.1) 56(84) bytes of data.
64 bytes from 3.5.76.1: icmp_seq=1 ttl=63 time=604 ms
64 bytes from 3.5.76.1: icmp_seq=2 ttl=63 time=0.782 ms
64 bytes from 3.5.76.1: icmp_seq=3 ttl=63 time=757 ms
64 bytes from 3.5.76.1: icmp_seq=4 ttl=63 time=0.797 ms
64 bytes from 3.5.76.1: icmp_seq=5 ttl=63 time=283 ms
64 bytes from 3.5.76.1: icmp_seq=6 ttl=63 time=574 ms
64 bytes from 3.5.76.1: icmp_seq=7 ttl=63 time=19.3 ms
64 bytes from 3.5.76.1: icmp_seq=8 ttl=63 time=515 ms
64 bytes from 3.5.76.1: icmp_seq=9 ttl=63 time=724 ms
64 bytes from 3.5.76.1: icmp_seq=10 ttl=63 time=0.785 ms

--- 3.5.76.1 ping statistics ---
10 packets transmitted, 10 received, 0% packet loss, time 9036ms
rtt min/avg/max/mdev = 0.782/347.958/757.621/304.586 ms

// Not able to create a new TC fault
sh-4.2# curl http://169.254.170.2/api/ac440d03e4ba486f918488190b87ca71-3147973833/fault/v1/network-packet-loss/start  -d '{"LossPercent":10,"Sources":["0.0.0.0/0"],"SourcesToFilter":["169.254.170.2","209.54.181.198","52.119.199.54","67.220.242.18","67.220.251.145"]}'
{"Error":"There is already one network latency fault running"}sh-4.2# 
sh-4.2#

// Able to remove it
sh-4.2# curl http://169.254.170.2/api/ac440d03e4ba486f918488190b87ca71-3147973833/fault/v1/network-latency/stop  -d '{"DelayMilliseconds":0,"JitterMilliseconds":1000,"Sources":["0.0.0.0/0"],"SourcesToFilter":["169.254.170.2","209.54.181.198","52.119.199.54","67.220.242.18","67.220.251.145"]}'
{"Status":"stopped"}sh-4.2# 
sh-4.2# curl http://169.254.170.2/api/ac440d03e4ba486f918488190b87ca71-3147973833/fault/v1/network-latency/status  -d '{"DelayMilliseconds":0,"JitterMilliseconds":1000,"Sources":["0.0.0.0/0"],"SourcesToFilter":["169.254.170.2","209.54.181.198","52.119.199.54","67.220.242.18","67.220.251.145"]}'
{"Status":"not-running"}sh-4.2#

// Able to see the IP is not impacted after the fault is removed
sh-4.2# ping -c 10 3.5.76.1
PING 3.5.76.1 (3.5.76.1) 56(84) bytes of data.
64 bytes from 3.5.76.1: icmp_seq=1 ttl=63 time=1.89 ms
64 bytes from 3.5.76.1: icmp_seq=2 ttl=63 time=0.844 ms
64 bytes from 3.5.76.1: icmp_seq=3 ttl=63 time=0.817 ms
64 bytes from 3.5.76.1: icmp_seq=4 ttl=63 time=0.815 ms
64 bytes from 3.5.76.1: icmp_seq=5 ttl=63 time=0.835 ms
64 bytes from 3.5.76.1: icmp_seq=6 ttl=63 time=0.836 ms
64 bytes from 3.5.76.1: icmp_seq=7 ttl=63 time=0.854 ms
64 bytes from 3.5.76.1: icmp_seq=8 ttl=63 time=0.809 ms
64 bytes from 3.5.76.1: icmp_seq=9 ttl=63 time=0.810 ms
64 bytes from 3.5.76.1: icmp_seq=10 ttl=63 time=0.803 ms

--- 3.5.76.1 ping statistics ---
10 packets transmitted, 10 received, 0% packet loss, time 9189ms
rtt min/avg/max/mdev = 0.803/0.931/1.894/0.323 ms
sh-4.2#

```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Enhancement - Update network latency fault check

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
