### PR TITLE
Add shared library packages for IMDS-based task credential retrieval

### DIFF
--- a/ecs-agent/capability/capability.go
+++ b/ecs-agent/capability/capability.go
@@ -1,0 +1,20 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package capability provides ECS agent capability definitions shared across agents.
+package capability
+
+const (
+	// IMDSIAMRoles indicates that the agent supports retrieving task credentials via IMDS.
+	IMDSIAMRoles = "ecs.capability.imds-iam-roles"
+)

--- a/ecs-agent/credentials/imds/scanner.go
+++ b/ecs-agent/credentials/imds/scanner.go
@@ -1,0 +1,48 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package imds provides an IMDS credential scanner that retrieves task
+// credentials from IMDS.
+package imds
+
+import (
+	"context"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
+)
+
+// Scanner fetches task credentials from IMDS iam-ecs-* namespaces.
+type Scanner interface {
+	// Scan discovers iam-ecs-* namespaces, reads their info files, and fetches
+	// credentials only for task IDs present in the provided set. Credentials
+	// for unknown task IDs are ignored.
+	Scan(ctx context.Context, taskIDs map[string]bool) ([]TaskCredential, error)
+}
+
+// scanner implements the Scanner interface.
+type scanner struct {
+	ec2Client ec2.EC2MetadataClient
+}
+
+// NewScanner creates a new IMDS credential scanner.
+func NewScanner(ec2Client ec2.EC2MetadataClient) Scanner {
+	return &scanner{
+		ec2Client: ec2Client,
+	}
+}
+
+// Scan is a stub to satisfy the Scanner interface.
+// TODO: implementation
+func (s *scanner) Scan(ctx context.Context, taskIDs map[string]bool) ([]TaskCredential, error) {
+	return nil, nil
+}

--- a/ecs-agent/credentials/imds/types.go
+++ b/ecs-agent/credentials/imds/types.go
@@ -1,0 +1,35 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package imds
+
+// NamespaceInfo represents the parsed info file from an iam-ecs-* namespace.
+type NamespaceInfo struct {
+	LastUpdated     string                        `json:"LastUpdated"`
+	TaskCredentials map[string]TaskCredentialInfo `json:"TaskCredentials"`
+}
+
+// TaskCredentialInfo represents a single entry in the namespace info file.
+type TaskCredentialInfo struct {
+	RoleARN string `json:"RoleARN"`
+}
+
+// TaskCredential represents a task credential retrieved from IMDS.
+type TaskCredential struct {
+	TaskID          string
+	RoleARN         string
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+	Expiration      string
+}


### PR DESCRIPTION
### Summary

Add shared library packages for IMDS-based task credential retrieval.

### Implementation details

Two new packages in the ecs-agent/ shared library:

- **ecs-agent/capability/**: A new package for shared capability definitions across agents. Starts with the IMDSIAMRoles capability constant (ecs.capability.imds-iam-roles), which agents advertise to indicate support for retrieving task credentials via IMDS.

- **ecs-agent/credentials/imds/**: Scanner interface and types for retrieving task credentials from IMDS iam-ecs-* namespaces. The Scanner interface defines a Scan method that takes a set of running task IDs and returns credentials only for those tasks. The implementation is stubbed — full scanning logic will be added in a follow-up PR. Types include NamespaceInfo and TaskCredentialInfo for parsing IMDS namespace info files, and TaskCredential as the scanner's return type.

### Testing

go build ./capability/ ./credentials/imds/ passes. No tests yet — will be added alongside the scanner implementation.

New tests cover the changes: no

### Description for the changelog

Feature - Add IMDS credential scanner interface and capability constant for IMDS-based task credential retrieval

### Additional Information

Does this PR include breaking model changes? If so, Have you added transformation functions?
No.

Does this PR include the addition of new environment variables in the README?
No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.