### PR TITLE
taskresource: wait for execution role credentials upon agent restart

### DIFF
--- a/agent/engine/dependencygraph/graph.go
+++ b/agent/engine/dependencygraph/graph.go
@@ -45,9 +45,8 @@ const (
 )
 
 var (
-	// CredentialsNotResolvedErr is the error where a container needs to wait for
-	// credentials before it can process by agent
-	CredentialsNotResolvedErr = &dependencyError{err: errors.New("dependency graph: container execution credentials not available")}
+	// CredentialsNotResolvedErr is the error when a task needs to wait for credentials before it can be progressed to its desired status by the agent
+	CredentialsNotResolvedErr = &dependencyError{err: errors.New("dependency graph: execution role credentials not available")}
 	// DependentContainerNotResolvedErr is the error where a dependent container isn't in expected state
 	DependentContainerNotResolvedErr = &dependencyError{err: errors.New("dependency graph: dependent container not in expected state")}
 	// ContainerPastDesiredStatusErr is the error where the container status is bigger than desired status

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -868,8 +868,18 @@ func TestGMSATaskFileS3Err(t *testing.T) {
 	cfg.GMSACapable = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	cfg.AWSRegion = "us-west-2"
 
-	taskEngine, done, _ := setupGMSALinux(cfg, nil, t)
+	taskEngine, done, credentialsManager := setupGMSALinux(cfg, nil, t)
 	defer done()
+
+	// mock execution role credentials
+	mockCreds := &credentials.TaskIAMRoleCredentials{
+		ARN: "testGMSAFileTaskARN",
+		IAMRoleCredentials: credentials.IAMRoleCredentials{
+			RoleArn:       "arn:aws:iam::123456789012:role/execution-role",
+			CredentialsID: "exec-creds-id",
+		},
+	}
+	credentialsManager.SetTaskCredentials(mockCreds)
 
 	stateChangeEvents := taskEngine.StateChangeEvents()
 
@@ -880,11 +890,12 @@ func TestGMSATaskFileS3Err(t *testing.T) {
 	testContainer.DockerConfig.HostConfig = &hostConfig
 
 	testTask := &apitask.Task{
-		Arn:                 "testGMSAFileTaskARN",
-		Family:              "family",
-		Version:             "1",
-		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
-		Containers:          []*apicontainer.Container{testContainer},
+		Arn:                    "testGMSAFileTaskARN",
+		Family:                 "family",
+		Version:                "1",
+		DesiredStatusUnsafe:    apitaskstatus.TaskRunning,
+		Containers:             []*apicontainer.Container{testContainer},
+		ExecutionCredentialsID: "exec-creds-id",
 	}
 	testTask.Containers[0].TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
 	testTask.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
@@ -908,8 +919,18 @@ func TestGMSATaskFileSSMErr(t *testing.T) {
 	cfg.GMSACapable = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	cfg.AWSRegion = "us-west-2"
 
-	taskEngine, done, _ := setupGMSALinux(cfg, nil, t)
+	taskEngine, done, credentialsManager := setupGMSALinux(cfg, nil, t)
 	defer done()
+
+	// mock execution role credentials
+	mockCreds := &credentials.TaskIAMRoleCredentials{
+		ARN: "testGMSAFileTaskARN",
+		IAMRoleCredentials: credentials.IAMRoleCredentials{
+			RoleArn:       "arn:aws:iam::123456789012:role/execution-role",
+			CredentialsID: "exec-creds-id",
+		},
+	}
+	credentialsManager.SetTaskCredentials(mockCreds)
 
 	stateChangeEvents := taskEngine.StateChangeEvents()
 
@@ -920,11 +941,12 @@ func TestGMSATaskFileSSMErr(t *testing.T) {
 	testContainer.DockerConfig.HostConfig = &hostConfig
 
 	testTask := &apitask.Task{
-		Arn:                 "testGMSAFileTaskARN",
-		Family:              "family",
-		Version:             "1",
-		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
-		Containers:          []*apicontainer.Container{testContainer},
+		Arn:                    "testGMSAFileTaskARN",
+		Family:                 "family",
+		Version:                "1",
+		DesiredStatusUnsafe:    apitaskstatus.TaskRunning,
+		Containers:             []*apicontainer.Container{testContainer},
+		ExecutionCredentialsID: "exec-creds-id",
 	}
 	testTask.Containers[0].TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
 	testTask.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -219,7 +219,7 @@ func TestStartResourceTransitionsHappyPath(t *testing.T) {
 			task.AddResource("cgroup", res)
 			wg := sync.WaitGroup{}
 			wg.Add(1)
-			canTransition, transitions := task.startResourceTransitions(
+			canTransition, transitions, reasons := task.startResourceTransitions(
 				func(resource taskresource.TaskResource, nextStatus resourcestatus.ResourceStatus) {
 					assert.Equal(t, nextStatus, tc.TransitionStatus)
 					wg.Done()
@@ -230,6 +230,7 @@ func TestStartResourceTransitionsHappyPath(t *testing.T) {
 			resTransition, ok := transitions["cgroup"]
 			assert.True(t, ok)
 			assert.Equal(t, resTransition, tc.StatusString)
+			assert.Empty(t, reasons)
 		})
 	}
 }
@@ -277,12 +278,13 @@ func TestStartResourceTransitionsEmpty(t *testing.T) {
 				resourceStateChangeEvent: make(chan resourceStateChange),
 			}
 			mtask.Task.AddResource("cgroup", res)
-			canTransition, transitions := mtask.startResourceTransitions(
+			canTransition, transitions, reasons := mtask.startResourceTransitions(
 				func(resource taskresource.TaskResource, nextStatus resourcestatus.ResourceStatus) {
 					t.Error("Transition function should not be called when no transitions are possible")
 				})
 			assert.Equal(t, tc.CanTransition, canTransition)
 			assert.Empty(t, transitions)
+			assert.Empty(t, reasons)
 		})
 	}
 }

--- a/agent/taskresource/asmauth/asmauth.go
+++ b/agent/taskresource/asmauth/asmauth.go
@@ -444,3 +444,9 @@ func (auth *ASMAuthResource) BuildContainerDependency(containerName string, sati
 func (auth *ASMAuthResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
 }
+
+// RequiresExecutionRoleCredentials returns true if the resource requires execution role credentials.
+// ASM auth resource always requires the task execution role credentials.
+func (auth *ASMAuthResource) RequiresExecutionRoleCredentials() bool {
+	return true
+}

--- a/agent/taskresource/asmsecret/asmsecret.go
+++ b/agent/taskresource/asmsecret/asmsecret.go
@@ -542,3 +542,9 @@ func (secret *ASMSecretResource) BuildContainerDependency(containerName string, 
 func (secret *ASMSecretResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
 }
+
+// RequiresExecutionRoleCredentials returns true if the resource requires execution role credentials.
+// ASM secret resource always requires the task execution role credentials.
+func (secret *ASMSecretResource) RequiresExecutionRoleCredentials() bool {
+	return true
+}

--- a/agent/taskresource/cgroup/cgroup.go
+++ b/agent/taskresource/cgroup/cgroup.go
@@ -403,3 +403,9 @@ func (cgroup *CgroupResource) BuildContainerDependency(containerName string, sat
 func (cgroup *CgroupResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
 }
+
+// RequiresExecutionRoleCredentials returns true if the resource requires execution role credentials.
+// cgroup resource does not rely on task execution role credentials.
+func (cgroup *CgroupResource) RequiresExecutionRoleCredentials() bool {
+	return false
+}

--- a/agent/taskresource/cgroup/cgroup_unsupported.go
+++ b/agent/taskresource/cgroup/cgroup_unsupported.go
@@ -150,3 +150,8 @@ func (cgroup *CgroupResource) BuildContainerDependency(containerName string, sat
 func (cgroup *CgroupResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
 }
+
+// RequiresExecutionRoleCredentials returns true if the resource requires execution role credentials
+func (cgroup *CgroupResource) RequiresExecutionRoleCredentials() bool {
+	return false
+}

--- a/agent/taskresource/envFiles/envfile.go
+++ b/agent/taskresource/envFiles/envfile.go
@@ -616,3 +616,9 @@ func (envfile *EnvironmentFileResource) BuildContainerDependency(containerName s
 func (envfile *EnvironmentFileResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
 }
+
+// RequiresExecutionRoleCredentials returns true if the resource requires execution role credentials.
+// Envfile resource always requires the task execution role credentials, since the only resource type we support is S3.
+func (envfile *EnvironmentFileResource) RequiresExecutionRoleCredentials() bool {
+	return true
+}

--- a/agent/taskresource/firelens/firelens_unimplemented.go
+++ b/agent/taskresource/firelens/firelens_unimplemented.go
@@ -181,3 +181,8 @@ func (firelens *FirelensResource) BuildContainerDependency(containerName string,
 func (firelens *FirelensResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
 }
+
+// RequiresExecutionRoleCredentials returns true if the resource requires execution role credentials
+func (firelens *FirelensResource) RequiresExecutionRoleCredentials() bool {
+	return false // Unimplemented version doesn't support S3 external configs
+}

--- a/agent/taskresource/firelens/firelens_unix.go
+++ b/agent/taskresource/firelens/firelens_unix.go
@@ -602,3 +602,9 @@ func (firelens *FirelensResource) BuildContainerDependency(containerName string,
 func (firelens *FirelensResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
 }
+
+// RequiresExecutionRoleCredentials returns true if the resource requires execution role credentials.
+// We only need execution role credentials when there's an external config to pull from S3
+func (firelens *FirelensResource) RequiresExecutionRoleCredentials() bool {
+	return firelens.externalConfigType == ExternalConfigTypeS3
+}

--- a/agent/taskresource/firelens/firelens_unix_test.go
+++ b/agent/taskresource/firelens/firelens_unix_test.go
@@ -657,3 +657,36 @@ func TestCreateDirectories(t *testing.T) {
 		})
 	}
 }
+
+func TestRequiresExecutionRoleCredentials(t *testing.T) {
+	tests := []struct {
+		name               string
+		externalConfigType string
+		expected           bool
+	}{
+		{
+			name:               "no external config",
+			externalConfigType: "",
+			expected:           false,
+		},
+		{
+			name:               "file external config",
+			externalConfigType: ExternalConfigTypeFile,
+			expected:           false,
+		},
+		{
+			name:               "S3 external config",
+			externalConfigType: ExternalConfigTypeS3,
+			expected:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			firelens := &FirelensResource{
+				externalConfigType: tt.externalConfigType,
+			}
+			assert.Equal(t, tt.expected, firelens.RequiresExecutionRoleCredentials())
+		})
+	}
+}

--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_unsupported.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_unsupported.go
@@ -198,3 +198,8 @@ func (fv *FSxWindowsFileServerResource) BuildContainerDependency(containerName s
 func (fv *FSxWindowsFileServerResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
 }
+
+// RequiresExecutionRoleCredentials returns true if the resource requires execution role credentials
+func (fv *FSxWindowsFileServerResource) RequiresExecutionRoleCredentials() bool {
+	return true
+}

--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows.go
@@ -756,3 +756,10 @@ func (fv *FSxWindowsFileServerResource) BuildContainerDependency(containerName s
 func (fv *FSxWindowsFileServerResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
 }
+
+// RequiresExecutionRoleCredentials returns true if the resource requires execution role credentials.
+// FSx windows file server resource always requires the task execution role credentials to
+// query the file-system domain and retrieve authorization credentials.
+func (fv *FSxWindowsFileServerResource) RequiresExecutionRoleCredentials() bool {
+	return true
+}

--- a/agent/taskresource/interface.go
+++ b/agent/taskresource/interface.go
@@ -68,6 +68,8 @@ type TaskResource interface {
 	GetTerminalReason() string
 	// DependOnTaskNetwork shows whether the resource creation needs task network setup beforehand
 	DependOnTaskNetwork() bool
+	// RequiresExecutionRoleCredentials returns true if the resource requires execution role credentials
+	RequiresExecutionRoleCredentials() bool
 	// GetContainerDependencies returns dependent containers for a status
 	GetContainerDependencies(resourcestatus.ResourceStatus) []apicontainer.ContainerDependency
 	// BuildContainerDependency adds a new dependency container and its satisfied status

--- a/agent/taskresource/mocks/taskresource_mocks.go
+++ b/agent/taskresource/mocks/taskresource_mocks.go
@@ -289,6 +289,20 @@ func (mr *MockTaskResourceMockRecorder) NextKnownState() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NextKnownState", reflect.TypeOf((*MockTaskResource)(nil).NextKnownState))
 }
 
+// RequiresExecutionRoleCredentials mocks base method.
+func (m *MockTaskResource) RequiresExecutionRoleCredentials() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequiresExecutionRoleCredentials")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// RequiresExecutionRoleCredentials indicates an expected call of RequiresExecutionRoleCredentials.
+func (mr *MockTaskResourceMockRecorder) RequiresExecutionRoleCredentials() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequiresExecutionRoleCredentials", reflect.TypeOf((*MockTaskResource)(nil).RequiresExecutionRoleCredentials))
+}
+
 // SetAppliedStatus mocks base method.
 func (m *MockTaskResource) SetAppliedStatus(arg0 status.ResourceStatus) bool {
 	m.ctrl.T.Helper()

--- a/agent/taskresource/ssmsecret/ssmsecret.go
+++ b/agent/taskresource/ssmsecret/ssmsecret.go
@@ -512,3 +512,9 @@ func (secret *SSMSecretResource) BuildContainerDependency(containerName string, 
 func (secret *SSMSecretResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
 }
+
+// RequiresExecutionRoleCredentials returns true if the resource requires execution role credentials.
+// SSM secret resource always requires task execution role credentials to pull secrets from SSM.
+func (secret *SSMSecretResource) RequiresExecutionRoleCredentials() bool {
+	return true
+}

--- a/agent/taskresource/volume/dockervolume.go
+++ b/agent/taskresource/volume/dockervolume.go
@@ -535,3 +535,11 @@ func (vol *VolumeResource) GetPauseContainerPID() string {
 
 	return vol.pauseContainerPIDUnsafe
 }
+
+// RequiresExecutionRoleCredentials returns true if the resource requires execution role credentials.
+// Volume resource does not require task execution role credentials.
+// Note that the volume plugins (like the ECS volume plugin) may require credentials depending on the volume configuration,
+// but that's not handled by the VolumeResource object.
+func (vol *VolumeResource) RequiresExecutionRoleCredentials() bool {
+	return false
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR fixes the following race condition in ECS agent -

When the ECS agent receives a task payload from ACS, the payload contains the execution role credentials. The ECS agent uses these credentials to create task resources, before the task can be run.

If the ECS agent is restarted between the time when a task payload arrived and the task's resources were created, currently the task fails with error like "unable to find execution role credentials". 

This is because ECS agent only saves the credentials ID to its state during shutdown, not the credentials themselves. So after a restart, ECS agent needs to wait for the execution role credentials to (re)arrive from ACS, instead of trying to progress the task too soon and failing.

### Implementation details
<!-- How are the changes implemented? -->

Updated the task manager's resource transition logic to check whether the execution role is needed for a resource creation, and if so, whether it is available. If not, it will wait, like it waits for execution role credentials to pull container images of a task. The wait timeout is configured to be 1 minute.

Also, added a `RequiresExecutionRoleCredentials` method to the taskresource interface that tells whether a resource requires execution role credentials. This is used by the task manager during resource transitions.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes, added unit and integ tests. The integ test reproduces the race condition and now asserts that the fix works.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

bugfix: wait for execution role credentials to create task resource upon agent restart

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
