### PR TITLE
Implement IMDS scanner for task credential retrieval

### DIFF
--- a/ecs-agent/credentials/imds/scanner.go
+++ b/ecs-agent/credentials/imds/scanner.go
@@ -17,32 +17,237 @@ package imds
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+
+	"golang.org/x/time/rate"
+)
+
+const (
+	// namespacePrefix is the IMDS path prefix for ECS IAM namespaces.
+	namespacePrefix = "iam-ecs-"
+
+	// taskIDDelimiter separates the task ID from the rest of the IMDS key.
+	taskIDDelimiter = "-"
+
+	// infoPathFormat is the path to the info file within a namespace.
+	infoPathFormat = "%s/info"
+
+	// credentialPathFormat is the path to a credential file within a namespace.
+	credentialPathFormat = "%s/security-credentials/%s"
+
+	// imdsQueriesPerSec is the rate limit for IMDS requests.
+	//
+	// IMDS shares a 1024 packets-per-second (PPS) limit with other
+	// link local services (Route 53 DNS, NTP).
+	// Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+	// The rate limiter keeps credential scanning within ~10% of the total PPS budget
+	// to leave headroom for other link-local requests on the instance.
+	//
+	// TODO: this value will be finalized based on load testing.
+	imdsQueriesPerSec = 10
+
+	// imdsQueryBurstSize is the token bucket size for the rate limiter.
+	imdsQueryBurstSize = 1
 )
 
 // Scanner fetches task credentials from IMDS iam-ecs-* namespaces.
 type Scanner interface {
-	// Scan discovers iam-ecs-* namespaces, reads their info files, and fetches
-	// credentials only for task IDs present in the provided set. Credentials
-	// for unknown task IDs are ignored.
-	Scan(ctx context.Context, taskIDs map[string]bool) ([]TaskCredential, error)
+	// Scan discovers all ECS IAM namespaces, reads their info files, and
+	// fetches credentials from namespaces that have changed since the last scan.
+	Scan(ctx context.Context) ([]TaskCredential, error)
 }
 
 // scanner implements the Scanner interface.
+// TODO: add metricsFactory for operational metrics on scan failures.
 type scanner struct {
-	ec2Client ec2.EC2MetadataClient
+	ec2MetadataClient ec2.EC2MetadataClient
+	// rateLimiter controls the rate of IMDS requests.
+	rateLimiter *rate.Limiter
+	// lastUpdated tracks the LastUpdated timestamp from each namespace's info file.
+	lastUpdated map[string]time.Time
 }
 
 // NewScanner creates a new IMDS credential scanner.
