### PR TITLE
Fix CloudWatchLogs endpoints key in exec SSM Agent config for IPv6-only case

### DIFF
--- a/agent/engine/execcmd/manager_init_task.go
+++ b/agent/engine/execcmd/manager_init_task.go
@@ -72,7 +72,7 @@ var (
 	"Kms": {
 		"Endpoint": "%s"
 	},
-	"CloudWatch": {
+	"CloudWatchLogs": {
 		"Endpoint": "%s"
 	}
 }`

--- a/agent/engine/execcmd/manager_init_task_linux_test.go
+++ b/agent/engine/execcmd/manager_init_task_linux_test.go
@@ -250,7 +250,7 @@ func TestGetExecAgentConfigFileName(t *testing.T) {
 	"Kms": {
 		"Endpoint": ""
 	},
-	"CloudWatch": {
+	"CloudWatchLogs": {
 		"Endpoint": ""
 	}
 }`
@@ -503,18 +503,18 @@ func TestFormatSSMAgentConfig(t *testing.T) {
 		Kms struct {
 			Endpoint string `json:"Endpoint"`
 		} `json:"Kms"`
-		CloudWatch struct {
+		CloudWatchLogs struct {
 			Endpoint string `json:"Endpoint"`
-		} `json:"CloudWatch"`
+		} `json:"CloudWatchLogs"`
 	}
 
 	type expectedEndpoints struct {
-		mgs        string
-		ssm        string
-		mds        string
-		s3         string
-		kms        string
-		cloudWatch string
+		mgs            string
+		ssm            string
+		mds            string
+		s3             string
+		kms            string
+		cloudWatchLogs string
 	}
 
 	// Create mock ENIs for testing
@@ -543,12 +543,12 @@ func TestFormatSSMAgentConfig(t *testing.T) {
 	}
 
 	expectedDualstackEndpointsIAD := expectedEndpoints{
-		mgs:        "https://ssmmessages.us-east-1.api.aws",
-		ssm:        "https://ssm.us-east-1.api.aws",
-		mds:        "https://ec2messages.us-east-1.api.aws",
-		s3:         "https://s3.dualstack.us-east-1.amazonaws.com",
-		kms:        "https://kms.us-east-1.api.aws",
-		cloudWatch: "https://logs.us-east-1.api.aws",
+		mgs:            "https://ssmmessages.us-east-1.api.aws",
+		ssm:            "https://ssm.us-east-1.api.aws",
+		mds:            "https://ec2messages.us-east-1.api.aws",
+		s3:             "https://s3.dualstack.us-east-1.amazonaws.com",
+		kms:            "https://kms.us-east-1.api.aws",
+		cloudWatchLogs: "https://logs.us-east-1.api.aws",
 	}
 
 	testCases := []struct {
@@ -647,7 +647,7 @@ func TestFormatSSMAgentConfig(t *testing.T) {
 			assert.Equal(t, tc.expectedEndpoints.mds, config.Mds.Endpoint)
 			assert.Equal(t, tc.expectedEndpoints.s3, config.S3.Endpoint)
 			assert.Equal(t, tc.expectedEndpoints.kms, config.Kms.Endpoint)
-			assert.Equal(t, tc.expectedEndpoints.cloudWatch, config.CloudWatch.Endpoint)
+			assert.Equal(t, tc.expectedEndpoints.cloudWatchLogs, config.CloudWatchLogs.Endpoint)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
SSM Agent v3.3.2958.0 includes a change to allow overriding CloudWatch Logs endpoint it uses to upload exec session logs. We were under the impression that the key in amazon-ssm-agent config parameter would be "CloudWatch" but it ended up being "CloudWatchLogs". So, this change fixes the key in the amazon-ssm-agent configuration file that Agent creates for exec feature for IPv6-only tasks. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Ran a bridge task and an awsvpc task with exec enabled. Started exec sessions for both and verified that exec session logs were uploaded to S3 as well as CloudWatch Logs. 

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
bugfix: Fix CloudWatchLogs endpoints key in exec SSM Agent config for IPv6-only case

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
