### PR TITLE
Emit duration metrics for TACS connect/disconnect

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
@@ -61,9 +61,11 @@ const (
 	ACSDisconnectedDurationName = acsSessionNamespace + ".ACSDisconnectedDuration"
 
 	// TACS Connection Metrics
-	tacsConnectionNamespace  = "TACSConnection"
-	TACSConnectionFailure    = tacsConnectionNamespace + ".Failure"
-	TACSPublishMetricFailure = tacsConnectionNamespace + ".PublishMetricFailure"
+	tacsConnectionNamespace      = "TACSConnection"
+	TACSConnectionFailure        = tacsConnectionNamespace + ".Failure"
+	TACSPublishMetricFailure     = tacsConnectionNamespace + ".PublishMetricFailure"
+	TACSSessionCallDurationName  = tacsConnectionNamespace + ".ConnectDuration"
+	TACSDisconnectedDurationName = tacsConnectionNamespace + ".DisconnectedDuration"
 
 	// ECS Client Metrics
 	ecsClientNamespace               = "ECSClient"

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
@@ -75,6 +75,7 @@ type telemetrySession struct {
 	instanceStatusChannel         <-chan ecstcs.InstanceStatusMessage
 	doctor                        *doctor.Doctor
 	ecsClient                     TcsEcsClient
+	lastDisconnectedTime          time.Time
 }
 
 func NewTelemetrySession(
@@ -118,6 +119,7 @@ func NewTelemetrySession(
 		metricsFactory:                metricsFactory,
 		doctor:                        doctor,
 		ecsClient:                     ecsClient,
+		lastDisconnectedTime:          time.Time{},
 	}
 }
 
@@ -132,6 +134,7 @@ func (session *telemetrySession) Start(ctx context.Context) error {
 		default:
 		}
 		tcsError := session.StartTelemetrySession(ctx)
+		session.lastDisconnectedTime = time.Now()
 		switch tcsError {
 		case context.Canceled, context.DeadlineExceeded:
 			return tcsError
@@ -175,6 +178,7 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context) erro
 		defer session.deregisterInstanceEventStream.Unsubscribe(deregisterContainerInstanceHandler)
 	}
 
+	tacsConnectionStartTime := time.Now()
 	disconnectTimer, err := client.Connect(metrics.TCSDisconnectTimeoutMetricName,
 		session.disconnectTimeout,
 		session.disconnectJitterMax)
@@ -183,6 +187,12 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context) erro
 			field.Error: err,
 		})
 		return err
+	}
+	session.metricsFactory.New(metrics.TACSSessionCallDurationName).WithGauge(time.Since(tacsConnectionStartTime).
+		Milliseconds()).Done(nil)
+	if !session.GetLastDisconnectedTime().IsZero() {
+		session.metricsFactory.New(metrics.TACSDisconnectedDurationName).WithGauge(time.Since(
+			session.GetLastDisconnectedTime()).Milliseconds()).Done(nil)
 	}
 	defer disconnectTimer.Stop()
 	logger.Info("Connected to TCS endpoint")
@@ -211,6 +221,11 @@ func (session *telemetrySession) getTelemetryEndpoint() (string, error) {
 		return "", err
 	}
 	return tcsEndpoint, nil
+}
+
+// GetLastDisconnectedTime returns the timestamp that the last time Agent was disconnected from TACS.
+func (session *telemetrySession) GetLastDisconnectedTime() time.Time {
+	return session.lastDisconnectedTime
 }
 
 // heartbeatHandler resets the heartbeat timer when HeartbeatMessage message is received from tcs.

