### PR TITLE
Add NeuronDevices type and sysfs-based device discovery

### DIFF
--- a/ecs-agent/utils/neuron/neuron.go
+++ b/ecs-agent/utils/neuron/neuron.go
@@ -13,6 +13,11 @@
 
 package neuron
 
+import (
+	"maps"
+	"slices"
+)
+
 // NeuronDevice represents a physical Neuron device (chip)
 type NeuronDevice struct {
 	ID   string `json:"id"`   // Logical device ID: "0", "1"
@@ -77,4 +82,30 @@ func GetCoreIDs(cores []NeuronCore) []string {
 // This is exported only for use in tests.
 func NewNeuronCoresForTesting(coresMap map[string]NeuronCore) *NeuronCores {
 	return &NeuronCores{cores: coresMap}
+}
+
+// NeuronDevices contains all discovered Neuron devices.
+type NeuronDevices struct {
+	devices map[string]NeuronDevice // deviceID -> NeuronDevice
+}
+
+// DeviceByID returns the device with the given ID.
+// Returns false if device ID is not found.
+func (nd *NeuronDevices) DeviceByID(id string) (NeuronDevice, bool) {
+	d, ok := nd.devices[id]
+	return d, ok
+}
+
+// DeviceIDs returns all device IDs as strings.
+func (nd *NeuronDevices) DeviceIDs() []string {
+	if nd == nil {
+		return nil
+	}
+	return slices.Collect(maps.Keys(nd.devices))
+}
+
+// NewNeuronDevicesForTesting creates a NeuronDevices instance for testing.
+// This is exported only for use in tests.
+func NewNeuronDevicesForTesting(devicesMap map[string]NeuronDevice) *NeuronDevices {
+	return &NeuronDevices{devices: devicesMap}
 }

--- a/ecs-agent/utils/neuron/neuron_linux.go
+++ b/ecs-agent/utils/neuron/neuron_linux.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 )
 
 // DiscoverCores enumerates Neuron devices from sysfs, validates device paths exist,
@@ -95,4 +97,48 @@ func DiscoverCores(rootPath string) (*NeuronCores, error) {
 	}
 
 	return &NeuronCores{cores: cores}, nil
+}
+
+// DiscoverDevices enumerates Neuron devices from sysfs.
+// Returns nil if no devices are found (not an error).
+// Returns error only for I/O failures.
+// rootPath allows testing with custom sysfs location (use "/" for production).
+func DiscoverDevices(rootPath string) (*NeuronDevices, error) {
+	sysfsPath := filepath.Join(rootPath, "sys/class/neuron_device")
+	devPath := filepath.Join(rootPath, "dev")
+
+	devicePaths, err := filepath.Glob(filepath.Join(sysfsPath, "neuron*"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to enumerate neuron devices: %w", err)
+	}
+
+	if len(devicePaths) == 0 {
+		return nil, nil
+	}
+
+	devices := make(map[string]NeuronDevice)
+	for _, devicePath := range devicePaths {
+		// e.g. "/sys/class/neuron_device/neuron0" → "neuron0" → "0"
+		deviceName := filepath.Base(devicePath)
+		deviceID := strings.TrimPrefix(deviceName, "neuron")
+
+		// Skip entries where suffix is not a number
+		if _, err := strconv.Atoi(deviceID); err != nil {
+			logger.Info("Skipping non-numeric neuron sysfs entry", logger.Fields{"entry": deviceName})
+			continue
+		}
+
+		deviceFilePath := filepath.Join(devPath, deviceName)
+
+		if _, err := os.Stat(deviceFilePath); err != nil {
+			return nil, fmt.Errorf("neuron device file %s not found: %w", deviceFilePath, err)
+		}
+
+		devices[deviceID] = NeuronDevice{
+			ID:   deviceID,
+			Path: deviceFilePath,
+		}
+	}
+
+	return &NeuronDevices{devices: devices}, nil
 }

--- a/ecs-agent/utils/neuron/neuron_linux_test.go
+++ b/ecs-agent/utils/neuron/neuron_linux_test.go
@@ -16,6 +16,7 @@
 package neuron
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -216,4 +217,120 @@ func TestCoreIDs(t *testing.T) {
 		coreIDs := nc.CoreIDs()
 		assert.ElementsMatch(t, []string{"0", "1"}, coreIDs)
 	})
