### PR TITLE
Feature - Add support for ECS S3 Files integration

### DIFF
--- a/agent/acs/session/payload_responder.go
+++ b/agent/acs/session/payload_responder.go
@@ -120,6 +120,13 @@ func (pmHandler *payloadMessageHandler) addPayloadTasks(payload *ecsacs.PayloadM
 			initializeAttachmentTypeVolume(task, volName)
 		}
 
+		// Same for S3 Files attachments - mark matching volumes as "attachment" type
+		// so they pass through UnmarshalJSON without error.
+		s3filesVolNames := getS3FilesAttachmentVolumeNames(task)
+		for _, volName := range s3filesVolNames {
+			initializeAttachmentTypeVolume(task, volName)
+		}
+
 		apiTask, err := apitask.TaskFromACS(task, payload)
 		if err != nil {
 			pmHandler.handleInvalidTask(task, err, payload)
@@ -362,4 +369,19 @@ func initializeAttachmentTypeVolume(acsTask *ecsacs.Task, volName string) {
 			volume.Type = &newType
 		}
 	}
+}
+
+// getS3FilesAttachmentVolumeNames returns the volume names from all S3 Files attachments in the task.
+func getS3FilesAttachmentVolumeNames(acsTask *ecsacs.Task) []string {
+	var volNames []string
+	for _, attachment := range acsTask.Attachments {
+		if aws.ToString(attachment.AttachmentType) == apiresource.S3FilesTaskAttach {
+			for _, property := range attachment.AttachmentProperties {
+				if aws.ToString(property.Name) == apiresource.S3FilesVolumeNameKey {
+					volNames = append(volNames, aws.ToString(property.Value))
+				}
+			}
+		}
+	}
+	return volNames
 }

--- a/agent/acs/session/payload_responder_test.go
+++ b/agent/acs/session/payload_responder_test.go
@@ -1118,3 +1118,78 @@ func validateTaskAndCredentials(taskCredentialsAck, expectedCredentialsAckForTas
 	}
 	return nil
 }
