### PR TITLE
Managed Daemons networking changes.

### DIFF
--- a/ecs-agent/netlib/common_test.go
+++ b/ecs-agent/netlib/common_test.go
@@ -71,9 +71,10 @@ func getSingleNetNSAWSVPCTestData(testTaskID string) (*ecsacs.Task, tasknetworkc
 		NetworkMode: types.NetworkModeAwsvpc,
 		NetworkNamespaces: []*tasknetworkconfig.NetworkNamespace{
 			{
-				Name:  netNSName,
-				Path:  netNSPath,
-				Index: 0,
+				Name:        netNSName,
+				Path:        netNSPath,
+				Index:       0,
+				NetworkMode: types.NetworkModeAwsvpc,
 				NetworkInterfaces: []*networkinterface.NetworkInterface{
 					&netIfs[0],
 				},
@@ -156,9 +157,10 @@ func getMultiNetNSMultiIfaceAWSVPCTestData(testTaskID string) (*ecsacs.Task, tas
 		NetworkMode: types.NetworkModeAwsvpc,
 		NetworkNamespaces: []*tasknetworkconfig.NetworkNamespace{
 			{
-				Name:  primaryNetNSName,
-				Path:  primaryNetNSPath,
-				Index: 0,
+				Name:        primaryNetNSName,
+				Path:        primaryNetNSPath,
+				Index:       0,
+				NetworkMode: types.NetworkModeAwsvpc,
 				NetworkInterfaces: []*networkinterface.NetworkInterface{
 					&netIfs[0],
 				},
@@ -166,9 +168,10 @@ func getMultiNetNSMultiIfaceAWSVPCTestData(testTaskID string) (*ecsacs.Task, tas
 				DesiredState: status.NetworkReadyPull,
 			},
 			{
-				Name:  secondaryNetNSName,
-				Path:  secondaryNetNSPath,
-				Index: 1,
+				Name:        secondaryNetNSName,
+				Path:        secondaryNetNSPath,
+				Index:       1,
+				NetworkMode: types.NetworkModeAwsvpc,
 				NetworkInterfaces: []*networkinterface.NetworkInterface{
 					&netIfs[1],
 				},
@@ -323,6 +326,7 @@ func getV2NTestData(testTaskID string) (*ecsacs.Task, tasknetworkconfig.TaskNetw
 				Name:              netNSName,
 				Path:              netNSPath,
 				Index:             0,
+				NetworkMode:       types.NetworkModeAwsvpc,
 				NetworkInterfaces: netIfs,
 				KnownState:        status.NetworkNone,
 				DesiredState:      status.NetworkReadyPull,

--- a/ecs-agent/netlib/model/tasknetworkconfig/network_namespace.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/network_namespace.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/status"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 )
 
 // NetworkNamespace is model representing each network namespace.
@@ -29,6 +30,10 @@ type NetworkNamespace struct {
 	Name  string
 	Path  string
 	Index int
+
+	// NetworkMode represents the network mode for this namespace.
+	// Supported values: awsvpc (default), host(managed-instances only), daemon-bridge (managed-instances only).
+	NetworkMode types.NetworkMode
 
 	// NetworkInterfaces represents ENIs or any kind of network interface associated the particular netns.
 	NetworkInterfaces []*networkinterface.NetworkInterface
@@ -58,6 +63,7 @@ func NewNetworkNamespace(
 		NetworkInterfaces: networkInterfaces,
 		KnownState:        status.NetworkNone,
 		DesiredState:      status.NetworkReadyPull,
+		NetworkMode:       types.NetworkModeAwsvpc,
 	}
 
 	// Sort interfaces as per their index values in ascending order.
@@ -103,4 +109,10 @@ func (ns *NetworkNamespace) GetInterfaceByIndex(idx int64) *networkinterface.Net
 	}
 
 	return nil
+}
+
+// WithNetworkMode sets the NetworkMode field
+func (ns *NetworkNamespace) WithNetworkMode(mode types.NetworkMode) *NetworkNamespace {
+	ns.NetworkMode = mode
+	return ns
 }

--- a/ecs-agent/netlib/network_builder.go
+++ b/ecs-agent/netlib/network_builder.go
@@ -102,6 +102,8 @@ func (nb *networkBuilder) Start(
 		err = nb.startAWSVPC(ctx, taskID, netNS)
 	case types.NetworkModeHost:
 		err = nb.platformAPI.HandleHostMode()
+	case "daemon-bridge":
+		err = nb.platformAPI.ConfigureDaemonNetNS(netNS)
 	default:
 		err = errors.New("invalid network mode: " + string(mode))
 	}
@@ -132,6 +134,8 @@ func (nb *networkBuilder) Stop(ctx context.Context, mode types.NetworkMode, task
 		err = nb.stopAWSVPC(ctx, netNS)
 	case types.NetworkModeHost:
 		err = nb.platformAPI.HandleHostMode()
+	case "daemon-bridge":
+		err = nb.platformAPI.StopDaemonNetNS(ctx, netNS)
 	default:
 		err = errors.New("invalid network mode: " + string(mode))
 	}

--- a/ecs-agent/netlib/network_builder_linux_test.go
+++ b/ecs-agent/netlib/network_builder_linux_test.go
@@ -70,11 +70,13 @@ func TestNetworkBuilder_BuildTaskNetworkConfiguration(t *testing.T) {
 
 func TestNetworkBuilder_Start(t *testing.T) {
 	t.Run("awsvpc", testNetworkBuilder_StartAWSVPC)
+	t.Run("daemon-bridge", testNetworkBuilder_StartDaemonBridge)
 }
 
 // TestNetworkBuilder_Stop verifies stop workflow for AWSVPC mode.
 func TestNetworkBuilder_Stop(t *testing.T) {
 	t.Run("awsvpc", testNetworkBuilder_StopAWSVPC)
+	t.Run("daemon-bridge", testNetworkBuilder_StopDaemonBridge)
 }
 
 // getTestFunc returns a test function that verifies the capability of the networkBuilder
@@ -379,4 +381,66 @@ func getExpectedCalls_StopAWSVPC(
 	return append(calls,
 		platformAPI.EXPECT().DeleteDNSConfig(netNS.Name).Return(nil).Times(1),
 		platformAPI.EXPECT().DeleteNetNS(netNS.Path).Return(nil).Times(1))
+}
+
+// testNetworkBuilder_StartDaemonBridge verifies that the expected platform API calls
+// are made by the network builder for daemon-bridge network mode.
+func testNetworkBuilder_StartDaemonBridge(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.TODO()
+	platformAPI := mock_platform.NewMockAPI(ctrl)
+	metricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+	mockEntry := mock_metrics.NewMockEntry(ctrl)
+	netBuilder := &networkBuilder{
+		platformAPI:    platformAPI,
+		metricsFactory: metricsFactory,
+	}
+
+	netNS := &tasknetworkconfig.NetworkNamespace{
+		Name: "daemon-test",
+		Path: "/var/run/netns/daemon-test",
+	}
+
+	gomock.InOrder(
+		metricsFactory.EXPECT().New(metrics.BuildNetworkNamespaceMetricName).Return(mockEntry).Times(1),
+		mockEntry.EXPECT().WithFields(gomock.Any()).Return(mockEntry).Times(1),
+		platformAPI.EXPECT().ConfigureDaemonNetNS(netNS).Return(nil).Times(1),
+		mockEntry.EXPECT().Done(nil).Times(1),
+	)
+
+	err := netBuilder.Start(ctx, "daemon-bridge", taskID, netNS)
+	require.NoError(t, err)
+}
+
+// testNetworkBuilder_StopDaemonBridge verifies that the expected platform API calls
+// are made by the network builder for stopping daemon-bridge network mode.
+func testNetworkBuilder_StopDaemonBridge(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.TODO()
+	platformAPI := mock_platform.NewMockAPI(ctrl)
+	metricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+	mockEntry := mock_metrics.NewMockEntry(ctrl)
+	netBuilder := &networkBuilder{
+		platformAPI:    platformAPI,
+		metricsFactory: metricsFactory,
+	}
+
+	netNS := &tasknetworkconfig.NetworkNamespace{
+		Name: "daemon-test",
+		Path: "/var/run/netns/daemon-test",
+	}
+
+	gomock.InOrder(
+		metricsFactory.EXPECT().New(metrics.DeleteNetworkNamespaceMetricName).Return(mockEntry).Times(1),
+		mockEntry.EXPECT().WithFields(gomock.Any()).Return(mockEntry).Times(1),
+		platformAPI.EXPECT().StopDaemonNetNS(ctx, netNS).Return(nil).Times(1),
+		mockEntry.EXPECT().Done(nil).Times(1),
+	)
+
+	err := netBuilder.Stop(ctx, "daemon-bridge", taskID, netNS)
+	require.NoError(t, err)
 }

--- a/ecs-agent/netlib/platform/api.go
+++ b/ecs-agent/netlib/platform/api.go
@@ -78,6 +78,14 @@ type API interface {
 		primaryIf *networkinterface.NetworkInterface,
 		scConfig *serviceconnect.ServiceConnectConfig,
 	) error
+
+	// ConfigureDaemonNetNS configures a network namespace for workloads running as daemons.
+	// This is an internal networking mode available in EMI (ECS Managed Instances) only.
+	ConfigureDaemonNetNS(netNS *tasknetworkconfig.NetworkNamespace) error
+
+	// StopDaemonNetNS stops and cleans up a daemon network namespace.
+	// This is an internal networking mode available in EMI (ECS Managed Instances) only.
+	StopDaemonNetNS(ctx context.Context, netNS *tasknetworkconfig.NetworkNamespace) error
 }
 
 // Config contains platform-specific data.

--- a/ecs-agent/netlib/platform/cniconf.go
+++ b/ecs-agent/netlib/platform/cniconf.go
@@ -21,6 +21,10 @@ const (
 	ECSSubNet     = "169.254.172.0/22"
 	AgentEndpoint = "169.254.170.2/32"
 
+	// Daemon-bridge networking constants
+	DaemonBridgeGatewayIP   = "169.254.172.1"
+	DefaultRouteDestination = "0.0.0.0/0"
+
 	CNIPluginLogFileEnv    = "ECS_CNI_LOG_FILE"
 	VPCCNIPluginLogFileEnv = "VPC_CNI_LOG_FILE"
 	IPAMDataPathEnv        = "IPAM_DB_PATH"

--- a/ecs-agent/netlib/platform/common.go
+++ b/ecs-agent/netlib/platform/common.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/ecscni"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/tasknetworkconfig"
 
 	"github.com/containernetworking/cni/pkg/types"
 )
@@ -91,4 +92,16 @@ func (c *common) interfacesMACToName() (map[string]string, error) {
 // HandleHostMode by default we do not want to support host mode.
 func (c *common) HandleHostMode() error {
 	return errors.New("invalid platform for host mode")
+}
+
+// ConfigureDaemonNetNS configures a network namespace for workloads running as daemons.
+// This is an internal networking mode available in EMI (ECS Managed Instances) only.
+func (c *common) ConfigureDaemonNetNS(netNS *tasknetworkconfig.NetworkNamespace) error {
+	return errors.New("daemon network namespaces are not supported in this platform")
+}
+
+// StopDaemonNetNS stops and cleans up a daemon network namespace.
+// This is an internal networking mode available in EMI (ECS Managed Instances) only.
+func (c *common) StopDaemonNetNS(ctx context.Context, netNS *tasknetworkconfig.NetworkNamespace) error {
+	return errors.New("daemon network namespaces are not supported in this platform")
 }

--- a/ecs-agent/netlib/platform/common_linux.go
+++ b/ecs-agent/netlib/platform/common_linux.go
@@ -281,7 +281,7 @@ func (c *common) buildAWSVPCNetworkNamespaces(
 	return netNSs, nil
 }
 
-// buildNetNS creates a single network namespace object using the input network config data.
+// buildNetNS creates a single awsvpc network namespace object using the input network config data.
 func (c *common) buildNetNS(
 	taskID string,
 	index int,

--- a/ecs-agent/netlib/platform/common_linux_test.go
+++ b/ecs-agent/netlib/platform/common_linux_test.go
@@ -39,6 +39,7 @@ import (
 	mock_oswrapper "github.com/aws/amazon-ecs-agent/ecs-agent/utils/oswrapper/mocks"
 	mock_volume "github.com/aws/amazon-ecs-agent/ecs-agent/volume/mocks"
 
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	currentCNITypes "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -128,6 +129,7 @@ func TestCommon_CreateDNSFiles(t *testing.T) {
 		netns := &tasknetworkconfig.NetworkNamespace{
 			Name:              netNSName,
 			Path:              netNSPath,
+			NetworkMode:       ecstypes.NetworkModeAwsvpc,
 			NetworkInterfaces: []*networkinterface.NetworkInterface{cs.iface},
 		}
 
@@ -255,6 +257,7 @@ func TestCommon_CreateDNSFilesForDebug(t *testing.T) {
 			netns := &tasknetworkconfig.NetworkNamespace{
 				Name:              netNSName,
 				Path:              netNSPath,
+				NetworkMode:       ecstypes.NetworkModeAwsvpc,
 				NetworkInterfaces: []*networkinterface.NetworkInterface{testCase.iface},
 			}
 

--- a/ecs-agent/netlib/platform/containerd_windows.go
+++ b/ecs-agent/netlib/platform/containerd_windows.go
@@ -141,9 +141,10 @@ func (c *containerd) buildAWSVPCNetworkConfig(
 	}
 
 	netNS := &tasknetworkconfig.NetworkNamespace{
-		Name:  netNSName,
-		Path:  netNSPath,
-		Index: 0,
+		Name:        netNSName,
+		Path:        netNSPath,
+		Index:       0,
+		NetworkMode: ecstypes.NetworkModeAwsvpc,
 		NetworkInterfaces: []*networkinterface.NetworkInterface{
 			iface,
 		},

--- a/ecs-agent/netlib/platform/firecracker_linux_test.go
+++ b/ecs-agent/netlib/platform/firecracker_linux_test.go
@@ -32,6 +32,7 @@ import (
 	mock_oswrapper "github.com/aws/amazon-ecs-agent/ecs-agent/utils/oswrapper/mocks"
 	mock_volume "github.com/aws/amazon-ecs-agent/ecs-agent/volume/mocks"
 
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -54,6 +55,7 @@ func TestFirecracker_CreateDNSConfig(t *testing.T) {
 	netns := &tasknetworkconfig.NetworkNamespace{
 		Name:              primaryNetNSName,
 		Path:              primaryNetNSPath,
+		NetworkMode:       ecstypes.NetworkModeAwsvpc,
 		NetworkInterfaces: []*networkinterface.NetworkInterface{iface, v2nIface},
 	}
 

--- a/ecs-agent/netlib/platform/iptables_linux.go
+++ b/ecs-agent/netlib/platform/iptables_linux.go
@@ -1,0 +1,97 @@
+package platform
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	loggerfield "github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+)
+
+// iptablesAction enumerates different actions for the iptables command
+type iptablesAction string
+
+const (
+	iptablesExecutable = "iptables"
+	iptablesTableNat   = "nat"
+	sysctlExecutable   = "sysctl"
+	// iptablesAppend enumerates the 'append' action
+	iptablesAppend iptablesAction = "-A"
+	// iptablesCheck enumerates the 'check' action
+	iptablesCheck iptablesAction = "-C"
+
+	// sysctl configuration keys
+	ipForwardingKey        = "net.ipv4.ip_forward"
+	bridgeNetfilterCallKey = "net.bridge.bridge-nf-call-iptables"
+)
+
+// getNetfilterChainArgsFunc defines a function pointer type that returns
+// a slice of arguments for modifying a netfilter chain
+type getNetfilterChainArgsFunc func() []string
+
+// modifyNetfilterEntry modifies an entry in the netfilter table based on
+// the action and the function pointer to get arguments for modifying the chain
+func modifyNetfilterEntry(table string, action iptablesAction, getNetfilterChainArgs getNetfilterChainArgsFunc) error {
+	args := append(getTableArgs(table), string(action))
+	args = append(args, getNetfilterChainArgs()...)
+	cmd := exec.Command(iptablesExecutable, args...)
+
+	logger.Info("Executing iptables command", logger.Fields{
+		"executable": iptablesExecutable,
+		"args":       args,
+		"table":      table,
+		"action":     string(action),
+	})
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.Error("iptables command failed", logger.Fields{
+			"executable":      iptablesExecutable,
+			"args":            args,
+			"output":          string(output),
+			loggerfield.Error: err,
+		})
+		return err
+	}
+
+	logger.Info("iptables command succeeded", logger.Fields{
+		"executable": iptablesExecutable,
+		"args":       args,
+		"output":     string(output),
+	})
+
+	return nil
+}
+
+func getTableArgs(table string) []string {
+	return []string{"-t", table}
+}
+
+// getDaemonBridgeNATArgs returns arguments for daemon-bridge MASQUERADE rule
+func getDaemonBridgeNATArgs() []string {
+	return []string{
+		"POSTROUTING",
+		"-s", ECSSubNet,
+		"!", "-d", ECSSubNet,
+		"-j", "MASQUERADE",
+	}
+}
+
+// enableSysctlSetting enables a sysctl setting with the given key and value
+func enableSysctlSetting(key string, value string) error {
+	cmd := exec.Command(sysctlExecutable, "-w", fmt.Sprintf("%s=%s", key, value))
+	return cmd.Run()
+}
+
+// enableSystemSettings enables required system settings for NAT
+func enableSystemSettings() error {
+	// Enable IP forwarding
+	if err := enableSysctlSetting(ipForwardingKey, "1"); err != nil {
+		return fmt.Errorf("failed to enable IP forwarding: %w", err)
+	}
+
+	// Enable bridge forwarding (ignore errors if bridge module not loaded)
+	enableSysctlSetting(bridgeNetfilterCallKey, "1")
+
+	return nil
+}

--- a/ecs-agent/netlib/platform/iptables_linux_test.go
+++ b/ecs-agent/netlib/platform/iptables_linux_test.go
@@ -1,0 +1,178 @@
+//go:build linux && unit
+// +build linux,unit
+
+package platform
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTableArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		table    string
+		expected []string
+	}{
+		{
+			name:     "nat table",
+			table:    "nat",
+			expected: []string{"-t", "nat"},
+		},
+		{
+			name:     "filter table",
+			table:    "filter",
+			expected: []string{"-t", "filter"},
+		},
+		{
+			name:     "empty table",
+			table:    "",
+			expected: []string{"-t", ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getTableArgs(tt.table)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetDaemonBridgeNATArgs(t *testing.T) {
+	expected := []string{
+		"POSTROUTING",
+		"-s", ECSSubNet,
+		"!", "-d", ECSSubNet,
+		"-j", "MASQUERADE",
+	}
+
+	result := getDaemonBridgeNATArgs()
+	assert.Equal(t, expected, result)
+}
+
+func TestModifyNetfilterEntry(t *testing.T) {
+	tests := []struct {
+		name                    string
+		table                   string
+		action                  iptablesAction
+		getNetfilterChainArgs   getNetfilterChainArgsFunc
+		expectError             bool
+		expectedCommandContains []string
+	}{
+		{
+			name:                  "append daemon bridge NAT rule",
+			table:                 iptablesTableNat,
+			action:                iptablesAppend,
+			getNetfilterChainArgs: getDaemonBridgeNATArgs,
+			expectedCommandContains: []string{
+				"-t", "nat",
+				"-A",
+				"POSTROUTING",
+				"-s", ECSSubNet,
+				"!", "-d", ECSSubNet,
+				"-j", "MASQUERADE",
+			},
+		},
+		{
+			name:                  "check daemon bridge NAT rule",
+			table:                 iptablesTableNat,
+			action:                iptablesCheck,
+			getNetfilterChainArgs: getDaemonBridgeNATArgs,
+			expectedCommandContains: []string{
+				"-t", "nat",
+				"-C",
+				"POSTROUTING",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// We can't actually run iptables in unit tests, but we can verify
+			// the function constructs the command correctly by checking it doesn't panic
+			// and that the error is predictable (command not found or permission denied)
+			err := modifyNetfilterEntry(tt.table, tt.action, tt.getNetfilterChainArgs)
+
+			// In test environment, we expect either:
+			// - Command not found error (iptables not installed)
+			// - Permission denied error (not root)
+			// - Exit status error (iptables rules don't exist)
+			if err != nil {
+				// Verify it's an expected error type
+				if exitErr, ok := err.(*exec.ExitError); ok {
+					t.Logf("Expected exit error in test environment: %v", exitErr)
+				} else {
+					t.Logf("Expected error in test environment: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestEnableSysctlSetting(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{
+			name:  "enable IP forwarding",
+			key:   ipForwardingKey,
+			value: "1",
+		},
+		{
+			name:  "enable bridge netfilter",
+			key:   bridgeNetfilterCallKey,
+			value: "1",
+		},
+		{
+			name:  "custom setting",
+			key:   "net.test.setting",
+			value: "0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// We can't actually modify sysctl in unit tests, but we can verify
+			// the function doesn't panic and handles errors appropriately
+			err := enableSysctlSetting(tt.key, tt.value)
+
+			// In test environment, we expect either:
+			// - Command not found error (sysctl not available)
+			// - Permission denied error (not root)
+			// - File not found error (sysctl key doesn't exist)
+			if err != nil {
+				t.Logf("Expected error in test environment: %v", err)
+			}
+		})
+	}
+}
+
+func TestEnableSystemSettings(t *testing.T) {
+	// This test verifies that enableSystemSettings calls the required sysctl settings
+	// and handles errors appropriately
+	err := enableSystemSettings()
+
+	// In test environment, we expect errors due to lack of permissions or missing commands
+	// The important thing is that it doesn't panic and attempts both settings
+	if err != nil {
+		t.Logf("Expected error in test environment: %v", err)
+		// Verify the error is related to IP forwarding (the first setting that would fail)
+		assert.Contains(t, err.Error(), "failed to enable IP forwarding")
+	}
+}
+
+func TestIptablesConstants(t *testing.T) {
+	// Verify constants have expected values
+	assert.Equal(t, "iptables", iptablesExecutable)
+	assert.Equal(t, "nat", iptablesTableNat)
+	assert.Equal(t, "sysctl", sysctlExecutable)
+	assert.Equal(t, iptablesAction("-A"), iptablesAppend)
+	assert.Equal(t, iptablesAction("-C"), iptablesCheck)
+	assert.Equal(t, "net.ipv4.ip_forward", ipForwardingKey)
+	assert.Equal(t, "net.bridge.bridge-nf-call-iptables", bridgeNetfilterCallKey)
+}

--- a/ecs-agent/netlib/platform/managed_linux.go
+++ b/ecs-agent/netlib/platform/managed_linux.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/ipcompatibility"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	loggerfield "github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	netlibdata "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/data"
@@ -17,7 +18,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/tasknetworkconfig"
-	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/net"
+	utilsnet "github.com/aws/amazon-ecs-agent/ecs-agent/utils/net"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
@@ -56,9 +57,14 @@ func (m *managedLinux) BuildTaskNetworkConfiguration(
 			return nil, errors.Wrap(err, "failed to translate network configuration")
 		}
 	case types.NetworkModeHost:
-		netNSs, err = m.buildDefaultNetworkNamespace(taskID)
+		netNSs, err = m.buildHostNetworkNamespaceConfig(taskID)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create network namespace with host eni")
+		}
+	case "daemon-bridge":
+		netNSs, err = m.buildHostDaemonNamespaceConfig()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create daemon host namespace")
 		}
 	default:
 		return nil, errors.New("invalid network mode: " + string(mode))
@@ -204,8 +210,8 @@ func (m *managedLinux) ConfigureServiceConnect(
 	return m.common.configureServiceConnect(ctx, netNSPath, primaryIf, scConfig)
 }
 
-// buildDefaultNetworkNamespace return default network namespace of host ENI for host mode.
-func (m *managedLinux) buildDefaultNetworkNamespace(taskID string) ([]*tasknetworkconfig.NetworkNamespace, error) {
+// buildHostNetworkNamespaceConfig return default network namespace of host ENI for host mode.
+func (m *managedLinux) buildHostNetworkNamespaceConfig(taskID string) ([]*tasknetworkconfig.NetworkNamespace, error) {
 	macAddress, err1 := m.client.GetMetadata(MacResource)
 	ec2ID, err2 := m.client.GetMetadata(InstanceIDResource)
 	macToNames, err3 := m.common.interfacesMACToName()
@@ -227,7 +233,7 @@ func (m *managedLinux) buildDefaultNetworkNamespace(taskID string) ([]*tasknetwo
 		Index:                        aws.Int64(64),
 	}
 
-	ipComp, err := net.DetermineIPCompatibility(m.netlink, macAddress)
+	ipComp, err := utilsnet.DetermineIPCompatibility(m.netlink, macAddress)
 	if err != nil {
 		logger.Error("Failed to determine IP compatibility of host ENI", logger.Fields{
 			loggerfield.Error: err,
@@ -297,6 +303,7 @@ func (m *managedLinux) buildDefaultNetworkNamespace(taskID string) ([]*tasknetwo
 		})
 		return nil, err
 	}
+	defaultNameSpace = defaultNameSpace.WithNetworkMode(types.NetworkModeHost)
 	defaultNameSpace.KnownState = status.NetworkReady
 	defaultNameSpace.DesiredState = status.NetworkReady
 	return []*tasknetworkconfig.NetworkNamespace{defaultNameSpace}, nil
@@ -305,4 +312,218 @@ func (m *managedLinux) buildDefaultNetworkNamespace(taskID string) ([]*tasknetwo
 // HandleHostMode is a no op because Host Mode does not require network interface configuration. No need to invoke CNI plugins.
 func (m *managedLinux) HandleHostMode() error {
 	return nil
+}
+
+func (m *managedLinux) buildHostDaemonNamespaceConfig() ([]*tasknetworkconfig.NetworkNamespace, error) {
+	macAddress, err1 := m.client.GetMetadata(MacResource)
+	ec2ID, err2 := m.client.GetMetadata(InstanceIDResource)
+	macToNames, err3 := m.common.interfacesMACToName()
+	if err := goErr.Join(err1, err2, err3); err != nil {
+		logger.Error("Error fetching fields for default ENI", logger.Fields{
+			loggerfield.Error: err,
+		})
+		return nil, err
+	}
+
+	hostENI := &ecsacs.ElasticNetworkInterface{
+		AttachmentArn:                aws.String("arn"),
+		Ec2Id:                        aws.String(ec2ID),
+		MacAddress:                   aws.String(macAddress),
+		DomainNameServers:            []*string{},
+		DomainName:                   []*string{},
+		PrivateDnsName:               aws.String(DefaultArg),
+		InterfaceAssociationProtocol: aws.String(DefaultArg),
+		Index:                        aws.Int64(64),
+	}
+
+	ipComp, err := utilsnet.DetermineIPCompatibility(m.netlink, macAddress)
+	if err != nil {
+		logger.Error("Failed to determine IP compatibility of host ENI", logger.Fields{
+			loggerfield.Error: err,
+		})
+		return nil, err
+	}
+
+	if !ipComp.IsIPv4Compatible() && !ipComp.IsIPv6Compatible() {
+		return nil, errors.New("Failed to build the default network namespace because the host ENI is neither IPv4 enabled nor IPv6 enabled")
+	}
+
+	if err := m.configureIPv4ForHostENI(hostENI, macAddress, ipComp); err != nil {
+		return nil, err
+	}
+
+	if err := m.configureIPv6ForHostENI(hostENI, macAddress, ipComp); err != nil {
+		return nil, err
+	}
+
+	return m.createDaemonNetworkNamespace(hostENI, macToNames)
+}
+
+// configureIPv4ForHostENI configures IPv4 settings for the host ENI
+func (m *managedLinux) configureIPv4ForHostENI(hostENI *ecsacs.ElasticNetworkInterface, macAddress string, ipComp ipcompatibility.IPCompatibility) error {
+	if !ipComp.IsIPv4Compatible() {
+		return nil
+	}
+
+	privateIpv4, err1 := m.client.GetMetadata(PrivateIPv4Address)
+	ipv4SubNet, err2 := m.client.GetMetadata(fmt.Sprintf(IPv4SubNetCidrBlock, macAddress))
+	if err := goErr.Join(err1, err2); err != nil {
+		logger.Error("Error fetching IPv4 fields for default ENI", logger.Fields{
+			loggerfield.Error: err,
+		})
+		return err
+	}
+
+	hostENI.Ipv4Addresses = []*ecsacs.IPv4AddressAssignment{
+		{
+			Primary:        aws.Bool(true),
+			PrivateAddress: aws.String(privateIpv4),
+		},
+	}
+	hostENI.SubnetGatewayIpv4Address = aws.String(ipv4SubNet)
+	return nil
+}
+
+// configureIPv6ForHostENI configures IPv6 settings for the host ENI
+func (m *managedLinux) configureIPv6ForHostENI(hostENI *ecsacs.ElasticNetworkInterface, macAddress string, ipComp ipcompatibility.IPCompatibility) error {
+	if !ipComp.IsIPv6Compatible() {
+		return nil
+	}
+
+	privateIpv6, err1 := m.client.GetMetadata(PrivateIPv6Address)
+	ipv6SubNet, err2 := m.client.GetMetadata(fmt.Sprintf(IPv6SubNetCidrBlock, macAddress))
+	if err := goErr.Join(err1, err2); err != nil {
+		logger.Error("Error fetching IPv6 fields for default ENI", logger.Fields{
+			loggerfield.Error: err,
+		})
+		return err
+	}
+
+	hostENI.Ipv6Addresses = []*ecsacs.IPv6AddressAssignment{
+		{
+			Primary: aws.Bool(true),
+			Address: aws.String(privateIpv6),
+		},
+	}
+	hostENI.SubnetGatewayIpv6Address = aws.String(ipv6SubNet)
+	return nil
+}
+
+// createDaemonNetworkNamespace creates the final network namespace
+func (m *managedLinux) createDaemonNetworkNamespace(hostENI *ecsacs.ElasticNetworkInterface, macToNames map[string]string) ([]*tasknetworkconfig.NetworkNamespace, error) {
+	netNSName := "host-daemon"
+	netNSPath := m.common.GetNetNSPath(netNSName)
+	netInt, err := networkinterface.New(hostENI, DefaultArg, nil, macToNames)
+	if err != nil {
+		logger.Error("Failed to create the network interface", logger.Fields{
+			loggerfield.Error: err,
+		})
+		return nil, err
+	}
+
+	netInt.Default = true
+	netInt.DesiredStatus = status.NetworkReadyPull
+	netInt.KnownStatus = status.NetworkNone
+
+	daemonNamespace, err := tasknetworkconfig.NewNetworkNamespace(netNSName, netNSPath, 0, nil, netInt)
+	if err != nil {
+		logger.Error("Error building default network namespace for daemon-bridge mode", logger.Fields{
+			loggerfield.Error: err,
+		})
+		return nil, err
+	}
+
+	daemonNamespace = daemonNamespace.WithNetworkMode("daemon-bridge")
+	daemonNamespace.KnownState = status.NetworkNone
+	daemonNamespace.DesiredState = status.NetworkReadyPull
+
+	return []*tasknetworkconfig.NetworkNamespace{daemonNamespace}, nil
+}
+
+func (m *managedLinux) configureDaemonNetNS(ctx context.Context, taskID string, netNS *tasknetworkconfig.NetworkNamespace) error {
+	var err error
+	if netNS.DesiredState == status.NetworkDeleted {
+		return errors.New("invalid transition state encountered: " + netNS.DesiredState.String())
+	}
+	if netNS.KnownState == status.NetworkNone &&
+		netNS.DesiredState == status.NetworkReadyPull {
+
+		logger.Debug("Creating daemon netns: " + netNS.Path)
+		// Create network namespace on the host.
+		err = m.CreateNetNS(netNS.Path)
+		if err != nil {
+			return err
+		}
+
+		logger.Debug("Creating DNS config files for daemon NS")
+
+		// Create necessary DNS config files for the netns.
+		err = m.CreateDNSConfig(taskID, netNS)
+		if err != nil {
+			return err
+		}
+
+		// Create MI-Bridge for daemon-bridge mode
+		var cniNetConf []ecscni.PluginConfig
+		cniNetConf = append(cniNetConf, createDaemonBridgePluginConfig(netNS.Path))
+		add := true
+
+		_, err = m.common.executeCNIPlugin(ctx, add, cniNetConf...)
+		if err != nil {
+			err = errors.Wrap(err, "failed to setup daemon network namespace bridge")
+			return err
+		}
+
+		// Add NAT masquerade rule for external connectivity
+		err = m.addDaemonBridgeNATRule()
+		if err != nil {
+			logger.Warn("Failed to add NAT rule for daemon-bridge", logger.Fields{
+				loggerfield.Error: err,
+			})
+		}
+	}
+	return nil
+}
+
+// ConfigureDaemonNetNS will create a network namespace using the host ENI and host dns configuration.
+// It will contain a loopback interface and a bridge to the internal ECS subnet.
+func (m *managedLinux) ConfigureDaemonNetNS(netNS *tasknetworkconfig.NetworkNamespace) error {
+	return m.configureDaemonNetNS(context.Background(), netNS.Path, netNS)
+}
+
+// addDaemonBridgeNATRule adds iptables MASQUERADE rule for daemon-bridge external connectivity
+func (m *managedLinux) addDaemonBridgeNATRule() error {
+	if err := enableSystemSettings(); err != nil {
+		return err
+	}
+
+	// Check if rule already exists
+	err := modifyNetfilterEntry(iptablesTableNat, iptablesCheck, getDaemonBridgeNATArgs)
+	if err != nil {
+		// Rule doesn't exist, add it
+		return modifyNetfilterEntry(iptablesTableNat, iptablesAppend, getDaemonBridgeNATArgs)
+	}
+
+	return nil // Rule already exists
+}
+
+// StopDaemonNetNS stops and cleans up a daemon network namespace.
+func (m *managedLinux) StopDaemonNetNS(ctx context.Context, netNS *tasknetworkconfig.NetworkNamespace) error {
+
+	// Cleanup bridge config(veth pair).
+	var cniNetConf []ecscni.PluginConfig
+	cniNetConf = append(cniNetConf, createBridgePluginConfig(netNS.Path))
+	add := false
+
+	_, err := m.common.executeCNIPlugin(ctx, add, cniNetConf...)
+	if err != nil {
+		err = errors.Wrap(err, "failed to stop daemon network namespace bridge")
+	}
+
+	// NOTE: The daemon network namespace is intentionally not deleted here.
+	// Daemons are considered infrastructure on managed instances, which follow the
+	// "immutable infrastructure" pattern. The namespace persists for the instance
+	// lifetime and is cleaned up on instance termination.
+
+	return err
 }

--- a/ecs-agent/netlib/platform/mocks/platform_mocks.go
+++ b/ecs-agent/netlib/platform/mocks/platform_mocks.go
@@ -83,6 +83,20 @@ func (mr *MockAPIMockRecorder) ConfigureAppMesh(arg0, arg1, arg2 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureAppMesh", reflect.TypeOf((*MockAPI)(nil).ConfigureAppMesh), arg0, arg1, arg2)
 }
 
+// ConfigureDaemonNetNS mocks base method.
+func (m *MockAPI) ConfigureDaemonNetNS(arg0 *tasknetworkconfig.NetworkNamespace) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConfigureDaemonNetNS", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ConfigureDaemonNetNS indicates an expected call of ConfigureDaemonNetNS.
+func (mr *MockAPIMockRecorder) ConfigureDaemonNetNS(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureDaemonNetNS", reflect.TypeOf((*MockAPI)(nil).ConfigureDaemonNetNS), arg0)
+}
+
 // ConfigureInterface mocks base method.
 func (m *MockAPI) ConfigureInterface(arg0 context.Context, arg1 string, arg2 *networkinterface.NetworkInterface, arg3 data.NetworkDataClient) error {
 	m.ctrl.T.Helper()
@@ -193,4 +207,18 @@ func (m *MockAPI) HandleHostMode() error {
 func (mr *MockAPIMockRecorder) HandleHostMode() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleHostMode", reflect.TypeOf((*MockAPI)(nil).HandleHostMode))
+}
+
+// StopDaemonNetNS mocks base method.
+func (m *MockAPI) StopDaemonNetNS(arg0 context.Context, arg1 *tasknetworkconfig.NetworkNamespace) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StopDaemonNetNS", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StopDaemonNetNS indicates an expected call of StopDaemonNetNS.
+func (mr *MockAPIMockRecorder) StopDaemonNetNS(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopDaemonNetNS", reflect.TypeOf((*MockAPI)(nil).StopDaemonNetNS), arg0, arg1)
 }


### PR DESCRIPTION


Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:


### Summary
What does this pull request do?
This PR is for Managed Daemons Networking changes. Currently its only supported for Managed Instances.

### Implementation details
How are the changes implemented? 
This PR handles a new network mode(daemon-bridge) for daemon tasks, sets up a new network namespace(hots-daemon) for daemon tasks, handles it lifecycle, updates IPtables to support egress, connects to the fargate-bridge for TMDS support.

### Testing
<!-- How was this tested? -->
Tested with creating a debug AMI with these changes, and see the required namespace get setup when a daemon task is launched and connectivity with fargate-bridge on the host. Also ECS exec works fine with daemon tasks.

New tests cover the changes: Yes.

### Description for the changelog
Managed Daemons Networking changes for Managed Instance support.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No.

**Does this PR include the addition of new environment variables in the README?**
No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
