### PR TITLE
engine: skip execution role checks when task desired status is stopped

### DIFF
--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -1310,6 +1310,11 @@ func (mtask *managedTask) taskExecutionRoleCredentialsResolved(resource taskreso
 		return true
 	}
 
+	// If the task's desired status is stopped, no credentials are needed to transition resources.
+	if mtask.GetDesiredStatus().Terminal() {
+		return true
+	}
+
 	// Check if credentials are available
 	_, ok := mtask.credentialsManager.GetTaskCredentials(mtask.Task.GetExecutionCredentialsID())
 	return ok

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -2585,6 +2585,7 @@ func TestTaskExecutionRoleCredentialsResolved(t *testing.T) {
 		name                 string
 		requiresCredentials  bool
 		resourceStatus       resourcestatus.ResourceStatus
+		taskDesiredStatus    apitaskstatus.TaskStatus
 		credentialsAvailable bool
 		expectedResult       bool
 	}{
@@ -2592,6 +2593,7 @@ func TestTaskExecutionRoleCredentialsResolved(t *testing.T) {
 			name:                 "resource does not require execution role credentials",
 			requiresCredentials:  false,
 			resourceStatus:       resourcestatus.ResourceStatusNone,
+			taskDesiredStatus:    apitaskstatus.TaskRunning,
 			credentialsAvailable: false,
 			expectedResult:       true,
 		},
@@ -2599,6 +2601,7 @@ func TestTaskExecutionRoleCredentialsResolved(t *testing.T) {
 			name:                 "resource already created",
 			requiresCredentials:  true,
 			resourceStatus:       resourcestatus.ResourceCreated,
+			taskDesiredStatus:    apitaskstatus.TaskRunning,
 			credentialsAvailable: false,
 			expectedResult:       true,
 		},
@@ -2606,6 +2609,7 @@ func TestTaskExecutionRoleCredentialsResolved(t *testing.T) {
 			name:                 "credentials available",
 			requiresCredentials:  true,
 			resourceStatus:       resourcestatus.ResourceStatusNone,
+			taskDesiredStatus:    apitaskstatus.TaskRunning,
 			credentialsAvailable: true,
 			expectedResult:       true,
 		},
@@ -2613,8 +2617,17 @@ func TestTaskExecutionRoleCredentialsResolved(t *testing.T) {
 			name:                 "credentials not available",
 			requiresCredentials:  true,
 			resourceStatus:       resourcestatus.ResourceStatusNone,
+			taskDesiredStatus:    apitaskstatus.TaskRunning,
 			credentialsAvailable: false,
 			expectedResult:       false,
+		},
+		{
+			name:                 "task desired status is stopped",
+			requiresCredentials:  true,
+			resourceStatus:       resourcestatus.ResourceStatusNone,
+			taskDesiredStatus:    apitaskstatus.TaskStopped,
+			credentialsAvailable: false,
+			expectedResult:       true,
 		},
 	}
 
@@ -2629,6 +2642,7 @@ func TestTaskExecutionRoleCredentialsResolved(t *testing.T) {
 			task := &apitask.Task{
 				Arn:                    "test-task-arn",
 				ExecutionCredentialsID: "test-creds-id",
+				DesiredStatusUnsafe:    tc.taskDesiredStatus,
 			}
 			mtask := &managedTask{
 				Task:               task,
@@ -2638,7 +2652,7 @@ func TestTaskExecutionRoleCredentialsResolved(t *testing.T) {
 			mockResource.EXPECT().RequiresExecutionRoleCredentials().Return(tc.requiresCredentials)
 			if tc.requiresCredentials {
 				mockResource.EXPECT().GetKnownStatus().Return(tc.resourceStatus)
-				if tc.resourceStatus < resourcestatus.ResourceCreated {
+				if tc.resourceStatus < resourcestatus.ResourceCreated && !tc.taskDesiredStatus.Terminal() {
 					if tc.credentialsAvailable {
 						mockCredentialsManager.EXPECT().GetTaskCredentials("test-creds-id").Return(credentials.TaskIAMRoleCredentials{}, true)
 					} else {


### PR DESCRIPTION
### Summary

Fix a regression where a task with resources like ASM auth secret (requiring task execution role) gets stuck in PENDING/STOPPED indefinitely when StopTask is called immediately after RunTask.

### Implementation details

When StopTask is called within milliseconds of RunTask, the task may transition to PENDING/STOPPED in the control plane before ACS delivers execution role credentials to the agent. The agent then enters an infinite loop in progressTask():

1. startResourceTransitions() → taskExecutionRoleCredentialsResolved() returns false for asm-auth (credentials never arrived)
2. startContainerTransitions() → blocked by dependency on asm-auth
3. isWaitingForACSExecutionCredentials() finds CredentialsNotResolvedErr, waits 60s, times out, returns true
4. This prevents handleContainersUnableToTransitionState() from firing, which would force the task to STOPPED
5. Loop repeats forever

The fix adds a check in taskExecutionRoleCredentialsResolved(): if the task's desired status is stopped, no credentials are needed to transition resources. This allows the task to proceed through handleContainersUnableToTransitionState() and reach STOPPED.

### Testing

- Unit test added for the new code path (TestTaskExecutionRoleCredentialsResolved/task desired status is stopped)
- Manually reproduced the exact customer scenario in a test account:
  - Created a task definition with repositoryCredentials (Secrets Manager) to trigger asm-auth resource creation
  - Used a Python script calling RunTask + StopTask back-to-back via the SDK to reproduce the race condition
  - Verified agent received only desiredStatus=STOPPED payload (no RUNNING payload)
  - Without fix: task stuck in PENDING/STOPPED indefinitely with agent logging "Waiting for execution role credentials to arrive from ACS" every 60s
  - With fix: task transitions to STOPPED/STOPPED within seconds

New tests cover the changes: yes

### Description for the changelog

Bugfix - Fixed a regression where tasks with resources requiring task execution role get stuck in PENDING/STOPPED

### Additional Information

Does this PR include breaking model changes? If so, Have you added transformation functions?
No

Does this PR include the addition of new environment variables in the README?
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.