--- a/ecs-agent/metrics/constants.go
+++ b/ecs-agent/metrics/constants.go
@@ -61,9 +61,11 @@ const (
 	ACSDisconnectedDurationName = acsSessionNamespace + ".ACSDisconnectedDuration"
 
 	// TACS Connection Metrics
-	tacsConnectionNamespace  = "TACSConnection"
-	TACSConnectionFailure    = tacsConnectionNamespace + ".Failure"
-	TACSPublishMetricFailure = tacsConnectionNamespace + ".PublishMetricFailure"
+	tacsConnectionNamespace      = "TACSConnection"
+	TACSConnectionFailure        = tacsConnectionNamespace + ".Failure"
+	TACSPublishMetricFailure     = tacsConnectionNamespace + ".PublishMetricFailure"
+	TACSSessionCallDurationName  = tacsConnectionNamespace + ".ConnectDuration"
+	TACSDisconnectedDurationName = tacsConnectionNamespace + ".DisconnectedDuration"
 
 	// ECS Client Metrics
 	ecsClientNamespace               = "ECSClient"

--- a/ecs-agent/tcs/handler/handler.go
+++ b/ecs-agent/tcs/handler/handler.go
@@ -75,6 +75,7 @@ type telemetrySession struct {
 	instanceStatusChannel         <-chan ecstcs.InstanceStatusMessage
 	doctor                        *doctor.Doctor
 	ecsClient                     TcsEcsClient
+	lastDisconnectedTime          time.Time
 }
 
 func NewTelemetrySession(
@@ -118,6 +119,7 @@ func NewTelemetrySession(
 		metricsFactory:                metricsFactory,
 		doctor:                        doctor,
 		ecsClient:                     ecsClient,
+		lastDisconnectedTime:          time.Time{},
 	}
 }
 
@@ -132,6 +134,7 @@ func (session *telemetrySession) Start(ctx context.Context) error {
 		default:
 		}
 		tcsError := session.StartTelemetrySession(ctx)
+		session.lastDisconnectedTime = time.Now()
 		switch tcsError {
 		case context.Canceled, context.DeadlineExceeded:
 			return tcsError
@@ -175,6 +178,7 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context) erro
 		defer session.deregisterInstanceEventStream.Unsubscribe(deregisterContainerInstanceHandler)
 	}
 
+	tacsConnectionStartTime := time.Now()
 	disconnectTimer, err := client.Connect(metrics.TCSDisconnectTimeoutMetricName,
 		session.disconnectTimeout,
 		session.disconnectJitterMax)
@@ -183,6 +187,12 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context) erro
 			field.Error: err,
 		})
 		return err
+	}
+	session.metricsFactory.New(metrics.TACSSessionCallDurationName).WithGauge(time.Since(tacsConnectionStartTime).
+		Milliseconds()).Done(nil)
+	if !session.GetLastDisconnectedTime().IsZero() {
+		session.metricsFactory.New(metrics.TACSDisconnectedDurationName).WithGauge(time.Since(
+			session.GetLastDisconnectedTime()).Milliseconds()).Done(nil)
 	}
 	defer disconnectTimer.Stop()
 	logger.Info("Connected to TCS endpoint")
@@ -211,6 +221,11 @@ func (session *telemetrySession) getTelemetryEndpoint() (string, error) {
 		return "", err
 	}
 	return tcsEndpoint, nil
+}
+
+// GetLastDisconnectedTime returns the timestamp that the last time Agent was disconnected from TACS.
+func (session *telemetrySession) GetLastDisconnectedTime() time.Time {
+	return session.lastDisconnectedTime
 }
 
 // heartbeatHandler resets the heartbeat timer when HeartbeatMessage message is received from tcs.

--- a/ecs-agent/tcs/handler/handler_test.go
+++ b/ecs-agent/tcs/handler/handler_test.go
@@ -387,6 +387,90 @@ func TestConnectionInactiveTimeout(t *testing.T) {
 	closeSocket(closeWS)
 }
 
