### PR TITLE
Update ECS Anywhere exec agent version to 3.3.2958.0

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -745,7 +745,7 @@ find-copy-certs-exec() {
 }
 
 download-ssm-binaries-exec() {
-    BINARY_VERSION="3.3.2299.0"
+    BINARY_VERSION="3.3.2958.0"
     BINARY_PATH="/var/lib/ecs/deps/execute-command/bin/${BINARY_VERSION}"
     BINARY_DOWNLOAD_PATH="ssm-binaries"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update the version of exec agent downloaded by ecs-anywhere-install script to 3.3.2958.0. The updated version provides support for overriding CloudWatch Logs endpoint which is needed for CloudWatch logging of exec sessions on IPv6-only instances.

### Testing
Ran exec functional tests for ECS-Anywhere platform. They passed for all platforms with IPv4-only and IPv6-only setups (except ones with known other issues).

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
enhancement: Update ECS Anywhere exec agent version to 3.3.2958.0

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
