### PR TITLE
Enhancement - inject AWS_REGION and AWS_DEFAULT_REGION into task containers

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -82,6 +82,10 @@ const (
 	// credentials.
 	awsSDKCredentialsRelativeURIPathEnvironmentVariableName = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
 
+	// awsRegionEnvVar and awsDefaultRegionEnvVar are the standard AWS SDK region env vars.
+	awsRegionEnvVar        = "AWS_REGION"
+	awsDefaultRegionEnvVar = "AWS_DEFAULT_REGION"
+
 	NvidiaVisibleDevicesEnvVar = "NVIDIA_VISIBLE_DEVICES"
 	GPUAssociationType         = "gpu"
 
@@ -1022,6 +1026,38 @@ func (task *Task) initializeCredentialsEndpoint(credentialsManager credentials.M
 	}
 
 	task.SetCredentialsRelativeURI(credentialsEndpointRelativeURI)
+}
+
+// ApplyRegionToContainer injects AWS_REGION and AWS_DEFAULT_REGION into the
+// container environment. Injection is skipped if either var is already set in
+// the task definition, environment files, or container image.
+func (task *Task) ApplyRegionToContainer(container *apicontainer.Container, region string, imageManagedEnvKeys map[string]bool) {
+	if region == "" {
+		return
+	}
+	if container.IsInternal() {
+		// Internal containers (pause, SC relay, managed daemons) do not receive injected env vars.
+		return
+	}
+
+	// Skip if the customer set either var in the task definition or environment files.
+	// Environment file vars are merged into container.Environment.
+	_, hasRegion := container.Environment[awsRegionEnvVar]
+	_, hasDefaultRegion := container.Environment[awsDefaultRegionEnvVar]
+	if hasRegion || hasDefaultRegion {
+		return
+	}
+
+	// Skip if the image already has a region preference (e.g. Dockerfile ENV).
+	if imageManagedEnvKeys[awsRegionEnvVar] || imageManagedEnvKeys[awsDefaultRegionEnvVar] {
+		return
+	}
+
+	if container.Environment == nil {
+		container.Environment = make(map[string]string)
+	}
+	container.Environment[awsRegionEnvVar] = region
+	container.Environment[awsDefaultRegionEnvVar] = region
 }
 
 // initializeContainersV3MetadataEndpoint generates a v3 endpoint id for each container, constructs the

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -1406,6 +1406,104 @@ func TestInitializeContainersV1AgentAPIEndpoint(t *testing.T) {
 	}
 }
 
