### PR TITLE
Make block I/O stat Op parsing case insensitive

### DIFF
--- a/agent/stats/utils_unix.go
+++ b/agent/stats/utils_unix.go
@@ -18,6 +18,7 @@ package stats
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/cihub/seelog"
@@ -84,10 +85,10 @@ func getStorageStats(dockerStats *types.StatsJSON) (uint64, uint64) {
 	storageReadBytes := uint64(0)
 	storageWriteBytes := uint64(0)
 	for _, blockStat := range dockerStats.BlkioStats.IoServiceBytesRecursive {
-		switch op := blockStat.Op; op {
-		case "Read":
+		switch strings.ToLower(blockStat.Op) {
+		case "read":
 			storageReadBytes += blockStat.Value
-		case "Write":
+		case "write":
 			storageWriteBytes += blockStat.Value
 		default:
 			//ignoring "Async", "Total", "Sum", etc


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Make logic that parses block I/O `Op` from `docker stats` case insensitive.

This is because `docker stats` could return values of `Op` which may or may not have consistent capitalization (for example, Docker returns values of `Op` such as "read" and "write" for cgroups v2 as opposed to "Read" and "Write" for cgroups v1). Thus, without the change in this pull request, ECS Agent currently is susceptible to potentially ignore data that it actually should take it into account for storage metrics that ECS surfaces to CloudWatch.

### Implementation details
<!-- How are the changes implemented? -->
See "Summary" section above.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes (new unit test added and existing integ test updated)

Manually performed the following end to end test:
- Set up an ECS cluster with "Container Insights with enhanced observability" feature enabled with container instances using the latest AL2023 ECS-Optimized ARM64 AMI (which uses cgroups v2)
- In the cluster, launch an ECS task which explicitly writes to storage
- Observe that ECS emits a storage write metric value of 0 in CloudWatch
- Subsequently, stop ECS Agent and relaunch a custom ECS Agent incorporating the changes from this pull request
- After the custom ECS Agent has launched, confirm that ECS emits a nonzero storage write metric value in CloudWatch

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bugfix - Make block I/O stat Op parsing case insensitive

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