+
+func TestGetS3FilesAttachmentVolumeNames(t *testing.T) {
+	tests := []struct {
+		name            string
+		attachments     []*ecsacs.Attachment
+		expectedVolumes []string
+	}{
+		{
+			name: "found",
+			attachments: []*ecsacs.Attachment{
+				{
+					AttachmentType: aws.String(apiresource.S3FilesTaskAttach),
+					AttachmentProperties: []*ecsacs.AttachmentProperty{
+						{Name: aws.String("volumeId"), Value: aws.String("fs-123")},
+						{Name: aws.String("volumeName"), Value: aws.String("myS3Volume")},
+					},
+				},
+			},
+			expectedVolumes: []string{"myS3Volume"},
+		},
+		{
+			name: "no s3 files",
+			attachments: []*ecsacs.Attachment{
+				{
+					AttachmentType: aws.String(apiresource.EBSTaskAttach),
+					AttachmentProperties: []*ecsacs.AttachmentProperty{
+						{Name: aws.String("volumeName"), Value: aws.String("ebsVol")},
+					},
+				},
+			},
+			expectedVolumes: nil,
+		},
+		{
+			name: "mixed",
+			attachments: []*ecsacs.Attachment{
+				{
+					AttachmentType: aws.String(apiresource.EBSTaskAttach),
+					AttachmentProperties: []*ecsacs.AttachmentProperty{
+						{Name: aws.String("volumeName"), Value: aws.String("ebsVol")},
+					},
+				},
+				{
+					AttachmentType: aws.String(apiresource.S3FilesTaskAttach),
+					AttachmentProperties: []*ecsacs.AttachmentProperty{
+						{Name: aws.String("volumeId"), Value: aws.String("fs-111")},
+						{Name: aws.String("volumeName"), Value: aws.String("s3Vol1")},
+					},
+				},
+				{
+					AttachmentType: aws.String(apiresource.S3FilesTaskAttach),
+					AttachmentProperties: []*ecsacs.AttachmentProperty{
+						{Name: aws.String("volumeId"), Value: aws.String("fs-222")},
+						{Name: aws.String("volumeName"), Value: aws.String("s3Vol2")},
+					},
+				},
+			},
+			expectedVolumes: []string{"s3Vol1", "s3Vol2"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			acsTask := &ecsacs.Task{Attachments: tc.attachments}
+			volNames := getS3FilesAttachmentVolumeNames(acsTask)
+			if tc.expectedVolumes == nil {
+				assert.Empty(t, volNames)
+			} else {
+				require.Len(t, volNames, len(tc.expectedVolumes))
+				for _, expected := range tc.expectedVolumes {
+					assert.Contains(t, volNames, expected)
+				}
+			}
+		})
+	}
+}

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -43,6 +43,7 @@ import (
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	apiresource "github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment/resource"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/container/restart"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
@@ -384,6 +385,10 @@ func (task *Task) initializeVolumes(cfg *config.Config, dockerClient dockerapi.D
 		return apierrors.NewResourceInitError(task.Arn, err)
 	}
 	err = task.initializeEFSVolumes(cfg, dockerClient, ctx)
+	if err != nil {
+		return apierrors.NewResourceInitError(task.Arn, err)
+	}
+	err = task.initializeS3FilesVolumes(cfg, dockerClient, ctx)
 	if err != nil {
 		return apierrors.NewResourceInitError(task.Arn, err)
 	}
@@ -860,6 +865,58 @@ func (task *Task) addEFSVolumes(
 		"task",
 		false,
 		driverName,
+		driverOpts,
+		map[string]string{},
+		dockerClient,
+	)
+	if err != nil {
+		return err
+	}
+
+	vol.Volume = &volumeResource.VolumeConfig
+	task.AddResource(resourcetype.DockerVolumeKey, volumeResource)
+	task.updateContainerVolumeDependency(vol.Name)
+	return nil
+}
+
+// initializeS3FilesVolumes inspects the volume definitions in the attachment.
+// If it finds S3 Files volumes in the attachment, then it converts it to a docker
+// volume definition.
+func (task *Task) initializeS3FilesVolumes(cfg *config.Config, dockerClient dockerapi.DockerClient, ctx context.Context) error {
+	for i, vol := range task.Volumes {
+		if vol.Type != apiresource.S3FilesTaskAttach {
+			continue
+		}
+		s3vol, ok := vol.Volume.(*taskresourcevolume.S3FilesVolumeConfig)
+		if !ok {
+			return errors.New("task volume: volume configuration does not match the type 's3files'")
+		}
+		err := task.addS3FilesVolumes(ctx, cfg, dockerClient, &task.Volumes[i], s3vol)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addS3FilesVolumes converts the S3 Files task definition into an internal docker volume
+// using the ECS volume plugin and updates container dependency.
+func (task *Task) addS3FilesVolumes(
+	ctx context.Context,
+	cfg *config.Config,
+	dockerClient dockerapi.DockerClient,
+	vol *TaskVolume,
+	s3vol *taskresourcevolume.S3FilesVolumeConfig,
+) error {
+	driverOpts := s3vol.GetVolumePluginDriverOptions(task.GetCredentialsRelativeURI())
+	volumeResource, err := taskresourcevolume.NewVolumeResource(
+		ctx,
+		vol.Name,
+		taskresourcevolume.S3FilesVolumeType,
+		task.volumeName(vol.Name),
+		"task",
+		false,
+		taskresourcevolume.ECSVolumePlugin,
 		driverOpts,
 		map[string]string{},
 		dockerClient,

--- a/agent/api/task/task_attachment_handler.go
+++ b/agent/api/task/task_attachment_handler.go
@@ -79,12 +79,15 @@ func handleTaskAttachments(acsTask *ecsacs.Task, task *Task) error {
 	if acsTask.Attachments != nil {
 		var serviceConnectAttachment *ecsacs.Attachment
 		var ebsVolumeAttachments []*ecsacs.Attachment
+		var s3filesVolumeAttachments []*ecsacs.Attachment
 		for _, attachment := range acsTask.Attachments {
 			switch aws.ToString(attachment.AttachmentType) {
 			case serviceConnectAttachmentType:
 				serviceConnectAttachment = attachment
 			case apiresource.EBSTaskAttach:
 				ebsVolumeAttachments = append(ebsVolumeAttachments, attachment)
+			case apiresource.S3FilesTaskAttach:
+				s3filesVolumeAttachments = append(s3filesVolumeAttachments, attachment)
 			default:
 				logger.Debug("Received an attachment type", logger.Fields{
 					"attachmentType": attachment.AttachmentType,
@@ -124,14 +127,42 @@ func handleTaskAttachments(acsTask *ecsacs.Task, task *Task) error {
 				ebsVolumes[ebs.VolumeName] = true
 				task.Volumes = append(task.Volumes, taskVolume)
 			}
-			// We're removing all incorrect volume configuration that were intially passed over from ACS
-			for index, tv := range task.Volumes {
-				volumeName := tv.Name
-				volumeType := tv.Type
-				if ebsVolumes[volumeName] && volumeType != apiresource.EBSTaskAttach {
-					task.RemoveVolume(index)
+			// Remove all incorrect volume configurations that were initially passed over from ACS.
+			// We rebuild the slice to avoid index-shifting bugs when removing multiple entries.
+			filtered := make([]TaskVolume, 0, len(task.Volumes))
+			for _, tv := range task.Volumes {
+				if ebsVolumes[tv.Name] && tv.Type != apiresource.EBSTaskAttach {
+					continue
 				}
+				filtered = append(filtered, tv)
 			}
+			task.Volumes = filtered
+		}
+		if len(s3filesVolumeAttachments) > 0 {
+			s3filesVolumes := make(map[string]bool)
+			for _, attachment := range s3filesVolumeAttachments {
+				s3cfg, err := taskresourcevolume.ParseS3FilesTaskVolumeAttachment(attachment)
+				if err != nil {
+					return fmt.Errorf("unable to parse and validate S3 Files volume: %w", err)
+				}
+				taskVolume := TaskVolume{
+					Name:   s3cfg.VolumeName,
+					Type:   apiresource.S3FilesTaskAttach,
+					Volume: s3cfg,
+				}
+				s3filesVolumes[s3cfg.VolumeName] = true
+				task.Volumes = append(task.Volumes, taskVolume)
+			}
+			// Remove incomplete volumes with same name from ACS.
+			// We rebuild the slice to avoid index-shifting bugs when removing multiple entries.
+			filtered := make([]TaskVolume, 0, len(task.Volumes))
+			for _, tv := range task.Volumes {
+				if s3filesVolumes[tv.Name] && tv.Type != apiresource.S3FilesTaskAttach {
+					continue
+				}
+				filtered = append(filtered, tv)
+			}
+			task.Volumes = filtered
 		}
 	}
 	return nil

--- a/agent/api/task/task_attachment_handler_test.go
+++ b/agent/api/task/task_attachment_handler_test.go
@@ -308,3 +308,195 @@ func TestHandleTaskAttachmentsWithoutAttachment(t *testing.T) {
 	assert.Nil(t, err, "Should not return error")
 	assert.Nil(t, testTask.ServiceConnectConfig, "Should not return service connect config from attachments")
 }
+
+func TestHandleTaskAttachments_S3Files(t *testing.T) {
+	testAcsTask := &ecsacs.Task{
+		Attachments: []*ecsacs.Attachment{
+			{
+				AttachmentArn: stringToPointer("s3filesAttachmentArn"),
+				AttachmentProperties: []*ecsacs.AttachmentProperty{
+					{Name: stringToPointer("volumeId"), Value: stringToPointer("fs-123")},
+					{Name: stringToPointer("volumeName"), Value: stringToPointer("myS3Vol")},
+				},
+				AttachmentType: stringToPointer(apiresource.S3FilesTaskAttach),
+			},
+		},
+	}
+	testTask := &Task{}
+	err := handleTaskAttachments(testAcsTask, testTask)
+	require.NoError(t, err)
+
+	require.Len(t, testTask.Volumes, 1)
+	assert.Equal(t, "myS3Vol", testTask.Volumes[0].Name)
+	assert.Equal(t, apiresource.S3FilesTaskAttach, testTask.Volumes[0].Type)
+	s3cfg, ok := testTask.Volumes[0].Volume.(*taskresourcevolume.S3FilesVolumeConfig)
+	require.True(t, ok)
+	assert.Equal(t, "fs-123", s3cfg.VolumeId)
+	assert.Equal(t, "myS3Vol", s3cfg.VolumeName)
+}
+
+func TestHandleTaskAttachments_S3Files_DuplicateVolumeName(t *testing.T) {
+	testAcsTask := &ecsacs.Task{
+		Attachments: []*ecsacs.Attachment{
+			{
+				AttachmentArn: stringToPointer("s3filesAttachmentArn"),
+				AttachmentProperties: []*ecsacs.AttachmentProperty{
+					{Name: stringToPointer("volumeId"), Value: stringToPointer("fs-123")},
+					{Name: stringToPointer("volumeName"), Value: stringToPointer("myVol")},
+				},
+				AttachmentType: stringToPointer(apiresource.S3FilesTaskAttach),
+			},
+		},
+	}
+	testTask := &Task{
+		Volumes: []TaskVolume{
+			{
+				Name:   "myVol",
+				Type:   HostVolumeType,
+				Volume: &taskresourcevolume.FSHostVolume{FSSourcePath: "/host/path"},
+			},
+		},
+	}
+	err := handleTaskAttachments(testAcsTask, testTask)
+	require.NoError(t, err)
+
+	// Count volumes named "myVol"
+	var myVolCount int
+	var s3filesVol *TaskVolume
+	for i := range testTask.Volumes {
+		if testTask.Volumes[i].Name == "myVol" {
+			myVolCount++
+			if testTask.Volumes[i].Type == apiresource.S3FilesTaskAttach {
+				s3filesVol = &testTask.Volumes[i]
+			}
+		}
+	}
+	assert.Equal(t, 1, myVolCount, "expected exactly one volume named 'myVol'")
+	require.NotNil(t, s3filesVol, "expected the remaining volume to be s3files type")
+	assert.Equal(t, apiresource.S3FilesTaskAttach, s3filesVol.Type)
+}
+
+func TestHandleTaskAttachments_EBSAndMultipleS3Files(t *testing.T) {
+	testAcsTask := &ecsacs.Task{
+		Attachments: []*ecsacs.Attachment{
+			{
+				AttachmentArn: stringToPointer("ebsAttachmentArn"),
+				AttachmentProperties: []*ecsacs.AttachmentProperty{
+					{Name: stringToPointer(apiresource.VolumeIdKey), Value: stringToPointer(taskresourcevolume.TestVolumeId)},
+					{Name: stringToPointer(apiresource.VolumeSizeGibKey), Value: stringToPointer(taskresourcevolume.TestVolumeSizeGib)},
+					{Name: stringToPointer(apiresource.DeviceNameKey), Value: stringToPointer(taskresourcevolume.TestDeviceName)},
+					{Name: stringToPointer(apiresource.SourceVolumeHostPathKey), Value: stringToPointer(taskresourcevolume.TestSourceVolumeHostPath)},
+					{Name: stringToPointer(apiresource.VolumeNameKey), Value: stringToPointer(taskresourcevolume.TestVolumeName)},
+					{Name: stringToPointer(apiresource.FileSystemKey), Value: stringToPointer(taskresourcevolume.TestFileSystem)},
+				},
+				AttachmentType: stringToPointer(apiresource.EBSTaskAttach),
+			},
+			{
+				AttachmentArn: stringToPointer("s3filesAttachmentArn1"),
+				AttachmentProperties: []*ecsacs.AttachmentProperty{
+					{Name: stringToPointer("volumeId"), Value: stringToPointer("fs-aaa")},
+					{Name: stringToPointer("volumeName"), Value: stringToPointer("s3volA")},
+				},
+				AttachmentType: stringToPointer(apiresource.S3FilesTaskAttach),
+			},
+			{
+				AttachmentArn: stringToPointer("s3filesAttachmentArn2"),
+				AttachmentProperties: []*ecsacs.AttachmentProperty{
+					{Name: stringToPointer("volumeId"), Value: stringToPointer("fs-bbb")},
+					{Name: stringToPointer("volumeName"), Value: stringToPointer("s3volB")},
+				},
+				AttachmentType: stringToPointer(apiresource.S3FilesTaskAttach),
+			},
+		},
+	}
+	// Pre-populate task with placeholder volumes for all three (simulating ACS payload).
+	testTask := &Task{
+		Volumes: []TaskVolume{
+			{
+				Name:   taskresourcevolume.TestVolumeName,
+				Type:   HostVolumeType,
+				Volume: &taskresourcevolume.FSHostVolume{FSSourcePath: "/host/ebs"},
+			},
+			{
+				Name:   "s3volA",
+				Type:   HostVolumeType,
+				Volume: &taskresourcevolume.FSHostVolume{FSSourcePath: "/host/s3a"},
+			},
+			{
+				Name:   "s3volB",
+				Type:   HostVolumeType,
+				Volume: &taskresourcevolume.FSHostVolume{FSSourcePath: "/host/s3b"},
+			},
+		},
+	}
+	err := handleTaskAttachments(testAcsTask, testTask)
+	require.NoError(t, err)
+
+	// Expect exactly 3 volumes: 1 EBS + 2 S3Files, no placeholders remaining.
+	var ebsCount, s3Count, placeholderCount int
+	for _, vol := range testTask.Volumes {
+		switch vol.Type {
+		case apiresource.EBSTaskAttach:
+			ebsCount++
+		case apiresource.S3FilesTaskAttach:
+			s3Count++
+		case HostVolumeType:
+			placeholderCount++
+		}
+	}
+	assert.Equal(t, 0, placeholderCount, "no placeholder volumes should remain")
+	assert.Equal(t, 1, ebsCount, "expected 1 EBS volume")
+	assert.Equal(t, 2, s3Count, "expected 2 S3Files volumes")
+
+	// Verify EBS volume config
+	var ebsVol *taskresourcevolume.EBSTaskVolumeConfig
+	for _, vol := range testTask.Volumes {
+		if vol.Type == apiresource.EBSTaskAttach {
+			cfg, ok := vol.Volume.(*taskresourcevolume.EBSTaskVolumeConfig)
+			require.True(t, ok)
+			ebsVol = cfg
+		}
+	}
+	require.NotNil(t, ebsVol)
+	assert.Equal(t, taskresourcevolume.TestVolumeId, ebsVol.VolumeId)
+	assert.Equal(t, taskresourcevolume.TestVolumeName, ebsVol.VolumeName)
+
+	// Verify S3Files volume configs
+	s3Vols := map[string]string{}
+	for _, vol := range testTask.Volumes {
+		if vol.Type == apiresource.S3FilesTaskAttach {
+			cfg, ok := vol.Volume.(*taskresourcevolume.S3FilesVolumeConfig)
+			require.True(t, ok)
+			s3Vols[cfg.VolumeName] = cfg.VolumeId
+		}
+	}
+	assert.Equal(t, "fs-aaa", s3Vols["s3volA"])
+	assert.Equal(t, "fs-bbb", s3Vols["s3volB"])
+}
+
+func TestHandleTaskAttachments_NoS3Files(t *testing.T) {
+	testAcsTask := &ecsacs.Task{
+		Attachments: []*ecsacs.Attachment{
+			{
+				AttachmentArn: stringToPointer("ebsAttachmentArn"),
+				AttachmentProperties: []*ecsacs.AttachmentProperty{
+					{Name: stringToPointer(apiresource.VolumeIdKey), Value: stringToPointer(taskresourcevolume.TestVolumeId)},
+					{Name: stringToPointer(apiresource.VolumeSizeGibKey), Value: stringToPointer(taskresourcevolume.TestVolumeSizeGib)},
+					{Name: stringToPointer(apiresource.DeviceNameKey), Value: stringToPointer(taskresourcevolume.TestDeviceName)},
+					{Name: stringToPointer(apiresource.SourceVolumeHostPathKey), Value: stringToPointer(taskresourcevolume.TestSourceVolumeHostPath)},
+					{Name: stringToPointer(apiresource.VolumeNameKey), Value: stringToPointer(taskresourcevolume.TestVolumeName)},
+					{Name: stringToPointer(apiresource.FileSystemKey), Value: stringToPointer(taskresourcevolume.TestFileSystem)},
+				},
+				AttachmentType: stringToPointer(apiresource.EBSTaskAttach),
+			},
+		},
+	}
+	testTask := &Task{}
+	err := handleTaskAttachments(testAcsTask, testTask)
+	require.NoError(t, err)
+
+	// Verify no s3files volumes were added
+	for _, vol := range testTask.Volumes {
+		assert.NotEqual(t, apiresource.S3FilesTaskAttach, vol.Type)
+	}
+}

--- a/agent/api/task/taskvolume.go
+++ b/agent/api/task/taskvolume.go
@@ -79,6 +79,8 @@ func (tv *TaskVolume) UnmarshalJSON(b []byte) error {
 		return tv.unmarshalFSxWindowsFileServerVolume(intermediate["fsxWindowsFileServerVolumeConfiguration"])
 	case apiresource.EBSTaskAttach:
 		return tv.unmarshalEBSVolume(intermediate["ebsVolumeConfiguration"])
+	case apiresource.S3FilesTaskAttach:
+		return tv.unmarshalS3FilesVolume(intermediate["s3filesVolumeConfiguration"])
 	case AttachmentType:
 		seelog.Warn("Obtaining the volume configuration from task attachments.")
 		return nil
@@ -109,6 +111,8 @@ func (tv *TaskVolume) MarshalJSON() ([]byte, error) {
 		result["fsxWindowsFileServerVolumeConfiguration"] = tv.Volume
 	case apiresource.EBSTaskAttach:
 		result["ebsVolumeConfiguration"] = tv.Volume
+	case apiresource.S3FilesTaskAttach:
+		result["s3filesVolumeConfiguration"] = tv.Volume
 	default:
 		return nil, errors.Errorf("unrecognized volume type: %q", tv.Type)
 	}
@@ -193,6 +197,18 @@ func (tv *TaskVolume) unmarshalEBSVolume(data json.RawMessage) error {
 	}
 
 	tv.Volume = &ebsVoumeConfig
+	return nil
+}
+
+func (tv *TaskVolume) unmarshalS3FilesVolume(data json.RawMessage) error {
+	if data == nil {
+		return errors.New("invalid volume: empty s3files volume configuration")
+	}
+	var s3filesConfig taskresourcevolume.S3FilesVolumeConfig
+	if err := json.Unmarshal(data, &s3filesConfig); err != nil {
+		return err
+	}
+	tv.Volume = &s3filesConfig
 	return nil
 }
 

--- a/agent/api/task/taskvolume_test.go
+++ b/agent/api/task/taskvolume_test.go
@@ -813,3 +813,129 @@ func TestSetPausePIDInVolumeResources(t *testing.T) {
 	task.SetPausePIDInVolumeResources("pid")
 	assert.Equal(t, "pid", volRes.GetPauseContainerPID())
 }
+
+func TestUnmarshalS3FilesVolume(t *testing.T) {
+	taskDef := []byte(`{
+		"Arn": "test",
+		"Family": "",
+		"Version": "",
+		"Containers": null,
+		"associations": null,
+		"resources": null,
+		"volumes": [
+		  {
+			"s3filesVolumeConfiguration": {
+				"volumeId": "fs-123",
+				"volumeName": "myS3Vol",
+				"s3FilesRootDirectory": "/data",
+				"s3FilesTransitEncryptionPort": "2049",
+				"s3FilesAccessPointId": "fsap-456",
+				"dockerVolumeName": "docker-vol-name"
+			},
+			"name": "1",
+			"type": "s3files"
+		  }
+		],
+		"DesiredStatus": "NONE",
+		"KnownStatus": "NONE",
+		"KnownTime": "0001-01-01T00:00:00Z",
+		"PullStartedAt": "0001-01-01T00:00:00Z",
+		"PullStoppedAt": "0001-01-01T00:00:00Z",
+		"ExecutionStoppedAt": "0001-01-01T00:00:00Z",
+		"SentStatus": "NONE",
+		"executionCredentialsID": "",
+		"credentialsID": "",
+		"ENI": null,
+		"AppMesh": null,
+		"PlatformFields": {}
+	  }`)
+
+	var task Task
+	err := json.Unmarshal(taskDef, &task)
+	require.NoError(t, err, "Could not unmarshal task")
+
+	require.Len(t, task.Volumes, 1)
+	assert.Equal(t, apiresource.S3FilesTaskAttach, task.Volumes[0].Type)
+	assert.Equal(t, "1", task.Volumes[0].Name)
+	s3cfg, ok := task.Volumes[0].Volume.(*taskresourcevolume.S3FilesVolumeConfig)
+	require.True(t, ok)
+	assert.Equal(t, "fs-123", s3cfg.VolumeId)
+	assert.Equal(t, "myS3Vol", s3cfg.VolumeName)
+	assert.Equal(t, "/data", s3cfg.S3FilesRootDirectory)
+	assert.Equal(t, "2049", s3cfg.S3FilesTransitEncryptionPort)
+	assert.Equal(t, "fsap-456", s3cfg.S3FilesAccessPointId)
+	assert.Equal(t, "docker-vol-name", s3cfg.DockerVolumeName)
+}
+
+func TestMarshalS3FilesVolume(t *testing.T) {
+	task := &Task{
+		Arn: "test",
+		Volumes: []TaskVolume{
+			{
+				Name: "s3vol",
+				Type: apiresource.S3FilesTaskAttach,
+				Volume: &taskresourcevolume.S3FilesVolumeConfig{
+					VolumeId:                     "fs-123",
+					VolumeName:                   "myS3Vol",
+					S3FilesRootDirectory:         "/data",
+					S3FilesTransitEncryptionPort: "2049",
+					S3FilesAccessPointId:         "fsap-456",
+					DockerVolumeName:             "docker-vol-name",
+				},
+			},
+		},
+	}
+
+	marshal, err := json.Marshal(task)
+	require.NoError(t, err, "Could not marshal task")
+
+	var out Task
+	err = json.Unmarshal(marshal, &out)
+	require.NoError(t, err, "Could not unmarshal task")
+
+	require.Len(t, out.Volumes, 1)
+	assert.Equal(t, apiresource.S3FilesTaskAttach, out.Volumes[0].Type)
+	assert.Equal(t, "s3vol", out.Volumes[0].Name)
+	s3cfg, ok := out.Volumes[0].Volume.(*taskresourcevolume.S3FilesVolumeConfig)
+	require.True(t, ok)
+	assert.Equal(t, "fs-123", s3cfg.VolumeId)
+	assert.Equal(t, "myS3Vol", s3cfg.VolumeName)
+	assert.Equal(t, "/data", s3cfg.S3FilesRootDirectory)
+	assert.Equal(t, "2049", s3cfg.S3FilesTransitEncryptionPort)
+	assert.Equal(t, "fsap-456", s3cfg.S3FilesAccessPointId)
+	assert.Equal(t, "docker-vol-name", s3cfg.DockerVolumeName)
+}
+
+func TestUnmarshalS3FilesVolume_NilConfig(t *testing.T) {
+	taskDef := []byte(`{
+		"Arn": "test",
+		"Family": "",
+		"Version": "",
+		"Containers": null,
+		"associations": null,
+		"resources": null,
+		"volumes": [
+		  {
+			"name": "1",
+			"type": "s3files"
+		  }
+		],
+		"DesiredStatus": "NONE",
+		"KnownStatus": "NONE",
+		"KnownTime": "0001-01-01T00:00:00Z",
+		"PullStartedAt": "0001-01-01T00:00:00Z",
+		"PullStoppedAt": "0001-01-01T00:00:00Z",
+		"ExecutionStoppedAt": "0001-01-01T00:00:00Z",
+		"SentStatus": "NONE",
+		"executionCredentialsID": "",
+		"credentialsID": "",
+		"ENI": null,
+		"AppMesh": null,
+		"PlatformFields": {}
+	  }`)
+
+	var task Task
+	err := json.Unmarshal(taskDef, &task)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty s3files")
+}

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -85,6 +85,7 @@ const (
 	capabilityGpuDriverVersion                             = "gpu-driver-version"
 	capabilityEBSTaskAttach                                = "storage.ebs-task-volume-attach"
 	capabilityEBSTANonRootUser                             = "storage.ebsta-non-root-user"
+	capabilityS3Files                                      = "storage.s3-files"
 	capabilityContainerRestartPolicy                       = "container-restart-policy"
 	capabilityFaultInjection                               = "fault-injection"
 	capabilityIPv6Only                                     = "ipv6-only"
@@ -303,6 +304,9 @@ func (agent *ecsAgent) capabilities() ([]types.Attribute, error) {
 
 	// support efs on ecs capabilities
 	capabilities = agent.appendEFSCapabilities(capabilities)
+
+	// support S3Files on ecs capabilities
+	capabilities = agent.appendS3FilesCapabilities(capabilities)
 
 	// support external firelens config
 	capabilities = agent.appendFirelensConfigCapabilities(capabilities)

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -220,6 +220,10 @@ func (agent *ecsAgent) appendEFSCapabilities(capabilities []types.Attribute) []t
 	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityEFS)
 }
 
+func (agent *ecsAgent) appendS3FilesCapabilities(capabilities []types.Attribute) []types.Attribute {
+	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityS3Files)
+}
+
 func (agent *ecsAgent) appendEFSVolumePluginCapabilities(capabilities []types.Attribute, pluginCapability string) []types.Attribute {
 	return appendNameOnlyAttribute(capabilities, attributePrefix+pluginCapability)
 }

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -916,6 +916,7 @@ func TestCapabilitiesUnix(t *testing.T) {
 		attributePrefix + capabilityContainerPortRange,
 		attributePrefix + capabilityContainerRestartPolicy,
 		attributePrefix + capabilityEBSTANonRootUser,
+		attributePrefix + capabilityS3Files,
 	}
 
 	var expectedCapabilities []types.Attribute

--- a/agent/app/agent_capability_unspecified.go
+++ b/agent/app/agent_capability_unspecified.go
@@ -109,6 +109,10 @@ func (agent *ecsAgent) appendEFSCapabilities(capabilities []types.Attribute) []t
 	return capabilities
 }
 
+func (agent *ecsAgent) appendS3FilesCapabilities(capabilities []types.Attribute) []types.Attribute {
+	return capabilities
+}
+
 func (agent *ecsAgent) appendFirelensLoggingDriverCapabilities(capabilities []types.Attribute) []types.Attribute {
 	return capabilities
 }

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -97,6 +97,10 @@ func (agent *ecsAgent) appendEFSCapabilities(capabilities []types.Attribute) []t
 	return capabilities
 }
 
+func (agent *ecsAgent) appendS3FilesCapabilities(capabilities []types.Attribute) []types.Attribute {
+	return capabilities
+}
+
 func (agent *ecsAgent) appendFirelensLoggingDriverCapabilities(capabilities []types.Attribute) []types.Attribute {
 	return capabilities
 }

--- a/agent/taskresource/volume/dockervolume.go
+++ b/agent/taskresource/volume/dockervolume.go
@@ -42,6 +42,7 @@ const (
 	resourceProvisioningError = "VolumeError: Agent could not create task's volume resources"
 	EFSVolumeType             = "efs"
 	EBSVolumeType             = "ebs"
+	S3FilesVolumeType         = "s3files"
 	DockerVolumeType          = "docker"
 	FSHostVolumeType          = "fshost"
 	netNSFormat               = "/proc/%s/ns/net"
@@ -484,14 +485,14 @@ func (vol *VolumeResource) GetAppliedStatus() resourcestatus.ResourceStatus {
 
 // DependOnTaskNetwork shows whether the resource creation needs task network setup beforehand
 func (vol *VolumeResource) DependOnTaskNetwork() bool {
-	return vol.VolumeType == EFSVolumeType
+	return vol.VolumeType == EFSVolumeType || vol.VolumeType == S3FilesVolumeType
 }
 
 // BuildContainerDependency sets the container dependencies of the resource.
 func (vol *VolumeResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
 	dependent resourcestatus.ResourceStatus) {
-	// No op for non-EFS volume type
-	if vol.VolumeType != EFSVolumeType {
+	// No op for non-EFS and non-S3Files volume type
+	if vol.VolumeType != EFSVolumeType && vol.VolumeType != S3FilesVolumeType {
 		return
 	}
 
@@ -509,8 +510,8 @@ func (vol *VolumeResource) BuildContainerDependency(containerName string, satisf
 
 // GetContainerDependencies returns the container dependencies of the resource.
 func (vol *VolumeResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
-	// No op for non-EFS volume type
-	if vol.VolumeType != EFSVolumeType {
+	// No op for non-EFS and non-S3Files volume type
+	if vol.VolumeType != EFSVolumeType && vol.VolumeType != S3FilesVolumeType {
 		return nil
 	}
 

--- a/agent/taskresource/volume/dockervolume_s3files.go
+++ b/agent/taskresource/volume/dockervolume_s3files.go
@@ -1,0 +1,132 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volume
+
+import (
+	"fmt"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	apiresource "github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment/resource"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+const (
+	s3filesVolumePluginDriverType = "s3files"
+)
+
+// S3FilesVolumeConfig represents S3 Files volume configuration.
+type S3FilesVolumeConfig struct {
+	VolumeId                     string `json:"volumeId"`
+	VolumeName                   string `json:"volumeName"`
+	S3FilesRootDirectory         string `json:"s3FilesRootDirectory,omitempty"`
+	S3FilesTransitEncryptionPort string `json:"s3FilesTransitEncryptionPort,omitempty"`
+	S3FilesAccessPointId         string `json:"s3FilesAccessPointId,omitempty"`
+	// DockerVolumeName is internal docker name for this volume.
+	DockerVolumeName string `json:"dockerVolumeName"`
+}
+
+// Source returns the name of the volume resource which is used as the source of the volume mount.
+func (cfg *S3FilesVolumeConfig) Source() string {
+	return cfg.DockerVolumeName
+}
+
+// GetType returns the S3 Files volume type.
+func (cfg *S3FilesVolumeConfig) GetType() string {
+	return S3FilesVolumeType
+}
+
+// GetVolumeId returns the volume ID.
+func (cfg *S3FilesVolumeConfig) GetVolumeId() string {
+	return cfg.VolumeId
+}
+
+// GetVolumeName returns the volume name.
+func (cfg *S3FilesVolumeConfig) GetVolumeName() string {
+	return cfg.VolumeName
+}
+
+// ParseS3FilesTaskVolumeAttachment parses the S3 Files task volume config
+// from the given attachment.
+func ParseS3FilesTaskVolumeAttachment(attachment *ecsacs.Attachment) (*S3FilesVolumeConfig, error) {
+	cfg := &S3FilesVolumeConfig{}
+	for _, property := range attachment.AttachmentProperties {
+		if property == nil {
+			return nil, fmt.Errorf("failed to parse s3files attachment, encountered nil property")
+		}
+		if aws.ToString(property.Value) == "" {
+			return nil, fmt.Errorf("failed to parse s3files attachment, encountered empty value for property: %s",
+				aws.ToString(property.Name))
+		}
+		switch aws.ToString(property.Name) {
+		case apiresource.S3FilesVolumeIdKey:
+			cfg.VolumeId = aws.ToString(property.Value)
+		case apiresource.S3FilesVolumeNameKey:
+			cfg.VolumeName = aws.ToString(property.Value)
+		case apiresource.S3FilesRootDirectoryKey:
+			cfg.S3FilesRootDirectory = aws.ToString(property.Value)
+		case apiresource.S3FilesTransitEncryptionPortKey:
+			cfg.S3FilesTransitEncryptionPort = aws.ToString(property.Value)
+		case apiresource.S3FilesAccessPointIdKey:
+			cfg.S3FilesAccessPointId = aws.ToString(property.Value)
+		default:
+			logger.Warn("Received an unrecognized s3files attachment property", logger.Fields{
+				"attachmentProperty": property.String(),
+			})
+		}
+	}
+	if err := validateS3FilesAttachment(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// validateS3FilesAttachment validates that required fields are present in the S3 Files config.
+func validateS3FilesAttachment(cfg *S3FilesVolumeConfig) error {
+	if cfg.VolumeId == "" {
+		return fmt.Errorf("missing %s in the S3 Files config", apiresource.S3FilesVolumeIdKey)
+	}
+	if cfg.VolumeName == "" {
+		return fmt.Errorf("missing %s in the S3 Files config", apiresource.S3FilesVolumeNameKey)
+	}
+	return nil
+}
+
+// GetVolumePluginDriverOptions returns the options for creating an S3 Files volume
+// using the ECS volume plugin.
+func (cfg *S3FilesVolumeConfig) GetVolumePluginDriverOptions(credsRelativeURI string) map[string]string {
+	device := cfg.VolumeId
+	if cfg.S3FilesRootDirectory != "" {
+		device = fmt.Sprintf("%s:%s", device, cfg.S3FilesRootDirectory)
+	}
+
+	mntOpt := NewVolumeMountOptions()
+	// S3 Files always uses TLS.
+	mntOpt.AddOption("tls", "")
+	if cfg.S3FilesTransitEncryptionPort != "" {
+		mntOpt.AddOption("tlsport", cfg.S3FilesTransitEncryptionPort)
+	}
+	// S3 Files always uses IAM auth.
+	mntOpt.AddOption("iam", "")
+	mntOpt.AddOption("awscredsuri", credsRelativeURI)
+	if cfg.S3FilesAccessPointId != "" {
+		mntOpt.AddOption("accesspoint", cfg.S3FilesAccessPointId)
+	}
+
+	return map[string]string{
+		"type":   s3filesVolumePluginDriverType,
+		"device": device,
+		"o":      mntOpt.String(),
+	}
+}

--- a/agent/taskresource/volume/dockervolume_s3files_test.go
+++ b/agent/taskresource/volume/dockervolume_s3files_test.go
@@ -1,0 +1,180 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volume
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseS3FilesTaskVolumeAttachment_AllProperties(t *testing.T) {
+	attachment := &ecsacs.Attachment{
+		AttachmentProperties: []*ecsacs.AttachmentProperty{
+			{Name: aws.String("volumeId"), Value: aws.String("fs-123")},
+			{Name: aws.String("volumeName"), Value: aws.String("myVolume")},
+			{Name: aws.String("s3FilesRootDirectory"), Value: aws.String("/data")},
+			{Name: aws.String("s3FilesTransitEncryptionPort"), Value: aws.String("2049")},
+			{Name: aws.String("s3FilesAccessPointId"), Value: aws.String("fsap-123")},
+		},
+	}
+
+	cfg, err := ParseS3FilesTaskVolumeAttachment(attachment)
+	require.NoError(t, err)
+	assert.Equal(t, "fs-123", cfg.VolumeId)
+	assert.Equal(t, "myVolume", cfg.VolumeName)
+	assert.Equal(t, "/data", cfg.S3FilesRootDirectory)
+	assert.Equal(t, "2049", cfg.S3FilesTransitEncryptionPort)
+	assert.Equal(t, "fsap-123", cfg.S3FilesAccessPointId)
+}
+
+func TestParseS3FilesTaskVolumeAttachment_RequiredOnly(t *testing.T) {
+	attachment := &ecsacs.Attachment{
+		AttachmentProperties: []*ecsacs.AttachmentProperty{
+			{Name: aws.String("volumeId"), Value: aws.String("fs-456")},
+			{Name: aws.String("volumeName"), Value: aws.String("vol2")},
+		},
+	}
+
+	cfg, err := ParseS3FilesTaskVolumeAttachment(attachment)
+	require.NoError(t, err)
+	assert.Equal(t, "fs-456", cfg.VolumeId)
+	assert.Equal(t, "vol2", cfg.VolumeName)
+	assert.Empty(t, cfg.S3FilesRootDirectory)
+	assert.Empty(t, cfg.S3FilesTransitEncryptionPort)
+	assert.Empty(t, cfg.S3FilesAccessPointId)
+}
+
+func TestParseS3FilesTaskVolumeAttachment_NilProperty(t *testing.T) {
+	attachment := &ecsacs.Attachment{
+		AttachmentProperties: []*ecsacs.AttachmentProperty{
+			{Name: aws.String("volumeId"), Value: aws.String("fs-123")},
+			nil,
+			{Name: aws.String("volumeName"), Value: aws.String("myVolume")},
+		},
+	}
+
+	_, err := ParseS3FilesTaskVolumeAttachment(attachment)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil property")
+}
+
+func TestParseS3FilesTaskVolumeAttachment_EmptyValue(t *testing.T) {
+	attachment := &ecsacs.Attachment{
+		AttachmentProperties: []*ecsacs.AttachmentProperty{
+			{Name: aws.String("volumeId"), Value: aws.String("")},
+			{Name: aws.String("volumeName"), Value: aws.String("myVolume")},
+		},
+	}
+
+	_, err := ParseS3FilesTaskVolumeAttachment(attachment)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty value")
+}
+
+func TestParseS3FilesTaskVolumeAttachment_UnrecognizedProperty(t *testing.T) {
+	attachment := &ecsacs.Attachment{
+		AttachmentProperties: []*ecsacs.AttachmentProperty{
+			{Name: aws.String("volumeId"), Value: aws.String("fs-789")},
+			{Name: aws.String("volumeName"), Value: aws.String("vol3")},
+			{Name: aws.String("unknownProperty"), Value: aws.String("someValue")},
+		},
+	}
+
+	cfg, err := ParseS3FilesTaskVolumeAttachment(attachment)
+	require.NoError(t, err)
+	assert.Equal(t, "fs-789", cfg.VolumeId)
+	assert.Equal(t, "vol3", cfg.VolumeName)
+}
+
+func TestValidateS3FilesAttachment_MissingVolumeId(t *testing.T) {
+	cfg := &S3FilesVolumeConfig{
+		VolumeId:   "",
+		VolumeName: "myVolume",
+	}
+	err := validateS3FilesAttachment(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "volumeId")
+}
+
+func TestValidateS3FilesAttachment_MissingVolumeName(t *testing.T) {
+	cfg := &S3FilesVolumeConfig{
+		VolumeId:   "fs-123",
+		VolumeName: "",
+	}
+	err := validateS3FilesAttachment(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "volumeName")
+}
+
+func TestS3FilesVolumeConfig_Source(t *testing.T) {
+	cfg := &S3FilesVolumeConfig{
+		DockerVolumeName: "test-vol",
+	}
+	assert.Equal(t, "test-vol", cfg.Source())
+}
+
+func TestS3FilesVolumeConfig_GetType(t *testing.T) {
+	cfg := &S3FilesVolumeConfig{}
+	assert.Equal(t, "s3files", cfg.GetType())
+}
+
+func TestGetVolumePluginDriverOptions_Basic(t *testing.T) {
+	cfg := &S3FilesVolumeConfig{
+		VolumeId:   "fs-123",
+		VolumeName: "vol1",
+	}
+	options := cfg.GetVolumePluginDriverOptions("/creds")
+	assert.Equal(t, "s3files", options["type"])
+	assert.Equal(t, "fs-123", options["device"])
+	assert.Contains(t, options["o"], "tls")
+	assert.Contains(t, options["o"], "iam")
+	assert.Contains(t, options["o"], "awscredsuri=/creds")
+}
+
+func TestGetVolumePluginDriverOptions_WithAccessPoint(t *testing.T) {
+	cfg := &S3FilesVolumeConfig{
+		VolumeId:             "fs-123",
+		VolumeName:           "vol1",
+		S3FilesAccessPointId: "fsap-123",
+	}
+	options := cfg.GetVolumePluginDriverOptions("/creds")
+	assert.Contains(t, options["o"], "accesspoint=fsap-123")
+}
+
+func TestGetVolumePluginDriverOptions_WithRootDirectory(t *testing.T) {
+	cfg := &S3FilesVolumeConfig{
+		VolumeId:             "fs-123",
+		VolumeName:           "vol1",
+		S3FilesRootDirectory: "/data",
+	}
+	options := cfg.GetVolumePluginDriverOptions("/creds")
+	assert.Equal(t, "fs-123:/data", options["device"])
+}
+
+func TestGetVolumePluginDriverOptions_WithTLSPort(t *testing.T) {
+	cfg := &S3FilesVolumeConfig{
+		VolumeId:                     "fs-123",
+		VolumeName:                   "vol1",
+		S3FilesTransitEncryptionPort: "2049",
+	}
+	options := cfg.GetVolumePluginDriverOptions("/creds")
+	assert.Contains(t, options["o"], "tlsport=2049")
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment/resource/resource_attachment.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment/resource/resource_attachment.go
@@ -71,6 +71,13 @@ const (
 	SourceVolumeHostPathKey = "sourceVolumeHostPath"
 	VolumeNameKey           = "volumeName"
 	FileSystemKey           = "fileSystem"
+
+	// Properties specific to S3 Files attachment.
+	S3FilesVolumeIdKey              = "volumeId"
+	S3FilesVolumeNameKey            = "volumeName"
+	S3FilesRootDirectoryKey         = "s3FilesRootDirectory"
+	S3FilesTransitEncryptionPortKey = "s3FilesTransitEncryptionPort"
+	S3FilesAccessPointIdKey         = "s3FilesAccessPointId"
 )
 
 var (

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment/resource/resource_type.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/attachment/resource/resource_type.go
@@ -22,4 +22,6 @@ const (
 	ElasticBlockStorage = "ElasticBlockStorage"
 	// EBSTaskAttach is one of the attachment types in the attachment payload message for EBS attach tasks.
 	EBSTaskAttach = "amazonebs"
+	// S3FilesTaskAttach is one of the attachment types in the attachment payload message for tasks with S3 Files volumes.
+	S3FilesTaskAttach = "s3files"
 )

--- a/ecs-agent/api/attachment/resource/resource_attachment.go
+++ b/ecs-agent/api/attachment/resource/resource_attachment.go
@@ -71,6 +71,13 @@ const (
 	SourceVolumeHostPathKey = "sourceVolumeHostPath"
 	VolumeNameKey           = "volumeName"
 	FileSystemKey           = "fileSystem"
+
+	// Properties specific to S3 Files attachment.
+	S3FilesVolumeIdKey              = "volumeId"
+	S3FilesVolumeNameKey            = "volumeName"
+	S3FilesRootDirectoryKey         = "s3FilesRootDirectory"
+	S3FilesTransitEncryptionPortKey = "s3FilesTransitEncryptionPort"
+	S3FilesAccessPointIdKey         = "s3FilesAccessPointId"
 )
 
 var (

--- a/ecs-agent/api/attachment/resource/resource_type.go
+++ b/ecs-agent/api/attachment/resource/resource_type.go
@@ -22,4 +22,6 @@ const (
 	ElasticBlockStorage = "ElasticBlockStorage"
 	// EBSTaskAttach is one of the attachment types in the attachment payload message for EBS attach tasks.
 	EBSTaskAttach = "amazonebs"
+	// S3FilesTaskAttach is one of the attachment types in the attachment payload message for tasks with S3 Files volumes.
+	S3FilesTaskAttach = "s3files"
 )

--- a/ecs-init/volumes/ecs_volume_plugin.go
+++ b/ecs-init/volumes/ecs_volume_plugin.go
@@ -45,7 +45,8 @@ type AmazonECSVolumePlugin struct {
 func NewAmazonECSVolumePlugin() *AmazonECSVolumePlugin {
 	plugin := &AmazonECSVolumePlugin{
 		volumeDrivers: map[string]driver.VolumeDriver{
-			"efs": NewECSVolumeDriver(),
+			"efs":     NewECSVolumeDriver(),
+			"s3files": NewECSVolumeDriver(),
 		},
 		volumes: make(map[string]*types.Volume),
 		state:   NewStateManager(),

--- a/ecs-init/volumes/ecs_volume_plugin_test.go
+++ b/ecs-init/volumes/ecs_volume_plugin_test.go
@@ -1187,3 +1187,46 @@ func TestPluginUnmount(t *testing.T) {
 		})
 	}
 }
+
+func TestGetVolumeDriver_S3Files(t *testing.T) {
+	plugin := NewAmazonECSVolumePlugin()
+	driver, err := plugin.getVolumeDriver("s3files")
+	assert.NoError(t, err)
+	assert.NotNil(t, driver)
+}
+
+func TestCreate_S3FilesVolume(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]driver.VolumeDriver{
+			"s3files": NewTestVolumeDriver(),
+		},
+		volumes: make(map[string]*types.Volume),
+		state:   NewStateManager(),
+	}
+	req := &volume.CreateRequest{
+		Name: "s3vol",
+		Options: map[string]string{
+			"type":   "s3files",
+			"device": "fs-123",
+			"o":      "tls,iam",
+		},
+	}
+	createMountPath = func(path string) error {
+		return nil
+	}
+	saveStateToDisk = func(b []byte) error {
+		return nil
+	}
+	defer func() {
+		createMountPath = createMountDir
+		saveStateToDisk = saveState
+	}()
+	err := plugin.Create(req)
+	assert.NoError(t, err, "create s3files volume should be successful")
+	assert.Len(t, plugin.volumes, 1)
+	vol, ok := plugin.volumes["s3vol"]
+	assert.True(t, ok)
+	assert.Equal(t, "s3files", vol.Type)
+	assert.Equal(t, VolumeMountPathPrefix+"s3vol", vol.Path)
+	assert.NotEmpty(t, vol.CreatedAt)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This commit adds S3 Files volume support to the ECS Agent. It enables tasks to mount S3-backed file systems as NFS volumes via the ECS volume plugin, following the same architectural pattern used for EFS volumes. The agent advertises the storage.s3-files capability, receives S3 Files volume attachments from ACS, converts them into volume definitions using the ECS volume plugin, and manages their lifecycle with proper task-network dependencies.

<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->
  New Attachment Type & Constants (ecs-agent/api/attachment/resource/)
  
  - Defines S3FilesTaskAttach = "s3files" as a new attachment type.
  - Adds property key constants: S3FilesVolumeIdKey, S3FilesVolumeNameKey, S3FilesRootDirectoryKey, S3FilesTransitEncryptionPortKey,
  S3FilesAccessPointIdKey.
  
  S3 Files Volume Configuration (agent/taskresource/volume/dockervolume_s3files.go)
  
  - New S3FilesVolumeConfig struct holding volume ID, name, root directory, TLS port, access point ID, and internal Docker volume name.
  - ParseS3FilesTaskVolumeAttachment() — parses ACS attachment properties into the config, validates required fields (volumeId, volumeName).
  - GetVolumePluginDriverOptions() — builds the driver options map (type, device, o) for the ECS volume plugin. Mount options include tls, iam,
  awscredsuri, and optionally tlsport and accesspoint.
  
  ACS Payload Handling (agent/acs/session/payload_responder.go)
  
  - getS3FilesAttachmentVolumeNames() extracts volume names from S3 Files attachments.
  - Before TaskFromACS deserialization, marks matching volumes as "attachment" type so UnmarshalJSON doesn't reject them.
  
  Task Attachment Handler (agent/api/task/task_attachment_handler.go)
  
  - Routes s3files attachments to a dedicated handler that parses each into S3FilesVolumeConfig, appends it as a TaskVolume, and removes any
  pre-existing placeholder volume with the same name.
  
  Volume Initialization (agent/api/task/task.go)
  
  - initializeS3FilesVolumes() iterates task volumes of type s3files, calls addS3FilesVolumes() which creates a VolumeResource via the ECS volume
  plugin with the driver options, registers it as a task resource, and sets up container volume dependencies.
  
  Task Volume Serialization (agent/api/task/taskvolume.go)
  
  - Adds s3files case to UnmarshalJSON/MarshalJSON using the s3filesVolumeConfiguration JSON key.
  
  Docker Volume Resource (agent/taskresource/volume/dockervolume.go)
  
  - S3FilesVolumeType = "s3files" constant.
  - S3 Files volumes depend on task network (like EFS) — DependOnTaskNetwork(), BuildContainerDependency(), and GetContainerDependencies() now include
  the S3FilesVolumeType.
  
  Agent Capability (agent/app/agent_capability*.go)
  
  - Registers ecs.capability.storage.s3-files on Linux. Windows and unspecified platforms return a no-op.
  
  ECS Volume Plugin (ecs-init/volumes/ecs_volume_plugin.go)
  
  - Registers "s3files" as a volume driver type using the same ECSVolumeDriver implementation as EFS.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
This was tested manually on an EC2 instance. See following logs
```
level=info time=2026-05-08T01:15:09Z msg="Creating new volume ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00"
level=info time=2026-05-08T01:15:09Z msg="Creating mount target for new volume ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00"
level=info time=2026-05-08T01:15:09Z msg="Saving state of new volume ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00"
level=info time=2026-05-08T01:15:13Z msg="Returning volume information for ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00"
level=info time=2026-05-08T01:15:13Z msg="Returning volume information for ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00"
level=info time=2026-05-08T01:15:13Z msg="Received mount request &{Name:ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00 ID:6800b3e816b634cc7b6cda3ef77d09f9ccdbdb545981fb74b0d38efd14153901}"
level=info time=2026-05-08T01:15:13Z msg="Mounting volume ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00 as there are no existing mounts for it"
level=info time=2026-05-08T01:15:13Z msg="Validating create options for volume ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00"
level=info time=2026-05-08T01:15:13Z msg="Mounting volume ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00 of type s3files at path /var/lib/ecs/volumes/ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00"
level=info time=2026-05-08T01:15:14Z msg="Volume ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00 mounted successfully"
level=info time=2026-05-08T01:15:14Z msg="Adding mount 6800b3e816b634cc7b6cda3ef77d09f9ccdbdb545981fb74b0d38efd14153901 to volume ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00"
level=info time=2026-05-08T01:15:25Z msg="Returning volume information for ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00"
level=info time=2026-05-08T01:15:25Z msg="Received unmount request &{Name:ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00 ID:6800b3e816b634cc7b6cda3ef77d09f9ccdbdb545981fb74b0d38efd14153901}"
level=info time=2026-05-08T01:15:25Z msg="Removing mount 6800b3e816b634cc7b6cda3ef77d09f9ccdbdb545981fb74b0d38efd14153901 from volume ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00"
level=info time=2026-05-08T01:15:25Z msg="No active mounts left on volume ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00, unmounting it"
level=info time=2026-05-08T01:15:25Z msg="Unmounted volume ecs-S3Files-attach-1-s3files-aea4ebc5e189ece77e00 successfully."
```

New tests cover the changes: <!-- yes|no -->

New tests passed in preprod:
```
--- PASS: TestS3Files (1.16s)
    --- PASS: TestS3Files/rw-host (11.00s)
    --- PASS: TestS3Files/rw-br (11.06s)
    --- PASS: TestS3Files/rw-none (11.17s)
    --- PASS: TestS3Files/rw-avpc (21.65s)
```

### Description for the changelog

Feature - Add support for ECS S3 Files integration

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
