### PR TITLE
Add Kiro steering docs for implementation and testing conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ ecs-agent-*.tar
 pkg/
 .vscode/
 .kiro/
+!.kiro/steering/

--- a/.kiro/steering/implementation.md
+++ b/.kiro/steering/implementation.md
@@ -1,0 +1,53 @@
+---
+inclusion: always
+---
+
+# Implementation Guide
+
+## Project Structure
+
+This is a multi-module Go repository for the Amazon ECS Agent. The three primary modules are:
+
+- `ecs-agent/` — shared library code (credentials, networking, logging, API models, utilities). This is the lowest-level module and must not import from `agent/`.
+- `agent/` — the main ECS agent binary. Imports `ecs-agent/` via a `replace` directive (treated as a local dependency, not a vendored one).
+- `ecs-init/` — the init/systemd process that manages the agent container lifecycle.
+
+Each module vendors its own dependencies (`go mod vendor`). A local fork of `aws-sdk-go-v2/service/ecs` lives in `aws-sdk-go-v2/` and is pulled in via `replace` directives.
+
+## Code Style
+
+- Import groups separated by blank lines: (1) standard library, (2) local (`github.com/aws/amazon-ecs-agent/...`), (3) third-party vendor. The `agent/` module imports `ecs-agent/` packages in the local group, not the vendor group.
+- Run `goimports` and `gofmt` before committing. CI verifies no diff is generated.
+- Line length should not exceed 100 characters.
+- Write comments as complete sentences with punctuation.
+- No sensitive data in logs (credentials, keys, tokens).
+- Use `aws-sdk-go-v2`, not v1, for new code.
+
+## Logging
+
+- Use `ecs-agent/logger` (structured logging) for new code, not `seelog`.
+- Use predefined field constants from `ecs-agent/logger/field` (e.g., `field.TaskID`, `field.Error`) instead of raw strings.
+- Logging calls use `logger.Fields{}` maps: `logger.Info("message", logger.Fields{field.TaskID: id})`.
+
+## Dependency Management
+
+- Run `make gomod` to tidy and re-vendor all modules.
+
+## License Header
+
+Every `.go` file must start with the Apache 2.0 license header:
+
+```go
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+```

--- a/.kiro/steering/testing.md
+++ b/.kiro/steering/testing.md
@@ -1,0 +1,32 @@
+---
+inclusion: always
+---
+
+# Testing
+
+## Build Tags
+
+- All test files require a build tag. Unit tests use `//go:build unit`. Other tags: `integration`, `sudo`, `sudo_unit`, `e2e`.
+- Platform-specific tests combine tags (e.g., `//go:build !windows && unit`, `//go:build linux && sudo_unit`).
+
+## Running Tests
+
+- Run unit tests from the repo root: `make test`. This runs tests in both `agent/` and `ecs-agent/` modules with `-tags unit -mod vendor -count=1`.
+- Run a single test or package directly: `go test -tags unit ./path/... -count=1`.
+- Some packages may not compile on macOS due to Linux-specific dependencies. Run tests inside a Docker container when needed, for example:
+  ```bash
+  docker run --rm -v "$(pwd)":/src -w /src/agent golang:$(cat GO_VERSION) \
+    go test -tags unit -run TestName ./path/... -count=1
+  ```
+
+## Conventions
+
+- Tests must be written in a table-driven format, when there are multiple test cases testing the same function. Aim for 80%+ line coverage on new code.
+- Use AWS SDK v2 helpers for type conversions in tests (e.g., `aws.Bool()`, `aws.String()`).
+
+## Mock Generation
+
+- Mocks are generated with `mockgen` via `//go:generate` directives in `generate_mocks.go` files colocated with the source package.
+- Mock output goes to a `mocks/` subdirectory within the package.
+- All generated mocks include the Apache 2.0 license header via `-copyright_file=../../scripts/copyright_file` (path relative to the generate file).
+- Run `make gogenerate` to regenerate all mocks. CI verifies no diff is produced.


### PR DESCRIPTION
### Summary
Add Kiro steering docs to codify implementation and testing conventions for AI-assisted development.

### Implementation details
- `.kiro/steering/implementation.md`: project structure, code style (import ordering, line length, formatting), structured logging guidance, dependency management, and license header template.
- `.kiro/steering/testing.md`: build tags, test execution (including Docker for cross-compilation), table-driven test conventions, SDK helpers, and mock generation workflow.
- `.gitignore`: updated to track `.kiro/steering/` while continuing to ignore other `.kiro/` contents.

### Testing

Verified steering docs are picked up by Kiro in a fresh session by prompting a code change and confirming conventions (license header, import ordering, structured logger, build tags) were followed without explicit instruction.

New tests cover the changes: N/A

### Description for the changelog
Housekeeping - Add Kiro steering docs for implementation and testing conventions

### Additional Information

**Does this PR include breaking model changes?** No

**Does this PR include the addition of new environment variables in the README?** No

### Licensing
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.