### PR TITLE
Fix agent update on ipv6-only instances

### DIFF
--- a/agent/acs/updater/updater_test.go
+++ b/agent/acs/updater/updater_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/httpclient"
 	mock_http "github.com/aws/amazon-ecs-agent/ecs-agent/httpclient/mock"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/ipcompatibility"
 	mock_client "github.com/aws/amazon-ecs-agent/ecs-agent/wsclient/mock"
 
 	"github.com/golang/mock/gomock"
@@ -481,4 +482,88 @@ func TestValidationError(t *testing.T) {
 	})
 
 	assert.Equal(t, "update-tar-data", writtenFile.String(), "incorrect data written")
+}
+
+func TestConvertS3URLToDualStack(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "ap-northeast-2",
+			input:    "https://s3.ap-northeast-2.amazonaws.com/amazon-ecs-agent-ap-northeast-2/ecs-agent-v1.99.0.tar",
+			expected: "https://s3.dualstack.ap-northeast-2.amazonaws.com/amazon-ecs-agent-ap-northeast-2/ecs-agent-v1.99.0.tar",
+		},
+		{
+			name:     "us-east-1",
+			input:    "https://s3.us-east-1.amazonaws.com/bucket/key",
+			expected: "https://s3.dualstack.us-east-1.amazonaws.com/bucket/key",
+		},
+		{
+			name:     "us-gov-west-1",
+			input:    "https://s3.us-gov-west-1.amazonaws.com/bucket/key",
+			expected: "https://s3.dualstack.us-gov-west-1.amazonaws.com/bucket/key",
+		},
+		{
+			name:     "eusc-de-east-1",
+			input:    "https://s3.eusc-de-east-1.amazonaws.eu/bucket/key",
+			expected: "https://s3.dualstack.eusc-de-east-1.amazonaws.eu/bucket/key",
+		},
+		{
+			name:     "cn-north-1",
+			input:    "https://s3.cn-north-1.amazonaws.com.cn/bucket/key",
+			expected: "https://s3.dualstack.cn-north-1.amazonaws.com.cn/bucket/key",
+		},
+		{
+			name:     "Non-S3 URL",
+			input:    "https://example.com/file.tar",
+			expected: "https://example.com/file.tar",
+		},
+		{
+			name:     "URL with multiple s3. occurrences",
+			input:    "https://s3.us-west-2.amazonaws.com/bucket/s3.backup/file.tar",
+			expected: "https://s3.dualstack.us-west-2.amazonaws.com/bucket/s3.backup/file.tar",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := convertS3URLToDualStack(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestDownloadWithIPv6OnlyConfig(t *testing.T) {
+	cfg := &config.Config{
+		UpdatesEnabled:          config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
+		UpdateDownloadDir:       filepath.Clean("/tmp/test/"),
+		InstanceIPCompatibility: ipcompatibility.NewIPv6OnlyCompatibility(),
+	}
+
+	u, ctrl, mockacs, mockhttp := mocks(t, cfg)
+	defer ctrl.Finish()
+
+	defer mockOS()()
+
+	// Expect dual-stack URL instead of regular S3 URL
+	gomock.InOrder(
+		mockhttp.EXPECT().RoundTrip(mock_http.NewHTTPSimpleMatcher("GET", "https://s3.dualstack.amazonaws.com/amazon-ecs-agent/update.tar")).Return(mock_http.SuccessResponse("update-tar-data"), nil),
+		mockacs.EXPECT().MakeRequest(gomock.Eq(&ecsacs.AckRequest{
+			Cluster:           ptr("cluster").(*string),
+			ContainerInstance: ptr("containerInstance").(*string),
+			MessageId:         ptr("mid").(*string),
+		})),
+	)
+
+	u.stageUpdateHandler()(&ecsacs.StageUpdateMessage{
+		ClusterArn:           ptr("cluster").(*string),
+		ContainerInstanceArn: ptr("containerInstance").(*string),
+		MessageId:            ptr("mid").(*string),
+		UpdateInfo: &ecsacs.UpdateInfo{
+			Location:  ptr("https://s3.amazonaws.com/amazon-ecs-agent/update.tar").(*string),
+			Signature: ptr("6caeef375a080e3241781725b357890758d94b15d7ce63f6b2ff1cb5589f2007").(*string),
+		},
+	})
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This change fixes a bug in agent update (UpdateContainerAgent API) handling for IPv6-only instances. The update location (S3 URL) streamed down to Agent is currently not IPv6 compatible, so as a temporary workaround, Agent needs to convert it to IPv6-only compatible (dualstack) S3 URL.

Legacy S3 URLs have format -
```
s3.<aws-region>.<partition-suffix>/bucketname
```

Dualstack S3 URLs have format - 
```
s3.dualstack.<aws-region>.<partition-suffix>/bucketname
```

so, the conversion is rather simple and works for all partitions.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
I made some temporary changes to make Agent think that it's running v1.98.0 with its corresponding build ID. Then I ran that Agent on an IPv6-only instance and called UpdateContainerAgentAPI on it. Update was successful. 

Agent logs - 
```
level=info time=2025-09-16T16:21:38Z msg="Starting Amazon ECS Agent" version="1.98.0" commit="7d5ec06f"
...
level=debug time=2025-09-16T16:22:05Z msg="Staging updateupdate{\n  ClusterArn: \"arn:aws:ecs:us-west-2:979604884904:cluster/default\",\n  ContainerInstanceArn: \"arn:aws:ecs:us-west-2:979604884904:container-instance/default/d8d3da61c4504e67bdfbf298f5e5bd79\",\n  MessageId: \"14def9e9-de8f-4654-8a9d-f0ef9867e870\",\n  UpdateInfo: {\n    Location: \"https://s3.us-west-2.amazonaws.com/amazon-ecs-agent-us-west-2/ecs-agent-v1.99.0.tar\",\n    Signature: \"d884c06823f46705f065d3c89b351295c07a6ca85d8cc1155a97bc162eae59c5\"\n  }\n}" module=updater.go
level=info time=2025-09-16T16:22:05Z msg="Converting agent update URL to dual-stack for IPv6" originalURL="https://s3.us-west-2.amazonaws.com/amazon-ecs-agent-us-west-2/ecs-agent-v1.99.0.tar" dualStackURL="https://s3.dualstack.us-west-2.amazonaws.com/amazon-ecs-agent-us-west-2/ecs-agent-v1.99.0.tar"
...
level=debug time=2025-09-16T16:22:13Z msg="Got perform update request" module=updater.go
level=debug time=2025-09-16T16:22:13Z msg="Shutting down task engine for final save" module=termination_handler.go
level=debug time=2025-09-16T16:22:13Z msg="Saving state before shutting down" module=termination_handler.go
level=info time=2025-09-16T16:22:13Z msg="Starting Amazon ECS Agent" version="1.99.0" commit="ad700257"
```

Introspection before/after - 
```
[ec2-user@i-0859029921f52268e ~]$ curl -s http://localhost:51678/v1/metadata | python3 -mjson.tool
{
    "Cluster": "default",
    "ContainerInstanceArn": "arn:aws:ecs:us-west-2:979604884904:container-instance/default/d8d3da61c4504e67bdfbf298f5e5bd79",
    "Version": "Amazon ECS Agent - v1.98.0 (*7d5ec06f)"
}
[ec2-user@i-0859029921f52268e ~]$ curl -s http://localhost:51678/v1/metadata | python3 -mjson.tool
{
    "Cluster": "default",
    "ContainerInstanceArn": "arn:aws:ecs:us-west-2:979604884904:container-instance/default/d8d3da61c4504e67bdfbf298f5e5bd79",
    "Version": "Amazon ECS Agent - v1.99.0 (*ad700257)"
}
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
bugfix: Fix agent update handling for IPv6-only instances

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
