### PR TITLE
Switching NVIDIA_ACCELERATED_HARDWARE to ACCELERATED_COMPUTE to make it vendor agnostic. Adding INSUFFICENT_DATA as a valid health status.

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs/types.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs/types.go
@@ -66,10 +66,10 @@ type InstanceStatusMessage struct {
 }
 
 const (
-	InstanceHealthCheckTypeContainerRuntime = "ContainerRuntime"
-	InstanceHealthCheckTypeAgent            = "Agent"
-	InstanceHealthCheckTypeEBSDaemon        = "EBSDaemon"
-	InstanceHealthCheckTypeNvidia           = "NvidiaAcceleratedHardware"
+	InstanceHealthCheckTypeContainerRuntime   = "ContainerRuntime"
+	InstanceHealthCheckTypeAgent              = "Agent"
+	InstanceHealthCheckTypeEBSDaemon          = "EBSDaemon"
+	InstanceHealthCheckTypeAcceleratedCompute = "ACCELERATED_COMPUTE"
 )
 
 const (
@@ -79,15 +79,18 @@ const (
 	InstanceHealthCheckStatusOk
 	// HealthcheckStatusImpaired represents a healthcheck with a false/fail result.
 	InstanceHealthCheckStatusImpaired
+	// HealthcheckStatusInsufficientData represents a healthcheck where status cannot be determined.
+	InstanceHealthCheckStatusInsufficientData
 )
 
 // InstanceHealthCheckStatus is an enumeration of possible instance health check statuses.
 type InstanceHealthCheckStatus int32
 
 var instanceHealthCheckStatusMap = map[string]InstanceHealthCheckStatus{
-	"INITIALIZING": InstanceHealthCheckStatusInitializing,
-	"OK":           InstanceHealthCheckStatusOk,
-	"IMPAIRED":     InstanceHealthCheckStatusImpaired,
+	"INITIALIZING":      InstanceHealthCheckStatusInitializing,
+	"OK":                InstanceHealthCheckStatusOk,
+	"IMPAIRED":          InstanceHealthCheckStatusImpaired,
+	"INSUFFICIENT_DATA": InstanceHealthCheckStatusInsufficientData,
 }
 
 // String returns a human readable string representation of this object.

--- a/ecs-agent/tcs/model/ecstcs/types.go
+++ b/ecs-agent/tcs/model/ecstcs/types.go
@@ -66,10 +66,10 @@ type InstanceStatusMessage struct {
 }
 
 const (
-	InstanceHealthCheckTypeContainerRuntime = "ContainerRuntime"
-	InstanceHealthCheckTypeAgent            = "Agent"
-	InstanceHealthCheckTypeEBSDaemon        = "EBSDaemon"
-	InstanceHealthCheckTypeNvidia           = "NvidiaAcceleratedHardware"
+	InstanceHealthCheckTypeContainerRuntime   = "ContainerRuntime"
+	InstanceHealthCheckTypeAgent              = "Agent"
+	InstanceHealthCheckTypeEBSDaemon          = "EBSDaemon"
+	InstanceHealthCheckTypeAcceleratedCompute = "ACCELERATED_COMPUTE"
 )
 
 const (
@@ -79,15 +79,18 @@ const (
 	InstanceHealthCheckStatusOk
 	// HealthcheckStatusImpaired represents a healthcheck with a false/fail result.
 	InstanceHealthCheckStatusImpaired
+	// HealthcheckStatusInsufficientData represents a healthcheck where status cannot be determined.
+	InstanceHealthCheckStatusInsufficientData
 )
 
 // InstanceHealthCheckStatus is an enumeration of possible instance health check statuses.
 type InstanceHealthCheckStatus int32
 
 var instanceHealthCheckStatusMap = map[string]InstanceHealthCheckStatus{
-	"INITIALIZING": InstanceHealthCheckStatusInitializing,
-	"OK":           InstanceHealthCheckStatusOk,
-	"IMPAIRED":     InstanceHealthCheckStatusImpaired,
+	"INITIALIZING":      InstanceHealthCheckStatusInitializing,
+	"OK":                InstanceHealthCheckStatusOk,
+	"IMPAIRED":          InstanceHealthCheckStatusImpaired,
+	"INSUFFICIENT_DATA": InstanceHealthCheckStatusInsufficientData,
 }
 
 // String returns a human readable string representation of this object.

--- a/ecs-agent/tcs/model/ecstcs/types_test.go
+++ b/ecs-agent/tcs/model/ecstcs/types_test.go
@@ -28,9 +28,11 @@ func TestOk(t *testing.T) {
 	initializingStatus := InstanceHealthCheckStatusInitializing
 	okStatus := InstanceHealthCheckStatusOk
 	impairedStatus := InstanceHealthCheckStatusImpaired
+	insufficientDataStatus := InstanceHealthCheckStatusInsufficientData
 	assert.True(t, initializingStatus.Ok())
 	assert.True(t, okStatus.Ok())
 	assert.False(t, impairedStatus.Ok())
+	assert.False(t, insufficientDataStatus.Ok())
 }
 
 type testHealthcheckStatus struct {
@@ -54,4 +56,12 @@ func TestUnmarshalHealthcheckStatus(t *testing.T) {
 	// IMPAIRED should unmarshal to IMPAIRED.
 	assert.Equal(t, InstanceHealthCheckStatusImpaired, test.SomeStatus)
 	assert.Equal(t, impairedStr, test.SomeStatus.String())
+
+	var test2 testHealthcheckStatus
+	insufficientDataStr := "INSUFFICIENT_DATA"
+	err = json.Unmarshal([]byte(fmt.Sprintf(`{"status":"%s"}`, insufficientDataStr)), &test2)
+	assert.NoError(t, err)
+	// INSUFFICIENT_DATA should unmarshal to INSUFFICIENT_DATA.
+	assert.Equal(t, InstanceHealthCheckStatusInsufficientData, test2.SomeStatus)
+	assert.Equal(t, insufficientDataStr, test2.SomeStatus.String())
 }


### PR DESCRIPTION
### Summary
Changes some enums to match what the control plane is expecting. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
