### PR TITLE
[ON HOLD]Add InstanceStorageMetrics struct to TMDS v4 response.

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
@@ -36,6 +36,7 @@ type TaskResponse struct {
 	ServiceName             string                   `json:"ServiceName,omitempty"`
 	ClockDrift              *ClockDrift              `json:"ClockDrift,omitempty"`
 	EphemeralStorageMetrics *EphemeralStorageMetrics `json:"EphemeralStorageMetrics,omitempty"`
+	InstanceStorageMetrics  *InstanceStorageMetrics  `json:"InstanceStorageMetrics,omitempty"`
 	CredentialsID           string                   `json:"-"`
 	TaskNetworkConfig       *TaskNetworkConfig       `json:"-"`
 	FaultInjectionEnabled   bool                     `json:"FaultInjectionEnabled"`
@@ -88,6 +89,14 @@ type ClockDrift struct {
 type EphemeralStorageMetrics struct {
 	UtilizedMiBs int64 `json:"Utilized"`
 	ReservedMiBs int64 `json:"Reserved"`
+}
+
+// InstanceStorageMetrics represents instance-level storage metrics exposed via TMDS.
+// Both DataFilesystemUtilization and RootFilesystemUtilization are exposed to customers,
+// matching the metrics available via Container Insights.
+type InstanceStorageMetrics struct {
+	DataFilesystemUtilization float64 `json:"DataFilesystemUtilization"`
+	RootFilesystemUtilization float64 `json:"RootFilesystemUtilization"`
 }
 
 // ContainerResponse is the v4 Container response. It augments the v4 Network response

--- a/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/ecs-agent/tmds/handlers/v4/state/response.go
@@ -36,6 +36,7 @@ type TaskResponse struct {
 	ServiceName             string                   `json:"ServiceName,omitempty"`
 	ClockDrift              *ClockDrift              `json:"ClockDrift,omitempty"`
 	EphemeralStorageMetrics *EphemeralStorageMetrics `json:"EphemeralStorageMetrics,omitempty"`
+	InstanceStorageMetrics  *InstanceStorageMetrics  `json:"InstanceStorageMetrics,omitempty"`
 	CredentialsID           string                   `json:"-"`
 	TaskNetworkConfig       *TaskNetworkConfig       `json:"-"`
 	FaultInjectionEnabled   bool                     `json:"FaultInjectionEnabled"`
@@ -88,6 +89,14 @@ type ClockDrift struct {
 type EphemeralStorageMetrics struct {
 	UtilizedMiBs int64 `json:"Utilized"`
 	ReservedMiBs int64 `json:"Reserved"`
+}
+
+// InstanceStorageMetrics represents instance-level storage metrics exposed via TMDS.
+// Both DataFilesystemUtilization and RootFilesystemUtilization are exposed to customers,
+// matching the metrics available via Container Insights.
+type InstanceStorageMetrics struct {
+	DataFilesystemUtilization float64 `json:"DataFilesystemUtilization"`
+	RootFilesystemUtilization float64 `json:"RootFilesystemUtilization"`
 }
 
 // ContainerResponse is the v4 Container response. It augments the v4 Network response


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? --> Add InstanceStorageMetrics struct to TMDS v4 response. We want to expose both `InstanceDataFilesystemUtilization` and `InstanceOSFilesystemUtilization` through TMDS. The metrics are sent to TACS already to be present via container Insights. Generally, whatever is available via CI should be available via TMDS.
Local storage uses the same metric and is needed to be exposed via TMDS.

### Testing
<!-- How was this tested? --> existing tests pass.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. 


Format: [Category] Description
Categories: Enhancement

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
--> Enhancement - Add InstanceStorageMetrics struct to TMDS v4 response.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
--> No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