-func NewScanner(ec2Client ec2.EC2MetadataClient) Scanner {
+func NewScanner(ec2MetadataClient ec2.EC2MetadataClient) Scanner {
 	return &scanner{
-		ec2Client: ec2Client,
+		ec2MetadataClient: ec2MetadataClient,
+		rateLimiter:       rate.NewLimiter(rate.Limit(imdsQueriesPerSec), imdsQueryBurstSize),
+		lastUpdated:       make(map[string]time.Time),
 	}
 }
 
-// Scan is a stub to satisfy the Scanner interface.
-// TODO: implementation
-func (s *scanner) Scan(ctx context.Context, taskIDs map[string]bool) ([]TaskCredential, error) {
-	return nil, nil
+// Scan discovers all ECS IAM namespaces, reads their info files, and
+// fetches credentials from namespaces that have changed since the last scan.
+func (s *scanner) Scan(ctx context.Context) ([]TaskCredential, error) {
+	namespaces, err := s.discoverNamespaces(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("imds scan: discover namespaces: %w", err)
+	}
+
+	// No namespaces is expected when IMDS does not have ECS task credentials yet.
+	if len(namespaces) == 0 {
+		logger.Debug("No iam-ecs namespaces found in IMDS")
+		return nil, nil
+	}
+
+	var creds []TaskCredential
+	var scanErrors []error
+	for _, ns := range namespaces {
+		nsCreds, err := s.scanNamespace(ctx, ns)
+		if err != nil {
+			logger.Error("Failed to scan IMDS namespace", logger.Fields{
+				"namespace": ns,
+				field.Error: err,
+			})
+			scanErrors = append(scanErrors, err)
+			// Scanning for a namespace failed; try scanning remaining namespaces before returning.
+			continue
+		}
+		creds = append(creds, nsCreds...)
+	}
+
+	// Surface an error when all namespaces failed so the caller doesn't
+	// mistake it for "no credentials yet".
+	if len(creds) == 0 && len(scanErrors) > 0 {
+		return nil, fmt.Errorf("imds scan: all %d namespace(s) failed: %w",
+			len(scanErrors), errors.Join(scanErrors...))
+	}
+
+	return creds, nil
+}
+
+// discoverNamespaces lists the IMDS metadata root and returns all
+// iam-ecs-* namespace names.
+func (s *scanner) discoverNamespaces(ctx context.Context) ([]string, error) {
+	// An empty path queries the IMDS metadata root (/meta-data/),
+	// which returns a list of all available metadata categories.
+	resp, err := s.getMetadata(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var namespaces []string
+	// IMDS returns a newline-separated list of entries.
+	for _, line := range strings.Split(resp, "\n") {
+		// Directory entries may have a trailing slash (e.g. "iam/").
+		entry := strings.TrimSuffix(line, "/")
+		if strings.HasPrefix(entry, namespacePrefix) {
+			namespaces = append(namespaces, entry)
+		}
+	}
+
+	return namespaces, nil
+}
+
+// scanNamespace reads the info file for a namespace and fetches
+// credentials for each entry. Only successfully fetched credentials
+// are returned.
+func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCredential, error) {
+	infoPath := fmt.Sprintf(infoPathFormat, namespace)
+	infoResp, err := s.getMetadata(ctx, infoPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetch info for %s: %w", namespace, err)
+	}
+
+	var info NamespaceInfo
+	if err := json.Unmarshal([]byte(infoResp), &info); err != nil {
+		return nil, fmt.Errorf("parse info for %s: %w", namespace, err)
+	}
+
+	// Skip credential fetches if the namespace hasn't been updated since the last scan.
+	lastUpdated, err := time.Parse(time.RFC3339, info.LastUpdated)
+	if err != nil {
+		return nil, fmt.Errorf("parse LastUpdated for %s: %w", namespace, err)
+	}
+	if cached, ok := s.lastUpdated[namespace]; ok && lastUpdated.Equal(cached) {
+		logger.Debug("Skipping namespace with unchanged LastUpdated", logger.Fields{
+			"namespace": namespace,
+		})
+		return nil, nil
+	}
+
+	var creds []TaskCredential
+	var hasErrors bool
+	for key, entry := range info.TaskCredentials {
+		taskID, err := parseTaskID(key)
+		if err != nil {
+			logger.Error("Failed to parse task ID from IMDS namespace entry", logger.Fields{
+				"namespace": namespace,
+				field.Error: err,
+			})
+			// Cannot determine task ID; attempt the next credential.
+			hasErrors = true
+			continue
+		}
+
+		credPath := fmt.Sprintf(credentialPathFormat, namespace, key)
+		credResp, err := s.getMetadata(ctx, credPath)
+		if err != nil {
+			logger.Error("Failed to fetch from IMDS", logger.Fields{
+				field.TaskID: taskID,
+				"namespace":  namespace,
+				field.Error:  err,
+			})
+			// Fetch failed; try remaining credentials in this namespace.
+			hasErrors = true
+			continue
+		}
+
+		var imdsCred imdsCredential
+		if err := json.Unmarshal([]byte(credResp), &imdsCred); err != nil {
+			logger.Error("Failed to parse IMDS response", logger.Fields{
+				field.TaskID: taskID,
+				"namespace":  namespace,
+				field.Error:  err,
+			})
+			// Error parsing response; try remaining credentials in this namespace.
+			hasErrors = true
+			continue
+		}
+
+		creds = append(creds, TaskCredential{
+			TaskID:          taskID,
+			RoleArn:         entry.RoleArn,
+			AccessKeyID:     imdsCred.AccessKeyId,
+			SecretAccessKey: imdsCred.SecretAccessKey,
+			SessionToken:    imdsCred.Token,
+			Expiration:      imdsCred.Expiration,
+		})
+	}
+
+	// Only cache LastUpdated if all credentials were fetched successfully,
+	// so that failed fetches are retried on the next scan.
+	if !hasErrors {
+		s.lastUpdated[namespace] = lastUpdated
+	}
+
+	return creds, nil
+}
+
+// parseTaskID extracts the task ID from an IMDS key.
+// The expected key format is <taskID>-<suffix>.
+func parseTaskID(key string) (string, error) {
+	parts := strings.SplitN(key, taskIDDelimiter, 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("unexpected credential key format: %s", key)
+	}
+
+	return parts[0], nil
+}
+
+// getMetadata is a rate-limited wrapper around the EC2 metadata client.
+func (s *scanner) getMetadata(ctx context.Context, path string) (string, error) {
+	if err := s.rateLimiter.Wait(ctx); err != nil {
+		return "", err
+	}
+
+	return s.ec2MetadataClient.GetMetadata(path)
 }

--- a/ecs-agent/credentials/imds/scanner_test.go
+++ b/ecs-agent/credentials/imds/scanner_test.go
@@ -1,0 +1,439 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//go:build unit
+
+package imds
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	mock_ec2 "github.com/aws/amazon-ecs-agent/ecs-agent/ec2/mocks"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testTaskID1 = "0ee1b6f1feef4ff2bacdf2c99732d506"
+	testTaskID2 = "aabbccdd11223344aabbccdd11223344"
+	testRoleID1 = "AROAEXAMPLEROLEID1"
+	testRoleID2 = "AROAEXAMPLEROLEID2"
+	testRoleARN = "arn:aws:iam::123456789012:role/TestRole"
+)
+
+// testCredentialJSON returns a mock IMDS credential file JSON.
+func testCredentialJSON(accessKeyID string) string {
+	return fmt.Sprintf(`{
+		"AccessKeyId": "%s",
+		"SecretAccessKey": "secret",
+		"Token": "token",
+		"Expiration": "2026-04-28T00:00:00Z"
+	}`, accessKeyID)
+}
+
+// testInfoJSONWithTimestamp returns a mock IMDS info file JSON
+// with the given LastUpdated value.
+func testInfoJSONWithTimestamp(
+	lastUpdated string, entries map[string]string,
+) string {
+	entriesJSON := ""
+	for key, roleARN := range entries {
+		if entriesJSON != "" {
+			entriesJSON += ","
+		}
+		entriesJSON += fmt.Sprintf(
+			`"%s": {"RoleARN": "%s"}`, key, roleARN,
+		)
+	}
+	return fmt.Sprintf(
+		`{"LastUpdated": "%s", "TaskCredentials": {%s}}`,
+		lastUpdated, entriesJSON,
+	)
+}
+
+// testInfoJSON returns a mock IMDS info file JSON with a default timestamp.
+func testInfoJSON(entries map[string]string) string {
+	return testInfoJSONWithTimestamp("2026-04-28T00:00:00Z", entries)
+}
+
+// testCred is a helper func that returns a TaskCredential with the given fields.
+func testCred(taskID, roleArn, accessKeyID string) TaskCredential {
+	return TaskCredential{
+		TaskID:          taskID,
+		RoleArn:         roleArn,
+		AccessKeyID:     accessKeyID,
+		SecretAccessKey: "secret",
+		SessionToken:    "token",
+		Expiration:      "2026-04-28T00:00:00Z",
+	}
+}
+
+func TestDiscoverNamespaces(t *testing.T) {
+	tests := []struct {
+		name      string
+		imdsResp  string
+		imdsErr   error
+		expected  []string
+		expectErr bool
+	}{
+		{
+			name:     "no iam-ecs namespaces",
+			imdsResp: "ami-id\ninstance-id\niam/",
+			expected: nil,
+		},
+		{
+			name:     "single namespace",
+			imdsResp: "ami-id\niam-ecs-1\niam/",
+			expected: []string{"iam-ecs-1"},
+		},
+		{
+			name:     "multiple namespaces",
+			imdsResp: "iam-ecs-1\niam-ecs-2\niam-ecs-10\niam/",
+			expected: []string{"iam-ecs-1", "iam-ecs-2", "iam-ecs-10"},
+		},
+		{
+			name:     "trailing slash on namespace",
+			imdsResp: "iam-ecs-1/\niam/",
+			expected: []string{"iam-ecs-1"},
+		},
+		{
+			name:     "trailing newline",
+			imdsResp: "iam-ecs-1\n",
+			expected: []string{"iam-ecs-1"},
+		},
+		{
+			name:     "empty response",
+			imdsResp: "",
+			expected: nil,
+		},
+		{
+			name:      "IMDS error",
+			imdsErr:   errors.New("connection refused"),
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mock := mock_ec2.NewMockEC2MetadataClient(ctrl)
+			mock.EXPECT().GetMetadata("").Return(tc.imdsResp, tc.imdsErr)
+
+			s := NewScanner(mock).(*scanner)
+			namespaces, err := s.discoverNamespaces(context.Background())
+
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, namespaces)
+			}
+		})
+	}
+}
+
+func TestScanNamespace(t *testing.T) {
+	key1 := testTaskID1 + "-" + testRoleID1
+	key2 := testTaskID2 + "-" + testRoleID2
+
+	tests := []struct {
+		name          string
+		setupMock     func(*mock_ec2.MockEC2MetadataClient)
+		lastUpdated   map[string]time.Time
+		expectedCreds []TaskCredential
+		expectErr     bool
+		// expectLastUpdatedCached is a pointer to distinguish "don't check" (nil)
+		// from "assert not cached" (false).
+		expectLastUpdatedCached *bool
+	}{
+		{
+			name: "single credential",
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
+					testInfoJSON(map[string]string{key1: testRoleARN}), nil)
+				m.EXPECT().GetMetadata("iam-ecs-1/security-credentials/"+key1).Return(
+					testCredentialJSON("AKID1"), nil)
+			},
+			expectedCreds:           []TaskCredential{testCred(testTaskID1, testRoleARN, "AKID1")},
+			expectLastUpdatedCached: aws.Bool(true),
+		},
+		{
+			name: "multiple credentials",
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
+					testInfoJSON(map[string]string{
+						key1: testRoleARN,
+						key2: testRoleARN,
+					}), nil)
+				m.EXPECT().GetMetadata("iam-ecs-1/security-credentials/"+key1).Return(
+					testCredentialJSON("AKID1"), nil)
+				m.EXPECT().GetMetadata("iam-ecs-1/security-credentials/"+key2).Return(
+					testCredentialJSON("AKID2"), nil)
+			},
+			expectedCreds: []TaskCredential{
+				testCred(testTaskID1, testRoleARN, "AKID1"),
+				testCred(testTaskID2, testRoleARN, "AKID2"),
+			},
+		},
+		{
+			name: "info file fetch fails",
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
+					"", errors.New("not found"))
+			},
+			expectErr: true,
+		},
+		{
+			name: "info file invalid JSON",
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
+					"not json", nil)
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid LastUpdated timestamp",
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
+					testInfoJSONWithTimestamp("not-a-timestamp",
+						map[string]string{key1: testRoleARN}), nil)
+			},
+			expectErr: true,
+		},
+		{
+			name: "fetch for one credential fails, other succeeds",
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
+					testInfoJSON(map[string]string{
+						key1: testRoleARN,
+						key2: testRoleARN,
+					}), nil)
+				m.EXPECT().GetMetadata("iam-ecs-1/security-credentials/"+key1).Return(
+					"", errors.New("timeout"))
+				m.EXPECT().GetMetadata("iam-ecs-1/security-credentials/"+key2).Return(
+					testCredentialJSON("AKID2"), nil)
+			},
+			expectedCreds:           []TaskCredential{testCred(testTaskID2, testRoleARN, "AKID2")},
+			expectLastUpdatedCached: aws.Bool(false),
+		},
+		{
+			name: "credential response invalid JSON",
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
+					testInfoJSON(map[string]string{key1: testRoleARN}), nil)
+				m.EXPECT().GetMetadata("iam-ecs-1/security-credentials/"+key1).Return(
+					"not json", nil)
+			},
+		},
+		{
+			name: "invalid credential key format",
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
+					testInfoJSON(map[string]string{
+						"nodelimiterkey": testRoleARN,
+					}), nil)
+			},
+		},
+		{
+			name: "unchanged LastUpdated skips credential fetches",
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
+					testInfoJSON(map[string]string{key1: testRoleARN}), nil)
+			},
+			lastUpdated: map[string]time.Time{
+				"iam-ecs-1": time.Date(2026, 4, 28, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "changed LastUpdated re-fetches credentials",
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
+					testInfoJSONWithTimestamp("2026-04-28T01:00:00Z",
+						map[string]string{key1: testRoleARN}), nil)
+				m.EXPECT().GetMetadata("iam-ecs-1/security-credentials/"+key1).Return(
+					testCredentialJSON("AKID_NEW"), nil)
+			},
+			lastUpdated: map[string]time.Time{
+				"iam-ecs-1": time.Date(2026, 4, 28, 0, 0, 0, 0, time.UTC),
+			},
+			expectedCreds: []TaskCredential{testCred(testTaskID1, testRoleARN, "AKID_NEW")},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mock := mock_ec2.NewMockEC2MetadataClient(ctrl)
+			tc.setupMock(mock)
+
+			s := NewScanner(mock).(*scanner)
+			if tc.lastUpdated != nil {
+				s.lastUpdated = tc.lastUpdated
+			}
+
+			creds, err := s.scanNamespace(context.Background(), "iam-ecs-1")
+
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, creds)
+			} else {
+				assert.NoError(t, err)
+				assert.ElementsMatch(t, tc.expectedCreds, creds)
+			}
+			if tc.expectLastUpdatedCached != nil {
+				if *tc.expectLastUpdatedCached {
+					assert.Contains(t, s.lastUpdated, "iam-ecs-1")
+				} else {
+					assert.NotContains(t, s.lastUpdated, "iam-ecs-1")
+				}
+			}
+		})
+	}
+}
+func TestParseTaskID(t *testing.T) {
+	tests := []struct {
+		name           string
+		key            string
+		expectedTaskID string
+		expectError    bool
+	}{
+		{
+			name:           "standard key",
+			key:            testTaskID1 + "-" + testRoleID1,
+			expectedTaskID: testTaskID1,
+		},
+		{
+			name:        "no delimiter",
+			key:         testTaskID1,
+			expectError: true,
+		},
+		{
+			name:        "empty string",
+			key:         "",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			taskID, err := parseTaskID(tc.key)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedTaskID, taskID)
+			}
+		})
+	}
+}
+
+func TestScan(t *testing.T) {
+	tests := []struct {
+		name          string
+		ctx           context.Context
+		setupMock     func(*mock_ec2.MockEC2MetadataClient)
+		expectedCreds []TaskCredential
+		expectErr     bool
+	}{
+		{
+			name: "no namespaces",
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetMetadata("").Return("ami-id\niam/", nil)
+			},
+		},
+		{
+			name: "end to end with multiple namespaces",
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				key1 := testTaskID1 + "-" + testRoleID1
+				key2 := testTaskID2 + "-" + testRoleID2
+				m.EXPECT().GetMetadata("").Return("iam-ecs-1\niam-ecs-2", nil)
+				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
+					testInfoJSON(map[string]string{key1: testRoleARN}), nil)
+				m.EXPECT().GetMetadata("iam-ecs-1/security-credentials/"+key1).Return(
+					testCredentialJSON("AKID1"), nil)
+				m.EXPECT().GetMetadata("iam-ecs-2/info").Return(
+					testInfoJSON(map[string]string{key2: testRoleARN}), nil)
+				m.EXPECT().GetMetadata("iam-ecs-2/security-credentials/"+key2).Return(
+					testCredentialJSON("AKID2"), nil)
+			},
+			expectedCreds: []TaskCredential{
+				testCred(testTaskID1, testRoleARN, "AKID1"),
+				testCred(testTaskID2, testRoleARN, "AKID2"),
+			},
+		},
+		{
+			name: "namespace discovery fails",
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetMetadata("").Return("", errors.New("unreachable"))
+			},
+			expectErr: true,
+		},
+		{
+			name: "all namespaces fail",
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetMetadata("").Return("iam-ecs-1\niam-ecs-2", nil)
+				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
+					"", errors.New("timeout"))
+				m.EXPECT().GetMetadata("iam-ecs-2/info").Return(
+					"", errors.New("timeout"))
+			},
+			expectErr: true,
+		},
+		{
+			name: "cancelled context",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mock := mock_ec2.NewMockEC2MetadataClient(ctrl)
+			tc.setupMock(mock)
+
+			ctx := tc.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+
+			s := NewScanner(mock)
+			creds, err := s.Scan(ctx)
+
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, creds)
+			} else {
+				assert.NoError(t, err)
+				assert.ElementsMatch(t, tc.expectedCreds, creds)
+			}
+		})
+	}
+}