+func TestApplyRegionToContainerPrecedence(t *testing.T) {
+	tests := []struct {
+		name           string
+		containerType  apicontainer.ContainerType
+		taskDefEnvs    map[string]string
+		imageEnvKeys   map[string]bool
+		instanceRegion string
+		wantRegion     string // expected AWS_REGION ("" = not injected)
+		wantDefaultReg string // expected AWS_DEFAULT_REGION ("" = not injected)
+	}{
+		{
+			name:           "no overrides — inject both vars",
+			instanceRegion: "us-west-2",
+			wantRegion:     "us-west-2",
+			wantDefaultReg: "us-west-2",
+		},
+		{
+			name:           "nil image region keys — injection still proceeds",
+			instanceRegion: "us-west-2",
+			wantRegion:     "us-west-2",
+			wantDefaultReg: "us-west-2",
+		},
+		{
+			name:           "empty region — nothing injected",
+			instanceRegion: "",
+			wantRegion:     "",
+			wantDefaultReg: "",
+		},
+		{
+			name:           "internal container (CNI pause) — skip injection",
+			containerType:  apicontainer.ContainerCNIPause,
+			instanceRegion: "us-west-2",
+			wantRegion:     "",
+			wantDefaultReg: "",
+		},
+		{
+			// Image already has AWS_REGION: neither var is injected (both would be or neither).
+			name:           "image has AWS_REGION — no injection",
+			imageEnvKeys:   map[string]bool{awsRegionEnvVar: true},
+			instanceRegion: "us-west-2",
+			wantRegion:     "",
+			wantDefaultReg: "",
+		},
+		{
+			// Image already has AWS_DEFAULT_REGION: neither var is injected.
+			name:           "image has AWS_DEFAULT_REGION — no injection",
+			imageEnvKeys:   map[string]bool{awsDefaultRegionEnvVar: true},
+			instanceRegion: "us-west-2",
+			wantRegion:     "",
+			wantDefaultReg: "",
+		},
+		{
+			// Task def already has AWS_REGION: injection skipped, task def value preserved,
+			// AWS_DEFAULT_REGION is not added.
+			name:           "task definition has AWS_REGION — no injection, task def value preserved",
+			taskDefEnvs:    map[string]string{awsRegionEnvVar: "eu-west-1"},
+			instanceRegion: "us-west-2",
+			wantRegion:     "eu-west-1",
+			wantDefaultReg: "",
+		},
+		{
+			// Task def already has AWS_DEFAULT_REGION: injection skipped, task def value
+			// preserved, AWS_REGION is not added.
+			name:           "task definition has AWS_DEFAULT_REGION — no injection, task def value preserved",
+			taskDefEnvs:    map[string]string{awsDefaultRegionEnvVar: "ap-southeast-1"},
+			instanceRegion: "us-west-2",
+			wantRegion:     "",
+			wantDefaultReg: "ap-southeast-1",
+		},
+		{
+			// Task def check runs before image check: one var in task def suppresses
+			// injection entirely, so the other var from the image is also not applied.
+			name:           "task definition has AWS_REGION, image has AWS_DEFAULT_REGION — no injection",
+			taskDefEnvs:    map[string]string{awsRegionEnvVar: "eu-west-1"},
+			imageEnvKeys:   map[string]bool{awsDefaultRegionEnvVar: true},
+			instanceRegion: "us-west-2",
+			wantRegion:     "eu-west-1",
+			wantDefaultReg: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			container := &apicontainer.Container{
+				Name:        "app",
+				Type:        tt.containerType,
+				Environment: tt.taskDefEnvs,
+			}
+			task := Task{Containers: []*apicontainer.Container{container}}
+
+			task.ApplyRegionToContainer(container, tt.instanceRegion, tt.imageEnvKeys)
+
+			assert.Equal(t, tt.wantRegion, container.Environment[awsRegionEnvVar])
+			assert.Equal(t, tt.wantDefaultReg, container.Environment[awsDefaultRegionEnvVar])
+		})
+	}
+}
+
 func TestPostUnmarshalTaskWithLocalVolumes(t *testing.T) {
 	// Constants used here are defined in task_unix_test.go and task_windows_test.go
 	taskFromACS := ecsacs.Task{

--- a/agent/engine/common_testutil.go
+++ b/agent/engine/common_testutil.go
@@ -191,7 +191,7 @@ func validateContainerRunWorkflow(t *testing.T,
 	client.EXPECT().
 		TagImage(gomock.Any(), canonicalImageRef.String(), container.Image).Return(nil)
 	imageManager.EXPECT().RecordContainerReference(container).Return(nil)
-	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false)
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 	client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil)
 	dockerConfig, err := task.DockerConfig(container, defaultDockerClientAPIVersion)
 	if err != nil {

--- a/agent/engine/docker_image_manager.go
+++ b/agent/engine/docker_image_manager.go
@@ -139,7 +139,7 @@ func (imageManager *dockerImageManager) RecordContainerReference(container *apic
 	// On agent restart, container ID was retrieved from agent state file
 	// TODO add setter and getter for modifying this
 	if container.ImageID != "" {
-		if !imageManager.addContainerReferenceToExistingImageState(container) {
+		if !imageManager.addContainerReferenceToExistingImageState(container, nil) {
 			return fmt.Errorf("Failed to add container to existing image state")
 		}
 		return nil
@@ -164,9 +164,14 @@ func (imageManager *dockerImageManager) RecordContainerReference(container *apic
 		imageDigest := imageManager.fetchRepoDigest(imageInspected, container)
 		container.SetImageDigest(imageDigest)
 	}
-	added := imageManager.addContainerReferenceToExistingImageState(container)
+	// Capture managed image env keys for use at container create time.
+	var managedEnvKeys map[string]bool
+	if imageInspected.Config != nil {
+		managedEnvKeys = image.ParseManagedEnvKeys(imageInspected.Config.Env)
+	}
+	added := imageManager.addContainerReferenceToExistingImageState(container, managedEnvKeys)
 	if !added {
-		imageManager.addContainerReferenceToNewImageState(container, imageInspected.Size)
+		imageManager.addContainerReferenceToNewImageState(container, imageInspected.Size, managedEnvKeys)
 	}
 	return nil
 }
@@ -191,7 +196,7 @@ func (imageManager *dockerImageManager) fetchRepoDigest(imageInspected *types.Im
 	return resultRepoDigest
 }
 
-func (imageManager *dockerImageManager) addContainerReferenceToExistingImageState(container *apicontainer.Container) bool {
+func (imageManager *dockerImageManager) addContainerReferenceToExistingImageState(container *apicontainer.Container, managedEnvKeys map[string]bool) bool {
 	// this lock is used for reading the image states in the image manager
 	imageManager.updateLock.RLock()
 	defer imageManager.updateLock.RUnlock()
@@ -199,12 +204,16 @@ func (imageManager *dockerImageManager) addContainerReferenceToExistingImageStat
 	imageState, ok := imageManager.getImageState(container.ImageID)
 	if ok {
 		imageState.UpdateImageState(container)
+		if managedEnvKeys != nil {
+			// nil on restart (no inspect); preserves persisted value.
+			imageState.SetManagedEnvKeys(managedEnvKeys)
+		}
 		imageManager.saveImageStateData(imageState)
 	}
 	return ok
 }
 
-func (imageManager *dockerImageManager) addContainerReferenceToNewImageState(container *apicontainer.Container, imageSize int64) {
+func (imageManager *dockerImageManager) addContainerReferenceToNewImageState(container *apicontainer.Container, imageSize int64, managedEnvKeys map[string]bool) {
 	// this lock is used while creating and adding new image state to image manager
 	imageManager.updateLock.Lock()
 	defer imageManager.updateLock.Unlock()
@@ -213,6 +222,9 @@ func (imageManager *dockerImageManager) addContainerReferenceToNewImageState(con
 	imageState, ok := imageManager.getImageState(container.ImageID)
 	if ok {
 		imageState.UpdateImageState(container)
+		if managedEnvKeys != nil {
+			imageState.SetManagedEnvKeys(managedEnvKeys)
+		}
 		imageManager.saveImageStateData(imageState)
 	} else {
 		sourceImage := &image.Image{
@@ -220,9 +232,10 @@ func (imageManager *dockerImageManager) addContainerReferenceToNewImageState(con
 			Size:    imageSize,
 		}
 		sourceImageState := &image.ImageState{
-			Image:      sourceImage,
-			PulledAt:   time.Now(),
-			LastUsedAt: time.Now(),
+			Image:          sourceImage,
+			PulledAt:       time.Now(),
+			LastUsedAt:     time.Now(),
+			ManagedEnvKeys: managedEnvKeys,
 		}
 		sourceImageState.UpdateImageState(container)
 		imageManager.addImageState(sourceImageState)

--- a/agent/engine/docker_image_manager_data_test.go
+++ b/agent/engine/docker_image_manager_data_test.go
@@ -67,7 +67,7 @@ func TestAddContainerReferenceToNewImageStateSaveData(t *testing.T) {
 		dataClient: dataClient,
 	}
 
-	imageManager.addContainerReferenceToNewImageState(testContainerData, 0)
+	imageManager.addContainerReferenceToNewImageState(testContainerData, 0, nil)
 	imageStates, err := dataClient.GetImageStates()
 	assert.NoError(t, err)
 	assert.Len(t, imageStates, 1)
@@ -80,7 +80,7 @@ func TestAddContainerReferenceToExistingImageStateSaveData(t *testing.T) {
 		dataClient: dataClient,
 	}
 	imageManager.imageStates = append(imageManager.imageStates, testImageStateData)
-	imageManager.addContainerReferenceToExistingImageState(testContainerData)
+	imageManager.addContainerReferenceToExistingImageState(testContainerData, nil)
 	imageStates, err := dataClient.GetImageStates()
 	assert.NoError(t, err)
 	assert.Len(t, imageStates, 1)

--- a/agent/engine/docker_image_manager_test.go
+++ b/agent/engine/docker_image_manager_test.go
@@ -35,6 +35,7 @@ import (
 	ec2testutil "github.com/aws/amazon-ecs-agent/agent/utils/test/ec2util"
 
 	"github.com/docker/docker/api/types"
+	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -192,6 +193,90 @@ func TestRecordContainerReferenceInspectError(t *testing.T) {
 	}
 }
 
+func TestRecordContainerReferenceStoresManagedEnvKeysOnImageState(t *testing.T) {
+	envVars := []string{"PATH=/usr/local/bin", "AWS_DEFAULT_REGION=us-east-1"}
+	tests := []struct {
+		name        string
+		config      *dockercontainer.Config
+		wantEnvKeys map[string]bool
+	}{
+		{
+			name:        "image config with region env var — key stored on image state",
+			config:      &dockercontainer.Config{Env: envVars},
+			wantEnvKeys: map[string]bool{"AWS_DEFAULT_REGION": true},
+		},
+		{
+			name:        "nil image config — ManagedEnvKeys nil on image state",
+			config:      nil,
+			wantEnvKeys: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			client := mock_dockerapi.NewMockDockerClient(ctrl)
+
+			imageManager := NewImageManager(defaultTestConfig(), client, dockerstate.NewTaskEngineState())
+			imageManager.SetDataClient(data.NewNoopClient())
+
+			container := &apicontainer.Container{
+				Name:  "testContainer",
+				Image: "testContainerImage",
+			}
+			client.EXPECT().InspectImage(container.Image).Return(&types.ImageInspect{
+				ID:     "sha256:qwerty",
+				Config: tt.config,
+			}, nil)
+
+			err := imageManager.RecordContainerReference(container)
+			assert.NoError(t, err)
+
+			imageState, ok := imageManager.GetImageStateFromImageName(container.Image)
+			assert.True(t, ok)
+			assert.Equal(t, tt.wantEnvKeys, imageState.GetManagedEnvKeys())
+		})
+	}
+}
+
+// TestRecordContainerReferencePreservesManagedEnvKeysOnRestart verifies that when a container
+// already has an ImageID set (e.g. on agent restart from saved state), RecordContainerReference
+// does not re-inspect the image — the ManagedEnvKeys are already persisted on ImageState.
+func TestRecordContainerReferencePreservesManagedEnvKeysOnRestart(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := mock_dockerapi.NewMockDockerClient(ctrl)
+
+	imageManager := NewImageManager(defaultTestConfig(), client, dockerstate.NewTaskEngineState())
+	imageManager.SetDataClient(data.NewNoopClient())
+
+	const imageID = "sha256:qwerty"
+	existingKeys := map[string]bool{"AWS_DEFAULT_REGION": true}
+
+	// Seed the image state with persisted ManagedEnvKeys (as if loaded from state file).
+	sourceImageState := &image.ImageState{
+		Image:          &image.Image{ImageID: imageID},
+		ManagedEnvKeys: existingKeys,
+	}
+	imageManager.(*dockerImageManager).addImageState(sourceImageState)
+
+	container := &apicontainer.Container{
+		Name:    "testContainer",
+		Image:   "testContainerImage",
+		ImageID: imageID, // pre-populated, as it would be after agent restart
+	}
+
+	// No InspectImage call expected — keys are already persisted.
+	err := imageManager.RecordContainerReference(container)
+	assert.NoError(t, err)
+
+	// Verify the keys are still on the image state.
+	imageState, ok := imageManager.GetImageStateFromImageName(container.Image)
+	assert.True(t, ok)
+	assert.Equal(t, existingKeys, imageState.GetManagedEnvKeys())
+}
+
 func TestRecordContainerReferenceWithNoImageName(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -282,7 +367,7 @@ func TestAddContainerReferenceToExistingImageState(t *testing.T) {
 	sourceImageState1.AddImageName("testContainerImage")
 	imageManager.addImageState(sourceImageState)
 	imageManager.addImageState(sourceImageState1)
-	if !imageManager.addContainerReferenceToExistingImageState(container) {
+	if !imageManager.addContainerReferenceToExistingImageState(container, nil) {
 		t.Error("Error in adding container to an already existing image state")
 	}
 	if !reflect.DeepEqual(sourceImageState.Containers[0], container) {
@@ -371,7 +456,7 @@ func TestAddContainerReferenceToExistingImageStateNoState(t *testing.T) {
 		Image:   "testContainerImage",
 		ImageID: "sha256:qwerty",
 	}
-	if imageManager.addContainerReferenceToExistingImageState(container) {
+	if imageManager.addContainerReferenceToExistingImageState(container, nil) {
 		t.Error("Error adding container to an incorrect existing image state")
 	}
 }
@@ -390,7 +475,7 @@ func TestAddContainerReferenceToNewImageState(t *testing.T) {
 		Image:   "testContainerImage",
 		ImageID: imageID,
 	}
-	imageManager.addContainerReferenceToNewImageState(container, imageSize)
+	imageManager.addContainerReferenceToNewImageState(container, imageSize, nil)
 	_, ok := imageManager.getImageState(imageID)
 	if !ok {
 		t.Error("Error adding container reference to new image state")
@@ -426,7 +511,7 @@ func TestAddContainerReferenceToNewImageStateAddedState(t *testing.T) {
 	sourceImageState1.AddImageName("testContainerImage")
 	imageManager.addImageState(sourceImageState)
 	imageManager.addImageState(sourceImageState1)
-	imageManager.addContainerReferenceToNewImageState(container, imageSize)
+	imageManager.addContainerReferenceToNewImageState(container, imageSize, nil)
 	if !reflect.DeepEqual(sourceImageState.Containers[0], container) {
 		t.Error("Incorrect container added to an already existing image state")
 	}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -2058,6 +2058,16 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 		}
 	}
 
+	// Inject AWS_REGION / AWS_DEFAULT_REGION unless already set in the task definition,
+	// environment files, or image. Environment files are merged into container.Environment.
+	var imageManagedEnvKeys map[string]bool
+	if !container.IsInternal() {
+		if imageState, ok := engine.imageManager.GetImageStateFromImageName(container.Image); ok && imageState != nil {
+			imageManagedEnvKeys = imageState.GetManagedEnvKeys()
+		}
+	}
+	task.ApplyRegionToContainer(container, engine.cfg.AWSRegion, imageManagedEnvKeys)
+
 	config, err := task.DockerConfig(container, dockerClientVersion)
 	if err != nil {
 		return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(err)}

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -123,6 +123,7 @@ func TestResourceContainerProgression(t *testing.T) {
 	manifestPullClient := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	expectedCanonicalRef := sleepContainer.Image + "@" + testDigest.String()
+	imageManager.EXPECT().GetImageStateFromImageName(sleepContainer.Image).Return(nil, false).AnyTimes()
 	// Hierarchical memory accounting is always enabled in CgroupV2 and no controller file exists to configure it
 	if config.CgroupV2 {
 		gomock.InOrder(
@@ -143,7 +144,6 @@ func TestResourceContainerProgression(t *testing.T) {
 				TagImage(gomock.Any(), expectedCanonicalRef, sleepContainer.Image).
 				Return(nil),
 			imageManager.EXPECT().RecordContainerReference(sleepContainer).Return(nil),
-			imageManager.EXPECT().GetImageStateFromImageName(sleepContainer.Image).Return(nil, false),
 			client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
 			client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
 				func(ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, containerName string, z time.Duration) {
@@ -185,7 +185,6 @@ func TestResourceContainerProgression(t *testing.T) {
 				TagImage(gomock.Any(), expectedCanonicalRef, sleepContainer.Image).
 				Return(nil),
 			imageManager.EXPECT().RecordContainerReference(sleepContainer).Return(nil),
-			imageManager.EXPECT().GetImageStateFromImageName(sleepContainer.Image).Return(nil, false),
 			client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
 			client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
 				func(ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, containerName string, z time.Duration) {
@@ -605,10 +604,11 @@ func TestCreateFirelensContainer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
-			ctrl, client, mockTime, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+			ctrl, client, mockTime, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 			defer ctrl.Finish()
 
 			mockTime.EXPECT().Now().AnyTimes()
+			imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 			client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).AnyTimes()
 			client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
 				func(ctx context.Context,
@@ -721,7 +721,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 		TagImage(gomock.Any(), expectedCanonicalRef, sleepContainer.Image).
 		Return(nil)
 	imageManager.EXPECT().RecordContainerReference(sleepContainer).Return(nil)
-	imageManager.EXPECT().GetImageStateFromImageName(sleepContainer.Image).Return(nil, false)
+	imageManager.EXPECT().GetImageStateFromImageName(sleepContainer.Image).Return(nil, false).AnyTimes()
 
 	gomock.InOrder(
 		// Ensure that the pause container is created first
@@ -935,7 +935,7 @@ func TestPauseContainerHappyPath(t *testing.T) {
 		Return(dockerapi.DockerContainerMetadata{}).
 		Times(2)
 	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Return(nil).Times(2)
-	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(2)
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).Times(2)
 
 	dockerClient.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(),
@@ -1152,7 +1152,7 @@ func TestContainersWithServiceConnect(t *testing.T) {
 		Return(registry.DistributionInspect{}, nil)
 	dockerClient.EXPECT().PullImage(gomock.Any(), gomock.Any(), nil, gomock.Any()).Return(dockerapi.DockerContainerMetadata{}).Times(2)
 	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Return(nil).Times(2)
-	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(2)
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).Times(4)
 
 	serviceConnectCreate, _, scStop := setupMockSCTaskContainer("service-connect", sleepTask.Containers[2], scContainerID, 1337, containerNetNS, serviceConnectManager, dockerClient, nil)
@@ -1355,7 +1355,7 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 		Return(registry.DistributionInspect{}, nil)
 	dockerClient.EXPECT().PullImage(gomock.Any(), gomock.Any(), nil, gomock.Any()).Return(dockerapi.DockerContainerMetadata{}).Times(1)
 	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Return(nil).Times(1)
-	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(1)
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).Times(2)
 
 	cleanup := make(chan time.Time)
@@ -1544,8 +1544,10 @@ func TestWatchAppNetImage(t *testing.T) {
 func TestCredentialSpecResourceTaskFile(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, credentialsManager, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, credentialsManager, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
+
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 
 	// metadata required for createContainer workflow validation
 	credentialSpecTaskARN := "credentialSpecTask"

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -466,7 +466,7 @@ func TestStartTimeoutThenStart(t *testing.T) {
 			Return(nil)
 
 		imageManager.EXPECT().RecordContainerReference(container)
-		imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false)
+		imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 		client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
 			func(ctx interface{}, x, y, z, timeout interface{}) {
 				go func() { eventStream <- createDockerEvent(apicontainerstatus.ContainerCreated) }()
@@ -637,8 +637,9 @@ func TestStopWithPendingStops(t *testing.T) {
 func TestCreateContainerSaveDockerIDAndName(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, _, privateTaskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, _, privateTaskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 	dataClient := newTestDataClient(t)
 
 	taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
@@ -685,8 +686,9 @@ func TestCreateContainerMetadata(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
-			ctrl, client, _, privateTaskEngine, _, _, metadataManager, _ := mocks(t, ctx, &config.Config{})
+			ctrl, client, _, privateTaskEngine, _, imageManager, metadataManager, _ := mocks(t, ctx, &config.Config{})
 			defer ctrl.Finish()
+			imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 
 			taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
 			taskEngine.cfg.ContainerMetadataEnabled = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
@@ -708,8 +710,9 @@ func TestCreateContainerMetadata(t *testing.T) {
 func TestCreateContainerMergesLabels(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, _, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, _, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 
 	testTask := &apitask.Task{
 		Arn:     labelsTaskARN,
@@ -746,8 +749,9 @@ func TestCreateContainerMergesLabels(t *testing.T) {
 func TestCreateContainerAddV3EndpointIDToState(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, _, privateTaskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, _, privateTaskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 
 	taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
 
@@ -820,7 +824,7 @@ func TestTaskTransitionWhenStopContainerTimesout(t *testing.T) {
 			TagImage(gomock.Any(), expectedCanonicalRef, container.Image).
 			Return(nil)
 		imageManager.EXPECT().RecordContainerReference(container)
-		imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false)
+		imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 		client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil)
 
 		client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
@@ -881,6 +885,7 @@ func TestTaskTransitionWhenStopContainerReturnsUnretriableError(t *testing.T) {
 	mockTime.EXPECT().After(gomock.Any()).AnyTimes()
 	containerEventsWG := sync.WaitGroup{}
 	manifestPullClient := mock_dockerapi.NewMockDockerClient(ctrl)
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 	for _, container := range sleepTask.Containers {
 		expectedCanonicalRef := container.Image + "@" + testDigest.String()
 		gomock.InOrder(
@@ -898,7 +903,6 @@ func TestTaskTransitionWhenStopContainerReturnsUnretriableError(t *testing.T) {
 				TagImage(gomock.Any(), expectedCanonicalRef, container.Image).
 				Return(nil),
 			imageManager.EXPECT().RecordContainerReference(container),
-			imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false),
 			client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
 			// Simulate successful create container
 			client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
@@ -971,6 +975,7 @@ func TestTaskTransitionWhenStopContainerReturnsTransientErrorBeforeSucceeding(t 
 		Error: dockerapi.CannotStopContainerError{errors.New("Error stopping container")},
 	}
 	manifestPullClient := mock_dockerapi.NewMockDockerClient(ctrl)
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 	for _, container := range sleepTask.Containers {
 		expectedCanonicalRef := container.Image + "@" + testDigest.String()
 		gomock.InOrder(
@@ -986,7 +991,6 @@ func TestTaskTransitionWhenStopContainerReturnsTransientErrorBeforeSucceeding(t 
 				TagImage(gomock.Any(), expectedCanonicalRef, container.Image).
 				Return(nil),
 			imageManager.EXPECT().RecordContainerReference(container),
-			imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false),
 			// Simulate successful create container
 			client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
 			client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -1385,8 +1389,9 @@ func TestTaskWithCircularDependency(t *testing.T) {
 func TestCreateContainerOnAgentRestart(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, _, privateTaskEngine, _, _, _, _ := mocks(t, ctx, &config.Config{})
+	ctrl, client, _, privateTaskEngine, _, imageManager, _, _ := mocks(t, ctx, &config.Config{})
 	defer ctrl.Finish()
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 
 	taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
 	state := taskEngine.State()
@@ -1444,7 +1449,7 @@ func TestPullNormalImage(t *testing.T) {
 
 	client.EXPECT().PullImage(gomock.Any(), imageName, nil, gomock.Any())
 	imageManager.EXPECT().RecordContainerReference(container)
-	imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true)
+	imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true).AnyTimes()
 	metadata := taskEngine.pullContainer(task, container)
 	assert.Equal(t, dockerapi.DockerContainerMetadata{}, metadata, "expected empty metadata")
 }
@@ -1488,7 +1493,7 @@ func TestPullImageWithImagePullOnceBehavior(t *testing.T) {
 				client.EXPECT().PullImage(gomock.Any(), imageName, nil, gomock.Any())
 			}
 			imageManager.EXPECT().RecordContainerReference(container)
-			imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true).Times(2)
+			imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true).AnyTimes()
 			metadata := taskEngine.pullContainer(task, container)
 			assert.Equal(t, dockerapi.DockerContainerMetadata{}, metadata, "expected empty metadata")
 		})
@@ -1515,7 +1520,7 @@ func TestPullImageWithImagePullPreferCachedBehaviorWithCachedImage(t *testing.T)
 	}
 	client.EXPECT().InspectImage(imageName).Return(nil, nil)
 	imageManager.EXPECT().RecordContainerReference(container)
-	imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true)
+	imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true).AnyTimes()
 	metadata := taskEngine.pullContainer(task, container)
 	assert.Equal(t, dockerapi.DockerContainerMetadata{}, metadata, "expected empty metadata")
 }
@@ -1541,7 +1546,7 @@ func TestPullImageWithImagePullPreferCachedBehaviorWithoutCachedImage(t *testing
 	client.EXPECT().InspectImage(imageName).Return(nil, errors.New("error"))
 	client.EXPECT().PullImage(gomock.Any(), imageName, nil, gomock.Any())
 	imageManager.EXPECT().RecordContainerReference(container)
-	imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true)
+	imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true).AnyTimes()
 	metadata := taskEngine.pullContainer(task, container)
 	assert.Equal(t, dockerapi.DockerContainerMetadata{}, metadata, "expected empty metadata")
 }
@@ -1566,7 +1571,7 @@ func TestUpdateContainerReference(t *testing.T) {
 	}
 
 	imageManager.EXPECT().RecordContainerReference(container)
-	imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true)
+	imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true).AnyTimes()
 	taskEngine.updateContainerReference(true, container, task.Arn)
 	assert.True(t, imageState.PullSucceeded, "PullSucceeded set to false")
 }
@@ -1762,7 +1767,7 @@ func TestPullAndUpdateContainerReference(t *testing.T) {
 			}
 
 			imageManager.EXPECT().RecordContainerReference(container)
-			imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(tc.ImageState, false)
+			imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(tc.ImageState, false).AnyTimes()
 			metadata := taskEngine.pullAndUpdateContainerReference(task, container)
 			pulledContainersMap, _ := taskEngine.State().PulledContainerMapByArn(taskArn)
 			require.Len(t, pulledContainersMap, tc.NumOfPulledContainer)
@@ -1958,7 +1963,7 @@ func TestTaskUseExecutionRolePullECRImage(t *testing.T) {
 			assert.Equal(t, auth.ECRAuthData.GetPullCredentials(), executionRoleCredentials)
 		}).Return(dockerapi.DockerContainerMetadata{})
 	imageManager.EXPECT().RecordContainerReference(container).Return(nil)
-	imageManager.EXPECT().GetImageStateFromImageName(container.Image)
+	imageManager.EXPECT().GetImageStateFromImageName(container.Image).AnyTimes()
 
 	taskEngine.(*DockerTaskEngine).pullContainer(testTask, container)
 }
@@ -2031,7 +2036,7 @@ func TestTaskUseExecutionRolePullPrivateRegistryImage(t *testing.T) {
 			assert.Equal(t, password, dac.Password)
 		}).Return(dockerapi.DockerContainerMetadata{})
 	imageManager.EXPECT().RecordContainerReference(container).Return(nil)
-	imageManager.EXPECT().GetImageStateFromImageName(container.Image)
+	imageManager.EXPECT().GetImageStateFromImageName(container.Image).AnyTimes()
 
 	ret := taskEngine.(*DockerTaskEngine).pullContainer(testTask, container)
 	assert.Nil(t, ret.Error)
@@ -2121,7 +2126,7 @@ func TestPullStartedStoppedAtWasSetCorrectly(t *testing.T) {
 
 	client.EXPECT().PullImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
 	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Times(3)
-	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(3)
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 
 	gomock.InOrder(
 		// three container pull start timestamp
@@ -2174,7 +2179,7 @@ func TestPullStoppedAtWasSetCorrectlyWhenPullFail(t *testing.T) {
 			dockerapi.DockerContainerMetadata{Error: dockerapi.CannotPullContainerError{fmt.Errorf("error")}}),
 	)
 	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Times(3)
-	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(3)
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 	gomock.InOrder(
 		// three container pull start timestamp
 		mockTime.EXPECT().Now().Return(startTime1),
@@ -2824,8 +2829,10 @@ func TestTaskSecretsEnvironmentVariables(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
-			ctrl, client, mockTime, taskEngine, credentialsManager, _, _, _ := mocks(t, ctx, &defaultConfig)
+			ctrl, client, mockTime, taskEngine, credentialsManager, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 			defer ctrl.Finish()
+
+			imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 
 			// sample test
 			testTask := &apitask.Task{
@@ -3088,8 +3095,9 @@ func TestCreateContainerAwslogsLogDriver(t *testing.T) {
 			defer cancel()
 			cfg := config.DefaultConfig(ipcompatibility.NewIPv4OnlyCompatibility())
 			cfg.InstanceIPCompatibility = tc.instanceIPCompatibility
-			ctrl, client, _, taskEngine, _, _, _, _ := mocks(t, ctx, &cfg)
+			ctrl, client, _, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &cfg)
 			defer ctrl.Finish()
+			imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 
 			taskEngine.(*DockerTaskEngine).cfg.AWSRegion = tc.region
 
@@ -3183,8 +3191,9 @@ func TestCreateContainerLogDriverBufferSize(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
-			ctrl, client, _, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+			ctrl, client, _, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 			defer ctrl.Finish()
+			imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 
 			logConfig := map[string]string{}
 			if tc.logMode != "" {
@@ -3471,8 +3480,9 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
-			ctrl, client, _, taskEngine, _, _, _, serviceConnectManager := mocks(t, ctx, &defaultConfig)
+			ctrl, client, _, taskEngine, _, imageManager, _, serviceConnectManager := mocks(t, ctx, &defaultConfig)
 			defer ctrl.Finish()
+			imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 
 			client.EXPECT().Version(gomock.Any(), gomock.Any()).Return(testDockerServerVersion, nil).Times(1)
 			client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).AnyTimes()
@@ -3516,9 +3526,10 @@ func TestCreateFirelensContainerSetFluentdUID(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, _, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, _, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 	client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).AnyTimes()
 	client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
 		func(ctx context.Context,
@@ -4268,8 +4279,9 @@ func TestCreateContainerWithExecAgent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
-			ctrl, client, _, engine, _, _, _, _ := mocks(t, ctx, &config.Config{})
+			ctrl, client, _, engine, _, imageManager, _, _ := mocks(t, ctx, &config.Config{})
 			defer ctrl.Finish()
+			imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 			taskEngine, _ := engine.(*DockerTaskEngine)
 			stateChangeEvents := engine.StateChangeEvents()
 			execCmdMgr := mock_execcmdagent.NewMockManager(ctrl)
@@ -4779,6 +4791,7 @@ func TestManifestPullTaskShouldContinue(t *testing.T) {
 			transitionExpectations = append(transitionExpectations,
 				// Expectations for transition to CREATED
 				dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
+				imageManager.EXPECT().GetImageStateFromImageName(tc.container.Image).Return(nil, false),
 				dockerClient.EXPECT().
 					CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Do(

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -94,8 +94,10 @@ func TestDeleteTask(t *testing.T) {
 func TestCredentialSpecResourceTaskFile(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, credentialsManager, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, credentialsManager, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
+
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 
 	// metadata required for createContainer workflow validation
 	credentialSpecTaskARN := "credentialSpecTask"
@@ -177,8 +179,10 @@ func TestCredentialSpecResourceTaskFile(t *testing.T) {
 func TestCredentialSpecResourceTaskFileErr(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, credentialsManager, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, credentialsManager, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
+
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 
 	// metadata required for createContainer workflow validation
 	credentialSpecTaskARN := "credentialSpecTask"
@@ -346,7 +350,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 		TagImage(gomock.Any(), expectedCanonicalRef, sleepContainer.Image).
 		Return(nil)
 	imageManager.EXPECT().RecordContainerReference(sleepContainer).Return(nil)
-	imageManager.EXPECT().GetImageStateFromImageName(sleepContainer.Image).Return(nil, false)
+	imageManager.EXPECT().GetImageStateFromImageName(sleepContainer.Image).Return(nil, false).AnyTimes()
 
 	gomock.InOrder(
 		// Ensure that the pause container is created first
@@ -588,7 +592,7 @@ func TestPauseContainerHappyPath(t *testing.T) {
 		Return(dockerapi.DockerContainerMetadata{}).
 		Times(2)
 	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Return(nil).Times(2)
-	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(2)
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).AnyTimes()
 	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).Times(2)
 
 	dockerClient.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(),

--- a/agent/engine/image/types.go
+++ b/agent/engine/image/types.go
@@ -36,6 +36,33 @@ func (image *Image) String() string {
 	return fmt.Sprintf("ImageID: %s; Names: %s", image.ImageID, strings.Join(image.Names, ", "))
 }
 
+// managedEnvKeys is the set of image env var keys the agent tracks at the
+// image level. Presence of any of these keys in the image config suppresses
+// agent-side default injection at container create time.
+var managedEnvKeys = map[string]bool{
+	"AWS_REGION":         true,
+	"AWS_DEFAULT_REGION": true,
+}
+
+// ParseManagedEnvKeys returns the set of managed env var keys found in the
+// given image env list (formatted as "KEY=value" or "KEY").
+// A managed key with an empty value is still recorded; a warning is emitted.
+func ParseManagedEnvKeys(imageEnv []string) map[string]bool {
+	keys := make(map[string]bool)
+	for _, kv := range imageEnv {
+		key, value, found := strings.Cut(kv, "=")
+		if managedEnvKeys[key] {
+			if !found || value == "" {
+				logger.Warn("Image env var has empty value", logger.Fields{
+					"key": key,
+				})
+			}
+			keys[key] = true
+		}
+	}
+	return keys
+}
+
 // ImageState represents a docker image
 // and its state information such as containers associated with it
 type ImageState struct {
@@ -50,7 +77,24 @@ type ImageState struct {
 	// PullSucceeded defines whether this image has been pulled successfully before,
 	// this should be set to true when one of the pull image call succeeds.
 	PullSucceeded bool
-	lock          sync.RWMutex
+	// ManagedEnvKeys is the subset of agent-managed env var keys present in the
+	// image config. Persisted so the agent does not need to re-inspect on restart.
+	ManagedEnvKeys map[string]bool
+	lock           sync.RWMutex
+}
+
+// SetManagedEnvKeys records which managed env var keys are present in the image config.
+func (imageState *ImageState) SetManagedEnvKeys(keys map[string]bool) {
+	imageState.lock.Lock()
+	defer imageState.lock.Unlock()
+	imageState.ManagedEnvKeys = keys
+}
+
+// GetManagedEnvKeys returns the set of managed env var keys present in the image config.
+func (imageState *ImageState) GetManagedEnvKeys() map[string]bool {
+	imageState.lock.RLock()
+	defer imageState.lock.RUnlock()
+	return imageState.ManagedEnvKeys
 }
 
 // UpdateContainerReference updates container reference in image state
@@ -170,15 +214,17 @@ func (imageState *ImageState) MarshalJSON() ([]byte, error) {
 	defer imageState.lock.Unlock()
 
 	return json.Marshal(&struct {
-		Image         *Image
-		PulledAt      time.Time
-		LastUsedAt    time.Time
-		PullSucceeded bool
+		Image          *Image
+		PulledAt       time.Time
+		LastUsedAt     time.Time
+		PullSucceeded  bool
+		ManagedEnvKeys map[string]bool
 	}{
-		Image:         imageState.Image,
-		PulledAt:      imageState.PulledAt,
-		LastUsedAt:    imageState.LastUsedAt,
-		PullSucceeded: imageState.PullSucceeded,
+		Image:          imageState.Image,
+		PulledAt:       imageState.PulledAt,
+		LastUsedAt:     imageState.LastUsedAt,
+		PullSucceeded:  imageState.PullSucceeded,
+		ManagedEnvKeys: imageState.ManagedEnvKeys,
 	})
 }
 

--- a/agent/engine/image/types_test.go
+++ b/agent/engine/image/types_test.go
@@ -1,0 +1,73 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//go:build unit
+
+package image
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseManagedEnvKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageEnv []string
+		wantKeys map[string]bool
+	}{
+		{
+			name:     "no managed keys in image env",
+			imageEnv: []string{"PATH=/usr/local/bin", "HOME=/root"},
+			wantKeys: map[string]bool{},
+		},
+		{
+			name:     "AWS_REGION present with value",
+			imageEnv: []string{"AWS_REGION=us-east-1"},
+			wantKeys: map[string]bool{"AWS_REGION": true},
+		},
+		{
+			name:     "AWS_DEFAULT_REGION present with value",
+			imageEnv: []string{"PATH=/usr/local/bin", "AWS_DEFAULT_REGION=eu-west-1"},
+			wantKeys: map[string]bool{"AWS_DEFAULT_REGION": true},
+		},
+		{
+			name:     "both region vars present",
+			imageEnv: []string{"AWS_REGION=us-east-1", "AWS_DEFAULT_REGION=eu-west-1"},
+			wantKeys: map[string]bool{"AWS_REGION": true, "AWS_DEFAULT_REGION": true},
+		},
+		{
+			name:     "AWS_REGION set to empty (KEY=) — still recorded",
+			imageEnv: []string{"AWS_REGION="},
+			wantKeys: map[string]bool{"AWS_REGION": true},
+		},
+		{
+			name:     "AWS_REGION bare with no equals (KEY) — still recorded",
+			imageEnv: []string{"AWS_REGION"},
+			wantKeys: map[string]bool{"AWS_REGION": true},
+		},
+		{
+			name:     "nil image env",
+			imageEnv: nil,
+			wantKeys: map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseManagedEnvKeys(tt.imageEnv)
+			assert.Equal(t, tt.wantKeys, result)
+		})
+	}
+}


### PR DESCRIPTION
### Summary

Inject the instance region into normal container environments so the AWS SDK
can resolve the correct region without explicit task definition configuration.

Injection is skipped if either var is already set in the task definition,
environment files, or container image. The precedence order is:
task definition > environment files > container image > instance default.

Our current docs mention both AWS_REGION and AWS_DEFAULT_REGION
> AWS_DEFAULT_REGION – The default AWS Region for your AWS account. This is the default Region where your task runs.
> AWS_REGION – The Region where the task runs. If defined, this value overrides the AWS_DEFAULT_REGION.

Currently neither the Agent or Control Plane explicitly set these parameters. The Agent has to resolve the region in order to establish communication with the frontend to register the container instance and establish a websocket connection for task related data/events (payload, state changes).

Certain tooling, AWS CLI, benefits from these environment variables set. Today customers can provide these values in their task definitions to enable this behavior, but it has been noticed that there is a gap as Fargate tasks have this provided by default.

Docs: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-environment-variables.html
Related: https://github.com/aws/containers-roadmap/issues/1611

### Implementation details
1. Agent resolves AWS region
2. Agent connects to ACS and receives task payload
3. Agent merges environment file vars into the container environment
4. Agent injects AWS_REGION / AWS_DEFAULT_REGION (if not already supplied) into
   task containers

Agent region resolution chain (first non-empty value wins):

AWS_DEFAULT_REGION (agent environment)
→ /etc/ecs/ecs.config  (AWSRegion field)
→ EC2 user data        (ECSAgentConfiguration.AWSRegion)
→ EC2 IMDS             (instance identity document)

> Note: AWS_REGION on the instance env is not read by the agent — only AWS_DEFAULT_REGION seeds cfg.AWSRegion. The resolved value is then injected into containers as both AWS_REGION and AWS_DEFAULT_REGION.

Injection precedence (skipped if any of the following are already set):

1. Task definition environment
2. Environment files (`.env` files referenced in the task definition)
3. Container image (Dockerfile ENV)
4. Instance default (agent injects)

Environment file vars are merged into `container.Environment` before the region
injection runs, so the existing check in `ApplyRegionToContainer` naturally
covers all three customer-specified sources.

### Testing
Local testing and validations

New tests cover the changes: yes

### Description for the changelog
Enhancement - inject AWS_REGION and AWS_DEFAULT_REGION into task containers

### Additional Information

Could this be done in the Control Plane?

Yes, but it would still require some change within the agent code to respect if the customer set those values and overwrite the Control Plane supplied values.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
