### PR TITLE
Modify agent logs to be less verbose by truncating certain values

### DIFF
--- a/agent/acs/session/payload_responder.go
+++ b/agent/acs/session/payload_responder.go
@@ -30,6 +30,7 @@ import (
 	loggerfield "github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	nlappmesh "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/appmesh"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/pkg/errors"
@@ -159,7 +160,7 @@ func (pmHandler *payloadMessageHandler) addPayloadTasks(payload *ecsacs.PayloadM
 				loggerfield.TaskVersion:   apiTask.Version,
 				loggerfield.RoleARN:       taskIAMRoleCredentials.RoleArn,
 				loggerfield.RoleType:      taskIAMRoleCredentials.RoleType,
-				loggerfield.CredentialsID: taskIAMRoleCredentials.CredentialsID,
+				loggerfield.CredentialsID: utils.TruncateString(taskIAMRoleCredentials.CredentialsID, utils.CredentialsIDLogTruncationLen),
 			})
 			apiTask.SetCredentialsID(taskIAMRoleCredentials.CredentialsID)
 		}
@@ -207,7 +208,7 @@ func (pmHandler *payloadMessageHandler) addPayloadTasks(payload *ecsacs.PayloadM
 				loggerfield.TaskVersion:   apiTask.Version,
 				loggerfield.RoleARN:       taskExecutionIAMRoleCredentials.RoleArn,
 				loggerfield.RoleType:      taskExecutionIAMRoleCredentials.RoleType,
-				loggerfield.CredentialsID: taskExecutionIAMRoleCredentials.CredentialsID,
+				loggerfield.CredentialsID: utils.TruncateString(taskExecutionIAMRoleCredentials.CredentialsID, utils.CredentialsIDLogTruncationLen),
 			})
 			apiTask.SetExecutionRoleCredentialsID(taskExecutionIAMRoleCredentials.CredentialsID)
 		}

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1944,11 +1944,10 @@ func (task *Task) ApplyExecutionRoleLogsAuth(hostConfig *dockercontainer.HostCon
 		hostConfig.LogConfig.Config = map[string]string{}
 	}
 	logger.Info("Applying execution role credentials to container log auth", logger.Fields{
-		field.TaskARN:           executionRoleCredentials.ARN,
-		field.RoleType:          executionRoleCredentials.IAMRoleCredentials.RoleType,
-		field.RoleARN:           executionRoleCredentials.IAMRoleCredentials.RoleArn,
-		field.CredentialsID:     executionRoleCredentials.IAMRoleCredentials.CredentialsID,
-		awslogsCredsEndpointOpt: credentialsEndpointRelativeURI,
+		field.TaskARN:       executionRoleCredentials.ARN,
+		field.RoleType:      executionRoleCredentials.IAMRoleCredentials.RoleType,
+		field.RoleARN:       executionRoleCredentials.IAMRoleCredentials.RoleArn,
+		field.CredentialsID: commonutils.TruncateString(executionRoleCredentials.IAMRoleCredentials.CredentialsID, commonutils.CredentialsIDLogTruncationLen),
 	})
 	hostConfig.LogConfig.Config[awslogsCredsEndpointOpt] = credentialsEndpointRelativeURI
 	return nil

