### PR TITLE
Fix tmds response for unavailable credentials upon agent restart

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -245,10 +245,10 @@ type Task struct {
 	// perform some action at the task level, such as pulling image from ECR
 	ExecutionCredentialsID string `json:"executionCredentialsID"`
 
-	// credentialsID is used to set the CredentialsId field for the
+	// CredentialsID is used to set the CredentialsId field for the
 	// IAMRoleCredentials object associated with the task. This id can be
 	// used to look up the credentials for task in the credentials manager
-	credentialsID                string
+	CredentialsID                string `json:"credentialsID"`
 	credentialsRelativeURIUnsafe string
 
 	// ENIs is the list of Elastic Network Interfaces assigned to this task. The
@@ -2805,7 +2805,7 @@ func (task *Task) SetCredentialsID(id string) {
 	task.lock.Lock()
 	defer task.lock.Unlock()
 
-	task.credentialsID = id
+	task.CredentialsID = id
 }
 
 // GetCredentialsID gets the credentials ID for the task
@@ -2813,7 +2813,7 @@ func (task *Task) GetCredentialsID() string {
 	task.lock.RLock()
 	defer task.lock.RUnlock()
 
-	return task.credentialsID
+	return task.CredentialsID
 }
 
 // SetCredentialsRelativeURI sets the credentials relative uri for the task

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -1004,7 +1004,7 @@ func TestGetCredentialsEndpointWhenCredentialsAreSet(t *testing.T) {
 				Name:        "c2",
 				Environment: make(map[string]string),
 			}},