--- a/ecs-agent/credentials/imds/types.go
+++ b/ecs-agent/credentials/imds/types.go
@@ -14,6 +14,7 @@
 package imds
 
 // NamespaceInfo represents the parsed info file from an iam-ecs-* namespace.
+// JSON tags match the IMDS response format.
 type NamespaceInfo struct {
 	LastUpdated     string                        `json:"LastUpdated"`
 	TaskCredentials map[string]TaskCredentialInfo `json:"TaskCredentials"`
@@ -21,15 +22,25 @@ type NamespaceInfo struct {
 
 // TaskCredentialInfo represents a single entry in the namespace info file.
 type TaskCredentialInfo struct {
-	RoleARN string `json:"RoleARN"`
+	RoleArn string `json:"RoleARN"`
 }
 
 // TaskCredential represents a task credential retrieved from IMDS.
 type TaskCredential struct {
 	TaskID          string
-	RoleARN         string
+	RoleArn         string
 	AccessKeyID     string
 	SecretAccessKey string
 	SessionToken    string
 	Expiration      string
+}
+
+// imdsCredential is used internally by the scanner to deserialize IMDS
+// credential files, which use different field names than TaskCredential
+// (e.g. "Token" vs SessionToken). JSON tags match the IMDS response format.
+type imdsCredential struct {
+	AccessKeyId     string `json:"AccessKeyId"`
+	SecretAccessKey string `json:"SecretAccessKey"`
+	Token           string `json:"Token"`
+	Expiration      string `json:"Expiration"`
 }

--- a/ecs-agent/go.mod
+++ b/ecs-agent/go.mod
@@ -35,6 +35,7 @@ require (
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/net v0.48.0
 	golang.org/x/sys v0.39.0
+	golang.org/x/time v0.3.0
 	golang.org/x/tools v0.39.0
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.11
@@ -78,7 +79,6 @@ require (
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
-	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect


### PR DESCRIPTION
### Summary
Implements the IMDS credential scanner in the shared library (`ecs-agent/credentials/imds`). The scanner discovers `iam-ecs-*` IMDS namespaces, reads their info files, and fetches task credentials with rate limiting. The scanner is not used by the ECS agents today, and the feature is config-disabled. 

Changes to consume this shared library will come in a follow-up PR. Changes to incorporate metrics in the scanner will also come in a follow-up PR after operational review for the feature.

### Implementation details
- Implement Scanner.Scan() to discover iam-ecs-* namespaces, read info files, and fetch credentials.
- Add rate limiter (~10% of IMDS PPS budget) to leave headroom for other link-local requests on the instance.
- Cache LastUpdated per namespace to optimize IMDS call volume.

### Testing

New tests cover the changes: yes, added new unit tests

### Description for the changelog
Feature - Implement IMDS scanner for task credential retrieval, in the shared library

### Additional Information

**Does this PR include breaking model changes?** No

**Does this PR include the addition of new environment variables in the README?** No

### Licensing
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.