### PR TITLE
Fix undercounting of awsvpc network stats

### DIFF
--- a/agent/stats/task_linux.go
+++ b/agent/stats/task_linux.go
@@ -102,16 +102,16 @@ func (taskStat *StatsTask) populateNIDeviceList(containerPID string) ([]string, 
 	return deviceList, err
 }
 
-func linkStatsToDockerStats(netLinkStats *netlinklib.LinkStatistics, numberOfContainers uint64) dockerstats.NetworkStats {
+func linkStatsToDockerStats(netLinkStats *netlinklib.LinkStatistics) dockerstats.NetworkStats {
 	networkStats := dockerstats.NetworkStats{
-		RxBytes:   netLinkStats.RxBytes / numberOfContainers,
-		RxPackets: netLinkStats.RxPackets / numberOfContainers,
-		RxErrors:  netLinkStats.RxErrors / numberOfContainers,
-		RxDropped: netLinkStats.RxDropped / numberOfContainers,
-		TxBytes:   netLinkStats.TxBytes / numberOfContainers,
-		TxPackets: netLinkStats.TxPackets / numberOfContainers,
-		TxErrors:  netLinkStats.TxErrors / numberOfContainers,
-		TxDropped: netLinkStats.TxDropped / numberOfContainers,
+		RxBytes:   netLinkStats.RxBytes,
+		RxPackets: netLinkStats.RxPackets,
+		RxErrors:  netLinkStats.RxErrors,
+		RxDropped: netLinkStats.RxDropped,
+		TxBytes:   netLinkStats.TxBytes,
+		TxPackets: netLinkStats.TxPackets,
+		TxErrors:  netLinkStats.TxErrors,
+		TxDropped: netLinkStats.TxDropped,
 	}
 	return networkStats
 }
@@ -142,8 +142,7 @@ func (taskStat *StatsTask) retrieveNetworkStatistics() (map[string]dockerstats.N
 			return nil, err
 		}
 		netLinkStats := link.Attrs().Statistics
-		networkStats[link.Attrs().Name] = linkStatsToDockerStats(netLinkStats,
-			uint64(taskStat.TaskMetadata.NumberContainers))
+		networkStats[link.Attrs().Name] = linkStatsToDockerStats(netLinkStats)
 	}
 
 	return networkStats, nil

--- a/agent/stats/task_linux_test.go
+++ b/agent/stats/task_linux_test.go
@@ -93,7 +93,7 @@ func TestTaskStatsCollection(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, networkStatsSet)
-	rxSum := (*networkStatsSet.RxBytes.SampleCount * (int64(50))) / int64(numberOfContainers)
+	rxSum := *networkStatsSet.RxBytes.SampleCount * (int64(50))
 	assert.EqualValues(t, rxSum, *networkStatsSet.RxBytes.Sum)
 }
 
@@ -157,8 +157,8 @@ func TestTaskStatsCollectionError(t *testing.T) {
 
 	networkStatsSet, err := taskStats.StatsQueue.GetNetworkStatsSet()
 	assert.NoError(t, err)
-	assert.EqualValues(t, 50, *networkStatsSet.RxBytes.Sum)
-	assert.EqualValues(t, 2, *networkStatsSet.RxPackets.Sum)
+	assert.EqualValues(t, 100, *networkStatsSet.RxBytes.Sum)
+	assert.EqualValues(t, 4, *networkStatsSet.RxPackets.Sum)
 	assert.EqualValues(t, 2, *networkStatsSet.RxPackets.SampleCount)
 	assert.EqualValues(t, 2, *networkStatsSet.TxPackets.SampleCount)
 }


### PR DESCRIPTION
### Summary

As discussed in #4618, it seems that scaling down these network stats by the number of containers is simply incorrect. On that issue, I have empirically compared EC2 awsvpc numbers to both Fargate awsvpc and EC2 bridge numbers to deduce this.
<!-- What does this pull request do? -->

### Implementation details

Don't do that division.
<!-- How are the changes implemented? -->

### Testing
Existing unit tests were updated.

In terms of validating that this is the correct change, all I have is comparative analysis against existing behaviors of Fargate and EC2 with bridge networking. The only other way I can think to test this is to deploy this to a real EC2 instance and repeat the testing procedure discussed in #4618. I can find no documentation in this project on how to do this. I would appreciate your advice. 
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no.

### Description for the changelog

Bug - Fix undercounting of network stats when using the awsvpc networking mode.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No.

**Does this PR include the addition of new environment variables in the README?**
No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
