### PR TITLE
Skip iptables rules for introspection access from docker bridge when no bridge is found

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -16,7 +16,7 @@ package docker
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 	"os"
 	"os/exec"
@@ -165,6 +165,9 @@ var (
 	execCommand                   = exec.Command
 	execLookPath                  = exec.LookPath
 	checkNvidiaGPUDevicesPresence = nvidiaGPUDevicesPresent
+	// ErrNoBridgeNetwork indicates no docker bridge network interface was found
+	ErrNoBridgeNetwork = errors.New(
+		"unable to find any virtual docker bridge network interfaces on the host")
 )
 
 // client enables business logic for running the Agent inside Docker
@@ -694,5 +697,5 @@ func (c *client) FindDefaultBridgeNetworkInterfaceName() (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("unable to find any virtual docker bridge network interfaces on the host")
+	return "", ErrNoBridgeNetwork
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
ecs-init blocks all traffic to introspection endpoint except for that coming from docker bridge and localhost. It does this using `iptables` rules in `INPUT` table as shown below. 

```
dev ❱ sudo iptables -t filter -L INPUT -v -n | grep -E "target|51678" | column -t
pkts  bytes  target  prot  opt  in       out  source     destination
0     0      ACCEPT  tcp   --   docker0  *    0.0.0.0/0  0.0.0.0/0    tcp  dpt:51678
0     0      DROP    tcp   --   !lo      *    0.0.0.0/0  0.0.0.0/0    tcp  dpt:51678
```

But it is possible for a user to disable bridge networking in docker entirely with a config like below.
```
dev ❱ cat /etc/docker/daemon.json | jq '.'
{
  "bridge": "none"
}
```

In such a case, `ecs-init` fails to start up with the error below. 
```
Sep 18 14:10:11 cv-ap-southeast-1b-i-0193f0f4d9f71cc4c amazon-ecs-init[66376]: level=error time=2025-09-18T14:10:11Z msg="unable to find any virtual docker bridge network interfaces on the host"
Sep 18 14:10:11 cv-ap-southeast-1b-i-0193f0f4d9f71cc4c systemd[1]: ecs.service: Control process exited, code=exited, status=255/EXCEPTION
```

This change makes `ecs-init` accommodate the case when bridge networking is disabled in docker. `ecs-init` will now skip creating and deleting `iptables` rules for docker bridge if no bridge was found. `iptables` rules for introspection endpoint will be as shown below.

```
dev ❱ sudo iptables -t filter -L INPUT -v -n | grep -E "target|51678" | column -t
pkts  bytes  target  prot  opt  in   out  source     destination
0     0      DROP    tcp   --   !lo  *    0.0.0.0/0  0.0.0.0/0    tcp  dpt:51678
```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Disabled bridge networking in docker and restarted docker and ecs-init. Observed the `iptables` rules for introspection endpoint are as expected and ecs-init and agent did not fail start up.

Also verified ecs-init logs - 
```
level=info time=2025-09-23T17:41:41Z msg="No docker bridge network found, skipping bridge-specific iptables rules"
```

Stopped ecs-init and found no errors during stop as well. 
```
level=info time=2025-09-23T17:50:46Z msg="stop"
level=info time=2025-09-23T17:50:46Z msg="Stopping Amazon Elastic Container Service Agent"
level=info time=2025-09-23T17:50:46Z msg="Container name: /ecs-agent"
level=info time=2025-09-23T17:50:46Z msg="Agent exited with code 0"
level=info time=2025-09-23T17:50:46Z msg="Successfully created docker client with API version 1.25"
level=info time=2025-09-23T17:50:46Z msg="No docker bridge network found, skipping bridge-specific iptables rules"
level=info time=2025-09-23T17:50:46Z msg="post-stop"
level=info time=2025-09-23T17:50:46Z msg="Cleaning up the credentials endpoint setup for Amazon Elastic Container Service Agent"
level=info time=2025-09-23T17:50:46Z msg="Cleaning up any routes added for TMDS access on IPv6-only instances"
level=info time=2025-09-23T17:50:46Z msg="Successfully blocked IPv6 off-host access for introspection server with ip6tables."
```

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
bugfix: Skip iptables rules for introspection access from docker bridge when no bridge is found

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
