### PR TITLE
Check if ECS data directory exists within agent container

### DIFF
--- a/agent/data/client_test.go
+++ b/agent/data/client_test.go
@@ -17,14 +17,20 @@
 package data
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
 	generaldata "github.com/aws/amazon-ecs-agent/ecs-agent/data"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/modeltransformer"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
+)
+
+const (
+	statPathNotFoundErr = "stat %s: no such file or directory"
 )
 
 func newTestClient(t *testing.T) Client {
@@ -55,4 +61,44 @@ func newTestClient(t *testing.T) Client {
 		require.NoError(t, testClient.Close())
 	})
 	return testClient
+}
+
+func TestSetupInvalidDirectoryErrors(t *testing.T) {
+	originalDirExists := dirExists
+	defer func() {
+		dirExists = originalDirExists
+	}()
+	tcs := []struct {
+		name          string
+		dirPath       string
+		mockDirExists func(string) error
+		expectedError error
+	}{
+		{
+			name:    "path not found",
+			dirPath: "/path/",
+			mockDirExists: func(path string) error {
+				return fmt.Errorf(statPathNotFoundErr, path)
+			},
+			expectedError: fmt.Errorf(statPathNotFoundErr, "/path/"),
+		},
+		{
+			name:    "path is not a directory",
+			dirPath: "/data/blah.txt",
+			mockDirExists: func(path string) error {
+				return fmt.Errorf(notDirectoryErrorMsg, path)
+			},
+			expectedError: fmt.Errorf(notDirectoryErrorMsg, "/data/blah.txt"),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			dirExists = tc.mockDirExists
+
+			_, err := setup(tc.dirPath)
+
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR aims to make agent not panic if the ECS data directory does not exist within the agent container. Currently if you set a non-existent directory as with `ECS_DATADIR` then agent will crash with a seg fault. We should still exit but with better logs regarding why agent crashed/exited.

This is for the following github issue: https://github.com/aws/amazon-ecs-agent/issues/4767

### Implementation details
* `agent/data/client.go`: Added new helper function called `checkDirectoryExists` that checks if the data directory path exists within the agent container and if it's a directory.

### Testing
* Added unit testing 
* Manual testing:

```
[ec2-user@ip-172-31-18-210 ~]$ docker ps -a
CONTAINER ID   IMAGE                            COMMAND    CREATED         STATUS                     PORTS     NAMES
ae08c91ac890   amazon/amazon-ecs-agent:latest   "/agent"   6 seconds ago   Exited (1) 6 seconds ago             ecs-agent
[ec2-user@ip-172-31-18-210 ~]$ docker logs ecs-agent
level=info time=2025-10-23T23:24:48Z msg="Starting Amazon ECS Agent" version="1.100.0" commit="6f041555"
level=info time=2025-10-23T23:24:48Z msg="Loading configuration"
level=warn time=2025-10-23T23:24:48Z msg="Unable to fetch user data: operation error ec2imds: GetUserData, http response error StatusCode: 404, request to EC2 IMDS failed" module=config.go
level=info time=2025-10-23T23:24:48Z msg="No IP compatibility override provided, detecting instance IP compatibility for default config"
level=info time=2025-10-23T23:24:48Z msg="Successfully determined IP compatibilty of the container instance" IPv4=true IPv6=false
level=info time=2025-10-23T23:24:48Z msg="Unable to get Docker client for version 1.17: Error response from daemon: client version 1.17 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version" module=sdkclientfactory.go
level=info time=2025-10-23T23:24:48Z msg="Unable to get Docker client for version 1.18: Error response from daemon: client version 1.18 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version" module=sdkclientfactory.go
level=info time=2025-10-23T23:24:48Z msg="Unable to get Docker client for version 1.19: Error response from daemon: client version 1.19 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version" module=sdkclientfactory.go
level=info time=2025-10-23T23:24:48Z msg="Unable to get Docker client for version 1.20: Error response from daemon: client version 1.20 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version" module=sdkclientfactory.go
level=info time=2025-10-23T23:24:48Z msg="Unable to get Docker client for version 1.21: Error response from daemon: client version 1.21 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version" module=sdkclientfactory.go
level=info time=2025-10-23T23:24:48Z msg="Unable to get Docker client for version 1.22: Error response from daemon: client version 1.22 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version" module=sdkclientfactory.go
level=info time=2025-10-23T23:24:48Z msg="Unable to get Docker client for version 1.23: Error response from daemon: client version 1.23 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version" module=sdkclientfactory.go
level=info time=2025-10-23T23:24:48Z msg="Setting minimum docker API version" previousMinAPIVersion=1.21 newMinAPIVersion=1.24
level=critical time=2025-10-23T23:24:48Z msg="Error creating data client" error="stat \"/very/spooky/directory/\": no such file or directory"
```

New tests cover the changes: yes

### Description for the changelog
Enhancement - Check if ECS data directory exists within agent container 

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
