### PR TITLE
Add config/capability for IMDS-based task credential retrieval

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	dm "github.com/aws/amazon-ecs-agent/agent/engine/daemonmanager"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/capability"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	md "github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon"
@@ -345,6 +346,9 @@ func (agent *ecsAgent) capabilities() ([]types.Attribute, error) {
 
 	// IPv6-only cap
 	capabilities = appendIPv6OnlyCapability(capabilities)
+
+	// IMDS IAM roles cap
+	capabilities = agent.appendIMDSIAMRolesCapability(capabilities)
 
 	return capabilities, nil
 }
@@ -676,4 +680,12 @@ func removeAttributesByNames(attributes []types.Attribute, names []string) []typ
 		}
 	}
 	return ret
+}
+
+// appendIMDSIAMRolesCapability appends the IMDS IAM roles capability if the associated config is enabled and supported on this instance.
+func (agent *ecsAgent) appendIMDSIAMRolesCapability(capabilities []types.Attribute) []types.Attribute {
+	if !agent.cfg.IMDSIAMRolesEnabled {
+		return capabilities
+	}
+	return appendNameOnlyAttribute(capabilities, capability.IMDSIAMRoles)
 }

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -1668,3 +1668,40 @@ func TestAppendFaultInjectionCapabilities(t *testing.T) {
 		assert.Empty(t, capabilities)
 	})
 }
+
+func TestAppendIMDSIAMRolesCapability(t *testing.T) {
+	tests := []struct {
+		name     string
+		enabled  bool
+		expected bool
+	}{
+		{
+			name:     "disabled",
+			enabled:  false,
+			expected: false,
+		},
+		{
+			name:     "enabled",
+			enabled:  true,
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := &ecsAgent{
+				cfg: &config.Config{
+					IMDSIAMRolesEnabled: tc.enabled,
+				},
+			}
+			capabilities := agent.appendIMDSIAMRolesCapability([]types.Attribute{})
+			if tc.expected {
+				assert.Contains(t, capabilities, types.Attribute{
+					Name: aws.String("ecs.capability.imds-iam-roles"),
+				})
+			} else {
+				assert.Empty(t, capabilities)
+			}
+		})
+	}
+}

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -674,3 +674,26 @@ func IsFIPSEnabled() bool {
 func SetFIPSEnabled(enabled bool) {
 	isFIPSEnabled = enabled
 }
+
+// determineIMDSIAMRolesConfig determines whether the agent should use IMDS for task credential retrieval.
+//
+//lint:ignore U1000 will be used when the feature is enabled
+func (cfg *Config) determineIMDSIAMRolesConfig(imdsAvailable, previouslyEnabled, hasNonTerminalTasks bool) {
+	defer func() {
+		seelog.Debugf("IMDS IAM roles config resolved: enabled=%t", cfg.IMDSIAMRolesEnabled)
+	}()
+
+	// 1. Do not enable the config option if IMDS is not available on the instance.
+	if !imdsAvailable {
+		return
+	}
+
+	// 2. Do not enable the config option if this agent has been upgraded in-place
+	// with running tasks on the instance, to avoid disruption.
+	if hasNonTerminalTasks && !previouslyEnabled {
+		return
+	}
+
+	// Enable the config option
+	cfg.IMDSIAMRolesEnabled = true
+}

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -1033,3 +1033,55 @@ func setTestEnv(k, v string) func() {
 		os.Unsetenv(k)
 	}
 }
+
+func TestDetermineIMDSIAMRolesConfig(t *testing.T) {
+	tests := []struct {
+		name                string
+		imdsAvailable       bool
+		previouslyEnabled   bool
+		hasNonTerminalTasks bool
+		expectedEnabled     bool
+	}{
+		{
+			name:            "IMDS not available",
+			imdsAvailable:   false,
+			expectedEnabled: false,
+		},
+		{
+			name:                "fresh instance, no tasks",
+			imdsAvailable:       true,
+			previouslyEnabled:   false,
+			hasNonTerminalTasks: false,
+			expectedEnabled:     true,
+		},
+		{
+			name:                "previously enabled, tasks running (restart)",
+			imdsAvailable:       true,
+			previouslyEnabled:   true,
+			hasNonTerminalTasks: true,
+			expectedEnabled:     true,
+		},
+		{
+			name:                "not previously enabled, tasks running (in-place upgrade)",
+			imdsAvailable:       true,
+			previouslyEnabled:   false,
+			hasNonTerminalTasks: true,
+			expectedEnabled:     false,
+		},
+		{
+			name:                "previously enabled, no tasks",
+			imdsAvailable:       true,
+			previouslyEnabled:   true,
+			hasNonTerminalTasks: false,
+			expectedEnabled:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{}
+			cfg.determineIMDSIAMRolesConfig(tc.imdsAvailable, tc.previouslyEnabled, tc.hasNonTerminalTasks)
+			assert.Equal(t, tc.expectedEnabled, cfg.IMDSIAMRolesEnabled)
+		})
+	}
+}

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -402,4 +402,7 @@ type Config struct {
 
 	// IP version compatibility for the container instance's default network
 	InstanceIPCompatibility ipcompatibility.IPCompatibility
+
+	// IMDSIAMRolesEnabled controls whether the agent uses IMDS for task credential retrieval.
+	IMDSIAMRolesEnabled bool
 }

