### PR TITLE
Fix local IP address depletion by cleaning up network bridges for aws…

### DIFF
--- a/ecs-agent/netlib/platform/common_linux.go
+++ b/ecs-agent/netlib/platform/common_linux.go
@@ -697,10 +697,8 @@ func (c *common) configureRegularENI(ctx context.Context, netNSPath string, eni 
 		cniNetConf = append(cniNetConf, createENIPluginConfigs(netNSPath, eni))
 		add = true
 	case status.NetworkDeleted:
-		if eni.IsPrimary() {
-			cniNetConf = append(cniNetConf, createBridgePluginConfig(netNSPath))
-		}
-		cniNetConf = append(cniNetConf, createENIPluginConfigs(netNSPath, eni))
+		// Regular ENIs are used in single-use warmpool instances, so cleanup isn't necessary.
+		cniNetConf = nil
 		add = false
 	}
 
@@ -737,9 +735,6 @@ func (c *common) configureBranchENI(ctx context.Context, netNSPath string, eni *
 		// We block IMDS access in awsvpc tasks.
 		cniNetConf = append(cniNetConf, createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan, blockInstanceMetadataDefault))
 	case status.NetworkDeleted:
-		if eni.IsPrimary() {
-			cniNetConf = append(cniNetConf, createBridgePluginConfig(netNSPath))
-		}
 		cniNetConf = append(cniNetConf, createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan, blockInstanceMetadataDefault))
 		add = false
 	}

