### PR TITLE
Add integration test for credential refresher

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -1036,7 +1036,8 @@ func (agent *ecsAgent) getIMDSCredentialRefresher(
 	if agent.cfg.IMDSIAMRolesEnabled {
 		imdsScanner := imds.NewScanner(agent.ec2MetadataClient)
 		return imdscreds.NewIMDSCredentialRefresher(
-			agent.ctx, imdsScanner, credentialsManager, taskEngine,
+			agent.ctx, imdsScanner, credentialsManager,
+			taskEngine, imdscreds.ScanInterval,
 		)
 	}
 	return nil

--- a/agent/imdscreds/refresher.go
+++ b/agent/imdscreds/refresher.go
@@ -28,18 +28,19 @@ import (
 )
 
 const (
-	// scanInterval is the interval between IMDS credential scans.
+	// ScanInterval is the default interval between IMDS credential scans.
 	// TODO: this value will be finalized based on load testing.
-	scanInterval = 15 * time.Minute
+	ScanInterval = 15 * time.Minute
 )
 
 // IMDSCredentialRefresher periodically scans IMDS for rotated task credentials
 // and upserts them into the credentials manager.
 type IMDSCredentialRefresher struct {
-	ctx         context.Context
-	scanner     imds.Scanner
-	credManager credentials.Manager
-	taskEngine  engine.TaskEngine
+	ctx          context.Context
+	scanner      imds.Scanner
+	credManager  credentials.Manager
+	taskEngine   engine.TaskEngine
+	scanInterval time.Duration
 }
 
 // NewIMDSCredentialRefresher creates a new IMDS credential refresher.
@@ -48,12 +49,14 @@ func NewIMDSCredentialRefresher(
 	scanner imds.Scanner,
 	credManager credentials.Manager,
 	taskEngine engine.TaskEngine,
+	scanInterval time.Duration,
 ) *IMDSCredentialRefresher {
 	return &IMDSCredentialRefresher{
-		ctx:         ctx,
-		scanner:     scanner,
-		credManager: credManager,
-		taskEngine:  taskEngine,
+		ctx:          ctx,
+		scanner:      scanner,
+		credManager:  credManager,
+		taskEngine:   taskEngine,
+		scanInterval: scanInterval,
 	}
 }
 
@@ -61,7 +64,7 @@ func NewIMDSCredentialRefresher(
 // context is cancelled.
 func (r *IMDSCredentialRefresher) Start() {
 	logger.Info("Starting IMDS credential refresher")
-	ticker := time.NewTicker(scanInterval)
+	ticker := time.NewTicker(r.scanInterval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/agent/imdscreds/refresher_integ_test.go
+++ b/agent/imdscreds/refresher_integ_test.go
@@ -1,0 +1,257 @@
+//go:build integration
+// +build integration
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package imdscreds
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/engine"
+	apitaskstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
+	ecsagentimds "github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/testutil"
+	ecsagentec2 "github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
+
+	sdkimds "github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testScanInterval = 1 * time.Second
+
+	taskID1  = "0ee1b6f1feef4ff2bacdf2c99732d506"
+	taskID2  = "aabbccdd11223344aabbccdd11223344"
+	taskARN1 = "arn:aws:ecs:us-west-2:123456789012:" +
+		"task/cluster/" + taskID1
+	taskARN2 = "arn:aws:ecs:us-west-2:123456789012:" +
+		"task/cluster/" + taskID2
+
+	roleARN1 = "arn:aws:iam::123456789012:role/TaskRoleA"
+	roleARN2 = "arn:aws:iam::123456789012:role/TaskRoleB"
+
+	credID1App  = "cred-a-app"
+	credID2App  = "cred-b-app"
+	credID2Exec = "cred-b-exec"
+)
+
+// TestIMDSCredentialRefresh tests the integration between the IMDS
+// credential refresher, scanner, task engine state, credentials manager,
+// and a mock IMDS HTTP server.
+//
+// Phase 1: Setup the mock IMDS server, task engine, and credentials refresher.
+//
+// Phase 2: Simulate task payloads arriving with initial credentials, then
+// verify the IMDS scan overwrites them with values from the mock server.
+//
+// Phase 3: Rotate credentials on the mock server and verify the refresher
+// picks up the new values on the next scan cycle.
+func TestIMDSCredentialRefresh(t *testing.T) {
+	// Phase 1: Setup.
+	//
+	// Start a mock IMDS server.
+	mockIMDS := testutil.NewMockIMDSServer()
+	defer mockIMDS.Close()
+
+	// Setup the task engine and credentials manager.
+	taskEngine, cleanup, credManager := setupTestEngine(t)
+	defer cleanup()
+
+	// Setup the IMDS scanner.
+	scanner := ecsagentimds.NewScanner(newEC2Client(t, mockIMDS.URL()))
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Setup the credential refresher.
+	refresher := NewIMDSCredentialRefresher(
+		ctx, scanner, credManager, taskEngine, testScanInterval,
+	)
+
+	// Start the credentials refresher.
+	// Using a done channel ensures that the scanner stops
+	// before task engine and mock IMDS server are stopped.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		refresher.Start()
+	}()
+	defer func() {
+		cancel()
+		<-done
+	}()
+
+	// Simulate task payloads arriving with initial credentials.
+	addTaskToState(taskEngine, taskARN1, credID1App, "")
+	addTaskToState(taskEngine, taskARN2, credID2App, credID2Exec)
+
+	setInitialTaskCredentials(t, credManager, taskARN1, credID1App, "AKID_ACS_A_APP")
+	setInitialTaskCredentials(t, credManager, taskARN2, credID2App, "AKID_ACS_B_APP")
+	setInitialTaskCredentials(t, credManager, taskARN2, credID2Exec, "AKID_ACS_B_EXEC")
+
+	// Verify initial credentials are present in the credentials manager.
+	verifyCredential(t, credManager,
+		credID1App, taskARN1, "AKID_ACS_A_APP", "")
+	verifyCredential(t, credManager,
+		credID2App, taskARN2, "AKID_ACS_B_APP", "")
+	verifyCredential(t, credManager,
+		credID2Exec, taskARN2, "AKID_ACS_B_EXEC", "")
+
+	// Phase 2: IMDS scan upserts credentials.
+	//
+	// Add credentials to the mock IMDS server.
+	// Namespace 1: taskA with application role.
+	mockIMDS.AddCredential(
+		"iam-ecs-1", taskID1,
+		credentials.ApplicationRoleType, roleARN1, "AKID_IMDS_A_APP",
+	)
+	// Namespace 2: taskB with application + execution roles.
+	mockIMDS.AddCredential(
+		"iam-ecs-2", taskID2,
+		credentials.ApplicationRoleType, roleARN2, "AKID_IMDS_B_APP",
+	)
+	mockIMDS.AddCredential(
+		"iam-ecs-2", taskID2,
+		credentials.ExecutionRoleType, roleARN2, "AKID_IMDS_B_EXEC",
+	)
+
+	// Wait for the refresher to pick up the new credentials from IMDS
+	// and deliver it to the credentials manager. The refresher's scan interval is 1s for the test.
+	// require.Eventually polls every 200ms for up to 5s until the credentials appear.
+	require.Eventually(t, func() bool {
+		return hasAccessKey(credManager, credID1App, "AKID_IMDS_A_APP") &&
+			hasAccessKey(credManager, credID2App, "AKID_IMDS_B_APP") &&
+			hasAccessKey(credManager, credID2Exec, "AKID_IMDS_B_EXEC")
+	}, 5*time.Second, 200*time.Millisecond,
+		"IMDS credentials not upserted after scan")
+
+	verifyCredential(t, credManager,
+		credID1App, taskARN1, "AKID_IMDS_A_APP", roleARN1)
+	verifyCredential(t, credManager,
+		credID2App, taskARN2, "AKID_IMDS_B_APP", roleARN2)
+	verifyCredential(t, credManager,
+		credID2Exec, taskARN2, "AKID_IMDS_B_EXEC", roleARN2)
+
+	// Phase 3: Credential rotation.
+	//
+	// Rotate credentials on the mock IMDS server and verify the refresher
+	// picks up the new values on the next scan.
+	mockIMDS.RotateCredential(t,
+		"iam-ecs-1", taskID1,
+		credentials.ApplicationRoleType, "AKID_ROTATED_A_APP",
+	)
+	mockIMDS.RotateCredential(t,
+		"iam-ecs-2", taskID2,
+		credentials.ExecutionRoleType, "AKID_ROTATED_B_EXEC",
+	)
+
+	require.Eventually(t, func() bool {
+		return hasAccessKey(credManager, credID1App, "AKID_ROTATED_A_APP") &&
+			hasAccessKey(credManager, credID2Exec, "AKID_ROTATED_B_EXEC") &&
+			hasAccessKey(credManager, credID2App, "AKID_IMDS_B_APP")
+	}, 5*time.Second, 200*time.Millisecond,
+		"rotated credentials not picked up or non-rotated credential mutated")
+
+	verifyCredential(t, credManager,
+		credID1App, taskARN1, "AKID_ROTATED_A_APP", roleARN1)
+	verifyCredential(t, credManager,
+		credID2Exec, taskARN2, "AKID_ROTATED_B_EXEC", roleARN2)
+	// Verify non-rotated credential in the same namespace is unchanged.
+	verifyCredential(t, credManager,
+		credID2App, taskARN2, "AKID_IMDS_B_APP", roleARN2)
+}
+
+// setupTestEngine creates a test DockerTaskEngine with a credentials manager.
+func setupTestEngine(t *testing.T) (
+	engine.TaskEngine, func(), credentials.Manager,
+) {
+	taskEngine, cleanup, _, credManager := engine.SetupIntegTestTaskEngine(
+		engine.DefaultTestConfigIntegTest(), nil, t,
+	)
+	return taskEngine, cleanup, credManager
+}
+
+// addTaskToState adds a task to the engine's state.
+func addTaskToState(
+	taskEngine engine.TaskEngine,
+	arn, credID, execCredID string,
+) {
+	testTask := &task.Task{Arn: arn}
+	testTask.SetDesiredStatus(apitaskstatus.TaskRunning)
+	testTask.SetKnownStatus(apitaskstatus.TaskRunning)
+	if credID != "" {
+		testTask.SetCredentialsID(credID)
+	}
+	if execCredID != "" {
+		testTask.SetExecutionRoleCredentialsID(execCredID)
+	}
+	taskEngine.(*engine.DockerTaskEngine).State().AddTask(testTask)
+}
+
+// setInitialTaskCredentials sets the initial task credentials in the credentials manager.
+func setInitialTaskCredentials(
+	t *testing.T,
+	credManager credentials.Manager,
+	taskARN, credID, accessKeyID string,
+) {
+	err := credManager.SetTaskCredentials(&credentials.TaskIAMRoleCredentials{
+		ARN: taskARN,
+		IAMRoleCredentials: credentials.IAMRoleCredentials{
+			CredentialsID:   credID,
+			AccessKeyID:     accessKeyID,
+			SecretAccessKey: "secret-" + accessKeyID,
+			SessionToken:    "token-" + accessKeyID,
+		},
+	})
+	require.NoError(t, err)
+}
+
+// newEC2Client creates an EC2MetadataClient configured with the mock IMDS server.
+func newEC2Client(t *testing.T, endpoint string) ecsagentec2.EC2MetadataClient {
+	imdsClient := sdkimds.New(sdkimds.Options{Endpoint: endpoint})
+	ec2Client, err := ecsagentec2.NewEC2MetadataClient(imdsClient)
+	require.NoError(t, err)
+	return ec2Client
+}
+
+// hasAccessKey returns true if the credential with the given ID has the
+// expected access key.
+func hasAccessKey(
+	credManager credentials.Manager, credID, expectedKey string,
+) bool {
+	cred, ok := credManager.GetTaskCredentials(credID)
+	return ok && cred.IAMRoleCredentials.AccessKeyID == expectedKey
+}
+
+// verifyCredential asserts all fields of a credential in the credentials manager.
+func verifyCredential(
+	t *testing.T,
+	credManager credentials.Manager,
+	credID, expectedARN, expectedAccessKey, expectedRoleArn string,
+) {
+	cred, ok := credManager.GetTaskCredentials(credID)
+	require.True(t, ok, "credential %s not found", credID)
+	assert.Equal(t, expectedARN, cred.ARN)
+	assert.Equal(t, credID, cred.IAMRoleCredentials.CredentialsID)
+	assert.Equal(t, expectedRoleArn, cred.IAMRoleCredentials.RoleArn)
+	assert.Equal(t, expectedAccessKey, cred.IAMRoleCredentials.AccessKeyID)
+	assert.Equal(t,
+		"secret-"+expectedAccessKey, cred.IAMRoleCredentials.SecretAccessKey)
+	assert.Equal(t,
+		"token-"+expectedAccessKey, cred.IAMRoleCredentials.SessionToken)
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/testutil/mock_imds_server.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/testutil/mock_imds_server.go
@@ -1,0 +1,236 @@
+//go:build integration
+// +build integration
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package testutil provides a mock IMDS HTTP server for integration testing
+// the IMDS credential scanner with agent's refresher.
+package testutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// MockIMDSServer is an HTTP server that mimics the EC2 IMDS
+// endpoints.
+type MockIMDSServer struct {
+	mu         sync.Mutex
+	namespaces map[string]*mockNamespace
+	server     *httptest.Server
+}
+
+type mockNamespace struct {
+	lastUpdated time.Time
+	credentials map[string]*mockCredential
+}
+
+type mockCredential struct {
+	RoleArn         string
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+	Expiration      string
+}
+
+// NewMockIMDSServer creates and starts a mock IMDS HTTP server.
+func NewMockIMDSServer() *MockIMDSServer {
+	s := &MockIMDSServer{
+		namespaces: make(map[string]*mockNamespace),
+	}
+	s.server = httptest.NewServer(s)
+	return s
+}
+
+// URL returns the base URL of the mock server.
+func (s *MockIMDSServer) URL() string {
+	return s.server.URL
+}
+
+// Close shuts down the mock server.
+func (s *MockIMDSServer) Close() {
+	s.server.Close()
+}
+
+// AddCredential registers a credential in the mock IMDS server.
+// The namespace is auto-created if it doesn't exist.
+func (s *MockIMDSServer) AddCredential(
+	namespace, taskID, roleType, roleArn, accessKeyID string,
+) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ns := s.getOrCreateNamespace(namespace)
+	key := taskID + "-" + roleType
+	ns.credentials[key] = &mockCredential{
+		RoleArn:         roleArn,
+		AccessKeyID:     accessKeyID,
+		SecretAccessKey: "secret-" + accessKeyID,
+		SessionToken:    "token-" + accessKeyID,
+		Expiration:      time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339),
+	}
+	ns.lastUpdated = time.Now().UTC()
+}
+
+// RotateCredential updates a credential and bumps the namespace's
+// LastUpdated timestamp. Fails the test if the namespace or credential
+// key is not found.
+func (s *MockIMDSServer) RotateCredential(
+	t *testing.T,
+	namespace, taskID, roleType, newAccessKeyID string,
+) {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ns, ok := s.namespaces[namespace]
+	if !ok {
+		t.Fatalf("mock IMDS: namespace %q not registered", namespace)
+	}
+	key := taskID + "-" + roleType
+	cred, ok := ns.credentials[key]
+	if !ok {
+		t.Fatalf("mock IMDS: credential %q not found in namespace %q",
+			key, namespace)
+	}
+	cred.AccessKeyID = newAccessKeyID
+	cred.SecretAccessKey = "secret-" + newAccessKeyID
+	cred.SessionToken = "token-" + newAccessKeyID
+	ns.lastUpdated = time.Now().UTC()
+}
+
+// getOrCreateNamespace returns a existing namespace or creates a new
+// one if it doesn't exist yet.
+func (s *MockIMDSServer) getOrCreateNamespace(name string) *mockNamespace {
+	ns, ok := s.namespaces[name]
+	if !ok {
+		ns = &mockNamespace{
+			lastUpdated: time.Now().UTC(),
+			credentials: make(map[string]*mockCredential),
+		}
+		s.namespaces[name] = ns
+	}
+	return ns
+}
+
+// ServeHTTP handles IMDS requests.
+// Expected paths:
+//   - /latest/meta-data/ → list of entries including iam-ecs-* namespaces
+//   - /latest/meta-data/<ns>/info → NamespaceInfo JSON
+//   - /latest/meta-data/<ns>/security-credentials/<key> → credential JSON
+func (s *MockIMDSServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Handle IMDSv2 token request.
+	if r.Method == http.MethodPut && r.URL.Path == "/latest/api/token" {
+		w.Header().Set("X-aws-ec2-metadata-token-ttl-seconds", "21600")
+		fmt.Fprint(w, "mock-token")
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path := strings.TrimPrefix(r.URL.Path, "/latest/meta-data")
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimSuffix(path, "/")
+
+	// Root listing: return namespace names.
+	if path == "" {
+		var lines []string
+		for name := range s.namespaces {
+			lines = append(lines, name+"/")
+		}
+		fmt.Fprint(w, strings.Join(lines, "\n"))
+		return
+	}
+
+	// Instance identity metadata used by IsIMDSAvailable.
+	if path == "instance-id" {
+		fmt.Fprint(w, "i-mock12345")
+		return
+	}
+
+	// Check if path matches <namespace>/info
+	if ns, suffix, ok := strings.Cut(path, "/"); ok {
+		nsData, exists := s.namespaces[ns]
+		if !exists {
+			http.NotFound(w, r)
+			return
+		}
+
+		if suffix == "info" {
+			s.serveInfo(w, nsData)
+			return
+		}
+
+		// Check if path matches <namespace>/security-credentials/<key>
+		if credKey, ok := strings.CutPrefix(suffix, "security-credentials/"); ok {
+			s.serveCredential(w, r, nsData, credKey)
+			return
+		}
+	}
+
+	http.NotFound(w, r)
+}
+
+// serveInfo writes the namespace info JSON response containing
+// LastUpdated and the TaskCredentials map.
+func (s *MockIMDSServer) serveInfo(w http.ResponseWriter, ns *mockNamespace) {
+	type taskCredInfo struct {
+		RoleARN string `json:"RoleARN"`
+	}
+	info := struct {
+		LastUpdated     string                  `json:"LastUpdated"`
+		TaskCredentials map[string]taskCredInfo `json:"TaskCredentials"`
+	}{
+		LastUpdated:     ns.lastUpdated.Format(time.RFC3339Nano),
+		TaskCredentials: make(map[string]taskCredInfo),
+	}
+	for key, cred := range ns.credentials {
+		info.TaskCredentials[key] = taskCredInfo{RoleARN: cred.RoleArn}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(info)
+}
+
+// serveCredential writes the credential JSON response for a single
+// credential key within a namespace.
+func (s *MockIMDSServer) serveCredential(
+	w http.ResponseWriter, r *http.Request,
+	ns *mockNamespace, key string,
+) {
+	cred, ok := ns.credentials[key]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	resp := struct {
+		AccessKeyId     string `json:"AccessKeyId"`
+		SecretAccessKey string `json:"SecretAccessKey"`
+		Token           string `json:"Token"`
+		Expiration      string `json:"Expiration"`
+	}{
+		AccessKeyId:     cred.AccessKeyID,
+		SecretAccessKey: cred.SecretAccessKey,
+		Token:           cred.SessionToken,
+		Expiration:      cred.Expiration,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -31,6 +31,7 @@ github.com/aws/amazon-ecs-agent/ecs-agent/config
 github.com/aws/amazon-ecs-agent/ecs-agent/credentials
 github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds
 github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/mocks
+github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/testutil
 github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks
 github.com/aws/amazon-ecs-agent/ecs-agent/credentials/providers
 github.com/aws/amazon-ecs-agent/ecs-agent/csiclient

--- a/ecs-agent/credentials/imds/testutil/mock_imds_server.go
+++ b/ecs-agent/credentials/imds/testutil/mock_imds_server.go
@@ -1,0 +1,236 @@
+//go:build integration
+// +build integration
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package testutil provides a mock IMDS HTTP server for integration testing
+// the IMDS credential scanner with agent's refresher.
+package testutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// MockIMDSServer is an HTTP server that mimics the EC2 IMDS
+// endpoints.
+type MockIMDSServer struct {
+	mu         sync.Mutex
+	namespaces map[string]*mockNamespace
+	server     *httptest.Server
+}
+
+type mockNamespace struct {
+	lastUpdated time.Time
+	credentials map[string]*mockCredential
+}
+
+type mockCredential struct {
+	RoleArn         string
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+	Expiration      string
+}
+
+// NewMockIMDSServer creates and starts a mock IMDS HTTP server.
+func NewMockIMDSServer() *MockIMDSServer {
+	s := &MockIMDSServer{
+		namespaces: make(map[string]*mockNamespace),
+	}
+	s.server = httptest.NewServer(s)
+	return s
+}
+
+// URL returns the base URL of the mock server.
+func (s *MockIMDSServer) URL() string {
+	return s.server.URL
+}
+
+// Close shuts down the mock server.
+func (s *MockIMDSServer) Close() {
+	s.server.Close()
+}
+
+// AddCredential registers a credential in the mock IMDS server.
+// The namespace is auto-created if it doesn't exist.
+func (s *MockIMDSServer) AddCredential(
+	namespace, taskID, roleType, roleArn, accessKeyID string,
+) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ns := s.getOrCreateNamespace(namespace)
+	key := taskID + "-" + roleType
+	ns.credentials[key] = &mockCredential{
+		RoleArn:         roleArn,
+		AccessKeyID:     accessKeyID,
+		SecretAccessKey: "secret-" + accessKeyID,
+		SessionToken:    "token-" + accessKeyID,
+		Expiration:      time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339),
+	}
+	ns.lastUpdated = time.Now().UTC()
+}
+
+// RotateCredential updates a credential and bumps the namespace's
+// LastUpdated timestamp. Fails the test if the namespace or credential
+// key is not found.
+func (s *MockIMDSServer) RotateCredential(
+	t *testing.T,
+	namespace, taskID, roleType, newAccessKeyID string,
+) {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ns, ok := s.namespaces[namespace]
+	if !ok {
+		t.Fatalf("mock IMDS: namespace %q not registered", namespace)
+	}
+	key := taskID + "-" + roleType
+	cred, ok := ns.credentials[key]
+	if !ok {
+		t.Fatalf("mock IMDS: credential %q not found in namespace %q",
+			key, namespace)
+	}
+	cred.AccessKeyID = newAccessKeyID
+	cred.SecretAccessKey = "secret-" + newAccessKeyID
+	cred.SessionToken = "token-" + newAccessKeyID
+	ns.lastUpdated = time.Now().UTC()
+}
+
+// getOrCreateNamespace returns a existing namespace or creates a new
+// one if it doesn't exist yet.
+func (s *MockIMDSServer) getOrCreateNamespace(name string) *mockNamespace {
+	ns, ok := s.namespaces[name]
+	if !ok {
+		ns = &mockNamespace{
+			lastUpdated: time.Now().UTC(),
+			credentials: make(map[string]*mockCredential),
+		}
+		s.namespaces[name] = ns
+	}
+	return ns
+}
+
+// ServeHTTP handles IMDS requests.
+// Expected paths:
+//   - /latest/meta-data/ → list of entries including iam-ecs-* namespaces
+//   - /latest/meta-data/<ns>/info → NamespaceInfo JSON
+//   - /latest/meta-data/<ns>/security-credentials/<key> → credential JSON
+func (s *MockIMDSServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Handle IMDSv2 token request.
+	if r.Method == http.MethodPut && r.URL.Path == "/latest/api/token" {
+		w.Header().Set("X-aws-ec2-metadata-token-ttl-seconds", "21600")
+		fmt.Fprint(w, "mock-token")
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path := strings.TrimPrefix(r.URL.Path, "/latest/meta-data")
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimSuffix(path, "/")
+
+	// Root listing: return namespace names.
+	if path == "" {
+		var lines []string
+		for name := range s.namespaces {
+			lines = append(lines, name+"/")
+		}
+		fmt.Fprint(w, strings.Join(lines, "\n"))
+		return
+	}
+
+	// Instance identity metadata used by IsIMDSAvailable.
+	if path == "instance-id" {
+		fmt.Fprint(w, "i-mock12345")
+		return
+	}
+
+	// Check if path matches <namespace>/info
+	if ns, suffix, ok := strings.Cut(path, "/"); ok {
+		nsData, exists := s.namespaces[ns]
+		if !exists {
+			http.NotFound(w, r)
+			return
+		}
+
+		if suffix == "info" {
+			s.serveInfo(w, nsData)
+			return
+		}
+
+		// Check if path matches <namespace>/security-credentials/<key>
+		if credKey, ok := strings.CutPrefix(suffix, "security-credentials/"); ok {
+			s.serveCredential(w, r, nsData, credKey)
+			return
+		}
+	}
+
+	http.NotFound(w, r)
+}
+
+// serveInfo writes the namespace info JSON response containing
+// LastUpdated and the TaskCredentials map.
+func (s *MockIMDSServer) serveInfo(w http.ResponseWriter, ns *mockNamespace) {
+	type taskCredInfo struct {
+		RoleARN string `json:"RoleARN"`
+	}
+	info := struct {
+		LastUpdated     string                  `json:"LastUpdated"`
+		TaskCredentials map[string]taskCredInfo `json:"TaskCredentials"`
+	}{
+		LastUpdated:     ns.lastUpdated.Format(time.RFC3339Nano),
+		TaskCredentials: make(map[string]taskCredInfo),
+	}
+	for key, cred := range ns.credentials {
+		info.TaskCredentials[key] = taskCredInfo{RoleARN: cred.RoleArn}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(info)
+}
+
+// serveCredential writes the credential JSON response for a single
+// credential key within a namespace.
+func (s *MockIMDSServer) serveCredential(
+	w http.ResponseWriter, r *http.Request,
+	ns *mockNamespace, key string,
+) {
+	cred, ok := ns.credentials[key]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	resp := struct {
+		AccessKeyId     string `json:"AccessKeyId"`
+		SecretAccessKey string `json:"SecretAccessKey"`
+		Token           string `json:"Token"`
+		Expiration      string `json:"Expiration"`
+	}{
+		AccessKeyId:     cred.AccessKeyID,
+		SecretAccessKey: cred.SecretAccessKey,
+		Token:           cred.SessionToken,
+		Expiration:      cred.Expiration,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}


### PR DESCRIPTION
### Summary

Add a mock IMDS HTTP server for integration testing and an integration test that exercises the IMDS credential scanner and refresher.

### Implementation details

- ecs-agent/credentials/imds/testutil/: Mock IMDS HTTP server (httptest.Server) that serves namespace discovery, info files, and credential files. Supports adding and rotating credentials. 
- agent/imdscreds/: Integration test that wires a real SDK IMDS client, real scanner, real credentials manager, and real task engine state against the mock server. Tests initial credential upsert and credential rotation across multiple tasks and namespaces.
- agent/imdscreds/: Make scanInterval a constructor parameter (ScanInterval) so the integration test can use a short interval (1s) instead of the production 15 minutes.
- agent/app/: Pass imdscreds.ScanInterval to the refresher constructor.

### Testing

New tests cover the changes: yes, this PR adds an integ test only, no new functional change.

### Description for the changelog

Enhancement - Add mock IMDS server and integration test for credential refresher.

### Additional Information

Does this PR include breaking model changes? No

Does this PR include the addition of new environment variables in the README? No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.