### PR TITLE
Update the list of docker-remote-api capabilities

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -148,6 +148,14 @@ var (
 	capabilityExecRootDir = filepath.Join(capabilityDepsRootDir, capabilityExec)
 	binDir                = filepath.Join(capabilityExecRootDir, capabilityExecBinRelativePath)
 	configDir             = filepath.Join(capabilityExecRootDir, capabilityExecConfigRelativePath)
+
+	// excludedDockerAPIVersions contains Docker API versions that should not be reported as capabilities
+	// This is in addition to versions 1.33 and beyond
+	excludedDockerAPIVersions = map[dockerclient.DockerVersion]bool{
+		dockerclient.Version_1_26: true,
+		dockerclient.Version_1_27: true,
+		dockerclient.Version_1_31: true,
+	}
 )
 
 // capabilities returns the supported capabilities of this agent / docker-client pair.
@@ -220,8 +228,14 @@ func (agent *ecsAgent) capabilities() ([]types.Attribute, error) {
 	// Determine API versions to report as supported via com.amazonaws.ecs.capability.docker-remote-api.X.XX capabilities
 	// and for determining which features we support that depend on specific docker API versions
 	for _, version := range dockerclient.SupportedVersionsExtended(agent.dockerClient.SupportedVersions) {
-		capabilities = appendNameOnlyAttribute(capabilities, capabilityPrefix+"docker-remote-api."+string(version))
 		supportedVersions[version] = true
+		// Every new Docker version update brings in new client API versions that agent can support.
+		// We have a limit on the number of capabilities that agent can send during instance registration.
+		// Hence, we don't report  1.26, 1.27 and 1.31, 1.33 and beyond.
+		// We need to continue reporting all other versions to support legacy ECS backend logic.
+		if version.Compare(dockerclient.Version_1_33) < 0 && !excludedDockerAPIVersions[version] {
+			capabilities = appendNameOnlyAttribute(capabilities, capabilityPrefix+"docker-remote-api."+string(version))
+		}
 	}
 
 	capabilities = agent.appendLoggingDriverCapabilities(capabilities, supportedVersions)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR updates the list of docker-remote-api capabilities that the agent reports to ECS during instance registration.

Every new Docker server release brings in new client API versions that it can support. Over time, the number of supported Docker API versions has grown significantly - currently at about 27. We have a limit on the number of capabilities that agent can send during instance registration, hence we stop reporting v1.33+. We are also going to stop reporting 1.26, 1.27, and 1.31, as these are unused. We need to continue reporting all other versions to support legacy ECS back-end logic.

This change give us a headroom of about 15 capabilities, while also stopping addition of new Docker remote API capabilities for every new Docker server version.

### Implementation details
<!-- How are the changes implemented? -->
Updated the agent capability parsing to exclude unnwanted docker-remote-api capabilities.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

I manually verified that the container instances no longer report the excluded capabilities. 

```
aws ecs describe-container-instances --cluster {cluster-name} --container-instances {instance-id} --query 'containerInstances[0].attributes[?starts_with(name, `com.amazonaws.ecs.capability.docker`)]' --output table --region us-west-2
---------------------------------------------------------
|              DescribeContainerInstances               |
+-------------------------------------------------------+
|                         name                          |
+-------------------------------------------------------+
|  com.amazonaws.ecs.capability.docker-remote-api.1.30  |
|  com.amazonaws.ecs.capability.docker-remote-api.1.32  |
|  com.amazonaws.ecs.capability.docker-remote-api.1.24  |
|  com.amazonaws.ecs.capability.docker-remote-api.1.25  |
|  com.amazonaws.ecs.capability.docker-remote-api.1.28  |
|  com.amazonaws.ecs.capability.docker-remote-api.1.29  |
|  com.amazonaws.ecs.capability.docker-remote-api.1.20  |
|  com.amazonaws.ecs.capability.docker-remote-api.1.21  |
|  com.amazonaws.ecs.capability.docker-remote-api.1.22  |
|  com.amazonaws.ecs.capability.docker-remote-api.1.23  |
|  com.amazonaws.ecs.capability.docker-remote-api.1.17  |
|  com.amazonaws.ecs.capability.docker-remote-api.1.18  |
|  com.amazonaws.ecs.capability.docker-remote-api.1.19  |
+-------------------------------------------------------+
```

I also verified that there are no customers (across all AWS regions) that rely on these unwanted docker-remote-api capabilities, via ECS task placement constraints.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement: Remove unwanted docker-remote-api capabilities

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No, I also verified that there's no mention of docker-remote-api capabilities in the README and ECS public docs.
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
