### PR TITLE
Track and emit metric for disconnect time from ACS

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/session.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/session.go
@@ -100,6 +100,7 @@ type session struct {
 	disconnectJitter               time.Duration
 	inactiveInstanceReconnectDelay time.Duration
 	lastConnectedTime              time.Time
+	lastDisconnectedTime           time.Time
 	firstACSConnectionTime         time.Time
 }
 
@@ -160,6 +161,7 @@ func NewSession(containerInstanceARN string,
 		disconnectJitter:               wsclient.DisconnectJitterMax,
 		inactiveInstanceReconnectDelay: inactiveInstanceReconnectDelay,
 		lastConnectedTime:              time.Time{},
+		lastDisconnectedTime:           time.Time{},
 		firstACSConnectionTime:         time.Time{},
 	}
 }
@@ -190,6 +192,7 @@ func (s *session) Start(ctx context.Context) error {
 			acsError := s.startSessionOnce(ctx)
 
 			// Session with ACS was stopped with some error, start processing the error.
+			s.lastDisconnectedTime = time.Now()
 			reconnectDelay, ok := s.reconnectDelay(acsError)
 
 			if ok {
@@ -270,6 +273,10 @@ func (s *session) startSessionOnce(ctx context.Context) error {
 		return err
 	}
 	s.metricsFactory.New(metrics.ACSSessionCallDurationName).WithGauge(time.Since(acsConnectionStartTime).Milliseconds()).Done(nil)
+	if !s.GetLastDisconnectedTime().IsZero() {
+		s.metricsFactory.New(metrics.ACSDisconnectedDurationName).WithGauge(time.Since(s.GetLastDisconnectedTime()).
+			Milliseconds()).Done(nil)
+	}
 	defer disconnectTimer.Stop()
 
 	if s.GetFirstACSConnectionTime().IsZero() {
@@ -486,6 +493,11 @@ func formatDockerVersion(dockerVersionValue string) string {
 // GetLastConnectedTime returns the timestamp that the last connection was established to ACS.
 func (s *session) GetLastConnectedTime() time.Time {
 	return s.lastConnectedTime
+}
+
+// GetLastDisconnectedTime returns the timestamp that the last time Agent was disconnected from ACS.
+func (s *session) GetLastDisconnectedTime() time.Time {
+	return s.lastDisconnectedTime
 }
 
 func (s *session) GetFirstACSConnectionTime() time.Time {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
@@ -55,9 +55,10 @@ const (
 	TCSDisconnectTimeoutMetricName = agentAvailabilityNamespace + ".TCSDisconnectTimeout"
 
 	// ACS Session Metrics
-	acsSessionNamespace        = "ACSSession"
-	ACSSessionFailureCallName  = acsSessionNamespace + ".ACSConnectFailure"
-	ACSSessionCallDurationName = acsSessionNamespace + ".ACSConnectDuration"
+	acsSessionNamespace         = "ACSSession"
+	ACSSessionFailureCallName   = acsSessionNamespace + ".ACSConnectFailure"
+	ACSSessionCallDurationName  = acsSessionNamespace + ".ACSConnectDuration"
+	ACSDisconnectedDurationName = acsSessionNamespace + ".ACSDisconnectedDuration"
 
 	// TACS Connection Metrics
 	tacsConnectionNamespace  = "TACSConnection"

--- a/ecs-agent/acs/session/session.go
+++ b/ecs-agent/acs/session/session.go
@@ -100,6 +100,7 @@ type session struct {
 	disconnectJitter               time.Duration
 	inactiveInstanceReconnectDelay time.Duration
 	lastConnectedTime              time.Time
+	lastDisconnectedTime           time.Time
 	firstACSConnectionTime         time.Time
 }
 
@@ -160,6 +161,7 @@ func NewSession(containerInstanceARN string,
 		disconnectJitter:               wsclient.DisconnectJitterMax,
 		inactiveInstanceReconnectDelay: inactiveInstanceReconnectDelay,
 		lastConnectedTime:              time.Time{},
+		lastDisconnectedTime:           time.Time{},
 		firstACSConnectionTime:         time.Time{},
 	}
 }
@@ -190,6 +192,7 @@ func (s *session) Start(ctx context.Context) error {
 			acsError := s.startSessionOnce(ctx)
 
 			// Session with ACS was stopped with some error, start processing the error.
+			s.lastDisconnectedTime = time.Now()
 			reconnectDelay, ok := s.reconnectDelay(acsError)
 
 			if ok {
@@ -270,6 +273,10 @@ func (s *session) startSessionOnce(ctx context.Context) error {
 		return err
 	}
 	s.metricsFactory.New(metrics.ACSSessionCallDurationName).WithGauge(time.Since(acsConnectionStartTime).Milliseconds()).Done(nil)
+	if !s.GetLastDisconnectedTime().IsZero() {
+		s.metricsFactory.New(metrics.ACSDisconnectedDurationName).WithGauge(time.Since(s.GetLastDisconnectedTime()).
+			Milliseconds()).Done(nil)
+	}
 	defer disconnectTimer.Stop()
 
 	if s.GetFirstACSConnectionTime().IsZero() {
@@ -486,6 +493,11 @@ func formatDockerVersion(dockerVersionValue string) string {
 // GetLastConnectedTime returns the timestamp that the last connection was established to ACS.
 func (s *session) GetLastConnectedTime() time.Time {
 	return s.lastConnectedTime
+}
+
+// GetLastDisconnectedTime returns the timestamp that the last time Agent was disconnected from ACS.
+func (s *session) GetLastDisconnectedTime() time.Time {
+	return s.lastDisconnectedTime
 }
 
 func (s *session) GetFirstACSConnectionTime() time.Time {

--- a/ecs-agent/acs/session/session_test.go
+++ b/ecs-agent/acs/session/session_test.go
@@ -237,6 +237,11 @@ func TestSessionReconnectsOnConnectErrors(t *testing.T) {
 	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
+	mockACSDisconnectedDurationEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSDisconnectedDuration").Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
@@ -370,6 +375,11 @@ func TestSessionReconnectsWithoutBackoffOnEOFError(t *testing.T) {
 	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
+	mockACSDisconnectedDurationEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSDisconnectedDuration").Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
@@ -430,6 +440,11 @@ func TestSessionReconnectsWithBackoffOnNonEOFError(t *testing.T) {
 	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+
+	mockACSDisconnectedDurationEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSDisconnectedDuration").Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
@@ -492,6 +507,11 @@ func TestSessionCallsInactiveInstanceCB(t *testing.T) {
 	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+
+	mockACSDisconnectedDurationEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSDisconnectedDuration").Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
@@ -559,6 +579,11 @@ func TestSessionReconnectDelayForInactiveInstanceError(t *testing.T) {
 	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+
+	mockACSDisconnectedDurationEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSDisconnectedDuration").Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
@@ -632,6 +657,11 @@ func TestSessionReconnectsOnServeErrors(t *testing.T) {
 	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
+	mockACSDisconnectedDurationEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSDisconnectedDuration").Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
@@ -693,6 +723,12 @@ func TestSessionStopsWhenContextIsCanceled(t *testing.T) {
 	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
+	mockACSDisconnectedDurationEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSDisconnectedDuration").Return(mockACSDisconnectedDurationEntry)
+	mockACSDisconnectedDurationEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSDisconnectedDurationEntry)
+	// ACSDisconnectedDuration metric should be emitted exactly once - upon reconnection only.
+	mockACSDisconnectedDurationEntry.EXPECT().Done(gomock.Any())
+
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
@@ -709,12 +745,6 @@ func TestSessionStopsWhenContextIsCanceled(t *testing.T) {
 		Return(time.NewTimer(wsclient.DisconnectTimeout), nil).AnyTimes()
 	mockWsClient.EXPECT().WriteCloseMessage().Return(nil).AnyTimes()
 	mockWsClient.EXPECT().Close().Return(nil).AnyTimes()
-	gomock.InOrder(
-		mockWsClient.EXPECT().Serve(gomock.Any()).Return(io.EOF),
-		mockWsClient.EXPECT().Serve(gomock.Any()).Do(func(interface{}) {
-			cancel()
-		}).Return(inactiveInstanceError),
-	)
 	acsSession := session{
 		containerInstanceARN: testconst.ContainerInstanceARN,
 		ecsClient:            ecsClient,
@@ -728,6 +758,17 @@ func TestSessionStopsWhenContextIsCanceled(t *testing.T) {
 		backoff: retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax,
 			connectionBackoffJitter, connectionBackoffMultiplier),
 	}
+
+	// Last disconnected time should only be set upon reconnection (i.e., not for initial connection).
+	gomock.InOrder(
+		mockWsClient.EXPECT().Serve(gomock.Any()).Do(func(interface{}) {
+			assert.True(t, acsSession.GetLastDisconnectedTime().IsZero())
+		}).Return(io.EOF),
+		mockWsClient.EXPECT().Serve(gomock.Any()).Do(func(interface{}) {
+			assert.False(t, acsSession.GetLastDisconnectedTime().IsZero())
+			cancel()
+		}).Return(inactiveInstanceError),
+	)
 
 	err := acsSession.Start(ctx)
 	assert.Equal(t, context.Canceled, err)
@@ -749,6 +790,11 @@ func TestSessionStopsWhenContextIsErrorDueToTimeout(t *testing.T) {
 	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+
+	mockACSDisconnectedDurationEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSDisconnectedDuration").Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
@@ -802,6 +848,11 @@ func TestSessionReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+
+	mockACSDisconnectedDurationEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSDisconnectedDuration").Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -876,6 +927,11 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+
+	mockACSDisconnectedDurationEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSDisconnectedDuration").Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
@@ -1135,6 +1191,11 @@ func TestSessionCorrectlySetsSendCredentials(t *testing.T) {
 	mockMetricsFactory.EXPECT().New("ACSSession.ACSConnectDuration").Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSConnectDurationEndpointEntry).AnyTimes()
 	mockACSConnectDurationEndpointEntry.EXPECT().Done(gomock.Any()).AnyTimes()
+
+	mockACSDisconnectedDurationEntry := mock_metrics.NewMockEntry(ctrl)
+	mockMetricsFactory.EXPECT().New("ACSSession.ACSDisconnectedDuration").Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().WithGauge(gomock.Any()).Return(mockACSDisconnectedDurationEntry).AnyTimes()
+	mockACSDisconnectedDurationEntry.EXPECT().Done(gomock.Any()).AnyTimes()
 
 	const numInvocations = 10
 	ecsClient := mock_ecs.NewMockECSClient(ctrl)

--- a/ecs-agent/metrics/constants.go
+++ b/ecs-agent/metrics/constants.go
@@ -55,9 +55,10 @@ const (
 	TCSDisconnectTimeoutMetricName = agentAvailabilityNamespace + ".TCSDisconnectTimeout"
 
 	// ACS Session Metrics
-	acsSessionNamespace        = "ACSSession"
-	ACSSessionFailureCallName  = acsSessionNamespace + ".ACSConnectFailure"
-	ACSSessionCallDurationName = acsSessionNamespace + ".ACSConnectDuration"
+	acsSessionNamespace         = "ACSSession"
+	ACSSessionFailureCallName   = acsSessionNamespace + ".ACSConnectFailure"
+	ACSSessionCallDurationName  = acsSessionNamespace + ".ACSConnectDuration"
+	ACSDisconnectedDurationName = acsSessionNamespace + ".ACSDisconnectedDuration"
 
 	// TACS Connection Metrics
 	tacsConnectionNamespace  = "TACSConnection"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Track time ECS Agent last disconnected from ACS and emit as a metric upon reconnecting to ACS which measures how long ECS Agent spent disconnected before reconnecting to ACS.

### Implementation details
<!-- How are the changes implemented? -->
- Add `lastDisconnectedTime` field to `session` struct. It gets set to `time.Now()` whenever a disconnection from ACS occurs
- Define new `ACSSession.ACSDisconnectedDuration` metric and emit whenever ECS Agent reconnects to ACS. The metric captures how long the ECS Agent is disconnected for until it reestablishes a WebSocket connection with ACS 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes (existing tests updated)

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
