### PR TITLE
Use env variable to read user input when mounting FSx volumes

### DIFF
--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows.go
@@ -19,6 +19,7 @@ package fsxwindowsfileserver
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -46,7 +47,7 @@ import (
 )
 
 const (
-	psCredentialCommandFormat = "$(New-Object System.Management.Automation.PSCredential('%s', $(ConvertTo-SecureString '%s' -AsPlainText -Force)))"
+	psCredentialCommandFormat = "$(New-Object System.Management.Automation.PSCredential($Env:fsxUsername, $(ConvertTo-SecureString $Env:fsxPassword -AsPlainText -Force)))"
 	resourceProvisioningError = "VolumeError: Agent could not create task's volume resources"
 	fsxVolumeType             = "fsx"
 )
@@ -589,13 +590,9 @@ func (fv *FSxWindowsFileServerResource) performHostMount(remotePath string, user
 		}
 	}
 
-	// formatting to keep powershell happy
-	// Replace ' with '' so that Powershell would convert it back to '.
-	password = strings.ReplaceAll(password, "'", "''")
-	credsCommand := fmt.Sprintf(psCredentialCommandFormat, username, password)
-	credsArg := fmt.Sprintf("-Credential %s", credsCommand)
+	credsArg := fmt.Sprintf("-Credential %s", psCredentialCommandFormat)
 
-	remotePathArg := fmt.Sprintf("-RemotePath '%s'", remotePath)
+	remotePathArg := "-RemotePath $Env:fsxRemotePath"
 
 	// New-SmbGlobalMapping cmdlet creates an SMB mapping between the container instance
 	// and SMB share (FSx for Windows File Server file-system)
@@ -612,6 +609,9 @@ func (fv *FSxWindowsFileServerResource) performHostMount(remotePath string, user
 	seelog.Debugf("Executing mapping of fsxwindowsfileserver with cmd: %v %v", strings.Join(args[:3], " "), strings.Join(args[4:], " "))
 
 	cmd := execCommand("powershell.exe", args...)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("fsxUsername=%s", username))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("fsxPassword=%s", password))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("fsxRemotePath=%s", remotePath))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		safeOutput := strings.ReplaceAll(string(out), password, "<pass>")

--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows_test.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -782,12 +783,50 @@ func TestSpecialCharactersInPasswordPSCommand(t *testing.T) {
 	username := "Administrator"
 	password := "AWS@`~!@#$var%^&*()/1asd"
 
-	credsCommand := fmt.Sprintf(psCredentialCommandFormat, username, password)
-
 	// Perform actual exec to determine if the credentials are generated.
 	// Go tests are platform specific and therefore, this would work.
-	cmd := exec.Command("powershell.exe", credsCommand)
+	cmd := exec.Command("pwsh.exe", "-Command", psCredentialCommandFormat)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("fsxUsername=%s", username))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("fsxPassword=%s", password))
 	_, err := cmd.CombinedOutput()
 
+	assert.NoError(t, err)
+}
+
+func TestCommandChainingInPSCommand(t *testing.T) {
+	username := "Administrator'); echo hello; ('"
+	password := "AWS@`~!@#$var%^&*()/1asd"
+
+	// Perform actual exec to determine if the credentials are generated with multiple commands.
+	// Go tests are platform specific and therefore, this would work.
+	cmd := exec.Command("pwsh.exe", "-Command", psCredentialCommandFormat)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("fsxUsername=%s", username))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("fsxPassword=%s", password))
+
+	out, err := cmd.CombinedOutput()
+
+	assert.Contains(t, string(out), "echo")
+	assert.NoError(t, err)
+}
+
+func TestSpecialPasswordInPSCommand(t *testing.T) {
+	password := "AWS@`~!@#$var%^&*()/1asd"
+
+	tempPsCredentialCommandUsingEnv := "$Env:fsxPassword"
+	// Wrap password in single quotes to prevent PowerShell from interpreting special characters.
+	// Escape any single quotes within the password by doubling them.
+	escapedPassword := strings.ReplaceAll(password, "'", "''")
+	tempPsCredentialCommandUsingValue := fmt.Sprintf("'%s'", escapedPassword)
+
+	cmd := exec.Command("pwsh.exe", "-Command", tempPsCredentialCommandUsingEnv)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("fsxPassword=%s", password))
+
+	outEnv, err := cmd.CombinedOutput()
+	assert.NoError(t, err)
+
+	cmd = exec.Command("pwsh.exe", "-Command", tempPsCredentialCommandUsingValue)
+	outValue, err := cmd.CombinedOutput()
+
+	assert.Equal(t, string(outEnv), string(outValue))
 	assert.NoError(t, err)
 }


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This change uses env variable to read user input when mounting FSx volumes. This removes the custom logic for allowing special characters in password.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

1. Tested the change if FSx still works on all 2019, 2022, 2025 - PASS 
2. Tested using special characters in password, this work as expected i.e. special password was still allowed.
3. I have added 2 new unit tests for above use-cases. They are green.

New tests cover the changes: <!-- yes|no --> yes

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

This is a bug fix.

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
