### PR TITLE
Fix 'occured' -> 'occurred' typos in utils_windows error messages

### DIFF
--- a/agent/eni/networkutils/utils_windows.go
+++ b/agent/eni/networkutils/utils_windows.go
@@ -174,7 +174,7 @@ func (utils *networkUtils) ConvertInterfaceAliasToLUID(interfaceAlias string) (u
 	// https://learn.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-convertinterfacealiastoluid
 	retVal, _, _ := utils.funcConvertInterfaceAliasToLuid(uintptr(unsafe.Pointer(alias)), uintptr(unsafe.Pointer(&luid)))
 	if retVal != 0 {
-		return 0, errors.Errorf("error occured while calling ConvertInterfaceAliasToLuid: %s", syscall.Errno(retVal))
+		return 0, errors.Errorf("error occurred while calling ConvertInterfaceAliasToLuid: %s", syscall.Errno(retVal))
 	}
 
 	return luid, nil
@@ -191,7 +191,7 @@ func (utils *networkUtils) GetMIBIfEntryFromLUID(ifaceLUID uint64) (*MibIfRow2, 
 	// https://learn.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-getifentry2ex
 	retVal, _, _ := utils.funcGetIfEntry2Ex(uintptr(0), uintptr(unsafe.Pointer(row)))
 	if retVal != 0 {
-		return nil, errors.Errorf("error occured while calling GetIfEntry2Ex: %s", syscall.Errno(retVal))
+		return nil, errors.Errorf("error occurred while calling GetIfEntry2Ex: %s", syscall.Errno(retVal))
 	}
 
 	return row, nil


### PR DESCRIPTION
Two `errors.Errorf` strings in `agent/eni/networkutils/utils_windows.go` (lines 177 and 194) read `error occured while calling ConvertInterfaceAliasToLuid` and `error occured while calling GetIfEntry2Ex`. Both surface as wrapped errors during Windows ENI bring-up failures, so the spelling reaches operators in agent logs. String-literal-only change.