### PR TITLE
Update SSM Agent Binaries to 3.3.3572.0 for ECS-A

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -745,7 +745,7 @@ find-copy-certs-exec() {
 }
 
 download-ssm-binaries-exec() {
-    BINARY_VERSION="3.3.3050.0"
+    BINARY_VERSION="3.3.3572.0"
     BINARY_PATH="/var/lib/ecs/deps/execute-command/bin/${BINARY_VERSION}"
     BINARY_DOWNLOAD_PATH="ssm-binaries"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Update SSM Agent Binary version to 3.3.3572.0 in ECS Anywhere install script

### Testing
Ran Exec functional tests with the updated script for External Launch type for different platforms and both amd64/arm64 arch

All tests passed successfully

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
