### PR TITLE
Fix stats engine race condition

### DIFF
--- a/agent/stats/engine_unix.go
+++ b/agent/stats/engine_unix.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build !windows
+// +build !windows
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //


### PR DESCRIPTION
This commit addresses multiple issues in the DockerStatsEngine:

Race Condition Fixes:
- Add context cancellation checks in taskContainerMetricsUnsafe to prevent metrics collection on containers that are in the middle of being cleaned up.
- Implement removeContainerFromAllTasksUnsafe method to handle orphaned container cleanup. This prevents container leaks when the Docker Task Engine has already cleaned up the container but the stats engine still has it tracked.

This fixes the condition where the ECS agent gets stuck in a state logging messages like this continuously for a particular container:

```
ecs_agent_logs/ecs-agent.log:1496:level=error time=2025-09-12T11:18:54Z msg="Error collecting cloudwatch metrics for container" container="111222333444555" error="need at least 1 non-NaN data points in queue to calculate CW stats set"
ecs_agent_logs/ecs-agent.log:1500:level=error time=2025-09-12T11:19:14Z msg="Error collecting cloudwatch metrics for container" container="111222333444555" error="need at least 1 non-NaN data points in queue to calculate CW stats set"
ecs_agent_logs/ecs-agent.log:1507:level=error time=2025-09-12T11:19:34Z msg="Error collecting cloudwatch metrics for container" container="111222333444555" error="need at least 1 non-NaN data points in queue to calculate CW stats set"
```

Unrelated but also rename engine_linux.go to engine_unix.go so that this package can compile on macOS more easily.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

functional testing

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Bugfix: fix "Error collecting cloudwatch metrics for container" errors

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
