### PR TITLE
Make pause containers appear first in bridge task metadata response

### DIFF
--- a/agent/handlers/v4/tmdsstate.go
+++ b/agent/handlers/v4/tmdsstate.go
@@ -15,7 +15,9 @@ package v4
 import (
 	"errors"
 	"fmt"
+	"sort"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/stats"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs"
@@ -187,6 +189,17 @@ func (s *TMDSAgentState) getTaskMetadata(v3EndpointID string, includeTags bool, 
 		taskResponse.TaskNetworkConfig = taskNetworkConfig
 	}
 
+	// For bridge mode tasks, sort containers so that CNI_PAUSE containers appear first.
+	// Bridge tasks with pause containers are Service Connect enabled and only pause containers
+	// contain actual network information in that case.
+	//
+	// Service Connect Agent versions older than v1.29.12.1 depend on the first container in the
+	// task metadata response to infer the task's supported IP families, so making pause containers
+	// appear first is needed for the infer logic to work correctly.
+	if task.IsNetworkModeBridge() {
+		sortContainersCNIPauseFirst(taskResponse.Containers)
+	}
+
 	return *taskResponse, nil
 }
 
@@ -234,4 +247,12 @@ func (s *TMDSAgentState) GetTaskStats(v3EndpointID string) (map[string]*tmdsv4.S
 	}
 
 	return taskStatsResponse, nil
+}
+
+// sortContainersCNIPauseFirst sorts containers so that CNI_PAUSE containers appear first.
+// Other containers maintain their relative order.
+func sortContainersCNIPauseFirst(containers []tmdsv4.ContainerResponse) {
+	sort.SliceStable(containers, func(i, j int) bool {
+		return containers[i].Type == apicontainer.ContainerCNIPause.String()
+	})
 }

--- a/agent/handlers/v4/tmdsstate_test.go
+++ b/agent/handlers/v4/tmdsstate_test.go
@@ -1,0 +1,91 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v4
+
+import (
+	"testing"
+
+	v2 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v2"
+	tmdsv4 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortContainersCNIPauseFirst(t *testing.T) {
+	// Local constants for container types used in tests
+	const (
+		cniPause        = "CNI_PAUSE"
+		normal          = "NORMAL"
+		emptyHostVolume = "EMPTY_HOST_VOLUME"
+	)
+
+	testCases := []struct {
+		name  string
+		input []string // Container types
+		want  []string // Expected order of types
+	}{
+		{
+			name:  "CNI_PAUSE containers appear first",
+			input: []string{normal, cniPause, normal, cniPause},
+			want:  []string{cniPause, cniPause, normal, normal},
+		},
+		{
+			name:  "only CNI_PAUSE containers",
+			input: []string{cniPause, cniPause},
+			want:  []string{cniPause, cniPause},
+		},
+		{
+			name:  "only normal containers",
+			input: []string{normal, normal},
+			want:  []string{normal, normal},
+		},
+		{
+			name:  "empty list",
+			input: []string{},
+			want:  []string{},
+		},
+		{
+			name:  "mixed types",
+			input: []string{normal, cniPause, emptyHostVolume},
+			want:  []string{cniPause, normal, emptyHostVolume},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Convert input to ContainerResponse slice
+			containers := make([]tmdsv4.ContainerResponse, len(tc.input))
+			for i, containerType := range tc.input {
+				containers[i] = tmdsv4.ContainerResponse{
+					ContainerResponse: &v2.ContainerResponse{Type: containerType},
+				}
+			}
+
+			// Sort the containers
+			sortContainersCNIPauseFirst(containers)
+
+			// Extract types from result
+			result := make([]string, len(containers))
+			for i, container := range containers {
+				result[i] = container.ContainerResponse.Type
+			}
+
+			// Verify the result
+			assert.Equal(t, tc.want, result)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
