### PR TITLE
Revert "Initialize OS type detailed attribute during container instance registration"

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/ecs/client/ecs_client.go
@@ -54,7 +54,6 @@ const (
 	cpuArchAttrName             = "ecs.cpu-architecture"
 	osTypeAttrName              = "ecs.os-type"
 	osFamilyAttrName            = "ecs.os-family"
-	osTypeDetailedAttrName      = "ecs.os-type-detailed"
 	// RoundtripTimeout should only time out after dial and TLS handshake timeouts have elapsed.
 	// Add additional 2 seconds to the sum of these 2 timeouts to be extra sure of this.
 	RoundtripTimeout = httpclient.DefaultDialTimeout + httpclient.DefaultTLSHandshakeTimeout + 2*time.Second
@@ -566,17 +565,6 @@ func (client *ecsClient) getAdditionalAttributes() []types.Attribute {
 			Value: aws.String(client.configAccessor.OSFamily()),
 		})
 	}
-
-	// OSFamilyDetailed should be treated as an optional field as it is not applicable for all agents
-	// using ecs client shared library. Add a check to ensure only non-empty values are added
-	// to API call.
-	if client.configAccessor.OSFamilyDetailed() != "" {
-		attrs = append(attrs, types.Attribute{
-			Name:  aws.String(osTypeDetailedAttrName),
-			Value: aws.String(client.configAccessor.OSFamilyDetailed()),
-		})
-	}
-
 	// Send CPU arch attribute directly when running on external capacity. When running on EC2 or Fargate launch type,
 	// this is not needed since the CPU arch is reported via instance identity document in those cases.
 	if client.configAccessor.External() {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface/networkinterface.go
@@ -46,7 +46,7 @@ type NetworkInterface struct {
 	// SubnetGatewayIPV4Address is the IPv4 address of the subnet gateway of the NetworkInterface
 	SubnetGatewayIPV4Address string `json:",omitempty"`
 	// SubnetGatewayIPV6Address is the IPv6 address of the subnet gateway of the NetworkInterface
-	SubnetGatewayIPV6Address string `json:",omitempty"`
+	SubnetGatewayIPV6Address string `json:",omitempty`
 	// DomainNameServers specifies the nameserver IP addresses for the eni
 	DomainNameServers []string `json:",omitempty"`
 	// DomainNameSearchList specifies the search list for the domain

--- a/ecs-agent/api/ecs/client/ecs_client.go
+++ b/ecs-agent/api/ecs/client/ecs_client.go
@@ -54,7 +54,6 @@ const (
 	cpuArchAttrName             = "ecs.cpu-architecture"
 	osTypeAttrName              = "ecs.os-type"
 	osFamilyAttrName            = "ecs.os-family"
-	osTypeDetailedAttrName      = "ecs.os-type-detailed"
 	// RoundtripTimeout should only time out after dial and TLS handshake timeouts have elapsed.
 	// Add additional 2 seconds to the sum of these 2 timeouts to be extra sure of this.
 	RoundtripTimeout = httpclient.DefaultDialTimeout + httpclient.DefaultTLSHandshakeTimeout + 2*time.Second
@@ -566,17 +565,6 @@ func (client *ecsClient) getAdditionalAttributes() []types.Attribute {
 			Value: aws.String(client.configAccessor.OSFamily()),
 		})
 	}
-
-	// OSFamilyDetailed should be treated as an optional field as it is not applicable for all agents
-	// using ecs client shared library. Add a check to ensure only non-empty values are added
-	// to API call.
-	if client.configAccessor.OSFamilyDetailed() != "" {
-		attrs = append(attrs, types.Attribute{
-			Name:  aws.String(osTypeDetailedAttrName),
-			Value: aws.String(client.configAccessor.OSFamilyDetailed()),
-		})
-	}
-
 	// Send CPU arch attribute directly when running on external capacity. When running on EC2 or Fargate launch type,
 	// this is not needed since the CPU arch is reported via instance identity document in those cases.
 	if client.configAccessor.External() {

--- a/ecs-agent/api/ecs/client/ecs_client_test.go
+++ b/ecs-agent/api/ecs/client/ecs_client_test.go
@@ -26,8 +26,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	ecsservice "github.com/aws/aws-sdk-go-v2/service/ecs"
-	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,6 +45,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/httpclient"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
+	ecsservice "github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 )
 
 const (
@@ -481,12 +481,6 @@ func TestRegisterContainerInstance(t *testing.T) {
 				cfgAccessor.EXPECT().External().Return(true).AnyTimes()
 			},
 		},
-		{
-			name: "empty os detailed attribute",
-			mockCfgAccessorOverride: func(cfgAccessor *mock_config.MockAgentConfigAccessor) {
-				cfgAccessor.EXPECT().OSFamilyDetailed().Return("").AnyTimes()
-			},
-		},
 	}
 
 	for _, tc := range testCases {
@@ -514,10 +508,6 @@ func TestRegisterContainerInstance(t *testing.T) {
 				"ecs.availability-zone":     availabilityZone,
 				"ecs.outpost-arn":           outpostARN,
 				cpuArchAttrName:             getCPUArch(),
-			}
-			// Add ecs.os-type-detailed only if OSFamilyDetailed() returns a non-empty value
-			if tester.mockCfgAccessor.OSFamilyDetailed() != "" {
-				expectedAttributes["ecs.os-type-detailed"] = tester.mockCfgAccessor.OSFamilyDetailed()
 			}
 			capabilities := buildAttributeList(fakeCapabilities, nil)
 			platformDevices := []types.PlatformDevice{
@@ -564,18 +554,12 @@ func TestRegisterContainerInstance(t *testing.T) {
 			var expectedNumOfAttributes int
 			if !tester.mockCfgAccessor.External() {
 				// 2 capability attributes: capability1, capability2
-				// Base attributes: ecs.os-type, ecs.os-family, ecs.outpost-arn, my_custom_attribute, my_other_custom_attribute (5)
-				// Plus ecs.os-type-detailed if OSFamilyDetailed() is not empty
-				expectedNumOfAttributes = 7 // 2 capabilities + 5 base attributes
-				if tester.mockCfgAccessor.OSFamilyDetailed() != "" {
-					expectedNumOfAttributes = 8
-				}
+				// and 5 other attributes:
+				// ecs.os-type, ecs.os-family, ecs.outpost-arn, my_custom_attribute, my_other_custom_attribute.
+				expectedNumOfAttributes = 7
 			} else {
 				// One more attribute for external case: ecs.cpu-architecture.
 				expectedNumOfAttributes = 8
-				if tester.mockCfgAccessor.OSFamilyDetailed() != "" {
-					expectedNumOfAttributes = 9
-				}
 			}
 
 			gomock.InOrder(
@@ -647,7 +631,6 @@ func TestRegisterContainerInstanceWithRetryNonTerminalError(t *testing.T) {
 	expectedAttributes := map[string]string{
 		"ecs.os-type":               tester.mockCfgAccessor.OSType(),
 		"ecs.os-family":             tester.mockCfgAccessor.OSFamily(),
-		"ecs.os-type-detailed":      tester.mockCfgAccessor.OSFamilyDetailed(),
 		"my_custom_attribute":       "Custom_Value1",
 		"my_other_custom_attribute": "Custom_Value2",
 		"ecs.availability-zone":     availabilityZone,
@@ -743,7 +726,6 @@ func TestReRegisterContainerInstance(t *testing.T) {
 	expectedAttributes := map[string]string{
 		"ecs.os-type":           tester.mockCfgAccessor.OSType(),
 		"ecs.os-family":         tester.mockCfgAccessor.OSFamily(),
-		"ecs.os-type-detailed":  tester.mockCfgAccessor.OSFamilyDetailed(),
 		"ecs.availability-zone": availabilityZone,
 		"ecs.outpost-arn":       outpostARN,
 	}
@@ -768,8 +750,8 @@ func TestReRegisterContainerInstance(t *testing.T) {
 				resource, ok := findResource(req.TotalResources, "PORTS_UDP")
 				assert.True(t, ok, `Could not find resource "PORTS_UDP"`)
 				assert.Equal(t, "STRINGSET", *resource.Type, `Wrong type for resource "PORTS_UDP"`)
-				// "ecs.os-type", ecs.os-family, ecs.os-type-detailed, ecs.outpost-arn and the 2 that we specified as additionalAttributes.
-				assert.Equal(t, 6, len(req.Attributes), "Wrong number of Attributes")
+				// "ecs.os-type", ecs.os-family, ecs.outpost-arn and the 2 that we specified as additionalAttributes.
+				assert.Equal(t, 5, len(req.Attributes), "Wrong number of Attributes")
 				reqAttributes := func() map[string]string {
 					rv := make(map[string]string, len(req.Attributes))
 					for i := range req.Attributes {
@@ -840,7 +822,6 @@ func TestRegisterContainerInstanceWithEmptyTags(t *testing.T) {
 	expectedAttributes := map[string]string{
 		"ecs.os-type":               tester.mockCfgAccessor.OSType(),
 		"ecs.os-family":             tester.mockCfgAccessor.OSFamily(),
-		"ecs.os-type-detailed":      tester.mockCfgAccessor.OSFamilyDetailed(),
 		"my_custom_attribute":       "Custom_Value1",
 		"my_other_custom_attribute": "Custom_Value2",
 	}
@@ -906,9 +887,8 @@ func TestRegisterBlankCluster(t *testing.T) {
 	tester := setup(t, ctrl, mockEC2Metadata, cfgAccessorOverrideFunc)
 
 	expectedAttributes := map[string]string{
-		"ecs.os-type":          tester.mockCfgAccessor.OSType(),
-		"ecs.os-family":        tester.mockCfgAccessor.OSFamily(),
-		"ecs.os-type-detailed": tester.mockCfgAccessor.OSFamilyDetailed(),
+		"ecs.os-type":   tester.mockCfgAccessor.OSType(),
+		"ecs.os-family": tester.mockCfgAccessor.OSFamily(),
 	}
 	defaultCluster := tester.mockCfgAccessor.DefaultClusterName()
 	gomock.InOrder(
@@ -956,9 +936,8 @@ func TestRegisterBlankClusterNotCreatingClusterWhenErrorNotClusterNotFound(t *te
 	tester := setup(t, ctrl, mockEC2Metadata, cfgAccessorOverrideFunc)
 
 	expectedAttributes := map[string]string{
-		"ecs.os-type":          tester.mockCfgAccessor.OSType(),
-		"ecs.os-family":        tester.mockCfgAccessor.OSFamily(),
-		"ecs.os-type-detailed": tester.mockCfgAccessor.OSFamilyDetailed(),
+		"ecs.os-type":   tester.mockCfgAccessor.OSType(),
+		"ecs.os-family": tester.mockCfgAccessor.OSFamily(),
 	}
 
 	defaultCluster := tester.mockCfgAccessor.DefaultClusterName()

--- a/ecs-agent/netlib/model/networkinterface/networkinterface.go
+++ b/ecs-agent/netlib/model/networkinterface/networkinterface.go
@@ -46,7 +46,7 @@ type NetworkInterface struct {
 	// SubnetGatewayIPV4Address is the IPv4 address of the subnet gateway of the NetworkInterface
 	SubnetGatewayIPV4Address string `json:",omitempty"`
 	// SubnetGatewayIPV6Address is the IPv6 address of the subnet gateway of the NetworkInterface
-	SubnetGatewayIPV6Address string `json:",omitempty"`
+	SubnetGatewayIPV6Address string `json:",omitempty`
 	// DomainNameServers specifies the nameserver IP addresses for the eni
 	DomainNameServers []string `json:",omitempty"`
 	// DomainNameSearchList specifies the search list for the domain


### PR DESCRIPTION
Reverts aws/amazon-ecs-agent#4724