--- a/agent/data/client.go
+++ b/agent/data/client.go
@@ -107,6 +107,9 @@ type Client interface {
 	// GetMetadata gets the value of a certain kind of metadata.
 	GetMetadata(string) (string, error)
 
+	// HasNonTerminalTasks returns true if there are any pending or running tasks in the database.
+	HasNonTerminalTasks() bool
+
 	// Close closes the connection to database.
 	Close() error
 }

--- a/agent/data/container_client_test.go
+++ b/agent/data/container_client_test.go
@@ -42,7 +42,7 @@ func TestManageContainers(t *testing.T) {
 		DockerName: testDockerName,
 		Container: &apicontainer.Container{
 			Name:          testContainerName,
-			TaskARNUnsafe: testTaskArn,
+			TaskARNUnsafe: testTaskArn1,
 		},
 	}
 	require.NoError(t, testClient.SaveDockerContainer(testDockerContainer))
@@ -58,7 +58,7 @@ func TestManageContainers(t *testing.T) {
 	// Test saving a container with SaveContainer.
 	testContainer := &apicontainer.Container{
 		Name:          testContainerName2,
-		TaskARNUnsafe: testTaskArn,
+		TaskARNUnsafe: testTaskArn1,
 	}
 	require.NoError(t, testClient.SaveContainer(testContainer))
 	res, err = testClient.GetContainers()
@@ -90,7 +90,7 @@ func TestSaveContainerInvalidID(t *testing.T) {
 
 func TestGetContainerID(t *testing.T) {
 	c := &apicontainer.Container{
-		TaskARNUnsafe: testTaskArn,
+		TaskARNUnsafe: testTaskArn1,
 		Name:          testContainerName,
 	}
 	id, err := GetContainerID(c)

--- a/agent/data/metadata_client.go
+++ b/agent/data/metadata_client.go
@@ -24,6 +24,14 @@ const (
 	ContainerInstanceARNKey = "container-instance-arn"
 	EC2InstanceIDKey        = "ec2-instance-id"
 	TaskManifestSeqNumKey   = "task-manifest-seq-num"
+
+	// IMDSIAMRolesKey tracks whether this instance had previously enabled support
+	// for IMDS-based task credential retrieval.
+	//
+	// This helps distinguish a restart from an in-place agent upgrade where
+	// running tasks were launched without IMDS IAM roles support,
+	// ensuring in-place agent upgrade doesn't disrupt credential delivery.
+	IMDSIAMRolesKey = "imds-iam-roles"
 )
 
 func (c *client) SaveMetadata(key, val string) error {

--- a/agent/data/noop_client.go
+++ b/agent/data/noop_client.go
@@ -101,6 +101,10 @@ func (c *noopClient) GetMetadata(string) (string, error) {
 	return "", nil
 }
 
+func (c *noopClient) HasNonTerminalTasks() bool {
+	return false
+}
+
 func (c *noopClient) Close() error {
 	return nil
 }

--- a/agent/data/task_client.go
+++ b/agent/data/task_client.go
@@ -73,3 +73,18 @@ func (c *client) GetTasks() ([]*apitask.Task, error) {
 	})
 	return tasks, err
 }
+
+// HasNonTerminalTasks returns true if there are any pending or running tasks in the database.
+func (c *client) HasNonTerminalTasks() bool {
+	tasks, err := c.GetTasks()
+	if err != nil {
+		logger.Warn("Failed to get tasks from DB for running tasks check", logger.Fields{"error": err})
+		return false
+	}
+	for _, task := range tasks {
+		if !task.GetKnownStatus().Terminal() {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/data/task_client_test.go
+++ b/agent/data/task_client_test.go
@@ -20,20 +20,22 @@ import (
 	"testing"
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 const (
-	testTaskArn = "arn:aws:ecs:us-west-2:1234567890:task/test-cluster/abc"
+	testTaskArn1 = "arn:aws:ecs:us-west-2:1234567890:task/test-cluster/abc"
+	testTaskArn2 = "arn:aws:ecs:us-west-2:1234567890:task/test-cluster/def"
 )
 
 func TestManageTask(t *testing.T) {
 	testClient := newTestClient(t)
 
 	testTask := &apitask.Task{
-		Arn: testTaskArn,
+		Arn: testTaskArn1,
 	}
 
 	require.NoError(t, testClient.SaveTask(testTask))
@@ -54,4 +56,57 @@ func TestSaveTaskInvalidID(t *testing.T) {
 		Arn: "invalid-arn",
 	}
 	assert.Error(t, testClient.SaveTask(testTask))
+}
+
+func TestHasNonTerminalTasks(t *testing.T) {
+	tests := []struct {
+		name     string
+		tasks    []*apitask.Task
+		expected bool
+	}{
+		{
+			name:     "no tasks",
+			tasks:    nil,
+			expected: false,
+		},
+		{
+			name: "all stopped",
+			tasks: func() []*apitask.Task {
+				task := &apitask.Task{Arn: testTaskArn1}
+				task.SetKnownStatus(apitaskstatus.TaskStopped)
+				return []*apitask.Task{task}
+			}(),
+			expected: false,
+		},
+		{
+			name: "one running",
+			tasks: func() []*apitask.Task {
+				task := &apitask.Task{Arn: testTaskArn1}
+				task.SetKnownStatus(apitaskstatus.TaskRunning)
+				return []*apitask.Task{task}
+			}(),
+			expected: true,
+		},
+		{
+			name: "mixed stopped and running",
+			tasks: func() []*apitask.Task {
+				stopped := &apitask.Task{Arn: testTaskArn1}
+				stopped.SetKnownStatus(apitaskstatus.TaskStopped)
+				running := &apitask.Task{Arn: testTaskArn2}
+				running.SetKnownStatus(apitaskstatus.TaskRunning)
+				return []*apitask.Task{stopped, running}
+			}(),
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			testClient := newTestClient(t)
+			for _, task := range tc.tasks {
+				require.NoError(t, testClient.SaveTask(task))
+			}
+			assert.Equal(t, tc.expected, testClient.HasNonTerminalTasks())
+		})
+	}
 }

--- a/agent/utils/ec2metadata/imds.go
+++ b/agent/utils/ec2metadata/imds.go
@@ -1,0 +1,25 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ec2metadata
+
+import "github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
+
+// IsIMDSAvailable checks whether IMDS is reachable on the instance.
+// AWS SDK v2 does not provide an equivalent of the v1 Available() method.
+// This follows the same approach as v1: querying instance-id via GetMetadata.
+// Ref: https://github.com/aws/aws-sdk-go/blob/070853e88d22854d2355c2543d0958a5f76ad407/aws/ec2metadata/api.go#L208
+func IsIMDSAvailable(client ec2.EC2MetadataClient) bool {
+	_, err := client.GetMetadata("instance-id")
+	return err == nil
+}

--- a/agent/utils/ec2metadata/imds_test.go
+++ b/agent/utils/ec2metadata/imds_test.go
@@ -1,0 +1,51 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ec2metadata
+
+import (
+	"errors"
+	"testing"
+
+	mock_ec2 "github.com/aws/amazon-ecs-agent/ecs-agent/ec2/mocks"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsIMDSAvailable(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "available",
+			expected: true,
+		},
+		{
+			name:     "unavailable",
+			err:      errors.New("request timeout"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockClient := mock_ec2.NewMockEC2MetadataClient(ctrl)
+			mockClient.EXPECT().GetMetadata("instance-id").Return("", tc.err)
+			assert.Equal(t, tc.expected, IsIMDSAvailable(mockClient))
+		})
+	}
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/capability/capability.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/capability/capability.go
@@ -1,0 +1,20 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package capability provides ECS agent capability definitions shared across agents.
+package capability
+
+const (
+	// IMDSIAMRoles indicates that the agent supports retrieving task credentials via IMDS.
+	IMDSIAMRoles = "ecs.capability.imds-iam-roles"
+)

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -26,6 +26,7 @@ github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status
 github.com/aws/amazon-ecs-agent/ecs-agent/async
 github.com/aws/amazon-ecs-agent/ecs-agent/async/mocks
 github.com/aws/amazon-ecs-agent/ecs-agent/awsrulesfn
+github.com/aws/amazon-ecs-agent/ecs-agent/capability
 github.com/aws/amazon-ecs-agent/ecs-agent/config
 github.com/aws/amazon-ecs-agent/ecs-agent/credentials
 github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks


### PR DESCRIPTION
### Summary

Add config/capability for IMDS-based task credential retrieval. This also acts as the feature flag, which is **disabled** for now.

### Implementation details

- config: Resolves whether the feature should be enabled based on IMDS availability and instance state. The new helper method to check these conditions isn't invoked in this PR, hence the configuration stays disabled by virtue of Go's default boolean value of false.
- data: Persists enablement across restarts and detects in-place upgrades via running/pending task state. The new key is also not used currently.
- capability: Advertises the capability when the config is enabled.
- utils/ec2metadata: Checks IMDS reachability on the instance.

### Testing

New tests cover the changes: yes, added new unit tests

Manually built this on an ECS instance, and verified that the new config and capability isn't enabled. 

### Description for the changelog

Feature - Add config/capability for IMDS-based task credential retrieval (disabled for now).

### Additional Information

Does this PR include breaking model changes? If so, Have you added transformation functions?
No.

Does this PR include the addition of new environment variables in the README?
No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.