### PR TITLE
deflake ecs-agent/acs/session unit tests

### DIFF
--- a/ecs-agent/acs/session/session_test.go
+++ b/ecs-agent/acs/session/session_test.go
@@ -743,7 +743,7 @@ func TestSessionStopsWhenContextIsErrorDueToTimeout(t *testing.T) {
 
 	mockACSConnectEndpointEntry := mock_metrics.NewMockEntry(ctrl)
 	mockACSConnectEndpointEntry.EXPECT().Done(gomock.Any())
-	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectFailure").Return(mockACSConnectEndpointEntry)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectFailure").Return(mockACSConnectEndpointEntry).AnyTimes()
 
 	mockACSConnectDurationEndpointEntry := mock_metrics.NewMockEntry(ctrl)
 	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
@@ -796,7 +796,7 @@ func TestSessionReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 
 	mockACSConnectEndpointEntry := mock_metrics.NewMockEntry(ctrl)
 	mockACSConnectEndpointEntry.EXPECT().Done(gomock.Any())
-	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectFailure").Return(mockACSConnectEndpointEntry)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectFailure").Return(mockACSConnectEndpointEntry).AnyTimes()
 
 	mockACSConnectDurationEndpointEntry := mock_metrics.NewMockEntry(ctrl)
 	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
@@ -869,7 +869,7 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 	mockMetricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
 
 	mockACSConnectEndpointEntry := mock_metrics.NewMockEntry(ctrl)
-	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectFailure").Return(mockACSConnectEndpointEntry)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectFailure").Return(mockACSConnectEndpointEntry).AnyTimes()
 	mockACSConnectEndpointEntry.EXPECT().Done(gomock.Any())
 
 	mockACSConnectDurationEndpointEntry := mock_metrics.NewMockEntry(ctrl)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

The ecs-agent/ ACS session unit tests are flaky. When run via the GH PR checks, all the different tests in this file run in parallel, interfering with each other's assertions. 

See the Linux GH action history to get an idea of how flaky these tests are: https://github.com/aws/amazon-ecs-agent/actions/workflows/linux.yml?query=is%3Afailure.

### Implementation details
<!-- How are the changes implemented? -->

Relax the ACSConnectFailure mock assertions.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

This command fails without this change and passes with it. It runs the tests in the session test file, 100 times.

```
cd ~/go/src/github.com/aws/amazon-ecs-agent && docker run -v $(pwd):/workspace -w /workspace golang:1.23 sh -c "cd ecs-agent && GO111MODULE=on go test -count=100 -tags unit -mod vendor -timeout=5m ./acs/session"
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