+}
+
+func TestDiscoverDevices(t *testing.T) {
+	t.Run("no devices", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "sys/class/neuron_device"), 0755))
+
+		devices, err := DiscoverDevices(tmpDir)
+		assert.NoError(t, err)
+		assert.Nil(t, devices)
+	})
+
+	t.Run("single device", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "sys/class/neuron_device/neuron0"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "dev"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "dev/neuron0"), []byte{}, 0644))
+
+		devices, err := DiscoverDevices(tmpDir)
+		require.NoError(t, err)
+
+		expected := &NeuronDevices{
+			devices: map[string]NeuronDevice{
+				"0": {ID: "0", Path: filepath.Join(tmpDir, "dev/neuron0")},
+			},
+		}
+		assert.Equal(t, expected, devices)
+	})
+
+	t.Run("multiple devices", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "dev"), 0755))
+		for i := 0; i < 3; i++ {
+			require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, fmt.Sprintf("sys/class/neuron_device/neuron%d", i)), 0755))
+			require.NoError(t, os.WriteFile(filepath.Join(tmpDir, fmt.Sprintf("dev/neuron%d", i)), []byte{}, 0644))
+		}
+
+		devices, err := DiscoverDevices(tmpDir)
+		require.NoError(t, err)
+
+		expected := &NeuronDevices{
+			devices: map[string]NeuronDevice{
+				"0": {ID: "0", Path: filepath.Join(tmpDir, "dev/neuron0")},
+				"1": {ID: "1", Path: filepath.Join(tmpDir, "dev/neuron1")},
+				"2": {ID: "2", Path: filepath.Join(tmpDir, "dev/neuron2")},
+			},
+		}
+		assert.Equal(t, expected, devices)
+	})
+
+	t.Run("missing device file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "sys/class/neuron_device/neuron0"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "dev"), 0755))
+
+		devices, err := DiscoverDevices(tmpDir)
+		assert.Error(t, err)
+		assert.Nil(t, devices)
+		assert.ErrorContains(t, err, fmt.Sprintf("neuron device file %s not found", filepath.Join(tmpDir, "dev/neuron0")))
+	})
+
+	t.Run("non-device neuron entries in sysfs", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		// neuron0 is a real device, neuron_monitor matches the glob but is not a device
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "sys/class/neuron_device/neuron0"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "sys/class/neuron_device/neuron_monitor"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "dev"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "dev/neuron0"), []byte{}, 0644))
+
+		devices, err := DiscoverDevices(tmpDir)
+		require.NoError(t, err)
+
+		expected := &NeuronDevices{
+			devices: map[string]NeuronDevice{
+				"0": {ID: "0", Path: filepath.Join(tmpDir, "dev/neuron0")},
+			},
+		}
+		assert.Equal(t, expected, devices)
+	})
+}
+
+func TestNeuronDevices_DeviceIDs(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		var nd *NeuronDevices
+		assert.Nil(t, nd.DeviceIDs())
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		nd := &NeuronDevices{devices: make(map[string]NeuronDevice)}
+		assert.Empty(t, nd.DeviceIDs())
+	})
+
+	t.Run("with devices", func(t *testing.T) {
+		nd := &NeuronDevices{
+			devices: map[string]NeuronDevice{
+				"0": {ID: "0", Path: "/dev/neuron0"},
+				"1": {ID: "1", Path: "/dev/neuron1"},
+			},
+		}
+		assert.ElementsMatch(t, []string{"0", "1"}, nd.DeviceIDs())
+	})
+}
+
+func TestNeuronDevices_DeviceByID(t *testing.T) {
+	nd := &NeuronDevices{
+		devices: map[string]NeuronDevice{
+			"0": {ID: "0", Path: "/dev/neuron0"},
+		},
+	}
+
+	device, ok := nd.DeviceByID("0")
+	assert.True(t, ok)
+	assert.Equal(t, NeuronDevice{ID: "0", Path: "/dev/neuron0"}, device)
+
+	_, ok = nd.DeviceByID("99")
+	assert.False(t, ok)
 }


### PR DESCRIPTION
### Summary

Add device-level Neuron discovery in the shared neuron utils package.

### Implementation details

- `NeuronDevices` struct with `DeviceByID()` and `DeviceIDs()` methods in `ecs-agent/utils/neuron/neuron.go`
- `DiscoverDevices()` in `ecs-agent/utils/neuron/neuron_linux.go` — enumerates `/sys/class/neuron_device/neuron*`, validates `/dev/neuronX` exists, skips non-numeric sysfs entries

### Testing

- Unit tests for `DiscoverDevices()`: no devices, single device, multiple devices, missing device file, non-device sysfs entries
- Unit tests for `NeuronDevices` methods: `DeviceIDs()` (nil, empty, populated), `DeviceByID()` (found, not found)

New tests cover the changes: yes

### Description for the changelog

Enhancement - Add device-level Neuron discovery utils to shared library

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No

**Does this PR include the addition of new environment variables in the README?**
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.