### PR TITLE
Add semgrep security scan for command injection in Windows files

### DIFF
--- a/.github/semgrep/rules.yml
+++ b/.github/semgrep/rules.yml
@@ -1,0 +1,41 @@
+rules:
+  - id: command-injection-exec-variable
+    patterns:
+      - pattern-either:
+          - pattern: execCommand($CMD, $...ARGS)
+          - pattern: exec.Command($CMD, $...ARGS)
+          - pattern: exec.CommandContext($CTX, $CMD, $...ARGS)
+      - pattern-not: execCommand("...", "...")
+      - pattern-not: exec.Command("...", "...")
+      - pattern-not: exec.CommandContext($CTX, "...", "...")
+    message: >
+      Potential command injection: variable arguments passed to shell execution function.
+      Use environment variables to pass untrusted input to subprocesses instead of
+      interpolating into command strings. See https://github.com/aws/amazon-ecs-agent/commit/09f274e0157dcbc777c4bbb2e40b6c55ae6646ad
+    languages: [go]
+    severity: ERROR
+    paths:
+      include:
+        - '*windows*'
+    metadata:
+      cwe: "CWE-78"
+      confidence: MEDIUM
+
+  - id: unsanitized-powershell-interpolation
+    patterns:
+      - pattern: fmt.Sprintf($FMT, ..., $VAR, ...)
+      - metavariable-regex:
+          metavariable: $FMT
+          regex: ".*powershell.*|.*PSCredential.*|.*RemotePath.*|.*New-Smb.*"
+    message: >
+      String interpolation into PowerShell command without sanitization.
+      Use environment variables to pass untrusted input to subprocesses instead of
+      interpolating into command strings. See https://github.com/aws/amazon-ecs-agent/commit/09f274e0157dcbc777c4bbb2e40b6c55ae6646ad
+    languages: [go]
+    severity: WARNING
+    paths:
+      include:
+        - '*windows*'
+    metadata:
+      cwe: "CWE-78"
+      confidence: MEDIUM

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,45 @@
+name: "Security Scan"
+on: [push, pull_request]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  semgrep:
+    name: Semgrep Security Scanner
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run semgrep on new changes
+        run: |
+          pip install semgrep --quiet
+          BASELINE=$(git merge-base HEAD origin/dev 2>/dev/null || echo "")
+          BASELINE_FLAG=""
+          if [ -n "$BASELINE" ]; then
+            BASELINE_FLAG="--baseline-commit $BASELINE"
+          fi
+
+          # Emit PR annotations as warnings
+          semgrep --config .github/semgrep/rules.yml $BASELINE_FLAG --json 2>/dev/null | \
+            jq -r '.results[] | "::warning file=\(.path),line=\(.start.line),endLine=\(.end.line)::[\(.check_id)] \(.extra.message)"' || true
+
+      - name: Comment on PR with findings
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BASELINE=$(git merge-base HEAD origin/dev 2>/dev/null || echo "")
+          BASELINE_FLAG=""
+          if [ -n "$BASELINE" ]; then
+            BASELINE_FLAG="--baseline-commit $BASELINE"
+          fi
+
+          RESULTS=$(semgrep --config .github/semgrep/rules.yml $BASELINE_FLAG --json 2>/dev/null | jq '.results | length')
+          if [ "$RESULTS" -gt 0 ]; then
+            COMMENT="## ⚠️ Security Scan Findings\n\n"
+            COMMENT+=$(semgrep --config .github/semgrep/rules.yml $BASELINE_FLAG --json 2>/dev/null | \
+              jq -r '.results[] | "- **\(.check_id)** in `\(.path):\(.start.line)`\n  \(.extra.message)\n"')
+            echo -e "$COMMENT" | gh pr comment ${{ github.event.pull_request.number }} --body-file -
+          fi


### PR DESCRIPTION
## Summary

Adds custom semgrep rules to detect potential command injection vulnerabilities (CWE-78) in Windows-specific code paths during PRs.

## Implementation details

Two custom semgrep rules:

1. **command-injection-exec-variable** — Flags `execCommand`/`exec.Command`/`exec.CommandContext` calls with variable (non-literal) arguments
2. **unsanitized-powershell-interpolation** — Flags `fmt.Sprintf` with PowerShell-related format strings where variables are interpolated without sanitization

## Behavior

- Only scans files with `windows` in the filename
- Diff-aware: only reports findings in new/changed code
- Posts warning annotations inline on PR files
- Posts a summary comment on the PR if findings exist
- Does not block merge (informational only)

## Testing

Validated with test PRs on fork:
- Windows file with vulnerable pattern → detected ✅
- Linux file with same pattern → correctly skipped ✅

New tests cover the changes: no

## Description for the changelog

security: add semgrep scan for command injection in Windows files

## Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.