### PR TITLE
Add NEURON_DEVICE to PlatformDeviceType enum

### DIFF
--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecs/types/enums.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecs/types/enums.go
@@ -825,6 +825,7 @@ type PlatformDeviceType string
 // Enum values for PlatformDeviceType
 const (
 	PlatformDeviceTypeGpu PlatformDeviceType = "GPU"
+	PlatformDeviceTypeNeuronDevice PlatformDeviceType = "NEURON_DEVICE"
 )
 
 // Values returns all known values for PlatformDeviceType. Note that this can be
@@ -834,6 +835,7 @@ const (
 func (PlatformDeviceType) Values() []PlatformDeviceType {
 	return []PlatformDeviceType{
 		"GPU",
+		"NEURON_DEVICE",
 	}
 }
 

--- a/aws-sdk-go-v2/aws-models/ecs.json
+++ b/aws-sdk-go-v2/aws-models/ecs.json
@@ -8523,6 +8523,12 @@
                     "traits": {
                         "smithy.api#enumValue": "GPU"
                     }
+                },
+                "NEURON_DEVICE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NEURON_DEVICE"
+                    }
                 }
             }
         },

--- a/aws-sdk-go-v2/service/ecs/types/enums.go
+++ b/aws-sdk-go-v2/service/ecs/types/enums.go
@@ -825,6 +825,7 @@ type PlatformDeviceType string
 // Enum values for PlatformDeviceType
 const (
 	PlatformDeviceTypeGpu PlatformDeviceType = "GPU"
+	PlatformDeviceTypeNeuronDevice PlatformDeviceType = "NEURON_DEVICE"
 )
 
 // Values returns all known values for PlatformDeviceType. Note that this can be
@@ -834,6 +835,7 @@ const (
 func (PlatformDeviceType) Values() []PlatformDeviceType {
 	return []PlatformDeviceType{
 		"GPU",
+		"NEURON_DEVICE",
 	}
 }
 

--- a/ecs-agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecs/types/enums.go
+++ b/ecs-agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecs/types/enums.go
@@ -825,6 +825,7 @@ type PlatformDeviceType string
 // Enum values for PlatformDeviceType
 const (
 	PlatformDeviceTypeGpu PlatformDeviceType = "GPU"
+	PlatformDeviceTypeNeuronDevice PlatformDeviceType = "NEURON_DEVICE"
 )
 
 // Values returns all known values for PlatformDeviceType. Note that this can be
@@ -834,6 +835,7 @@ const (
 func (PlatformDeviceType) Values() []PlatformDeviceType {
 	return []PlatformDeviceType{
 		"GPU",
+		"NEURON_DEVICE",
 	}
 }
 


### PR DESCRIPTION
### Summary
Adds `NEURON_DEVICE` to the `PlatformDeviceType` enum in the vendored ECS SDK model and generated Go types.

### Implementation details
- Added `NEURON_DEVICE` enum member to `aws-sdk-go-v2/aws-models/ecs.json`.
- Added the corresponding `PlatformDeviceTypeNeuronDevice` constant and entry in `Values()` in `aws-sdk-go-v2/service/ecs/types/enums.go`.

### Testing
`go build ./...` passes in `agent/` and `ecs-agent/`.

New tests cover the changes: N/A

### Description for the changelog
Enhancement - Add `NEURON_DEVICE` to `PlatformDeviceType` enum in ECS SDK

### Additional Information

**Does this PR include breaking model changes?** No

**Does this PR include the addition of new environment variables in the README?** No

### Licensing
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.