--- a/agent/dockerclient/dockerauth/ecr.go
+++ b/agent/dockerclient/dockerauth/ecr.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -148,7 +149,7 @@ func (authProvider *ecrAuthProvider) getAuthConfigFromECR(image string, key cach
 
 	logger.Debug("Calling ECR.GetAuthorizationToken", logger.Fields{
 		field.Image:         image,
-		field.CredentialsID: key.credentialsID,
+		field.CredentialsID: utils.TruncateString(key.credentialsID, utils.CredentialsIDLogTruncationLen),
 		field.RegistryID:    key.registryID,
 		field.RoleARN:       key.roleARN,
 		"endpointOverride":  key.endpointOverride,

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -55,6 +55,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	commonutils "github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime"
 
@@ -1719,7 +1720,7 @@ func (engine *DockerTaskEngine) setRegistryCredentials(
 				field.TaskID:        task.GetID(),
 				field.Container:     container.Name,
 				field.Image:         container.Image,
-				field.CredentialsID: task.GetExecutionCredentialsID(),
+				field.CredentialsID: commonutils.TruncateString(task.GetExecutionCredentialsID(), commonutils.CredentialsIDLogTruncationLen),
 				field.RoleType:      credentials.ExecutionRoleType,
 			})
 			return nil, dockerapi.CannotPullECRContainerError{
@@ -1734,7 +1735,7 @@ func (engine *DockerTaskEngine) setRegistryCredentials(
 			field.Image:         container.Image,
 			field.RoleType:      iamCredentials.RoleType,
 			field.RoleARN:       iamCredentials.RoleArn,
-			field.CredentialsID: iamCredentials.CredentialsID,
+			field.CredentialsID: commonutils.TruncateString(iamCredentials.CredentialsID, commonutils.CredentialsIDLogTruncationLen),
 		})
 		container.SetRegistryAuthCredentials(iamCredentials)
 		cleanup = func() { container.SetRegistryAuthCredentials(credentials.IAMRoleCredentials{}) }

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -43,6 +43,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime"
 )
@@ -1630,7 +1631,7 @@ func (mtask *managedTask) cleanupTask(taskStoppedDuration time.Duration) {
 	if taskExecutionCredentialsID != "" {
 		logger.Info("Cleaning up task's execution credentials", logger.Fields{
 			field.TaskID:        mtask.GetID(),
-			field.CredentialsID: taskExecutionCredentialsID,
+			field.CredentialsID: utils.TruncateString(taskExecutionCredentialsID, utils.CredentialsIDLogTruncationLen),
 		})
 		mtask.credentialsManager.RemoveCredentials(taskExecutionCredentialsID)
 	}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/payload_responder.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/payload_responder.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/wsclient"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/pkg/errors"
@@ -102,7 +103,7 @@ func (r *payloadResponder) sendAck(ackRequest interface{}) {
 	credentialsAck, ok := ackRequest.(*ecsacs.IAMRoleCredentialsAckRequest)
 	if ok {
 		logger.Debug(fmt.Sprintf("ACKing credentials associated with %s", PayloadMessageName), logger.Fields{
-			field.CredentialsID: aws.ToString(credentialsAck.CredentialsId),
+			field.CredentialsID: utils.TruncateString(aws.ToString(credentialsAck.CredentialsId), utils.CredentialsIDLogTruncationLen),
 			field.MessageID:     aws.ToString(credentialsAck.MessageId),
 		})
 	} else {
@@ -124,7 +125,7 @@ func (r *payloadResponder) sendAck(ackRequest interface{}) {
 		if credentialsAck != nil {
 			logger.Warn(fmt.Sprintf("Error acknowledging credentials associated with %s",
 				PayloadMessageName), logger.Fields{
-				field.CredentialsID: aws.ToString(credentialsAck.CredentialsId),
+				field.CredentialsID: utils.TruncateString(aws.ToString(credentialsAck.CredentialsId), utils.CredentialsIDLogTruncationLen),
 				field.MessageID:     aws.ToString(credentialsAck.MessageId),
 				field.Error:         err,
 			})

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils.go
@@ -166,3 +166,16 @@ func JsonBlockToStringToStringMap(jsonBlock string) (map[string]string, error) {
 	err := json.Unmarshal([]byte(jsonBlock), &out)
 	return out, err
 }
+
+// CredentialsIDLogTruncationLen is the number of characters to retain when
+// logging a credentials ID. The full ID is sensitive (bearer token for TMDS).
+const CredentialsIDLogTruncationLen = 8
+
+// TruncateString truncates a string to the specified length and appends
+// "-REDACTED" to indicate the value has been redacted.
+func TruncateString(s string, length int) string {
+	if len(s) <= length {
+		return s
+	}
+	return s[:length] + "-REDACTED"
+}

--- a/ecs-agent/acs/session/payload_responder.go
+++ b/ecs-agent/acs/session/payload_responder.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/wsclient"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/pkg/errors"
@@ -102,7 +103,7 @@ func (r *payloadResponder) sendAck(ackRequest interface{}) {
 	credentialsAck, ok := ackRequest.(*ecsacs.IAMRoleCredentialsAckRequest)
 	if ok {
 		logger.Debug(fmt.Sprintf("ACKing credentials associated with %s", PayloadMessageName), logger.Fields{
-			field.CredentialsID: aws.ToString(credentialsAck.CredentialsId),
+			field.CredentialsID: utils.TruncateString(aws.ToString(credentialsAck.CredentialsId), utils.CredentialsIDLogTruncationLen),
 			field.MessageID:     aws.ToString(credentialsAck.MessageId),
 		})
 	} else {
@@ -124,7 +125,7 @@ func (r *payloadResponder) sendAck(ackRequest interface{}) {
 		if credentialsAck != nil {
 			logger.Warn(fmt.Sprintf("Error acknowledging credentials associated with %s",
 				PayloadMessageName), logger.Fields{
-				field.CredentialsID: aws.ToString(credentialsAck.CredentialsId),
+				field.CredentialsID: utils.TruncateString(aws.ToString(credentialsAck.CredentialsId), utils.CredentialsIDLogTruncationLen),
 				field.MessageID:     aws.ToString(credentialsAck.MessageId),
 				field.Error:         err,
 			})

--- a/ecs-agent/utils/utils.go
+++ b/ecs-agent/utils/utils.go
@@ -166,3 +166,16 @@ func JsonBlockToStringToStringMap(jsonBlock string) (map[string]string, error) {
 	err := json.Unmarshal([]byte(jsonBlock), &out)
 	return out, err
 }
+
+// CredentialsIDLogTruncationLen is the number of characters to retain when
+// logging a credentials ID. The full ID is sensitive (bearer token for TMDS).
+const CredentialsIDLogTruncationLen = 8
+
+// TruncateString truncates a string to the specified length and appends
+// "-REDACTED" to indicate the value has been redacted.
+func TruncateString(s string, length int) string {
+	if len(s) <= length {
+		return s
+	}
+	return s[:length] + "-REDACTED"
+}

--- a/ecs-init/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils.go
+++ b/ecs-init/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils.go
@@ -166,3 +166,16 @@ func JsonBlockToStringToStringMap(jsonBlock string) (map[string]string, error) {
 	err := json.Unmarshal([]byte(jsonBlock), &out)
 	return out, err
 }
+
+// CredentialsIDLogTruncationLen is the number of characters to retain when
+// logging a credentials ID. The full ID is sensitive (bearer token for TMDS).
+const CredentialsIDLogTruncationLen = 8
+
+// TruncateString truncates a string to the specified length and appends
+// "-REDACTED" to indicate the value has been redacted.
+func TruncateString(s string, length int) string {
+	if len(s) <= length {
+		return s
+	}
+	return s[:length] + "-REDACTED"
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR aims to truncate certain values that are logged within the ECS agent application. It also cleans up unnecessary log values that aren't helpful.

### Implementation details
* Added new utility function to truncate strings up to a specific length

### Testing

Manual testing via a custom ECS Agent container image. Launched a simple nginx webapp task. ECS Agent logs:

```
level=info time=2026-04-23T21:50:47Z msg="Successfully got ECS instance credentials from provider: EC2RoleProvider"     
  level=info time=2026-04-23T21:50:48Z msg="Establishing a Websocket connection"                                          
  url="https://ecs-a-12.us-west-2.amazonaws.com/ws?agentHash=fbc95536&agentVersion=1.103.0&clusterArn=default&containerIns
  tanceArn=arn%3Aaws%3Aecs%3Aus-west-2%3A<ACCOUNT_ID>%3Acontainer-instance%2Fdefault%2F<CONTAINER_INSTANCE_ID>&dockerVersi
  on=DockerVersion%3A+25.0.14&protocolVersion=2&sendCredentials=true&seqNum=1"                                            
  level=info time=2026-04-23T21:50:48Z msg="Websocket connection established." ExpectedDisconnectTime="2026-04-23         
  22:20:48"                                                                                                               
  URL="https://ecs-a-12.us-west-2.amazonaws.com/ws?agentHash=fbc95536&agentVersion=1.103.0&clusterArn=default&containerIns
  tanceArn=arn%3Aaws%3Aecs%3Aus-west-2%3A<ACCOUNT_ID>%3Acontainer-instance%2Fdefault%2F<CONTAINER_INSTANCE_ID>&dockerVersi
  on=DockerVersion%3A+25.0.14&protocolVersion=2&sendCredentials=true&seqNum=1"                                            
  ConnectTime="2026-04-23 21:50:48" maxConnectionDuration=30m50.572348903s                                                
  level=info time=2026-04-23T21:51:23Z msg="Found application credentials for task" roleType="TaskApplication"            
  credentialsID="767f1b27-REDACTED" taskARN="arn:aws:ecs:us-west-2:<ACCOUNT_ID>:task/default/<TASK_ID>" taskVersion="1"   
  roleARN="arn:aws:iam::<ACCOUNT_ID>:role/ecsTaskExecutionRole"                                                           
  level=info time=2026-04-23T21:51:23Z msg="Found execution credentials for task"                                         
  taskARN="arn:aws:ecs:us-west-2:<ACCOUNT_ID>:task/default/<TASK_ID>" taskVersion="1"                                     
  roleARN="arn:aws:iam::<ACCOUNT_ID>:role/TaskExecutionRoleARN" roleType="TaskExecution" credentialsID="8f42fc44-REDACTED"
  level=info time=2026-04-23T21:51:23Z msg="Found application credentials for task"                                       
  taskARN="arn:aws:ecs:us-west-2:<ACCOUNT_ID>:task/default/<TASK_ID>" taskVersion="1"                                     
  roleARN="arn:aws:iam::<ACCOUNT_ID>:role/ecsTaskExecutionRole" roleType="TaskApplication"                                
  credentialsID="f7b3db46-REDACTED"                                                                                       
  level=info time=2026-04-23T21:51:23Z msg="Found execution credentials for task"                                         
  taskARN="arn:aws:ecs:us-west-2:<ACCOUNT_ID>:task/default/<TASK_ID>" taskVersion="1"                                     
  roleARN="arn:aws:iam::<ACCOUNT_ID>:role/TaskExecutionRoleARN" roleType="TaskExecution" credentialsID="b35d70f2-REDACTED"
```

New tests cover the changes: yes

### Description for the changelog
enhancement: Truncate log values to make agent logs less verbose

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