-		credentialsID: credentialsIDInTask,
+		CredentialsID: credentialsIDInTask,
 	}
 
 	taskCredentials := credentials.TaskIAMRoleCredentials{

--- a/agent/api/task/taskvolume_test.go
+++ b/agent/api/task/taskvolume_test.go
@@ -121,6 +121,7 @@ func TestMarshalTaskVolumesEFS(t *testing.T) {
 		"ExecutionStoppedAt": "0001-01-01T00:00:00Z",
 		"SentStatus": "NONE",
 		"executionCredentialsID": "",
+		"credentialsID": "",
 		"ENI": null,
 		"AppMesh": null,
 		"PlatformFields": %s
@@ -168,6 +169,7 @@ func TestUnmarshalTaskVolumesEFS(t *testing.T) {
 		"ExecutionStoppedAt": "0001-01-01T00:00:00Z",
 		"SentStatus": "NONE",
 		"executionCredentialsID": "",
+		"credentialsID": "",
 		"ENI": null,
 		"AppMesh": null,
 		"PlatformFields": {}
@@ -241,6 +243,7 @@ func TestMarshalEBSVolumes(t *testing.T) {
 		"ExecutionStoppedAt": "0001-01-01T00:00:00Z",
 		"SentStatus": "NONE",
 		"executionCredentialsID": "",
+		"credentialsID": "",
 		"ENI": null,
 		"AppMesh": null,
 		"PlatformFields": %s
@@ -286,6 +289,7 @@ func TestUnmarshalEBSVolumes(t *testing.T) {
 		"ExecutionStoppedAt": "0001-01-01T00:00:00Z",
 		"SentStatus": "NONE",
 		"executionCredentialsID": "",
+		"credentialsID": "",
 		"ENI": null,
 		"AppMesh": null,
 		"PlatformFields": {}

--- a/agent/api/task/taskvolume_windows_test.go
+++ b/agent/api/task/taskvolume_windows_test.go
@@ -78,6 +78,7 @@ func TestMarshalTaskVolumeFSxWindowsFileServer(t *testing.T) {
 		"ExecutionStoppedAt": "0001-01-01T00:00:00Z",
 		"SentStatus": "NONE",
 		"executionCredentialsID": "",
+		"credentialsID": "",
 		"ENI": null,
 		"AppMesh": null,
 		"PlatformFields": %s
@@ -117,6 +118,7 @@ func TestUnmarshalTaskVolumeFSxWindowsFileServer(t *testing.T) {
 		"ExecutionStoppedAt": "0001-01-01T00:00:00Z",
 		"SentStatus": "NONE",
 		"executionCredentialsID": "",
+		"credentialsID": "",
 		"ENI": null,
 		"AppMesh": null,
 		"PlatformFields": {}

--- a/agent/engine/data.go
+++ b/agent/engine/data.go
@@ -56,6 +56,18 @@ func (engine *DockerTaskEngine) loadTasks() error {
 	for _, task := range tasks {
 		engine.state.AddTask(task)
 
+		// Register the task role's ID in credentials manager as soon as possible.
+		// This ensures TMDS can distinguish between invalid credentials requests (400) and
+		// known credentials that aren't available yet (503) after agent restart.
+		if credentialsID := task.GetCredentialsID(); credentialsID != "" {
+			engine.credentialsManager.AddKnownCredentialsID(credentialsID)
+		}
+
+		// Also register execution role credentials ID for the same reason as above
+		if executionCredentialsID := task.GetExecutionCredentialsID(); executionCredentialsID != "" {
+			engine.credentialsManager.AddKnownCredentialsID(executionCredentialsID)
+		}
+
 		// TODO: Will need to clean up all of the STOPPED managed daemon tasks
 		md, ok := task.IsManagedDaemonTask()
 		if ok {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/interface.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/interface.go
@@ -20,4 +20,6 @@ type Manager interface {
 	SetTaskCredentials(*TaskIAMRoleCredentials) error
 	GetTaskCredentials(string) (TaskIAMRoleCredentials, bool)
 	RemoveCredentials(string)
+	IsCredentialsPending(string) bool
+	AddKnownCredentialsID(string)
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks/credentials_mocks.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks/credentials_mocks.go
@@ -48,6 +48,18 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
+// AddKnownCredentialsID mocks base method.
+func (m *MockManager) AddKnownCredentialsID(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddKnownCredentialsID", arg0)
+}
+
+// AddKnownCredentialsID indicates an expected call of AddKnownCredentialsID.
+func (mr *MockManagerMockRecorder) AddKnownCredentialsID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddKnownCredentialsID", reflect.TypeOf((*MockManager)(nil).AddKnownCredentialsID), arg0)
+}
+
 // GetTaskCredentials mocks base method.
 func (m *MockManager) GetTaskCredentials(arg0 string) (credentials.TaskIAMRoleCredentials, bool) {
 	m.ctrl.T.Helper()
@@ -61,6 +73,20 @@ func (m *MockManager) GetTaskCredentials(arg0 string) (credentials.TaskIAMRoleCr
 func (mr *MockManagerMockRecorder) GetTaskCredentials(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskCredentials", reflect.TypeOf((*MockManager)(nil).GetTaskCredentials), arg0)
+}
+
+// IsCredentialsPending mocks base method.
+func (m *MockManager) IsCredentialsPending(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsCredentialsPending", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsCredentialsPending indicates an expected call of IsCredentialsPending.
+func (mr *MockManagerMockRecorder) IsCredentialsPending(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsCredentialsPending", reflect.TypeOf((*MockManager)(nil).IsCredentialsPending), arg0)
 }
 
 // RemoveCredentials mocks base method.

--- a/ecs-agent/credentials/interface.go
+++ b/ecs-agent/credentials/interface.go
@@ -20,4 +20,6 @@ type Manager interface {
 	SetTaskCredentials(*TaskIAMRoleCredentials) error
 	GetTaskCredentials(string) (TaskIAMRoleCredentials, bool)
 	RemoveCredentials(string)
+	IsCredentialsPending(string) bool
+	AddKnownCredentialsID(string)
 }

--- a/ecs-agent/credentials/mocks/credentials_mocks.go
+++ b/ecs-agent/credentials/mocks/credentials_mocks.go
@@ -48,6 +48,18 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
+// AddKnownCredentialsID mocks base method.
+func (m *MockManager) AddKnownCredentialsID(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddKnownCredentialsID", arg0)
+}
+
+// AddKnownCredentialsID indicates an expected call of AddKnownCredentialsID.
+func (mr *MockManagerMockRecorder) AddKnownCredentialsID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddKnownCredentialsID", reflect.TypeOf((*MockManager)(nil).AddKnownCredentialsID), arg0)
+}
+
 // GetTaskCredentials mocks base method.
 func (m *MockManager) GetTaskCredentials(arg0 string) (credentials.TaskIAMRoleCredentials, bool) {
 	m.ctrl.T.Helper()
@@ -61,6 +73,20 @@ func (m *MockManager) GetTaskCredentials(arg0 string) (credentials.TaskIAMRoleCr
 func (mr *MockManagerMockRecorder) GetTaskCredentials(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskCredentials", reflect.TypeOf((*MockManager)(nil).GetTaskCredentials), arg0)
+}
+
+// IsCredentialsPending mocks base method.
+func (m *MockManager) IsCredentialsPending(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsCredentialsPending", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsCredentialsPending indicates an expected call of IsCredentialsPending.
+func (mr *MockManagerMockRecorder) IsCredentialsPending(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsCredentialsPending", reflect.TypeOf((*MockManager)(nil).IsCredentialsPending), arg0)
 }
 
 // RemoveCredentials mocks base method.

--- a/ecs-agent/tmds/handlers/credentials_handler_test.go
+++ b/ecs-agent/tmds/handlers/credentials_handler_test.go
@@ -155,6 +155,8 @@ func credentialsNotFoundCase(
 				gomock.Any(),
 				http.StatusBadRequest,
 				audit.GetCredentialsInvalidRoleTypeEventType)
+			credManager.EXPECT().IsCredentialsPending("credsid").
+				Return(false)
 			credManager.EXPECT().GetTaskCredentials("credsid").
 				Return(credentials.TaskIAMRoleCredentials{}, false)
 
@@ -191,9 +193,9 @@ func credentialsUninitializedCase(
 				gomock.Any(),
 				http.StatusServiceUnavailable,
 				audit.GetCredentialsInvalidRoleTypeEventType)
-			credManager.EXPECT().GetTaskCredentials("credsid").
-				Return(credentials.TaskIAMRoleCredentials{}, true)
-
+			credManager.EXPECT().IsCredentialsPending("credsid").
+				Return(true)
+			// GetTaskCredentials should not be called since IsCredentialsPending returns true
 			return makeHandler(credManager, auditLogger)
 		},
 		ExpectedStatusCode: http.StatusServiceUnavailable,
@@ -325,6 +327,7 @@ func testCredentialsHandlerSuccess(t *testing.T, makePath MakePath, makeHandler 
 		gomock.Any(),
 		http.StatusOK,
 		audit.GetCredentialsEventType)
+	credManager.EXPECT().IsCredentialsPending(credsId).Return(false)
 	credManager.EXPECT().GetTaskCredentials(credsId).Return(
 		credentials.TaskIAMRoleCredentials{ARN: taskArn, IAMRoleCredentials: creds}, true)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR fixes the error that a container sees when it requests credentials over the TMDS credentials endpoint (`169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`), when the credentials are unavailable.

The agent does not save task IAM role and task execution IAM role credentials to its state. So when an agent restart occurs, the agent needs ACS to resend the credentials. Until ACS does so, the agent must return a meaningful error code and reason in the response. Currently, customer would see a error code 400 (Invalid credentials ID), whereas they should see a 503 (credentials uninitialized).

The TMDS handler does have logic in place to throw 503 under such conditions but it is broken. This PR fixes it.

### Implementation details
<!-- How are the changes implemented? -->

- Export and add a JSON tag to the `CredentialsID` in the task object. When the agent saves the task object in its state file, this change helps store the credentials ID field as well. This makes it consistent with how agent saves the execution role credentials ID to its state.
- Add a new map to the credentials manager to track known credentials IDs.
- When agent restarts and loads all the tasks from its state file, we now add known credential IDs to the credentials manager. This is done early in the agent initialization (before TMDS is up), so that the credentials manager knows when to return 503 vs 400.
- Updated the credentials manager interface with new helper methods that the TMDS handler and engine could use to (1) add known credentials ID and (2) determine whether a credentials ID is known but credentials have not yet arrived from ACS.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

Added unit tests and also manually tested the scenario as described below.

Steps to reproduce the issue:
- Launch an ECS container instance and run an ECS task that has a task IAM role.
- Exec into the task container and query the TMDS credentials endpoint. You should get valid credentials in the response.
- Next, add the following iptables rules to block outbound traffic to ACS, and restart the ECS agent. 

```
sudo iptables -A OUTPUT -d 0.0.0.0/0 -p tcp --dport 443 -m string --string "ecs-a" --algo bm -j DROP
sudo iptables -A OUTPUT -d 0.0.0.0/0 -p tcp --dport 80 -m string --string "ecs-a" --algo bm -j DROP
```

- When the agent restarts, it won't be able to establish a connection with ACS, hence the creds will never arrive. Querying the TMDS creds endpoint would yield: 

```
{"code":"InvalidIdInRequest",
"message":"CredentialsV2Request: Credentials not found","HTTPErrorCode":400}
```

- Build a test agent using the changes in this PR and repeat the above steps. It now yields
```
{"code":"CredentialsUninitialized",
"message":"CredentialsV2Request: Credentials uninitialized for ID","HTTPErrorCode":503}
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Bugfix: Fix tmds response for unavailable credentials upon agent restart. 

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
