### PR TITLE
Service Connect stats bugfix

### DIFF
--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -957,11 +957,10 @@ func (engine *DockerStatsEngine) doRemoveContainerUnsafe(container *StatsContain
 		// Delete will do nothing if the specified key doesn't exist.
 		delete(engine.tasksToDefinitions, taskArn)
 		seelog.Debugf("Deleted task from tasks, arn: %s", taskArn)
-	}
 
-	if _, ok := engine.taskToServiceConnectStats[taskArn]; ok {
+		// Stop collecting service connect stats for this task
 		delete(engine.taskToServiceConnectStats, taskArn)
-		seelog.Debugf("Deleted task from service connect stats watch list, arn: %s", taskArn)
+		seelog.Debugf("Deleted task from the Service Connect stats watchlist, task ARN: %s", taskArn)
 	}
 
 	// Remove the container from health container watch list


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR fixes an issue with Service Connect stats.

The ECS agent collects Service Connect (SC) stats from the SC relay daemon container. Currently, the ECS agent stops collecting stats as soon as one container of an ECS task stops. This becomes an issue when the ECS task has a non-essential container - SC stats stop being reported to ECS control-plane, even though other essential containers are running.

### Implementation details
<!-- How are the changes implemented? -->

Updated the ECS agent stats cleanup logic - only stop collecting SC stats when all containers of the ECS task stop.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> Yes, added a new unit test, and also tested this end-to-end with the help of ECS networking team. 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Bugfix: Stop collecting Service Connect stats only when there are zero running containers in the task.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
