### PR TITLE
Bump minimum required docker version in ecs-init spec file

### DIFF
--- a/build-infrastructure/codebuild-devbuild-stack.yml
+++ b/build-infrastructure/codebuild-devbuild-stack.yml
@@ -34,7 +34,7 @@ Resources:
       ConcurrentBuildLimit: 10
       Description: A CodeBuild project to build artifacts (AMD/x86_64). Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3
       Environment:
-        ComputeType: BUILD_GENERAL1_SMALL
+        ComputeType: BUILD_GENERAL1_MEDIUM
         Image: 'public.ecr.aws/lts/ubuntu:20.04'
         ImagePullCredentialsType: CODEBUILD
         PrivilegedMode: false
@@ -63,7 +63,7 @@ Resources:
       ConcurrentBuildLimit: 10
       Description: A CodeBuild project to build artifacts (ARM). Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3
       Environment:
-        ComputeType: BUILD_GENERAL1_SMALL
+        ComputeType: BUILD_GENERAL1_MEDIUM
         Image: 'public.ecr.aws/lts/ubuntu:20.04'
         ImagePullCredentialsType: CODEBUILD
         PrivilegedMode: false
@@ -92,7 +92,7 @@ Resources:
       ConcurrentBuildLimit: 10
       Description: A CodeBuild project to build artifacts (ARM). Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3
       Environment:
-        ComputeType: BUILD_GENERAL1_SMALL
+        ComputeType: BUILD_GENERAL1_MEDIUM
         Image: 'aws/codebuild/amazonlinux2-aarch64-standard:3.0'
         ImagePullCredentialsType: CODEBUILD
         PrivilegedMode: true
@@ -121,7 +121,7 @@ Resources:
       ConcurrentBuildLimit: 10
       Description: A CodeBuild project to build artifacts (AMD/x86_64). Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3
       Environment:
-        ComputeType: BUILD_GENERAL1_SMALL
+        ComputeType: BUILD_GENERAL1_MEDIUM
         Image: 'aws/codebuild/amazonlinux2-x86_64-standard:5.0'
         ImagePullCredentialsType: CODEBUILD
         PrivilegedMode: true
@@ -136,7 +136,7 @@ Resources:
       TimeoutInMinutes: 60
       Visibility: PRIVATE
 
-  # Creates a CodeBuild project for Amazon Linux 2 ARM    
+  # Creates a CodeBuild project for Amazon Linux 2 ARM
   Amzn2ArmProject:
     Type: 'AWS::CodeBuild::Project'
     Properties:
@@ -152,7 +152,7 @@ Resources:
       ConcurrentBuildLimit: 10
       Description: A CodeBuild project to build artifacts (ARM) on Amazon Linux 2. Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3.
       Environment:
-        ComputeType: BUILD_GENERAL1_SMALL
+        ComputeType: BUILD_GENERAL1_MEDIUM
         Image: 'aws/codebuild/amazonlinux2-aarch64-standard:2.0'
         ImagePullCredentialsType: CODEBUILD
         PrivilegedMode: true
@@ -183,7 +183,7 @@ Resources:
       ConcurrentBuildLimit: 10
       Description: A CodeBuild project to build artifacts (AMD/x86_64) on Amazon Linux 2. Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3.
       Environment:
-        ComputeType: BUILD_GENERAL1_SMALL
+        ComputeType: BUILD_GENERAL1_MEDIUM
         Image: 'aws/codebuild/amazonlinux2-x86_64-standard:4.0'
         ImagePullCredentialsType: CODEBUILD
         PrivilegedMode: true
@@ -214,7 +214,7 @@ Resources:
       ConcurrentBuildLimit: 10
       Description: A CodeBuild project to build artifacts (ARM) on Amazon-Linux 2023. Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3.
       Environment:
-        ComputeType: BUILD_GENERAL1_SMALL
+        ComputeType: BUILD_GENERAL1_MEDIUM
         Image: 'aws/codebuild/amazonlinux2-aarch64-standard:3.0'
         ImagePullCredentialsType: CODEBUILD
         PrivilegedMode: true
@@ -245,7 +245,7 @@ Resources:
       ConcurrentBuildLimit: 10
       Description: A CodeBuild project to build artifacts (AMD/x86_64) on Amazon-Linux 2023. Builds are triggered by PR creation, updates, and merges, and artifacts are saved in S3.
       Environment:
