### PR TITLE
Populate HostIPv6Address in container metadata file for IPv6-only instances

### DIFF
--- a/agent/containermetadata/manager.go
+++ b/agent/containermetadata/manager.go
@@ -40,6 +40,7 @@ type Manager interface {
 	SetAvailabilityZone(string)
 	SetHostPrivateIPv4Address(string)
 	SetHostPublicIPv4Address(string)
+	SetHostIPv6Address(string)
 	Create(*dockercontainer.Config, *dockercontainer.HostConfig, *apitask.Task, string, []string) error
 	Update(context.Context, string, *apitask.Task, string) error
 	Clean(string) error
@@ -66,6 +67,8 @@ type metadataManager struct {
 	hostPrivateIPv4Address string
 	// hostPublicIPv4Address is the public IPv4 address associated with the EC2 instance
 	hostPublicIPv4Address string
+	// hostIPv6Address is the IPv6 address associated with the EC2 instance
+	hostIPv6Address string
 }
 
 // NewManager creates a metadataManager for a given DockerTaskEngine settings.
@@ -100,6 +103,12 @@ func (manager *metadataManager) SetHostPrivateIPv4Address(ipv4address string) {
 // at its creation as this information is not present immediately at the agent's startup
 func (manager *metadataManager) SetHostPublicIPv4Address(ipv4address string) {
 	manager.hostPublicIPv4Address = ipv4address
+}
+
+// SetHostIPv6Address sets the metadataManager's hostIPv6Address which is not available
+// at its creation as this information is not present immediately at the agent's startup
+func (manager *metadataManager) SetHostIPv6Address(ipv6address string) {
+	manager.hostIPv6Address = ipv6address
 }
 
 var mkdirAll = os.MkdirAll

--- a/agent/containermetadata/manager_test.go
+++ b/agent/containermetadata/manager_test.go
@@ -45,6 +45,7 @@ const (
 	availabilityZone       = "us-west-2b"
 	hostPrivateIPv4Address = "127.0.0.1"
 	hostPublicIPv4Address  = "127.0.0.1"
+	hostIPv6Address        = "2001:db8::1"
 )
 
 func managerSetup(t *testing.T) (*mock_containermetadata.MockDockerMetadataClient, oswrapper.File, func()) {
@@ -92,6 +93,16 @@ func TestSetHostPublicIPv4Address(t *testing.T) {
 	newManager := &metadataManager{}
 	newManager.SetHostPublicIPv4Address(hostPublicIPv4Address)
 	assert.Equal(t, hostPublicIPv4Address, newManager.hostPublicIPv4Address)
+}
+
+// TestSetHostIPv6Address checks whether the container hostIPv6Address is set correctly.
+func TestSetHostIPv6Address(t *testing.T) {
+	_, _, done := managerSetup(t)
+	defer done()
+	newManager := &metadataManager{}
+	hostIPv6Address := "2001:db8::1"
+	newManager.SetHostIPv6Address(hostIPv6Address)
+	assert.Equal(t, hostIPv6Address, newManager.hostIPv6Address)
 }
 
 // TestCreateMalformedFilepath checks case when taskARN is invalid resulting in an invalid file path

--- a/agent/containermetadata/mocks/containermetadata_mocks.go
+++ b/agent/containermetadata/mocks/containermetadata_mocks.go
@@ -104,6 +104,18 @@ func (mr *MockManagerMockRecorder) SetContainerInstanceARN(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContainerInstanceARN", reflect.TypeOf((*MockManager)(nil).SetContainerInstanceARN), arg0)
 }
 
+// SetHostIPv6Address mocks base method.
+func (m *MockManager) SetHostIPv6Address(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetHostIPv6Address", arg0)
+}
+
+// SetHostIPv6Address indicates an expected call of SetHostIPv6Address.
+func (mr *MockManagerMockRecorder) SetHostIPv6Address(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHostIPv6Address", reflect.TypeOf((*MockManager)(nil).SetHostIPv6Address), arg0)
+}
+
 // SetHostPrivateIPv4Address mocks base method.
 func (m *MockManager) SetHostPrivateIPv4Address(arg0 string) {
 	m.ctrl.T.Helper()

--- a/agent/containermetadata/parse_metadata.go
+++ b/agent/containermetadata/parse_metadata.go
@@ -44,6 +44,7 @@ func (manager *metadataManager) parseMetadataAtContainerCreate(task *apitask.Tas
 		availabilityZone:       manager.availabilityZone,
 		hostPrivateIPv4Address: manager.hostPrivateIPv4Address,
 		hostPublicIPv4Address:  manager.hostPublicIPv4Address,
+		hostIPv6Address:        manager.hostIPv6Address,
 	}
 }
 
@@ -67,6 +68,7 @@ func (manager *metadataManager) parseMetadata(dockerContainer *types.ContainerJS
 		availabilityZone:        manager.availabilityZone,
 		hostPrivateIPv4Address:  manager.hostPrivateIPv4Address,
 		hostPublicIPv4Address:   manager.hostPublicIPv4Address,
+		hostIPv6Address:         manager.hostIPv6Address,
 	}
 }
 

--- a/agent/containermetadata/parse_metadata_test.go
+++ b/agent/containermetadata/parse_metadata_test.go
@@ -49,6 +49,7 @@ func newBasicFixture() *testFixture {
 		availabilityZone:       availabilityZone,
 		hostPrivateIPv4Address: hostPrivateIPv4Address,
 		hostPublicIPv4Address:  hostPublicIPv4Address,
+		hostIPv6Address:        hostIPv6Address,
 	}
 
 	return &testFixture{
@@ -123,6 +124,7 @@ func validateBasicMetadata(t *testing.T, metadata *Metadata, fixture *testFixtur
 	assert.Equal(t, fixture.manager.availabilityZone, metadata.availabilityZone, "Expected availabilityZone "+fixture.manager.availabilityZone)
 	assert.Equal(t, fixture.manager.hostPrivateIPv4Address, metadata.hostPrivateIPv4Address, "Expected hostPrivateIPv4Address "+fixture.manager.hostPrivateIPv4Address)
 	assert.Equal(t, fixture.manager.hostPublicIPv4Address, metadata.hostPublicIPv4Address, "Expected hostPublicIPv4Address "+fixture.manager.hostPublicIPv4Address)
+	assert.Equal(t, fixture.manager.hostIPv6Address, metadata.hostIPv6Address, "Expected hostIPv6Address "+fixture.manager.hostIPv6Address)
 	assert.Equal(t, fixture.expectedStatus, string(metadata.metadataStatus), "Expected status "+fixture.expectedStatus)
 }
 

--- a/agent/containermetadata/types.go
+++ b/agent/containermetadata/types.go
@@ -125,6 +125,7 @@ type Metadata struct {
 	availabilityZone        string
 	hostPrivateIPv4Address  string
 	hostPublicIPv4Address   string
+	hostIPv6Address         string
 }
 
 // metadataSerializer is an intermediate struct that converts the information
@@ -146,6 +147,7 @@ type metadataSerializer struct {
 	AvailabilityZone       string                     `json:"AvailabilityZone,omitempty"`
 	HostPrivateIPv4Address string                     `json:"HostPrivateIPv4Address,omitempty"`
 	HostPublicIPv4Address  string                     `json:"HostPublicIPv4Address,omitempty"`
+	HostIPv6Address        string                     `json:"HostIPv6Address,omitempty"`
 }
 
 func (m Metadata) MarshalJSON() ([]byte, error) {
@@ -167,5 +169,6 @@ func (m Metadata) MarshalJSON() ([]byte, error) {
 			AvailabilityZone:       m.availabilityZone,
 			HostPrivateIPv4Address: m.hostPrivateIPv4Address,
 			HostPublicIPv4Address:  m.hostPublicIPv4Address,
+			HostIPv6Address:        m.hostIPv6Address,
 		})
 }

--- a/agent/utils/test/ec2util/ec2client.go
+++ b/agent/utils/test/ec2util/ec2client.go
@@ -80,6 +80,10 @@ func (FakeEC2MetadataClient) PublicIPv4Address() (string, error) {
 	return "", errors.New("not implemented")
 }
 
+func (FakeEC2MetadataClient) IPv6Address() (string, error) {
+	return "", errors.New("not implemented")
+}
+
 func (FakeEC2MetadataClient) SpotInstanceAction() (string, error) {
 	return "", errors.New("not implemented")
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/ec2/blackhole_ec2_metadata_client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/ec2/blackhole_ec2_metadata_client.go
@@ -77,6 +77,10 @@ func (blackholeMetadataClient) PrivateIPv4Address() (string, error) {
 	return "", errors.New("blackholed")
 }
 
+func (blackholeMetadataClient) IPv6Address() (string, error) {
+	return "", errors.New("blackholed")
+}
+
 func (blackholeMetadataClient) PublicIPv4Address() (string, error) {
 	return "", errors.New("blackholed")
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/ec2/ec2_metadata_client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/ec2/ec2_metadata_client.go
@@ -41,6 +41,7 @@ const (
 	AvailabilityZoneID                        = "placement/availability-zone-id"
 	PrivateIPv4Resource                       = "local-ipv4"
 	PublicIPv4Resource                        = "public-ipv4"
+	IPv6Resource                              = "ipv6"
 	OutpostARN                                = "outpost-arn"
 	PrimaryIPV4VPCCIDRResourceFormat          = "network/interfaces/macs/%s/vpc-ipv4-cidr-block"
 	TargetLifecycleState                      = "autoscaling/target-lifecycle-state"
@@ -85,6 +86,7 @@ type EC2MetadataClient interface {
 	AvailabilityZoneID() (string, error)
 	PrivateIPv4Address() (string, error)
 	PublicIPv4Address() (string, error)
+	IPv6Address() (string, error)
 	SpotInstanceAction() (string, error)
 	OutpostARN() (string, error)
 	TargetLifecycleState() (string, error)
@@ -258,6 +260,11 @@ func (c *ec2MetadataClientImpl) PublicIPv4Address() (string, error) {
 // PrivateIPv4Address returns the private IPv4 of this instance
 func (c *ec2MetadataClientImpl) PrivateIPv4Address() (string, error) {
 	return c.GetMetadata(PrivateIPv4Resource)
+}
+
+// IPv6Address returns the IPv6 address of this instance
+func (c *ec2MetadataClientImpl) IPv6Address() (string, error) {
+	return c.GetMetadata(IPv6Resource)
 }
 
 // SpotInstanceAction returns the spot instance-action, if it has been set.

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/ec2/mocks/ec2_mocks.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/ec2/mocks/ec2_mocks.go
@@ -142,6 +142,21 @@ func (mr *MockEC2MetadataClientMockRecorder) GetUserData() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserData", reflect.TypeOf((*MockEC2MetadataClient)(nil).GetUserData))
 }
 
+// IPv6Address mocks base method.
+func (m *MockEC2MetadataClient) IPv6Address() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IPv6Address")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IPv6Address indicates an expected call of IPv6Address.
+func (mr *MockEC2MetadataClientMockRecorder) IPv6Address() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IPv6Address", reflect.TypeOf((*MockEC2MetadataClient)(nil).IPv6Address))
+}
+
 // InstanceID mocks base method.
 func (m *MockEC2MetadataClient) InstanceID() (string, error) {
 	m.ctrl.T.Helper()

--- a/ecs-agent/ec2/blackhole_ec2_metadata_client.go
+++ b/ecs-agent/ec2/blackhole_ec2_metadata_client.go
@@ -77,6 +77,10 @@ func (blackholeMetadataClient) PrivateIPv4Address() (string, error) {
 	return "", errors.New("blackholed")
 }
 
+func (blackholeMetadataClient) IPv6Address() (string, error) {
+	return "", errors.New("blackholed")
+}
+
 func (blackholeMetadataClient) PublicIPv4Address() (string, error) {
 	return "", errors.New("blackholed")
 }

--- a/ecs-agent/ec2/ec2_metadata_client.go
+++ b/ecs-agent/ec2/ec2_metadata_client.go
@@ -41,6 +41,7 @@ const (
 	AvailabilityZoneID                        = "placement/availability-zone-id"
 	PrivateIPv4Resource                       = "local-ipv4"
 	PublicIPv4Resource                        = "public-ipv4"
+	IPv6Resource                              = "ipv6"
 	OutpostARN                                = "outpost-arn"
 	PrimaryIPV4VPCCIDRResourceFormat          = "network/interfaces/macs/%s/vpc-ipv4-cidr-block"
 	TargetLifecycleState                      = "autoscaling/target-lifecycle-state"
@@ -85,6 +86,7 @@ type EC2MetadataClient interface {
 	AvailabilityZoneID() (string, error)
 	PrivateIPv4Address() (string, error)
 	PublicIPv4Address() (string, error)
+	IPv6Address() (string, error)
 	SpotInstanceAction() (string, error)
 	OutpostARN() (string, error)
 	TargetLifecycleState() (string, error)
@@ -258,6 +260,11 @@ func (c *ec2MetadataClientImpl) PublicIPv4Address() (string, error) {
 // PrivateIPv4Address returns the private IPv4 of this instance
 func (c *ec2MetadataClientImpl) PrivateIPv4Address() (string, error) {
 	return c.GetMetadata(PrivateIPv4Resource)
+}
+
+// IPv6Address returns the IPv6 address of this instance
+func (c *ec2MetadataClientImpl) IPv6Address() (string, error) {
+	return c.GetMetadata(IPv6Resource)
 }
 
 // SpotInstanceAction returns the spot instance-action, if it has been set.

--- a/ecs-agent/ec2/ec2_metadata_client_test.go
+++ b/ecs-agent/ec2/ec2_metadata_client_test.go
@@ -294,6 +294,26 @@ func TestPublicIPv4Address(t *testing.T) {
 	assert.Equal(t, publicIP, publicIPResponse)
 }
 
+func TestIPv6Address(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockGetter := mock_ec2.NewMockHttpClient(ctrl)
+	testClient, err := ec2.NewEC2MetadataClient(mockGetter)
+	assert.NoError(t, err)
+
+	ipv6 := "2001:db8::1"
+	mockGetter.EXPECT().GetMetadata(gomock.Any(), &imds.GetMetadataInput{
+		Path: ec2.IPv6Resource,
+	}).Return(&imds.GetMetadataOutput{
+		Content: nopReadCloser(ipv6),
+	}, nil)
+
+	ipv6Response, err := testClient.IPv6Address()
+	assert.NoError(t, err)
+	assert.Equal(t, ipv6, ipv6Response)
+}
+
 func TestSpotInstanceAction(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/ecs-agent/ec2/mocks/ec2_mocks.go
+++ b/ecs-agent/ec2/mocks/ec2_mocks.go
@@ -142,6 +142,21 @@ func (mr *MockEC2MetadataClientMockRecorder) GetUserData() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserData", reflect.TypeOf((*MockEC2MetadataClient)(nil).GetUserData))
 }
 
+// IPv6Address mocks base method.
+func (m *MockEC2MetadataClient) IPv6Address() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IPv6Address")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IPv6Address indicates an expected call of IPv6Address.
+func (mr *MockEC2MetadataClientMockRecorder) IPv6Address() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IPv6Address", reflect.TypeOf((*MockEC2MetadataClient)(nil).IPv6Address))
+}
+
 // InstanceID mocks base method.
 func (m *MockEC2MetadataClient) InstanceID() (string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This change makes Agent add HostIPv6Address field to container metadata file if the instance is IPv6-only. 

### Implementation details
<!-- How are the changes implemented? -->
* Update EC2 Metadata Client implementation to support querying IPv6 address from IMDS.
* Update metadata file manager and serializer to have HostIPv6Address fields. 
* Update Agent startup to query IMDS to populate HostIPv6Address field in metadata file manager if the instance is IPv6-only. IPv4 address population is skipped in this case.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Ran Agent on a dualstack instance with `ECS_INSTANCE_IP_COMPATIBILITY` set to `true` to enable IPv6-only behavior. Ran a task on it and verified the contents of the container metadata file.

```
ip-10-0-0-23 ❱ docker exec f492bd79d809 sh -c 'cat $ECS_CONTAINER_METADATA_FILE' | jq '.'
{
  "Cluster": "test",
  "ContainerInstanceARN": "<container instance ARN>",
  "TaskARN": "<task ARN>",
  "TaskDefinitionFamily": "myamazonlinux-bridge",
  "TaskDefinitionRevision": "3",
  "ContainerID": "<container ID>",
  "ContainerName": "al",
  "DockerContainerName": "/ecs-myamazonlinux-bridge-3-al-b6cdb9b1dbf4949b0b00",
  "ImageID": "sha256:0ce501908ab4af6e7501468a49ae535c6db4f22d16ea153924e6514c482b6f7a",
  "ImageName": "<my image>",
  "Networks": [
    {
      "NetworkMode": "bridge",
      "IPv4Addresses": [
        "172.17.0.2"
      ],
      "IPv6Addresses": [
        "2001:db8:1::242:ac11:2"
      ]
    }
  ],
  "MetadataFileStatus": "READY",
  "AvailabilityZone": "us-west-2a",
  "HostIPv6Address": "2600:1f14:323a:e001:3120:f10b:dc95:ce8f"
}
```

For non-IPv6-only instances, the file contents are unchanged. 
```
ip-10-0-0-23 ❱ docker exec 85433192f5ac sh -c 'cat $ECS_CONTAINER_METADATA_FILE' | jq '.'
{
  "Cluster": "test",
  "ContainerInstanceARN": "arn:aws:ecs:us-west-2:REDACTED:container-instance/test/REDACTED",
  "TaskARN": "arn:aws:ecs:us-west-2:REDACTED:task/test/REDACTED",
  "TaskDefinitionFamily": "myamazonlinux-bridge",
  "TaskDefinitionRevision": "3",
  "ContainerID": "REDACTED",
  "ContainerName": "al",
  "DockerContainerName": "/ecs-myamazonlinux-bridge-3-al-REDACTED",
  "ImageID": "sha256:REDACTED",
  "ImageName": "REDACTED.dkr-ecr.us-west-2.on.aws/myamazonlinux:latest",
  "Networks": [
    {
      "NetworkMode": "bridge",
      "IPv4Addresses": [
        "172.17.0.2"
      ],
      "IPv6Addresses": [
        "2001:db8:1::242:ac11:2"
      ]
    }
  ],
  "MetadataFileStatus": "READY",
  "AvailabilityZone": "us-west-2a",
  "HostPrivateIPv4Address": "10.0.0.23",
  "HostPublicIPv4Address": "34.222.16.122"
}
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement: Populate HostIPv6Address in container metadata file for IPv6-only instances

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