+// TestTACSDurationMetrics tests that the TACSSessionCallDurationName and TACSDisconnectedDuration and metrics are
+// emitted when they should be.
+func TestTACSDurationMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	numTimesConnectToTACS := 2
+	mockMetricsFactory := mock_metrics.NewMockEntryFactory(ctrl)
+
+	// TACSSessionCallDuration is emitted on all connections to TACS.
+	mockDurationEntry := mock_metrics.NewMockEntry(ctrl)
+	mockDurationEntry.EXPECT().WithGauge(gomock.Any()).Return(mockDurationEntry).Times(numTimesConnectToTACS)
+	mockDurationEntry.EXPECT().Done(gomock.Any()).Times(numTimesConnectToTACS)
+	mockMetricsFactory.EXPECT().New(metrics.TACSSessionCallDurationName).Return(mockDurationEntry).
+		Times(numTimesConnectToTACS)
+
+	// TACSDisconnectedDuration should be emitted upon reconnection to TACS only (i.e., all connections to TACS except
+	// the very first one).
+	mockDisconnectedEntry := mock_metrics.NewMockEntry(ctrl)
+	mockDisconnectedEntry.EXPECT().WithGauge(gomock.Any()).Return(mockDisconnectedEntry).Times(numTimesConnectToTACS - 1)
+	mockDisconnectedEntry.EXPECT().Done(gomock.Any()).Times(numTimesConnectToTACS - 1)
+	mockMetricsFactory.EXPECT().New(metrics.TACSDisconnectedDurationName).Return(mockDisconnectedEntry).
+		Times(numTimesConnectToTACS - 1)
+
+	// Start test server.
+	closeWS := make(chan []byte)
+	server, _, requestChan, _, err := wsmock.GetMockServer(closeWS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	go func() {
+		for {
+			select {
+			case <-requestChan:
+			}
+		}
+	}()
+
+	testecsclient := &wsmock.TestECSClient{
+		TCSurl: server.URL,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	deregisterInstanceEventStream := eventstream.NewEventStream("Deregister_Instance", ctx)
+	deregisterInstanceEventStream.StartListening()
+
+	telemetryMessages := make(chan ecstcs.TelemetryMessage, testTelemetryChannelDefaultBufferSize)
+	healthMessages := make(chan ecstcs.HealthMessage, testTelemetryChannelDefaultBufferSize)
+	instanceStatusMessages := make(chan ecstcs.InstanceStatusMessage, testTelemetryChannelDefaultBufferSize)
+
+	tacsSession := telemetrySession{
+		containerInstanceArn:          testInstanceArn,
+		cluster:                       testClusterArn,
+		agentVersion:                  testAgentVersion,
+		agentHash:                     testAgentHash,
+		containerRuntimeVersion:       testContainerRuntimeVersion,
+		disableMetrics:                false,
+		credentialsCache:              aws.NewCredentialsCache(testCreds),
+		cfg:                           testCfg,
+		deregisterInstanceEventStream: deregisterInstanceEventStream,
+		heartbeatTimeout:              50 * time.Millisecond, // use smaller value than testHeartbeatTimeout
+		heartbeatJitterMax:            10 * time.Millisecond, // use smaller value than testHeartbeatJitter
+		disconnectTimeout:             testDisconnectionTimeout,
+		disconnectJitterMax:           testDisconnectionJitter,
+		metricsFactory:                mockMetricsFactory, // use the mock metrics factory
+		metricsChannel:                telemetryMessages,
+		healthChannel:                 healthMessages,
+		instanceStatusChannel:         instanceStatusMessages,
+		doctor:                        emptyDoctor,
+		ecsClient:                     testecsclient,
+		lastDisconnectedTime:          time.Time{},
+	}
+
+	for i := 0; i < numTimesConnectToTACS; i++ {
+		tacsSession.StartTelemetrySession(ctx)
+		tacsSession.lastDisconnectedTime = time.Now()
+	}
+}
+
 // TestTACSConnectionFailureMetric tests that the TACSConnectionFailure metric is recorded when there's a connection error
 func TestTACSConnectionFailureMetric(t *testing.T) {
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Emit connection/disconnected duration metrics for TACS which are already implemented and tracked for ACS. These metrics capture:
- how long ECS Agent takes to connect to TACS
- how long ECS Agent spent disconnected before reconnecting to TACS

### Implementation details
<!-- How are the changes implemented? -->
Define new metrics `metrics.TACSSessionCallDurationName`and `metrics.TACSDisconnectedDurationName` and have them mirror the behavior of what is done in [`ecs-agent/acs/session/session.go`](https://github.com/aws/amazon-ecs-agent/blob/dev/ecs-agent/acs/session/session.go) for `metrics.ACSSessionCallDurationName` and `metrics.ACSDisconnectedDurationName`.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.