-        ComputeType: BUILD_GENERAL1_SMALL
+        ComputeType: BUILD_GENERAL1_MEDIUM
         Image: 'aws/codebuild/amazonlinux2-x86_64-standard:5.0'
         ImagePullCredentialsType: CODEBUILD
         PrivilegedMode: true
@@ -258,8 +258,8 @@ Resources:
         Location: !Ref GithubFullRepoName
         Type: GITHUB
       TimeoutInMinutes: 60
-      Visibility: PRIVATE     
-  
+      Visibility: PRIVATE
+
   # Defines the service roles for the CodeBuild projects
   ServiceRoleAmd:
     Type: 'AWS::IAM::Role'
@@ -303,7 +303,7 @@ Resources:
                   - 's3:GetBucketAcl'
                   - 's3:GetBucketLocation'
           PolicyName: !Sub '${AWS::StackName}-ServicePolicyAmd'
-      RoleName: !Sub '${AWS::StackName}-ServiceRoleAmd'   
+      RoleName: !Sub '${AWS::StackName}-ServiceRoleAmd'
   ServiceRoleUbuntuAmd:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -432,7 +432,7 @@ Resources:
                   - 's3:GetBucketAcl'
                   - 's3:GetBucketLocation'
           PolicyName: !Sub '${AWS::StackName}-ServicePolicyUbuntuArm'
-      RoleName: !Sub '${AWS::StackName}-ServiceRoleUbuntuArm'   
+      RoleName: !Sub '${AWS::StackName}-ServiceRoleUbuntuArm'
   ServiceRoleAmzn2Arm:
     Type: 'AWS::IAM::Role'
     Properties:

--- a/buildspecs/pr-build-amzn.yml
+++ b/buildspecs/pr-build-amzn.yml
@@ -49,23 +49,20 @@ phases:
       # Need to install GOLANG explicitly as required versions do not come preinstalled
       # Remove existing go installation (goenv utility)
       - sudo rm -rf /root/.goenv
-      - sudo rm -rf /usr/local/go/bin/go 
+      - sudo rm -rf /usr/local/go/bin/go
 
-      # Define the Go version to install
-      - GOVERSION="$(cat GO_VERSION)"
-      
       # Install Go and define variables based on Amazon Linux version (2 or 2023)
       # Amazon Linux 2023 uses package manager DNF, while older versions use YUM
       # Set the appropriate AL23 version echo string to include in build log
       - |
         if [[ "$amzn_version" = "amzn2023" ]]; then
           sudo dnf --releasever="$AL23_VERSION" update -y
-          sudo dnf install -y golang-$GOVERSION
+          sudo dnf install -y golang
           echo "Amazon Linux 2023 Version: $AL23_VERSION" 2>&1 | tee -a $BUILD_LOG
-          
+
         elif [[ "$amzn_version" = "amzn2" ]]; then
-          sudo yum install -y golang-$GOVERSION
-          
+          sudo yum install -y golang
+
         else
           echo "Unsupported Amazon Linux version"
           exit 1
@@ -74,10 +71,10 @@ phases:
       # Define the log file with AL version (amzn2 or amzn23) and the architecture
       - BUILD_LOG="build_${amzn_version}_${architecture}.log"
 
-      # Print all environment variables to the log file 
+      # Print all environment variables to the log file
       - which go | tee -a $BUILD_LOG
       - go version | tee -a $BUILD_LOG
-      
+
   build:
     commands:
       # Print the current working directory to the log file
@@ -108,7 +105,7 @@ phases:
           AMZN_LINUX_RPM="ecs-init-${AGENT_VERSION}-1.${amzn_version}.aarch64.rpm"
         fi
 
-      # List directory files to view artifacts in build log 
+      # List directory files to view artifacts in build log
       - ls
 
   post_build:

--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -50,7 +50,7 @@ Requires:       systemd
 Requires:       upstart
 %endif
 Requires:       iptables
-Requires:       docker >= 17.06.2ce
+Requires:       docker >= 20.10.0
 Requires:       procps
 
 # The following 'Provides' lists the vendored dependencies bundled in


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

1. Bump minimum required docker version in the ecs-init spec file to 20.10
2. Bump up the codebuild PR build job size from SMALL to MEDIUM, as many of these jobs have been getting OOM-killed for some time.
3. Remove GO_VERSION parsing and installation since AL2 and AL2023 now can often have different golang versions, for now just use the latest of what each platform has available upstream.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Used codebuild to verify that the ecs-init rpms are built on AL2 and AL2023. Verify that they work as intended with functional tests.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement: Bump minimum required docker version for ecs-init rpm to 20.10

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