--- a/ecs-agent/netlib/platform/common_linux_test.go
+++ b/ecs-agent/netlib/platform/common_linux_test.go
@@ -409,8 +409,6 @@ func testRegularENIConfiguration(t *testing.T) {
 	gomock.InOrder(
 		osWrapper.EXPECT().Setenv("ECS_CNI_LOG_FILE", ecscni.PluginLogPath).Times(1),
 		osWrapper.EXPECT().Setenv("IPAM_DB_PATH", filepath.Join(commonPlatform.stateDBDir, "eni-ipam.db")),
-		cniClient.EXPECT().Del(gomock.Any(), bridgeConfig).Return(nil).Times(1),
-		cniClient.EXPECT().Del(gomock.Any(), eniConfig).Return(nil).Times(1),
 	)
 	err = commonPlatform.configureInterface(ctx, netNSPath, eni, nil)
 	require.NoError(t, err)
@@ -450,7 +448,6 @@ func testBranchENIConfiguration(t *testing.T) {
 	// Delete workflow.
 	branchENI.DesiredStatus = status.NetworkDeleted
 	osWrapper.EXPECT().Setenv("IPAM_DB_PATH", filepath.Join(commonPlatform.stateDBDir, "eni-ipam.db"))
-	cniClient.EXPECT().Del(gomock.Any(), bridgeConfig).Return(nil).Times(1)
 	cniClient.EXPECT().Del(gomock.Any(), cniConfig).Return(nil).Times(1)
 	err = commonPlatform.configureInterface(ctx, netNSPath, branchENI, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
### Summary
Scope down IP address depletion fix to managed linux platform only.

Previously in https://github.com/aws/amazon-ecs-agent/pull/4717, we made the change to fix the IP address depletion issue (for managed linux platform). However, since the change was made in common_linux, it introduced bug in existing platforms. This change is to scope down the fix to only apply to the managed linux platform.

### Implementation details
Instead of invoking the CNI clean-up logic in the common_linux code path, methods `configureRegularENI` and `configureBranchENI` are created for the managed_linux platform, where we will use logic specific to managed linux platform, instead of using the common code path.

### Testing
**Unit Test**
New tests cover the changes: YES
Introduced new unit tests `TestManagedLinux_TestConfigureInterface/regular-eni` and `TestManagedLinux_TestConfigureInterface/branch-eni`
```
% go test -tags unit -v -run TestManagedLinux_TestConfigureInterface /workplace/tianzes/amazon-ecs-agent/ecs-agent/netlib/platform
=== RUN   TestManagedLinux_TestConfigureInterface
=== RUN   TestManagedLinux_TestConfigureInterface/regular-eni
1754427458660162039 [Info] logger=structured msg="Configuring regular ENI" ENIName="" NetNSPath="ns1"
1754427458660242370 [Info] logger=structured msg="Configuring regular ENI" ENIName="" NetNSPath="ns1"
1754427458660426941 [Info] logger=structured msg="Configuring regular ENI" NetNSPath="ns1" ENIName=""
=== RUN   TestManagedLinux_TestConfigureInterface/branch-eni
1754427458660969428 [Info] logger=structured msg="Configuring branch ENI" ENIName="" NetNSPath="ns1"
1754427458661023942 [Info] logger=structured msg="Configuring branch ENI" ENIName="" NetNSPath="ns1"
1754427458661049387 [Info] logger=structured msg="Configuring branch ENI" ENIName="" NetNSPath="ns1"
--- PASS: TestManagedLinux_TestConfigureInterface (0.00s)
    --- PASS: TestManagedLinux_TestConfigureInterface/regular-eni (0.00s)
    --- PASS: TestManagedLinux_TestConfigureInterface/branch-eni (0.00s)
PASS
ok      github.com/aws/amazon-ecs-agent/ecs-agent/netlib/platform       (cached)
```

**E2E Testing**
Launched and stopped multiple tasks on the same host, then examined the CNI plugin log.
For task `8d919a758df041ba9f251e033275c961`, saw the following:
```
% sudo cat /var/log/ecs/ecs-cni-warmpool.log | grep 8d919a758df041ba9f251e033275c961
2025-08-05T21:30:41Z [INFO] msg="Creating the bridge" netns=/var/run/netns/8d919a758df041ba9f251e033275c961-024c06c4784d ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam
2025-08-05T21:30:41Z [INFO] msg="Creating veth pair for namespace" netns=/var/run/netns/8d919a758df041ba9f251e033275c961-024c06c4784d ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam
2025-08-05T21:30:41Z [INFO] msg="Attaching veth pair to bridge" netns=/var/run/netns/8d919a758df041ba9f251e033275c961-024c06c4784d ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam hostVethName=veth42de7dc3
2025-08-05T21:30:41Z [INFO] msg="Running IPAM plugin ADD" netns=/var/run/netns/8d919a758df041ba9f251e033275c961-024c06c4784d ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam hostVethName=veth42de7dc3
2025-08-05T21:30:41Z [INFO] msg="Configuring container's interface" netns=/var/run/netns/8d919a758df041ba9f251e033275c961-024c06c4784d ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam hostVethName=veth42de7dc3
2025-08-05T21:30:41Z [INFO] msg="Configuring bridge" netns=/var/run/netns/8d919a758df041ba9f251e033275c961-024c06c4784d ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam hostVethName=veth42de7dc3
2025-08-05T21:30:41Z [INFO] msg="Deleting veth interface" netns=/var/run/netns/8d919a758df041ba9f251e033275c961-024c06c4784d ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam
2025-08-05T21:30:41Z [INFO] msg="Running IPAM plugin DEL" netns=/var/run/netns/8d919a758df041ba9f251e033275c961-024c06c4784d ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam
2025-08-05T21:30:41Z [INFO] msg="Deleting container interface" netns=/var/run/netns/8d919a758df041ba9f251e033275c961-024c06c4784d ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam
```
Specifically, these 2 lines at the bottom prove that the fix to clean up netns kicked in:
```
2025-08-05T21:30:41Z [INFO] msg="Running IPAM plugin DEL" netns=/var/run/netns/8d919a758df041ba9f251e033275c961-024c06c4784d ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam
2025-08-05T21:30:41Z [INFO] msg="Deleting container interface" netns=/var/run/netns/8d919a758df041ba9f251e033275c961-024c06c4784d ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam
```

### Description for the changelog
Scope down IP address depletion fix to managed linux platform only.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
NO

**Does this PR include the addition of new environment variables in the README?**
NO

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
