### PR TITLE
Update amazon-ssm-agent version for exec to 3.3.3050.0

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -745,7 +745,7 @@ find-copy-certs-exec() {
 }
 
 download-ssm-binaries-exec() {
-    BINARY_VERSION="3.3.2958.0"
+    BINARY_VERSION="3.3.3050.0"
     BINARY_PATH="/var/lib/ecs/deps/execute-command/bin/${BINARY_VERSION}"
     BINARY_DOWNLOAD_PATH="ssm-binaries"
 


### PR DESCRIPTION
### Summary
This PR will bump the SSM Agent version that will be installed via our ECS Anywhere install script to 3.3.3050.0.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
Ran functional tests against the following platforms (ipv4 and ipv6):
- al2generic-amd64
- al2generic-arm64
- al2023generic-amd64
- al2023generic-arm64
- centos9-amd64
- centos9-arm64
- debian10-amd64
- debian12-amd64
- debian12-arm64
- ubuntu18-amd64
- ubuntu24-amd64
- ubuntu24-arm64

New tests cover the changes: Not Applicable

### Description for the changelog
Enhancement: Update SSM Agent version for exec for ecs-anywhere to 3.3.3050.0

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
