### PR TITLE
Fix for pre-mature deletion of veth pair for daemon-host network name…

### DIFF
--- a/ecs-agent/netlib/platform/cniconf_linux.go
+++ b/ecs-agent/netlib/platform/cniconf_linux.go
@@ -54,6 +54,7 @@ const (
 	VPCTunnelInterfaceTypeTap    = "tap"
 
 	BridgeInterfaceName = "fargate-bridge"
+	VethInterfaceType   = "veth"
 
 	IPAMDataFileName = "eni-ipam.db"
 


### PR DESCRIPTION
…space.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Fix for pre-mature deletion of veth pair for daemon-host network namespace, when error executing the CNI plugin. 

### Implementation details
This change only impacts daemon network namespace, all other existing namespaces are untouched. While setting up the veth pair for daemon network namespce, if an error happens and we return that error, the state transition function starts to tear down the network namespace. Since daemon-host network namespace is shared by all daemon tasks, we dont need to return this error when CNI plugin fails intermittently. The issue is reproducible intermittently in currently impl, whenever an error happens while executing the CNI plugin. Here is the flow - 

```
2025-12-22T21:26:26Z [ERROR] msg="Error executing ADD command: bridge create veth pair: unable to setup veth pair for interface: eth0: container veth name provided (eth0) already exists" netns=/var/run/netns/host-daemon ifname=eth0 containerID=container-id
2025-12-22T21:26:26Z [DEBUG] Loaded config: {{0.3.0 network-name ecs-bridge map[] {ecs-ipam} {[]  [] []}} fargate-bridge 1500}
2025-12-22T21:26:26Z [INFO] msg="Deleting veth interface" netns=/var/run/netns/host-daemon ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam
2025-12-22T21:26:26Z [INFO] msg="Running IPAM plugin DEL" netns=/var/run/netns/host-daemon ifname=eth0 containerID=container-id bridgeName=fargate-bridge ipamType=ecs-ipam
```

### Testing
<!-- How was this tested? -->
Tested via building a custom AMI with the fix, and making the CNI plugin fail, and now the daemon bridge network namespace does not get deleted while tasks are still using it. Also added UTs.

New tests cover the changes: yes

### Description for the changelog
Fix for pre-mature deletion of veth pair for daemon-host network namespace, when error executing the CNI plugin. 

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No

**Does this PR include the addition of new environment variables in the README?**
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
