### PR TITLE
Enhancement - Add retry mechanism to credentialsfetcher

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/gmsacredclient/credentialsfetcherclient.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/gmsacredclient/credentialsfetcherclient.go
@@ -1,3 +1,15 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
 package gmsacredclient
 
 import (
@@ -6,6 +18,7 @@ import (
 	"time"
 
 	pb "github.com/aws/amazon-ecs-agent/ecs-agent/gmsacredclient/credentialsfetcher"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 	"github.com/cihub/seelog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -13,9 +26,19 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// Retry policy for gRPC calls to the credentials fetcher daemon.
+const (
+	grpcCallRetryAttempts        = 3
+	grpcCallRetryBackoffMin      = 1 * time.Second
+	grpcCallRetryBackoffMax      = 5 * time.Second
+	grpcCallRetryBackoffJitter   = 0.2
+	grpcCallRetryBackoffMultiple = 2.0
+)
+
 type CredentialsFetcherClient struct {
 	conn    *grpc.ClientConn
 	timeout time.Duration
+	backoff retry.Backoff
 }
 
 // GetGrpcClientConnection() returns grpc client connection
@@ -50,6 +73,12 @@ func NewCredentialsFetcherClient(conn *grpc.ClientConn, timeout time.Duration) C
 	return CredentialsFetcherClient{
 		conn:    conn,
 		timeout: timeout,
+		backoff: retry.NewExponentialBackoff(
+			grpcCallRetryBackoffMin,
+			grpcCallRetryBackoffMax,
+			grpcCallRetryBackoffJitter,
+			grpcCallRetryBackoffMultiple,
+		),
 	}
 }
 
@@ -69,6 +98,60 @@ type CredentialsFetcherArnResponse struct {
 	KerberosTicketsMap map[string]string
 }
 
+// isRetriableGRPCError returns true for transient errors (Unavailable,
+// DeadlineExceeded, ResourceExhausted, Aborted, Internal) and false for
+// terminal ones (InvalidArgument, PermissionDenied, etc.).
+func isRetriableGRPCError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s, _ := status.FromError(err)
+	switch s.Code() {
+	case codes.Unavailable,
+		codes.DeadlineExceeded,
+		codes.ResourceExhausted,
+		codes.Aborted,
+		codes.Internal:
+		return true
+	default:
+		return false
+	}
+}
+
+// callWithRetry calls fn with retries on transient gRPC errors, stopping
+// immediately on terminal ones. The timeout is the total budget across all
+// attempts — each attempt gets an equal share of it.
+func callWithRetry[T any](ctx context.Context, backoff retry.Backoff, timeout time.Duration, operation string, fn func(context.Context) (T, error)) (T, error) {
+	var zero T
+	var result T
+	var lastErr error
+
+	perAttemptTimeout := timeout / grpcCallRetryAttempts
+
+	retry.RetryNWithBackoffCtx(ctx, backoff, grpcCallRetryAttempts, func() error {
+		callCtx, cancel := context.WithTimeout(ctx, perAttemptTimeout)
+		defer cancel()
+
+		r, err := fn(callCtx)
+		lastErr = err
+		if err != nil {
+			if isRetriableGRPCError(err) {
+				seelog.Warnf("transient error during %s, will retry: %v", operation, err)
+				return err
+			}
+			seelog.Errorf("terminal error during %s: %v", operation, err)
+			return nil
+		}
+		result = r
+		return nil
+	})
+
+	if lastErr != nil {
+		return zero, lastErr
+	}
+	return result, nil
+}
+
 // HealthCheck() invokes credentials fetcher daemon running on the host
 // to check the health status of daemon
 func (c CredentialsFetcherClient) HealthCheck(ctx context.Context, serviceName string) (string, error) {
@@ -80,12 +163,10 @@ func (c CredentialsFetcherClient) HealthCheck(ctx context.Context, serviceName s
 
 	request := &pb.HealthCheckRequest{Service: serviceName}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	response, err := client.HealthCheck(ctx, request)
+	response, err := callWithRetry(ctx, c.backoff, c.timeout, "credentials-fetcher health check", func(callCtx context.Context) (*pb.HealthCheckResponse, error) {
+		return client.HealthCheck(callCtx, request)
+	})
 	if err != nil {
-		seelog.Errorf("credentials-fetcher daemon status is unhealthy during health check: %v", err)
 		return "", err
 	}
 	seelog.Debugf("credentials-fetcher daemon is running")
@@ -109,12 +190,10 @@ func (c CredentialsFetcherClient) AddKerberosArnLease(ctx context.Context, crede
 
 	request := &pb.KerberosArnLeaseRequest{CredspecArns: credentialspecsArns, AccessKeyId: accessKeyId, SecretAccessKey: secretKey, SessionToken: sessionToken, Region: region}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	response, err := client.AddKerberosArnLease(ctx, request)
+	response, err := callWithRetry(ctx, c.backoff, c.timeout, "add kerberos ARN lease", func(callCtx context.Context) (*pb.CreateKerberosArnLeaseResponse, error) {
+		return client.AddKerberosArnLease(callCtx, request)
+	})
 	if err != nil {
-		seelog.Errorf("could not create kerberos tickets: %v", err)
 		return CredentialsFetcherArnResponse{}, err
 	}
 	seelog.Infof("created kerberos tickets and associated with LeaseID: %s", response.GetLeaseId())
@@ -147,12 +226,10 @@ func (c CredentialsFetcherClient) RenewKerberosArnLease(ctx context.Context, acc
 
 	request := &pb.RenewKerberosArnLeaseRequest{AccessKeyId: accessKeyId, SecretAccessKey: secretKey, SessionToken: sessionToken, Region: region}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	response, err := client.RenewKerberosArnLease(ctx, request)
+	response, err := callWithRetry(ctx, c.backoff, c.timeout, "renew kerberos ARN lease", func(callCtx context.Context) (*pb.RenewKerberosArnLeaseResponse, error) {
+		return client.RenewKerberosArnLease(callCtx, request)
+	})
 	if err != nil {
-		seelog.Errorf("could not renew kerberos tickets: %v", err)
 		return codes.Internal.String(), err
 	}
 
@@ -177,12 +254,10 @@ func (c CredentialsFetcherClient) AddKerberosLease(ctx context.Context, credenti
 
 	request := &pb.CreateKerberosLeaseRequest{CredspecContents: credentialspecs}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	response, err := client.AddKerberosLease(ctx, request)
+	response, err := callWithRetry(ctx, c.backoff, c.timeout, "add kerberos lease", func(callCtx context.Context) (*pb.CreateKerberosLeaseResponse, error) {
+		return client.AddKerberosLease(callCtx, request)
+	})
 	if err != nil {
-		seelog.Errorf("could not create kerberos tickets: %v", err)
 		return CredentialsFetcherResponse{}, err
 	}
 	seelog.Infof("created kerberos tickets and associated with LeaseID: %s", response.GetLeaseId())
@@ -213,12 +288,10 @@ func (c CredentialsFetcherClient) AddNonDomainJoinedKerberosLease(ctx context.Co
 
 	request := &pb.CreateNonDomainJoinedKerberosLeaseRequest{CredspecContents: credentialspecs, Username: username, Password: password, Domain: domain}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	response, err := client.AddNonDomainJoinedKerberosLease(ctx, request)
+	response, err := callWithRetry(ctx, c.backoff, c.timeout, "add non-domain-joined kerberos lease", func(callCtx context.Context) (*pb.CreateNonDomainJoinedKerberosLeaseResponse, error) {
+		return client.AddNonDomainJoinedKerberosLease(callCtx, request)
+	})
 	if err != nil {
-		seelog.Errorf("could not create kerberos tickets: %v", err)
 		return CredentialsFetcherResponse{}, err
 	}
 	seelog.Infof("created kerberos tickets and associated with LeaseID: %s", response.GetLeaseId())
@@ -244,12 +317,10 @@ func (c CredentialsFetcherClient) RenewNonDomainJoinedKerberosLease(ctx context.
 
 	request := &pb.RenewNonDomainJoinedKerberosLeaseRequest{Username: username, Password: password, Domain: domain}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	response, err := client.RenewNonDomainJoinedKerberosLease(ctx, request)
+	response, err := callWithRetry(ctx, c.backoff, c.timeout, "renew non-domain-joined kerberos lease", func(callCtx context.Context) (*pb.RenewNonDomainJoinedKerberosLeaseResponse, error) {
+		return client.RenewNonDomainJoinedKerberosLease(callCtx, request)
+	})
 	if err != nil {
-		seelog.Errorf("could not renew kerberos tickets: %v", err)
 		return CredentialsFetcherResponse{}, err
 	}
 
@@ -273,12 +344,10 @@ func (c CredentialsFetcherClient) DeleteKerberosLease(ctx context.Context, lease
 
 	request := &pb.DeleteKerberosLeaseRequest{LeaseId: leaseid}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	response, err := client.DeleteKerberosLease(ctx, request)
+	response, err := callWithRetry(ctx, c.backoff, c.timeout, "delete kerberos lease", func(callCtx context.Context) (*pb.DeleteKerberosLeaseResponse, error) {
+		return client.DeleteKerberosLease(callCtx, request)
+	})
 	if err != nil {
-		seelog.Errorf("could not delete kerberos tickets: %v", err)
 		return CredentialsFetcherResponse{}, err
 	}
 	seelog.Infof("deleted kerberos associated with LeaseID: %s", response.GetLeaseId())

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/gmsacredclient/credentialsfetcherclient.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/gmsacredclient/credentialsfetcherclient.go
@@ -18,8 +18,10 @@ import (
 	"time"
 
 	pb "github.com/aws/amazon-ecs-agent/ecs-agent/gmsacredclient/credentialsfetcher"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
-	"github.com/cihub/seelog"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -45,13 +47,13 @@ type CredentialsFetcherClient struct {
 func GetGrpcClientConnection() (*grpc.ClientConn, error) {
 	address, err := getSocketAddress()
 	if err != nil {
-		seelog.Errorf("could not find path to credentials fetcher host dir : %v", err)
+		logger.Error("could not find path to credentials fetcher host dir", logger.Fields{field.Error: err})
 		return nil, err
 	}
 
 	conn, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		seelog.Errorf("could not initialize client connection %v", err)
+		logger.Error("could not initialize client connection", logger.Fields{field.Error: err})
 		return nil, err
 	}
 	return conn, nil
@@ -98,60 +100,6 @@ type CredentialsFetcherArnResponse struct {
 	KerberosTicketsMap map[string]string
 }
 
-// isRetriableGRPCError returns true for transient errors (Unavailable,
-// DeadlineExceeded, ResourceExhausted, Aborted, Internal) and false for
-// terminal ones (InvalidArgument, PermissionDenied, etc.).
-func isRetriableGRPCError(err error) bool {
-	if err == nil {
-		return false
-	}
-	s, _ := status.FromError(err)
-	switch s.Code() {
-	case codes.Unavailable,
-		codes.DeadlineExceeded,
-		codes.ResourceExhausted,
-		codes.Aborted,
-		codes.Internal:
-		return true
-	default:
-		return false
-	}
-}
-
-// callWithRetry calls fn with retries on transient gRPC errors, stopping
-// immediately on terminal ones. The timeout is the total budget across all
-// attempts — each attempt gets an equal share of it.
-func callWithRetry[T any](ctx context.Context, backoff retry.Backoff, timeout time.Duration, operation string, fn func(context.Context) (T, error)) (T, error) {
-	var zero T
-	var result T
-	var lastErr error
-
-	perAttemptTimeout := timeout / grpcCallRetryAttempts
-
-	retry.RetryNWithBackoffCtx(ctx, backoff, grpcCallRetryAttempts, func() error {
-		callCtx, cancel := context.WithTimeout(ctx, perAttemptTimeout)
-		defer cancel()
-
-		r, err := fn(callCtx)
-		lastErr = err
-		if err != nil {
-			if isRetriableGRPCError(err) {
-				seelog.Warnf("transient error during %s, will retry: %v", operation, err)
-				return err
-			}
-			seelog.Errorf("terminal error during %s: %v", operation, err)
-			return nil
-		}
-		result = r
-		return nil
-	})
-
-	if lastErr != nil {
-		return zero, lastErr
-	}
-	return result, nil
-}
-
 // HealthCheck() invokes credentials fetcher daemon running on the host
 // to check the health status of daemon
 func (c CredentialsFetcherClient) HealthCheck(ctx context.Context, serviceName string) (string, error) {
@@ -163,13 +111,13 @@ func (c CredentialsFetcherClient) HealthCheck(ctx context.Context, serviceName s
 
 	request := &pb.HealthCheckRequest{Service: serviceName}
 
-	response, err := callWithRetry(ctx, c.backoff, c.timeout, "credentials-fetcher health check", func(callCtx context.Context) (*pb.HealthCheckResponse, error) {
+	response, attempts, err := retry.CallWithRetry(ctx, c.backoff, grpcCallRetryAttempts, c.timeout, func(callCtx context.Context) (*pb.HealthCheckResponse, error) {
 		return client.HealthCheck(callCtx, request)
 	})
 	if err != nil {
 		return "", err
 	}
-	seelog.Debugf("credentials-fetcher daemon is running")
+	logger.Debug("credentials-fetcher daemon is running", logger.Fields{field.Attempts: attempts})
 
 	return response.GetStatus(), nil
 }
@@ -190,13 +138,13 @@ func (c CredentialsFetcherClient) AddKerberosArnLease(ctx context.Context, crede
 
 	request := &pb.KerberosArnLeaseRequest{CredspecArns: credentialspecsArns, AccessKeyId: accessKeyId, SecretAccessKey: secretKey, SessionToken: sessionToken, Region: region}
 
-	response, err := callWithRetry(ctx, c.backoff, c.timeout, "add kerberos ARN lease", func(callCtx context.Context) (*pb.CreateKerberosArnLeaseResponse, error) {
+	response, attempts, err := retry.CallWithRetry(ctx, c.backoff, grpcCallRetryAttempts, c.timeout, func(callCtx context.Context) (*pb.CreateKerberosArnLeaseResponse, error) {
 		return client.AddKerberosArnLease(callCtx, request)
 	})
 	if err != nil {
 		return CredentialsFetcherArnResponse{}, err
 	}
-	seelog.Infof("created kerberos tickets and associated with LeaseID: %s", response.GetLeaseId())
+	logger.Info("created kerberos tickets", logger.Fields{field.LeaseID: response.GetLeaseId(), field.Attempts: attempts})
 
 	credentialsFetcherResponse := CredentialsFetcherArnResponse{
 		LeaseID:            response.GetLeaseId(),
@@ -226,7 +174,7 @@ func (c CredentialsFetcherClient) RenewKerberosArnLease(ctx context.Context, acc
 
 	request := &pb.RenewKerberosArnLeaseRequest{AccessKeyId: accessKeyId, SecretAccessKey: secretKey, SessionToken: sessionToken, Region: region}
 
-	response, err := callWithRetry(ctx, c.backoff, c.timeout, "renew kerberos ARN lease", func(callCtx context.Context) (*pb.RenewKerberosArnLeaseResponse, error) {
+	response, attempts, err := retry.CallWithRetry(ctx, c.backoff, grpcCallRetryAttempts, c.timeout, func(callCtx context.Context) (*pb.RenewKerberosArnLeaseResponse, error) {
 		return client.RenewKerberosArnLease(callCtx, request)
 	})
 	if err != nil {
@@ -237,7 +185,7 @@ func (c CredentialsFetcherClient) RenewKerberosArnLease(ctx context.Context, acc
 		return codes.Internal.String(), status.Errorf(codes.Internal, "renewal of kerberos tickets failed")
 	}
 
-	seelog.Infof("renewal of kerberos tickets are successful")
+	logger.Info("renewal of kerberos tickets are successful", logger.Fields{field.Attempts: attempts})
 
 	return codes.OK.String(), nil
 }
@@ -254,13 +202,13 @@ func (c CredentialsFetcherClient) AddKerberosLease(ctx context.Context, credenti
 
 	request := &pb.CreateKerberosLeaseRequest{CredspecContents: credentialspecs}
 
-	response, err := callWithRetry(ctx, c.backoff, c.timeout, "add kerberos lease", func(callCtx context.Context) (*pb.CreateKerberosLeaseResponse, error) {
+	response, attempts, err := retry.CallWithRetry(ctx, c.backoff, grpcCallRetryAttempts, c.timeout, func(callCtx context.Context) (*pb.CreateKerberosLeaseResponse, error) {
 		return client.AddKerberosLease(callCtx, request)
 	})
 	if err != nil {
 		return CredentialsFetcherResponse{}, err
 	}
-	seelog.Infof("created kerberos tickets and associated with LeaseID: %s", response.GetLeaseId())
+	logger.Info("created kerberos tickets", logger.Fields{field.LeaseID: response.GetLeaseId(), field.Attempts: attempts})
 
 	credentialsFetcherResponse := CredentialsFetcherResponse{
 		LeaseID:             response.GetLeaseId(),
@@ -274,12 +222,12 @@ func (c CredentialsFetcherClient) AddKerberosLease(ctx context.Context, credenti
 // to create kerberos tickets associated with gMSA accounts in domainless mode
 func (c CredentialsFetcherClient) AddNonDomainJoinedKerberosLease(ctx context.Context, credentialspecs []string, username string, password string, domain string) (CredentialsFetcherResponse, error) {
 	if len(credentialspecs) == 0 {
-		seelog.Error("credentialspecs request should not be empty")
+		logger.Error("credentialspecs request should not be empty")
 		return CredentialsFetcherResponse{}, status.Errorf(codes.InvalidArgument, "credentialspecs should not be empty")
 	}
 
 	if len(username) == 0 || len(password) == 0 || len(domain) == 0 {
-		seelog.Error("username, password or domain should not be empty")
+		logger.Error("username, password or domain should not be empty")
 		return CredentialsFetcherResponse{}, status.Errorf(codes.InvalidArgument, "username, password or domain should not be empty")
 	}
 
@@ -288,13 +236,13 @@ func (c CredentialsFetcherClient) AddNonDomainJoinedKerberosLease(ctx context.Co
 
 	request := &pb.CreateNonDomainJoinedKerberosLeaseRequest{CredspecContents: credentialspecs, Username: username, Password: password, Domain: domain}
 
-	response, err := callWithRetry(ctx, c.backoff, c.timeout, "add non-domain-joined kerberos lease", func(callCtx context.Context) (*pb.CreateNonDomainJoinedKerberosLeaseResponse, error) {
+	response, attempts, err := retry.CallWithRetry(ctx, c.backoff, grpcCallRetryAttempts, c.timeout, func(callCtx context.Context) (*pb.CreateNonDomainJoinedKerberosLeaseResponse, error) {
 		return client.AddNonDomainJoinedKerberosLease(callCtx, request)
 	})
 	if err != nil {
 		return CredentialsFetcherResponse{}, err
 	}
-	seelog.Infof("created kerberos tickets and associated with LeaseID: %s", response.GetLeaseId())
+	logger.Info("created kerberos tickets", logger.Fields{field.LeaseID: response.GetLeaseId(), field.Attempts: attempts})
 
 	credentialsFetcherResponse := CredentialsFetcherResponse{
 		LeaseID:             response.GetLeaseId(),
@@ -308,7 +256,7 @@ func (c CredentialsFetcherClient) AddNonDomainJoinedKerberosLease(ctx context.Co
 // to renew kerberos tickets associated with gMSA accounts in domainless mode
 func (c CredentialsFetcherClient) RenewNonDomainJoinedKerberosLease(ctx context.Context, username string, password string, domain string) (CredentialsFetcherResponse, error) {
 	if len(username) == 0 || len(password) == 0 || len(domain) == 0 {
-		seelog.Error("username, password or domain should not be empty")
+		logger.Error("username, password or domain should not be empty")
 		return CredentialsFetcherResponse{}, status.Errorf(codes.InvalidArgument, "username, password or domain should not be empty")
 	}
 
@@ -317,12 +265,13 @@ func (c CredentialsFetcherClient) RenewNonDomainJoinedKerberosLease(ctx context.
 
 	request := &pb.RenewNonDomainJoinedKerberosLeaseRequest{Username: username, Password: password, Domain: domain}
 
-	response, err := callWithRetry(ctx, c.backoff, c.timeout, "renew non-domain-joined kerberos lease", func(callCtx context.Context) (*pb.RenewNonDomainJoinedKerberosLeaseResponse, error) {
+	response, attempts, err := retry.CallWithRetry(ctx, c.backoff, grpcCallRetryAttempts, c.timeout, func(callCtx context.Context) (*pb.RenewNonDomainJoinedKerberosLeaseResponse, error) {
 		return client.RenewNonDomainJoinedKerberosLease(callCtx, request)
 	})
 	if err != nil {
 		return CredentialsFetcherResponse{}, err
 	}
+	logger.Info("renewed kerberos tickets", logger.Fields{field.Attempts: attempts})
 
 	credentialsFetcherResponse := CredentialsFetcherResponse{
 		KerberosTicketPaths: response.GetRenewedKerberosFilePaths(),
@@ -335,7 +284,7 @@ func (c CredentialsFetcherClient) RenewNonDomainJoinedKerberosLease(ctx context.
 // to delete kerberos tickets of gMSA accounts associated with the leaseid
 func (c CredentialsFetcherClient) DeleteKerberosLease(ctx context.Context, leaseid string) (CredentialsFetcherResponse, error) {
 	if len(leaseid) == 0 {
-		seelog.Error("invalid leaseid provided")
+		logger.Error("invalid leaseid provided")
 		return CredentialsFetcherResponse{}, status.Errorf(codes.InvalidArgument, "invalid leaseid provided")
 	}
 
@@ -344,13 +293,13 @@ func (c CredentialsFetcherClient) DeleteKerberosLease(ctx context.Context, lease
 
 	request := &pb.DeleteKerberosLeaseRequest{LeaseId: leaseid}
 
-	response, err := callWithRetry(ctx, c.backoff, c.timeout, "delete kerberos lease", func(callCtx context.Context) (*pb.DeleteKerberosLeaseResponse, error) {
+	response, attempts, err := retry.CallWithRetry(ctx, c.backoff, grpcCallRetryAttempts, c.timeout, func(callCtx context.Context) (*pb.DeleteKerberosLeaseResponse, error) {
 		return client.DeleteKerberosLease(callCtx, request)
 	})
 	if err != nil {
 		return CredentialsFetcherResponse{}, err
 	}
-	seelog.Infof("deleted kerberos associated with LeaseID: %s", response.GetLeaseId())
+	logger.Info("deleted kerberos tickets", logger.Fields{field.LeaseID: response.GetLeaseId(), field.Attempts: attempts})
 
 	credentialsFetcherResponse := CredentialsFetcherResponse{
 		LeaseID:             response.GetLeaseId(),

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
@@ -75,4 +75,6 @@ const (
 	Region                  = "region"
 	DockerVersion           = "dockerVersion"
 	NetworkInterface        = "networkInterface"
+	LeaseID                 = "leaseID"
+	Attempts                = "attempts"
 )

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry/grpc.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry/grpc.go
@@ -1,0 +1,79 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package retry
+
+import (
+	"context"
+	"time"
+
+	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// IsRetriableGRPCError returns true for transient gRPC errors (Unavailable,
+// DeadlineExceeded, ResourceExhausted, Aborted, Internal) and false for
+// terminal ones (InvalidArgument, PermissionDenied, etc.).
+func IsRetriableGRPCError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s, _ := status.FromError(err)
+	switch s.Code() {
+	case codes.Unavailable,
+		codes.DeadlineExceeded,
+		codes.ResourceExhausted,
+		codes.Aborted,
+		codes.Internal:
+		return true
+	default:
+		return false
+	}
+}
+
+// CallWithRetry calls fn with retries on transient gRPC errors, stopping
+// immediately on terminal ones. The timeout is the total budget across all
+// attempts — each attempt gets an equal share of it. Returns the result,
+// the number of attempts made, and any error.
+func CallWithRetry[T any](ctx context.Context, backoff Backoff, attempts int, timeout time.Duration, fn func(context.Context) (T, error)) (T, int, error) {
+	var zero T
+	var result T
+	var lastErr error
+	attemptsMade := 0
+
+	perAttemptTimeout := timeout / time.Duration(attempts)
+
+	RetryNWithBackoffCtx(ctx, backoff, attempts, func() error {
+		callCtx, cancel := context.WithTimeout(ctx, perAttemptTimeout)
+		defer cancel()
+
+		attemptsMade++
+		r, err := fn(callCtx)
+		lastErr = err
+		if err != nil {
+			if IsRetriableGRPCError(err) {
+				return apierrors.NewRetriableError(apierrors.NewRetriable(true), err)
+			}
+			return apierrors.NewRetriableError(apierrors.NewRetriable(false), err)
+		}
+		result = r
+		return nil
+	})
+
+	if lastErr != nil {
+		return zero, attemptsMade, lastErr
+	}
+	return result, attemptsMade, nil
+}

--- a/ecs-agent/gmsacredclient/credentialsfetcherclient.go
+++ b/ecs-agent/gmsacredclient/credentialsfetcherclient.go
@@ -1,3 +1,15 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
 package gmsacredclient
 
 import (
@@ -6,6 +18,7 @@ import (
 	"time"
 
 	pb "github.com/aws/amazon-ecs-agent/ecs-agent/gmsacredclient/credentialsfetcher"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 	"github.com/cihub/seelog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -13,9 +26,19 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// Retry policy for gRPC calls to the credentials fetcher daemon.
+const (
+	grpcCallRetryAttempts        = 3
+	grpcCallRetryBackoffMin      = 1 * time.Second
+	grpcCallRetryBackoffMax      = 5 * time.Second
+	grpcCallRetryBackoffJitter   = 0.2
+	grpcCallRetryBackoffMultiple = 2.0
+)
+
 type CredentialsFetcherClient struct {
 	conn    *grpc.ClientConn
 	timeout time.Duration
+	backoff retry.Backoff
 }
 
 // GetGrpcClientConnection() returns grpc client connection
@@ -50,6 +73,12 @@ func NewCredentialsFetcherClient(conn *grpc.ClientConn, timeout time.Duration) C
 	return CredentialsFetcherClient{
 		conn:    conn,
 		timeout: timeout,
+		backoff: retry.NewExponentialBackoff(
+			grpcCallRetryBackoffMin,
+			grpcCallRetryBackoffMax,
+			grpcCallRetryBackoffJitter,
+			grpcCallRetryBackoffMultiple,
+		),
 	}
 }
 
@@ -69,6 +98,60 @@ type CredentialsFetcherArnResponse struct {
 	KerberosTicketsMap map[string]string
 }
 
+// isRetriableGRPCError returns true for transient errors (Unavailable,
+// DeadlineExceeded, ResourceExhausted, Aborted, Internal) and false for
+// terminal ones (InvalidArgument, PermissionDenied, etc.).
+func isRetriableGRPCError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s, _ := status.FromError(err)
+	switch s.Code() {
+	case codes.Unavailable,
+		codes.DeadlineExceeded,
+		codes.ResourceExhausted,
+		codes.Aborted,
+		codes.Internal:
+		return true
+	default:
+		return false
+	}
+}
+
+// callWithRetry calls fn with retries on transient gRPC errors, stopping
+// immediately on terminal ones. The timeout is the total budget across all
+// attempts — each attempt gets an equal share of it.
+func callWithRetry[T any](ctx context.Context, backoff retry.Backoff, timeout time.Duration, operation string, fn func(context.Context) (T, error)) (T, error) {
+	var zero T
+	var result T
+	var lastErr error
+
+	perAttemptTimeout := timeout / grpcCallRetryAttempts
+
+	retry.RetryNWithBackoffCtx(ctx, backoff, grpcCallRetryAttempts, func() error {
+		callCtx, cancel := context.WithTimeout(ctx, perAttemptTimeout)
+		defer cancel()
+
+		r, err := fn(callCtx)
+		lastErr = err
+		if err != nil {
+			if isRetriableGRPCError(err) {
+				seelog.Warnf("transient error during %s, will retry: %v", operation, err)
+				return err
+			}
+			seelog.Errorf("terminal error during %s: %v", operation, err)
+			return nil
+		}
+		result = r
+		return nil
+	})
+
+	if lastErr != nil {
+		return zero, lastErr
+	}
+	return result, nil
+}
+
 // HealthCheck() invokes credentials fetcher daemon running on the host
 // to check the health status of daemon
 func (c CredentialsFetcherClient) HealthCheck(ctx context.Context, serviceName string) (string, error) {
@@ -80,12 +163,10 @@ func (c CredentialsFetcherClient) HealthCheck(ctx context.Context, serviceName s
 
 	request := &pb.HealthCheckRequest{Service: serviceName}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	response, err := client.HealthCheck(ctx, request)
+	response, err := callWithRetry(ctx, c.backoff, c.timeout, "credentials-fetcher health check", func(callCtx context.Context) (*pb.HealthCheckResponse, error) {
+		return client.HealthCheck(callCtx, request)
+	})
 	if err != nil {
-		seelog.Errorf("credentials-fetcher daemon status is unhealthy during health check: %v", err)
 		return "", err
 	}
 	seelog.Debugf("credentials-fetcher daemon is running")
@@ -109,12 +190,10 @@ func (c CredentialsFetcherClient) AddKerberosArnLease(ctx context.Context, crede
 
 	request := &pb.KerberosArnLeaseRequest{CredspecArns: credentialspecsArns, AccessKeyId: accessKeyId, SecretAccessKey: secretKey, SessionToken: sessionToken, Region: region}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	response, err := client.AddKerberosArnLease(ctx, request)
+	response, err := callWithRetry(ctx, c.backoff, c.timeout, "add kerberos ARN lease", func(callCtx context.Context) (*pb.CreateKerberosArnLeaseResponse, error) {
+		return client.AddKerberosArnLease(callCtx, request)
+	})
 	if err != nil {
-		seelog.Errorf("could not create kerberos tickets: %v", err)
 		return CredentialsFetcherArnResponse{}, err
 	}
 	seelog.Infof("created kerberos tickets and associated with LeaseID: %s", response.GetLeaseId())
@@ -147,12 +226,10 @@ func (c CredentialsFetcherClient) RenewKerberosArnLease(ctx context.Context, acc
 
 	request := &pb.RenewKerberosArnLeaseRequest{AccessKeyId: accessKeyId, SecretAccessKey: secretKey, SessionToken: sessionToken, Region: region}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	response, err := client.RenewKerberosArnLease(ctx, request)
+	response, err := callWithRetry(ctx, c.backoff, c.timeout, "renew kerberos ARN lease", func(callCtx context.Context) (*pb.RenewKerberosArnLeaseResponse, error) {
+		return client.RenewKerberosArnLease(callCtx, request)
+	})
 	if err != nil {
-		seelog.Errorf("could not renew kerberos tickets: %v", err)
 		return codes.Internal.String(), err
 	}
 
@@ -177,12 +254,10 @@ func (c CredentialsFetcherClient) AddKerberosLease(ctx context.Context, credenti
 
 	request := &pb.CreateKerberosLeaseRequest{CredspecContents: credentialspecs}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	response, err := client.AddKerberosLease(ctx, request)
+	response, err := callWithRetry(ctx, c.backoff, c.timeout, "add kerberos lease", func(callCtx context.Context) (*pb.CreateKerberosLeaseResponse, error) {
+		return client.AddKerberosLease(callCtx, request)
+	})
 	if err != nil {
-		seelog.Errorf("could not create kerberos tickets: %v", err)
 		return CredentialsFetcherResponse{}, err
 	}
 	seelog.Infof("created kerberos tickets and associated with LeaseID: %s", response.GetLeaseId())
@@ -213,12 +288,10 @@ func (c CredentialsFetcherClient) AddNonDomainJoinedKerberosLease(ctx context.Co
 
 	request := &pb.CreateNonDomainJoinedKerberosLeaseRequest{CredspecContents: credentialspecs, Username: username, Password: password, Domain: domain}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	response, err := client.AddNonDomainJoinedKerberosLease(ctx, request)
+	response, err := callWithRetry(ctx, c.backoff, c.timeout, "add non-domain-joined kerberos lease", func(callCtx context.Context) (*pb.CreateNonDomainJoinedKerberosLeaseResponse, error) {
+		return client.AddNonDomainJoinedKerberosLease(callCtx, request)
+	})
 	if err != nil {
-		seelog.Errorf("could not create kerberos tickets: %v", err)
 		return CredentialsFetcherResponse{}, err
 	}
 	seelog.Infof("created kerberos tickets and associated with LeaseID: %s", response.GetLeaseId())
@@ -244,12 +317,10 @@ func (c CredentialsFetcherClient) RenewNonDomainJoinedKerberosLease(ctx context.
 
 	request := &pb.RenewNonDomainJoinedKerberosLeaseRequest{Username: username, Password: password, Domain: domain}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	response, err := client.RenewNonDomainJoinedKerberosLease(ctx, request)
+	response, err := callWithRetry(ctx, c.backoff, c.timeout, "renew non-domain-joined kerberos lease", func(callCtx context.Context) (*pb.RenewNonDomainJoinedKerberosLeaseResponse, error) {
+		return client.RenewNonDomainJoinedKerberosLease(callCtx, request)
+	})
 	if err != nil {
-		seelog.Errorf("could not renew kerberos tickets: %v", err)
 		return CredentialsFetcherResponse{}, err
 	}
 
@@ -273,12 +344,10 @@ func (c CredentialsFetcherClient) DeleteKerberosLease(ctx context.Context, lease
 
 	request := &pb.DeleteKerberosLeaseRequest{LeaseId: leaseid}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	response, err := client.DeleteKerberosLease(ctx, request)
+	response, err := callWithRetry(ctx, c.backoff, c.timeout, "delete kerberos lease", func(callCtx context.Context) (*pb.DeleteKerberosLeaseResponse, error) {
+		return client.DeleteKerberosLease(callCtx, request)
+	})
 	if err != nil {
-		seelog.Errorf("could not delete kerberos tickets: %v", err)
 		return CredentialsFetcherResponse{}, err
 	}
 	seelog.Infof("deleted kerberos associated with LeaseID: %s", response.GetLeaseId())

--- a/ecs-agent/gmsacredclient/credentialsfetcherclient.go
+++ b/ecs-agent/gmsacredclient/credentialsfetcherclient.go
@@ -18,8 +18,10 @@ import (
 	"time"
 
 	pb "github.com/aws/amazon-ecs-agent/ecs-agent/gmsacredclient/credentialsfetcher"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
-	"github.com/cihub/seelog"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -45,13 +47,13 @@ type CredentialsFetcherClient struct {
 func GetGrpcClientConnection() (*grpc.ClientConn, error) {
 	address, err := getSocketAddress()
 	if err != nil {
-		seelog.Errorf("could not find path to credentials fetcher host dir : %v", err)
+		logger.Error("could not find path to credentials fetcher host dir", logger.Fields{field.Error: err})
 		return nil, err
 	}
 
 	conn, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		seelog.Errorf("could not initialize client connection %v", err)
+		logger.Error("could not initialize client connection", logger.Fields{field.Error: err})
 		return nil, err
 	}
 	return conn, nil
@@ -98,60 +100,6 @@ type CredentialsFetcherArnResponse struct {
 	KerberosTicketsMap map[string]string
 }
 
-// isRetriableGRPCError returns true for transient errors (Unavailable,
-// DeadlineExceeded, ResourceExhausted, Aborted, Internal) and false for
-// terminal ones (InvalidArgument, PermissionDenied, etc.).
-func isRetriableGRPCError(err error) bool {
-	if err == nil {
-		return false
-	}
-	s, _ := status.FromError(err)
-	switch s.Code() {
-	case codes.Unavailable,
-		codes.DeadlineExceeded,
-		codes.ResourceExhausted,
-		codes.Aborted,
-		codes.Internal:
-		return true
-	default:
-		return false
-	}
-}
-
-// callWithRetry calls fn with retries on transient gRPC errors, stopping
-// immediately on terminal ones. The timeout is the total budget across all
-// attempts — each attempt gets an equal share of it.
-func callWithRetry[T any](ctx context.Context, backoff retry.Backoff, timeout time.Duration, operation string, fn func(context.Context) (T, error)) (T, error) {
-	var zero T
-	var result T
-	var lastErr error
-
-	perAttemptTimeout := timeout / grpcCallRetryAttempts
-
-	retry.RetryNWithBackoffCtx(ctx, backoff, grpcCallRetryAttempts, func() error {
-		callCtx, cancel := context.WithTimeout(ctx, perAttemptTimeout)
-		defer cancel()
-
-		r, err := fn(callCtx)
-		lastErr = err
-		if err != nil {
-			if isRetriableGRPCError(err) {
-				seelog.Warnf("transient error during %s, will retry: %v", operation, err)
-				return err
-			}
-			seelog.Errorf("terminal error during %s: %v", operation, err)
-			return nil
-		}
-		result = r
-		return nil
-	})
-
-	if lastErr != nil {
-		return zero, lastErr
-	}
-	return result, nil
-}
-
 // HealthCheck() invokes credentials fetcher daemon running on the host
 // to check the health status of daemon
 func (c CredentialsFetcherClient) HealthCheck(ctx context.Context, serviceName string) (string, error) {
@@ -163,13 +111,13 @@ func (c CredentialsFetcherClient) HealthCheck(ctx context.Context, serviceName s
 
 	request := &pb.HealthCheckRequest{Service: serviceName}
 
-	response, err := callWithRetry(ctx, c.backoff, c.timeout, "credentials-fetcher health check", func(callCtx context.Context) (*pb.HealthCheckResponse, error) {
+	response, attempts, err := retry.CallWithRetry(ctx, c.backoff, grpcCallRetryAttempts, c.timeout, func(callCtx context.Context) (*pb.HealthCheckResponse, error) {
 		return client.HealthCheck(callCtx, request)
 	})
 	if err != nil {
 		return "", err
 	}
-	seelog.Debugf("credentials-fetcher daemon is running")
+	logger.Debug("credentials-fetcher daemon is running", logger.Fields{field.Attempts: attempts})
 
 	return response.GetStatus(), nil
 }
@@ -190,13 +138,13 @@ func (c CredentialsFetcherClient) AddKerberosArnLease(ctx context.Context, crede
 
 	request := &pb.KerberosArnLeaseRequest{CredspecArns: credentialspecsArns, AccessKeyId: accessKeyId, SecretAccessKey: secretKey, SessionToken: sessionToken, Region: region}
 
-	response, err := callWithRetry(ctx, c.backoff, c.timeout, "add kerberos ARN lease", func(callCtx context.Context) (*pb.CreateKerberosArnLeaseResponse, error) {
+	response, attempts, err := retry.CallWithRetry(ctx, c.backoff, grpcCallRetryAttempts, c.timeout, func(callCtx context.Context) (*pb.CreateKerberosArnLeaseResponse, error) {
 		return client.AddKerberosArnLease(callCtx, request)
 	})
 	if err != nil {
 		return CredentialsFetcherArnResponse{}, err
 	}
-	seelog.Infof("created kerberos tickets and associated with LeaseID: %s", response.GetLeaseId())
+	logger.Info("created kerberos tickets", logger.Fields{field.LeaseID: response.GetLeaseId(), field.Attempts: attempts})
 
 	credentialsFetcherResponse := CredentialsFetcherArnResponse{
 		LeaseID:            response.GetLeaseId(),
@@ -226,7 +174,7 @@ func (c CredentialsFetcherClient) RenewKerberosArnLease(ctx context.Context, acc
 
 	request := &pb.RenewKerberosArnLeaseRequest{AccessKeyId: accessKeyId, SecretAccessKey: secretKey, SessionToken: sessionToken, Region: region}
 
-	response, err := callWithRetry(ctx, c.backoff, c.timeout, "renew kerberos ARN lease", func(callCtx context.Context) (*pb.RenewKerberosArnLeaseResponse, error) {
+	response, attempts, err := retry.CallWithRetry(ctx, c.backoff, grpcCallRetryAttempts, c.timeout, func(callCtx context.Context) (*pb.RenewKerberosArnLeaseResponse, error) {
 		return client.RenewKerberosArnLease(callCtx, request)
 	})
 	if err != nil {
@@ -237,7 +185,7 @@ func (c CredentialsFetcherClient) RenewKerberosArnLease(ctx context.Context, acc
 		return codes.Internal.String(), status.Errorf(codes.Internal, "renewal of kerberos tickets failed")
 	}
 
-	seelog.Infof("renewal of kerberos tickets are successful")
+	logger.Info("renewal of kerberos tickets are successful", logger.Fields{field.Attempts: attempts})
 
 	return codes.OK.String(), nil
 }
@@ -254,13 +202,13 @@ func (c CredentialsFetcherClient) AddKerberosLease(ctx context.Context, credenti
 
 	request := &pb.CreateKerberosLeaseRequest{CredspecContents: credentialspecs}
 
-	response, err := callWithRetry(ctx, c.backoff, c.timeout, "add kerberos lease", func(callCtx context.Context) (*pb.CreateKerberosLeaseResponse, error) {
+	response, attempts, err := retry.CallWithRetry(ctx, c.backoff, grpcCallRetryAttempts, c.timeout, func(callCtx context.Context) (*pb.CreateKerberosLeaseResponse, error) {
 		return client.AddKerberosLease(callCtx, request)
 	})
 	if err != nil {
 		return CredentialsFetcherResponse{}, err
 	}
-	seelog.Infof("created kerberos tickets and associated with LeaseID: %s", response.GetLeaseId())
+	logger.Info("created kerberos tickets", logger.Fields{field.LeaseID: response.GetLeaseId(), field.Attempts: attempts})
 
 	credentialsFetcherResponse := CredentialsFetcherResponse{
 		LeaseID:             response.GetLeaseId(),
@@ -274,12 +222,12 @@ func (c CredentialsFetcherClient) AddKerberosLease(ctx context.Context, credenti
 // to create kerberos tickets associated with gMSA accounts in domainless mode
 func (c CredentialsFetcherClient) AddNonDomainJoinedKerberosLease(ctx context.Context, credentialspecs []string, username string, password string, domain string) (CredentialsFetcherResponse, error) {
 	if len(credentialspecs) == 0 {
-		seelog.Error("credentialspecs request should not be empty")
+		logger.Error("credentialspecs request should not be empty")
 		return CredentialsFetcherResponse{}, status.Errorf(codes.InvalidArgument, "credentialspecs should not be empty")
 	}
 
 	if len(username) == 0 || len(password) == 0 || len(domain) == 0 {
-		seelog.Error("username, password or domain should not be empty")
+		logger.Error("username, password or domain should not be empty")
 		return CredentialsFetcherResponse{}, status.Errorf(codes.InvalidArgument, "username, password or domain should not be empty")
 	}
 
@@ -288,13 +236,13 @@ func (c CredentialsFetcherClient) AddNonDomainJoinedKerberosLease(ctx context.Co
 
 	request := &pb.CreateNonDomainJoinedKerberosLeaseRequest{CredspecContents: credentialspecs, Username: username, Password: password, Domain: domain}
 
-	response, err := callWithRetry(ctx, c.backoff, c.timeout, "add non-domain-joined kerberos lease", func(callCtx context.Context) (*pb.CreateNonDomainJoinedKerberosLeaseResponse, error) {
+	response, attempts, err := retry.CallWithRetry(ctx, c.backoff, grpcCallRetryAttempts, c.timeout, func(callCtx context.Context) (*pb.CreateNonDomainJoinedKerberosLeaseResponse, error) {
 		return client.AddNonDomainJoinedKerberosLease(callCtx, request)
 	})
 	if err != nil {
 		return CredentialsFetcherResponse{}, err
 	}
-	seelog.Infof("created kerberos tickets and associated with LeaseID: %s", response.GetLeaseId())
+	logger.Info("created kerberos tickets", logger.Fields{field.LeaseID: response.GetLeaseId(), field.Attempts: attempts})
 
 	credentialsFetcherResponse := CredentialsFetcherResponse{
 		LeaseID:             response.GetLeaseId(),
@@ -308,7 +256,7 @@ func (c CredentialsFetcherClient) AddNonDomainJoinedKerberosLease(ctx context.Co
 // to renew kerberos tickets associated with gMSA accounts in domainless mode
 func (c CredentialsFetcherClient) RenewNonDomainJoinedKerberosLease(ctx context.Context, username string, password string, domain string) (CredentialsFetcherResponse, error) {
 	if len(username) == 0 || len(password) == 0 || len(domain) == 0 {
-		seelog.Error("username, password or domain should not be empty")
+		logger.Error("username, password or domain should not be empty")
 		return CredentialsFetcherResponse{}, status.Errorf(codes.InvalidArgument, "username, password or domain should not be empty")
 	}
 
@@ -317,12 +265,13 @@ func (c CredentialsFetcherClient) RenewNonDomainJoinedKerberosLease(ctx context.
 
 	request := &pb.RenewNonDomainJoinedKerberosLeaseRequest{Username: username, Password: password, Domain: domain}
 
-	response, err := callWithRetry(ctx, c.backoff, c.timeout, "renew non-domain-joined kerberos lease", func(callCtx context.Context) (*pb.RenewNonDomainJoinedKerberosLeaseResponse, error) {
+	response, attempts, err := retry.CallWithRetry(ctx, c.backoff, grpcCallRetryAttempts, c.timeout, func(callCtx context.Context) (*pb.RenewNonDomainJoinedKerberosLeaseResponse, error) {
 		return client.RenewNonDomainJoinedKerberosLease(callCtx, request)
 	})
 	if err != nil {
 		return CredentialsFetcherResponse{}, err
 	}
+	logger.Info("renewed kerberos tickets", logger.Fields{field.Attempts: attempts})
 
 	credentialsFetcherResponse := CredentialsFetcherResponse{
 		KerberosTicketPaths: response.GetRenewedKerberosFilePaths(),
@@ -335,7 +284,7 @@ func (c CredentialsFetcherClient) RenewNonDomainJoinedKerberosLease(ctx context.
 // to delete kerberos tickets of gMSA accounts associated with the leaseid
 func (c CredentialsFetcherClient) DeleteKerberosLease(ctx context.Context, leaseid string) (CredentialsFetcherResponse, error) {
 	if len(leaseid) == 0 {
-		seelog.Error("invalid leaseid provided")
+		logger.Error("invalid leaseid provided")
 		return CredentialsFetcherResponse{}, status.Errorf(codes.InvalidArgument, "invalid leaseid provided")
 	}
 
@@ -344,13 +293,13 @@ func (c CredentialsFetcherClient) DeleteKerberosLease(ctx context.Context, lease
 
 	request := &pb.DeleteKerberosLeaseRequest{LeaseId: leaseid}
 
-	response, err := callWithRetry(ctx, c.backoff, c.timeout, "delete kerberos lease", func(callCtx context.Context) (*pb.DeleteKerberosLeaseResponse, error) {
+	response, attempts, err := retry.CallWithRetry(ctx, c.backoff, grpcCallRetryAttempts, c.timeout, func(callCtx context.Context) (*pb.DeleteKerberosLeaseResponse, error) {
 		return client.DeleteKerberosLease(callCtx, request)
 	})
 	if err != nil {
 		return CredentialsFetcherResponse{}, err
 	}
-	seelog.Infof("deleted kerberos associated with LeaseID: %s", response.GetLeaseId())
+	logger.Info("deleted kerberos tickets", logger.Fields{field.LeaseID: response.GetLeaseId(), field.Attempts: attempts})
 
 	credentialsFetcherResponse := CredentialsFetcherResponse{
 		LeaseID:             response.GetLeaseId(),

--- a/ecs-agent/gmsacredclient/credentialsfetcherclient_test.go
+++ b/ecs-agent/gmsacredclient/credentialsfetcherclient_test.go
@@ -19,10 +19,12 @@ import (
 	"context"
 	"log"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	pb "github.com/aws/amazon-ecs-agent/ecs-agent/gmsacredclient/credentialsfetcher"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -107,11 +109,16 @@ func (*mockCredentialsFetcherServer) DeleteKerberosLease(ctx context.Context, re
 }
 
 func dialer() func(context.Context, string) (net.Conn, error) {
+	return dialerForServer(&mockCredentialsFetcherServer{})
+}
+
+// dialerForServer creates a bufconn-based dialer for the given gRPC server.
+func dialerForServer(srv pb.CredentialsFetcherServiceServer) func(context.Context, string) (net.Conn, error) {
 	listener := bufconn.Listen(1024 * 1024)
 
 	server := grpc.NewServer()
 
-	pb.RegisterCredentialsFetcherServiceServer(server, &mockCredentialsFetcherServer{})
+	pb.RegisterCredentialsFetcherServiceServer(server, srv)
 
 	go func() {
 		if err := server.Serve(listener); err != nil {
@@ -122,6 +129,23 @@ func dialer() func(context.Context, string) (net.Conn, error) {
 	return func(context.Context, string) (net.Conn, error) {
 		return listener.Dial()
 	}
+}
+
+// newConnForServer creates a gRPC client connection backed by the given server.
+func newConnForServer(t *testing.T, srv pb.CredentialsFetcherServiceServer) *grpc.ClientConn {
+	t.Helper()
+	ctx := context.Background()
+	conn, err := grpc.DialContext(ctx, "", grpc.WithInsecure(), grpc.WithContextDialer(dialerForServer(srv)))
+	require.NoError(t, err)
+	return conn
+}
+
+// newFastClient creates a CredentialsFetcherClient with a near-zero backoff so
+// retry tests complete quickly.
+func newFastClient(conn *grpc.ClientConn) CredentialsFetcherClient {
+	c := NewCredentialsFetcherClient(conn, time.Minute)
+	c.backoff = retry.NewExponentialBackoff(time.Nanosecond, time.Nanosecond, 0, 1)
+	return c
 }
 
 func TestCredentialsFetcherClient_Health(t *testing.T) {
@@ -449,4 +473,125 @@ func TestCredentialsFetcherClient_DeleteKerberosLease(t *testing.T) {
 			}
 		})
 	}
+}
+
+// transientThenSucceedServer is a mock gRPC server that returns a transient
+// Unavailable error for the first `failCount` calls, then succeeds.
+type transientThenSucceedServer struct {
+	pb.UnimplementedCredentialsFetcherServiceServer
+	// callCount tracks the total number of calls received across all methods.
+	callCount atomic.Int32
+	// failCount is the number of initial calls that should return a transient error.
+	failCount int32
+}
+
+func (s *transientThenSucceedServer) shouldFail() bool {
+	return s.callCount.Add(1) <= s.failCount
+}
+
+func (s *transientThenSucceedServer) AddKerberosLease(ctx context.Context, req *pb.CreateKerberosLeaseRequest) (*pb.CreateKerberosLeaseResponse, error) {
+	if s.shouldFail() {
+		return nil, status.Errorf(codes.Unavailable, "service temporarily unavailable")
+	}
+	return &pb.CreateKerberosLeaseResponse{
+		LeaseId:                  leaseid,
+		CreatedKerberosFilePaths: []string{"/var/credentials-fetcher/krbdir/123456/webapp01"},
+	}, nil
+}
+
+// terminalErrorServer always returns a terminal (non-retriable) error.
+type terminalErrorServer struct {
+	pb.UnimplementedCredentialsFetcherServiceServer
+	callCount atomic.Int32
+}
+
+func (s *terminalErrorServer) AddKerberosLease(ctx context.Context, req *pb.CreateKerberosLeaseRequest) (*pb.CreateKerberosLeaseResponse, error) {
+	s.callCount.Add(1)
+	return nil, status.Errorf(codes.PermissionDenied, "permission denied")
+}
+
+// renewFailedServer returns Status:"failed" from RenewKerberosArnLease with no gRPC error,
+// exercising the application-level failure branch in RenewKerberosArnLease.
+type renewFailedServer struct {
+	pb.UnimplementedCredentialsFetcherServiceServer
+}
+
+func (*renewFailedServer) RenewKerberosArnLease(_ context.Context, _ *pb.RenewKerberosArnLeaseRequest) (*pb.RenewKerberosArnLeaseResponse, error) {
+	return &pb.RenewKerberosArnLeaseResponse{Status: "failed"}, nil
+}
+
+// TestIsRetriableGRPCError verifies the error classification logic.
+func TestIsRetriableGRPCError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		retriable bool
+	}{
+		{"nil error", nil, false},
+		{"Unavailable", status.Errorf(codes.Unavailable, "unavailable"), true},
+		{"DeadlineExceeded", status.Errorf(codes.DeadlineExceeded, "deadline"), true},
+		{"ResourceExhausted", status.Errorf(codes.ResourceExhausted, "exhausted"), true},
+		{"Aborted", status.Errorf(codes.Aborted, "aborted"), true},
+		{"Internal", status.Errorf(codes.Internal, "internal"), true},
+		{"InvalidArgument", status.Errorf(codes.InvalidArgument, "bad arg"), false},
+		{"PermissionDenied", status.Errorf(codes.PermissionDenied, "denied"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.retriable, isRetriableGRPCError(tt.err))
+		})
+	}
+}
+
+// TestAddKerberosLease_RetryOnTransientError verifies that callWithRetry retries
+// on transient errors and eventually succeeds.
+func TestAddKerberosLease_RetryOnTransientError(t *testing.T) {
+	srv := &transientThenSucceedServer{failCount: 2}
+	conn := newConnForServer(t, srv)
+
+	response, err := newFastClient(conn).
+		AddKerberosLease(context.Background(), []string{credspec_webapp01})
+
+	require.NoError(t, err)
+	assert.Equal(t, leaseid, response.LeaseID)
+	assert.Equal(t, int32(3), srv.callCount.Load(), "expected 2 failures + 1 success = 3 total calls")
+}
+
+// TestAddKerberosLease_ExhaustsRetries verifies that callWithRetry gives up
+// after grpcCallRetryAttempts and returns the last error.
+func TestAddKerberosLease_ExhaustsRetries(t *testing.T) {
+	srv := &transientThenSucceedServer{failCount: grpcCallRetryAttempts + 1}
+	conn := newConnForServer(t, srv)
+
+	_, err := newFastClient(conn).
+		AddKerberosLease(context.Background(), []string{credspec_webapp01})
+
+	require.Error(t, err)
+	assert.Equal(t, int32(grpcCallRetryAttempts), srv.callCount.Load())
+}
+
+// TestAddKerberosLease_NoRetryOnTerminalError verifies that callWithRetry does
+// not retry terminal errors and preserves the original gRPC status code.
+func TestAddKerberosLease_NoRetryOnTerminalError(t *testing.T) {
+	srv := &terminalErrorServer{}
+	conn := newConnForServer(t, srv)
+
+	_, err := newFastClient(conn).
+		AddKerberosLease(context.Background(), []string{credspec_webapp01})
+
+	require.Error(t, err)
+	assert.Equal(t, int32(1), srv.callCount.Load())
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+// TestRenewKerberosArnLease_FailedStatus verifies that a daemon response with
+// Status:"failed" (no gRPC error) is returned as an error to the caller.
+func TestRenewKerberosArnLease_FailedStatus(t *testing.T) {
+	conn := newConnForServer(t, &renewFailedServer{})
+
+	_, err := newFastClient(conn).
+		RenewKerberosArnLease(context.Background(), "id", "secret", "token", "us-east-1")
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
 }

--- a/ecs-agent/gmsacredclient/credentialsfetcherclient_test.go
+++ b/ecs-agent/gmsacredclient/credentialsfetcherclient_test.go
@@ -25,6 +25,7 @@ import (
 
 	pb "github.com/aws/amazon-ecs-agent/ecs-agent/gmsacredclient/credentialsfetcher"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -520,30 +521,7 @@ func (*renewFailedServer) RenewKerberosArnLease(_ context.Context, _ *pb.RenewKe
 	return &pb.RenewKerberosArnLeaseResponse{Status: "failed"}, nil
 }
 
-// TestIsRetriableGRPCError verifies the error classification logic.
-func TestIsRetriableGRPCError(t *testing.T) {
-	tests := []struct {
-		name      string
-		err       error
-		retriable bool
-	}{
-		{"nil error", nil, false},
-		{"Unavailable", status.Errorf(codes.Unavailable, "unavailable"), true},
-		{"DeadlineExceeded", status.Errorf(codes.DeadlineExceeded, "deadline"), true},
-		{"ResourceExhausted", status.Errorf(codes.ResourceExhausted, "exhausted"), true},
-		{"Aborted", status.Errorf(codes.Aborted, "aborted"), true},
-		{"Internal", status.Errorf(codes.Internal, "internal"), true},
-		{"InvalidArgument", status.Errorf(codes.InvalidArgument, "bad arg"), false},
-		{"PermissionDenied", status.Errorf(codes.PermissionDenied, "denied"), false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.retriable, isRetriableGRPCError(tt.err))
-		})
-	}
-}
-
-// TestAddKerberosLease_RetryOnTransientError verifies that callWithRetry retries
+// TestAddKerberosLease_RetryOnTransientError verifies that retry.CallWithRetry retries
 // on transient errors and eventually succeeds.
 func TestAddKerberosLease_RetryOnTransientError(t *testing.T) {
 	srv := &transientThenSucceedServer{failCount: 2}
@@ -557,7 +535,7 @@ func TestAddKerberosLease_RetryOnTransientError(t *testing.T) {
 	assert.Equal(t, int32(3), srv.callCount.Load(), "expected 2 failures + 1 success = 3 total calls")
 }
 
-// TestAddKerberosLease_ExhaustsRetries verifies that callWithRetry gives up
+// TestAddKerberosLease_ExhaustsRetries verifies that retry.CallWithRetry gives up
 // after grpcCallRetryAttempts and returns the last error.
 func TestAddKerberosLease_ExhaustsRetries(t *testing.T) {
 	srv := &transientThenSucceedServer{failCount: grpcCallRetryAttempts + 1}
@@ -570,7 +548,7 @@ func TestAddKerberosLease_ExhaustsRetries(t *testing.T) {
 	assert.Equal(t, int32(grpcCallRetryAttempts), srv.callCount.Load())
 }
 
-// TestAddKerberosLease_NoRetryOnTerminalError verifies that callWithRetry does
+// TestAddKerberosLease_NoRetryOnTerminalError verifies that retry.CallWithRetry does
 // not retry terminal errors and preserves the original gRPC status code.
 func TestAddKerberosLease_NoRetryOnTerminalError(t *testing.T) {
 	srv := &terminalErrorServer{}

--- a/ecs-agent/logger/field/constants.go
+++ b/ecs-agent/logger/field/constants.go
@@ -75,4 +75,6 @@ const (
 	Region                  = "region"
 	DockerVersion           = "dockerVersion"
 	NetworkInterface        = "networkInterface"
+	LeaseID                 = "leaseID"
+	Attempts                = "attempts"
 )

--- a/ecs-agent/utils/retry/grpc.go
+++ b/ecs-agent/utils/retry/grpc.go
@@ -1,0 +1,79 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package retry
+
+import (
+	"context"
+	"time"
+
+	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// IsRetriableGRPCError returns true for transient gRPC errors (Unavailable,
+// DeadlineExceeded, ResourceExhausted, Aborted, Internal) and false for
+// terminal ones (InvalidArgument, PermissionDenied, etc.).
+func IsRetriableGRPCError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s, _ := status.FromError(err)
+	switch s.Code() {
+	case codes.Unavailable,
+		codes.DeadlineExceeded,
+		codes.ResourceExhausted,
+		codes.Aborted,
+		codes.Internal:
+		return true
+	default:
+		return false
+	}
+}
+
+// CallWithRetry calls fn with retries on transient gRPC errors, stopping
+// immediately on terminal ones. The timeout is the total budget across all
+// attempts — each attempt gets an equal share of it. Returns the result,
+// the number of attempts made, and any error.
+func CallWithRetry[T any](ctx context.Context, backoff Backoff, attempts int, timeout time.Duration, fn func(context.Context) (T, error)) (T, int, error) {
+	var zero T
+	var result T
+	var lastErr error
+	attemptsMade := 0
+
+	perAttemptTimeout := timeout / time.Duration(attempts)
+
+	RetryNWithBackoffCtx(ctx, backoff, attempts, func() error {
+		callCtx, cancel := context.WithTimeout(ctx, perAttemptTimeout)
+		defer cancel()
+
+		attemptsMade++
+		r, err := fn(callCtx)
+		lastErr = err
+		if err != nil {
+			if IsRetriableGRPCError(err) {
+				return apierrors.NewRetriableError(apierrors.NewRetriable(true), err)
+			}
+			return apierrors.NewRetriableError(apierrors.NewRetriable(false), err)
+		}
+		result = r
+		return nil
+	})
+
+	if lastErr != nil {
+		return zero, attemptsMade, lastErr
+	}
+	return result, attemptsMade, nil
+}

--- a/ecs-agent/utils/retry/grpc_test.go
+++ b/ecs-agent/utils/retry/grpc_test.go
@@ -1,0 +1,136 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package retry
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsRetriableGRPCError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		retriable bool
+	}{
+		{"nil error", nil, false},
+		{"Unavailable", status.Errorf(codes.Unavailable, "unavailable"), true},
+		{"DeadlineExceeded", status.Errorf(codes.DeadlineExceeded, "deadline"), true},
+		{"ResourceExhausted", status.Errorf(codes.ResourceExhausted, "exhausted"), true},
+		{"Aborted", status.Errorf(codes.Aborted, "aborted"), true},
+		{"Internal", status.Errorf(codes.Internal, "internal"), true},
+		{"InvalidArgument", status.Errorf(codes.InvalidArgument, "bad arg"), false},
+		{"PermissionDenied", status.Errorf(codes.PermissionDenied, "denied"), false},
+		{"NotFound", status.Errorf(codes.NotFound, "not found"), false},
+		{"non-gRPC error", errors.New("plain error"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.retriable, IsRetriableGRPCError(tt.err))
+		})
+	}
+}
+
+func TestCallWithRetry(t *testing.T) {
+	fastBackoff := NewExponentialBackoff(time.Nanosecond, time.Nanosecond, 0, 1)
+
+	t.Run("succeeds on first attempt", func(t *testing.T) {
+		result, attempts, err := CallWithRetry(context.Background(), fastBackoff, 3, time.Minute,
+			func(_ context.Context) (string, error) {
+				return "ok", nil
+			})
+		require.NoError(t, err)
+		assert.Equal(t, "ok", result)
+		assert.Equal(t, 1, attempts)
+	})
+
+	t.Run("retries on transient error and succeeds", func(t *testing.T) {
+		var callCount atomic.Int32
+		result, attempts, err := CallWithRetry(context.Background(), fastBackoff, 3, time.Minute,
+			func(_ context.Context) (string, error) {
+				if callCount.Add(1) < 3 {
+					return "", status.Errorf(codes.Unavailable, "transient")
+				}
+				return "ok", nil
+			})
+		require.NoError(t, err)
+		assert.Equal(t, "ok", result)
+		assert.Equal(t, 3, attempts)
+	})
+
+	t.Run("exhausts retries and returns last error", func(t *testing.T) {
+		var callCount atomic.Int32
+		_, attempts, err := CallWithRetry(context.Background(), fastBackoff, 3, time.Minute,
+			func(_ context.Context) (string, error) {
+				callCount.Add(1)
+				return "", status.Errorf(codes.Unavailable, "always unavailable")
+			})
+		require.Error(t, err)
+		assert.Equal(t, codes.Unavailable, status.Code(err))
+		assert.Equal(t, 3, attempts)
+		assert.Equal(t, int32(3), callCount.Load())
+	})
+
+	t.Run("does not retry non-gRPC error", func(t *testing.T) {
+		var callCount atomic.Int32
+		_, attempts, err := CallWithRetry(context.Background(), fastBackoff, 3, time.Minute,
+			func(_ context.Context) (string, error) {
+				callCount.Add(1)
+				return "", errors.New("plain error")
+			})
+		require.Error(t, err)
+		assert.Equal(t, "plain error", err.Error())
+		assert.Equal(t, 1, attempts)
+		assert.Equal(t, int32(1), callCount.Load(), "non-gRPC error should not be retried")
+	})
+
+	t.Run("does not retry terminal error", func(t *testing.T) {
+		var callCount atomic.Int32
+		_, attempts, err := CallWithRetry(context.Background(), fastBackoff, 3, time.Minute,
+			func(_ context.Context) (string, error) {
+				callCount.Add(1)
+				return "", status.Errorf(codes.PermissionDenied, "denied")
+			})
+		require.Error(t, err)
+		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+		assert.Equal(t, 1, attempts)
+		assert.Equal(t, int32(1), callCount.Load(), "terminal error should not be retried")
+	})
+
+	t.Run("context cancellation stops retries", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		var callCount atomic.Int32
+		_, _, err := CallWithRetry(ctx, fastBackoff, 3, time.Minute,
+			func(_ context.Context) (string, error) {
+				if callCount.Add(1) == 1 {
+					cancel()
+				}
+				return "", status.Errorf(codes.Unavailable, "transient")
+			})
+		// lastErr is preserved even when context is cancelled
+		require.Error(t, err)
+		assert.Equal(t, codes.Unavailable, status.Code(err))
+	})
+}


### PR DESCRIPTION
### Summary
Add exponential backoff retries to the credentials fetcher gRPC client to improve resilience against transient daemon unavailability during task startup and cleanup.

### Implementation details
Added a generic callWithRetry helper that wraps every gRPC call with up to 3 attempts using exponential backoff (1s–5s, 2× multiplier, 20% jitter). The total time budget per operation is unchanged from before — callers pass a timeout (default 1 minute) which is divided equally across attempts, so worst-case latency is the same as the original single-attempt code.

### Testing
Local testing and review on available gRPC errors

New tests cover the changes: yes

New tests cover: retry succeeds after transient failures, retries exhausted returns the last error, terminal errors are not retried and preserve the original gRPC status code, and the application-level Status:"failed" response from RenewKerberosArnLease.

### Description for the changelog
Enhancement - Add retry mechanism to credentialsfetcher

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
