### PR TITLE
Instance healthcheck: initialize LastUpdated during initialization

### DIFF
--- a/agent/doctor/docker_runtime_healthcheck.go
+++ b/agent/doctor/docker_runtime_healthcheck.go
@@ -25,6 +25,8 @@ import (
 
 const systemPingTimeout = time.Second * 2
 
+var timeNow = time.Now
+
 type dockerRuntimeHealthcheck struct {
 	// HealthcheckType is the reported healthcheck type
 	HealthcheckType string `json:"HealthcheckType,omitempty"`
@@ -45,12 +47,13 @@ type dockerRuntimeHealthcheck struct {
 }
 
 func NewDockerRuntimeHealthcheck(client dockerapi.DockerClient) *dockerRuntimeHealthcheck {
-	nowTime := time.Now()
+	nowTime := timeNow()
 	return &dockerRuntimeHealthcheck{
 		HealthcheckType:  doctor.HealthcheckTypeContainerRuntime,
 		Status:           doctor.HealthcheckStatusInitializing,
 		TimeStamp:        nowTime,
 		StatusChangeTime: nowTime,
+		LastTimeStamp:    nowTime,
 		client:           client,
 	}
 }

--- a/agent/doctor/docker_runtime_healthcheck_test.go
+++ b/agent/doctor/docker_runtime_healthcheck_test.go
@@ -19,8 +19,23 @@ func TestNewDockerRuntimeHealthCheck(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockDockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
-	dockerRuntimeHealthCheck := NewDockerRuntimeHealthcheck(mockDockerClient)
-	assert.Equal(t, doctor.HealthcheckStatusInitializing, dockerRuntimeHealthCheck.Status)
+
+	// Mock the time to have predictable values
+	mockTime := time.Now()
+	originalTimeNow := timeNow
+	timeNow = func() time.Time { return mockTime }
+	defer func() { timeNow = originalTimeNow }()
+
+	expectedDockerRuntimeHealthcheck := &dockerRuntimeHealthcheck{
+		HealthcheckType:  doctor.HealthcheckTypeContainerRuntime,
+		Status:           doctor.HealthcheckStatusInitializing,
+		TimeStamp:        mockTime,
+		StatusChangeTime: mockTime,
+		LastTimeStamp:    mockTime,
+		client:           mockDockerClient,
+	}
+	actualDockerRuntimeHealthcheck := NewDockerRuntimeHealthcheck(mockDockerClient)
+	assert.Equal(t, expectedDockerRuntimeHealthcheck, actualDockerRuntimeHealthcheck)
 }
 
 func TestRunCheck(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Background
<!-- What does this pull request do? -->
The ECS agent registers a default instance healthcheck (HC) of type `ContainerRuntime`. This HC transitions from INITIALIZING -> OK / IMPAIRED statuses (based on the HC success/failure), and so on.

In addition to the status, ECS agent also reports the following timestamps to TACS:
- LastTimeStamp: It represents the time when ECS agent last updated the instance HC. This gets translated to`LastUpdated` in our customer visible [response](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_InstanceHealthCheckResult.html).
- StatusChangeTime: It represents the time when the HC status changes.
- TimeStamp: It represents the time when agent sends the HC to TACS.

### Problem Statement: 
During HC initialization, container instances are currently reporting `LastUpdated` as very ancient, like: Fri Aug 30 22:43:42 UTC 1754, causing customer confusion.

The `LastTimeStamp` field is not explicitly initialized during the HC object creation. Hence, this gets initialized to Go's zero time (0001-01-01 00:00:00 UTC). While sending this to TACS, this zero time gets serialized to JSON via t.UnixNano() (called by aws.Time()), it produces a large negative number (-6795364578.871 seconds). When converted back to a human-readable date, this calculates to August 30, 1754.

### Solution
<!-- How are the changes implemented? -->
Initialize `LastUpdated` time to the current time (time.Now()) instead of leaving it as zero value. This initializes it to a reasonable time indicating when the HC was initialized.

Before
| lastStatusChange | **lastUpdated** | status | type |
|------------------|-------------|--------|------|
| 2025-08-08T10:51:35-07:00 | **1754-08-30T14:43:42-08:00** | INITIALIZING | CONTAINER_RUNTIME |

After

| lastStatusChange | **lastUpdated** | status | type |
|------------------|-------------|--------|------|
| 2025-08-08T10:42:10-07:00 | **2025-08-08T10:42:10-07:00** | INITIALIZING | CONTAINER_RUNTIME |

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> Yes, I updated the existing unit test. 

I also verified the output manually, as shown in the before/after outputs above.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Bugfix: Initialize `LastUpdated` during healthcheck initialization.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
