### PR TITLE
Bugfix: fix flaky tests depending on timers

### DIFF
--- a/agent/acs/session/attach_eni_common_test.go
+++ b/agent/acs/session/attach_eni_common_test.go
@@ -117,7 +117,9 @@ func testENIAckWithinTimeout(t *testing.T, attachmentType string) {
 	assert.True(t, ok)
 	eniAttachment.SetSentStatus()
 
-	time.Sleep(time.Millisecond * testconst.WaitTimeoutMillis)
+	// Invoke the timeout callback directly instead of sleeping and relying on the real timer.
+	// This tests the same logic (IsSent() prevents removal) without any timing dependency.
+	eniHandler.handleENIAckTimeout()
 
 	assert.Len(t, taskEngineState.(*dockerstate.DockerTaskEngineState).AllENIAttachments(), 1)
 }
@@ -159,7 +161,9 @@ func testHandleENIAttachment(t *testing.T, attachmentType, taskArn string) {
 	assert.True(t, ok)
 	eniAttachment.SetSentStatus()
 
-	time.Sleep(time.Millisecond * testconst.WaitTimeoutMillis)
+	// Invoke the timeout callback directly instead of sleeping and relying on the real timer.
+	// This tests the same logic (IsSent() prevents removal) without any timing dependency.
+	eniHandler.handleENIAckTimeout()
 
 	assert.Len(t, taskEngineState.(*dockerstate.DockerTaskEngineState).AllENIAttachments(), 1)
 	res, err := dataClient.GetENIAttachments()


### PR DESCRIPTION
### Summary
Failed test run: https://github.com/aws/amazon-ecs-agent/actions/runs/25521381952/job/74906012915?pr=4954

Ran into a race condition while observing another PRs test run. Triggering the timeout directly should execute the desired functionality without having a flaky test.

### Implementation details
- Remove time and replace with `eniHandler.handleENIAckTimeout()`

### Testing
`make test`

### Description for the changelog
Bugfix: fix flaky tests depending on timers

### Additional Information

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
