### PR TITLE
Rename IMDSCredentialRefresher to IMDSCredentialsRefresher

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -971,8 +971,8 @@ func (agent *ecsAgent) startAsyncRoutines(
 		go agent.startSpotInstanceDrainingPoller(agent.ctx, client)
 	}
 
-	// Start IMDS credential refresher for periodic task credential retrieval via IMDS.
-	if imdsRefresher := agent.getIMDSCredentialRefresher(credentialsManager, taskEngine); imdsRefresher != nil {
+	// Start IMDS credentials refresher for periodic task credential retrieval via IMDS.
+	if imdsRefresher := agent.getIMDSCredentialsRefresher(credentialsManager, taskEngine); imdsRefresher != nil {
 		go imdsRefresher.Start()
 	}
 
@@ -1027,15 +1027,15 @@ func (agent *ecsAgent) startSpotInstanceDrainingPoller(ctx context.Context, clie
 	}
 }
 
-// getIMDSCredentialRefresher returns an IMDS credential refresher
+// getIMDSCredentialsRefresher returns an IMDS credentials refresher
 // if the IMDSIAMRolesEnabled configuration is enabled.
-func (agent *ecsAgent) getIMDSCredentialRefresher(
+func (agent *ecsAgent) getIMDSCredentialsRefresher(
 	credentialsManager credentials.Manager,
 	taskEngine engine.TaskEngine,
-) *imdscreds.IMDSCredentialRefresher {
+) *imdscreds.IMDSCredentialsRefresher {
 	if agent.cfg.IMDSIAMRolesEnabled {
 		imdsScanner := imds.NewScanner(agent.ec2MetadataClient)
-		return imdscreds.NewIMDSCredentialRefresher(
+		return imdscreds.NewIMDSCredentialsRefresher(
 			agent.ctx, imdsScanner, credentialsManager,
 			taskEngine, imdscreds.ScanInterval,
 		)

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -2119,7 +2119,7 @@ func TestLoadManagedDaemonImage(t *testing.T) {
 	}
 }
 
-func TestGetIMDSCredentialRefresher(t *testing.T) {
+func TestGetIMDSCredentialsRefresher(t *testing.T) {
 	tests := []struct {
 		name            string
 		enabled         bool
@@ -2155,7 +2155,7 @@ func TestGetIMDSCredentialRefresher(t *testing.T) {
 				ec2MetadataClient: mockEC2Metadata,
 			}
 
-			result := agent.getIMDSCredentialRefresher(
+			result := agent.getIMDSCredentialsRefresher(
 				mockCredManager, mockEngine,
 			)
 			if tc.expectRefresher {

--- a/agent/imdscreds/refresher.go
+++ b/agent/imdscreds/refresher.go
@@ -28,14 +28,14 @@ import (
 )
 
 const (
-	// ScanInterval is the default interval between IMDS credential scans.
+	// ScanInterval is the default interval between IMDS credentials scans.
 	// TODO: this value will be finalized based on load testing.
 	ScanInterval = 15 * time.Minute
 )
 
-// IMDSCredentialRefresher periodically scans IMDS for rotated task credentials
+// IMDSCredentialsRefresher periodically scans IMDS for rotated task credentials
 // and upserts them into the credentials manager.
-type IMDSCredentialRefresher struct {
+type IMDSCredentialsRefresher struct {
 	ctx          context.Context
 	scanner      imds.Scanner
 	credManager  credentials.Manager
@@ -43,15 +43,15 @@ type IMDSCredentialRefresher struct {
 	scanInterval time.Duration
 }
 
-// NewIMDSCredentialRefresher creates a new IMDS credential refresher.
-func NewIMDSCredentialRefresher(
+// NewIMDSCredentialsRefresher creates a new IMDS credentials refresher.
+func NewIMDSCredentialsRefresher(
 	ctx context.Context,
 	scanner imds.Scanner,
 	credManager credentials.Manager,
 	taskEngine engine.TaskEngine,
 	scanInterval time.Duration,
-) *IMDSCredentialRefresher {
-	return &IMDSCredentialRefresher{
+) *IMDSCredentialsRefresher {
+	return &IMDSCredentialsRefresher{
 		ctx:          ctx,
 		scanner:      scanner,
 		credManager:  credManager,
@@ -60,10 +60,10 @@ func NewIMDSCredentialRefresher(
 	}
 }
 
-// Start begins the periodic IMDS credential scan loop. It blocks until the
+// Start begins the periodic IMDS credentials scan loop. It blocks until the
 // context is cancelled.
-func (r *IMDSCredentialRefresher) Start() {
-	logger.Info("Starting IMDS credential refresher")
+func (r *IMDSCredentialsRefresher) Start() {
+	logger.Info("Starting IMDS credentials refresher")
 	ticker := time.NewTicker(r.scanInterval)
 	defer ticker.Stop()
 	for {
@@ -71,18 +71,18 @@ func (r *IMDSCredentialRefresher) Start() {
 		case <-ticker.C:
 			r.refresh()
 		case <-r.ctx.Done():
-			logger.Info("IMDS credential refresher stopped")
+			logger.Info("IMDS credentials refresher stopped")
 			return
 		}
 	}
 }
 
-// refresh performs a single IMDS credential scan and upserts any matching
+// refresh performs a single IMDS credentials scan and upserts any matching
 // credentials into the credentials manager.
-func (r *IMDSCredentialRefresher) refresh() {
+func (r *IMDSCredentialsRefresher) refresh() {
 	tasks, err := r.taskEngine.ListTasks()
 	if err != nil {
-		logger.Error("IMDS credential refresh: failed to list tasks", logger.Fields{
+		logger.Error("IMDS credentials refresh: failed to list tasks", logger.Fields{
 			field.Error: err,
 		})
 		return
@@ -91,13 +91,13 @@ func (r *IMDSCredentialRefresher) refresh() {
 	// Build a map of task ID -> task for non-terminal tasks.
 	nonTerminalTasks := nonTerminalTasksByID(tasks)
 	if len(nonTerminalTasks) == 0 {
-		logger.Debug("IMDS credential refresh: no non-terminal tasks, skipping scan")
+		logger.Debug("IMDS credentials refresh: no non-terminal tasks, skipping scan")
 		return
 	}
 
 	creds, err := r.scanner.Scan(r.ctx)
 	if err != nil {
-		logger.Error("IMDS credential refresh: scan failed", logger.Fields{
+		logger.Error("IMDS credentials refresh: scan failed", logger.Fields{
 			field.Error: err,
 		})
 		return
@@ -108,7 +108,7 @@ func (r *IMDSCredentialRefresher) refresh() {
 		if !ok {
 			// Credential for a task that's either terminal or unknown
 			// (for example, due to data corruption); skip.
-			logger.Debug("IMDS credential refresh: task not in non-terminal set, skipping", logger.Fields{
+			logger.Debug("IMDS credentials refresh: task not in non-terminal set, skipping", logger.Fields{
 				field.TaskID: cred.TaskID,
 			})
 			continue
@@ -119,12 +119,12 @@ func (r *IMDSCredentialRefresher) refresh() {
 
 // upsertCredential maps an IMDS credential to the task's role type
 // and upserts it into the credentials manager.
-func (r *IMDSCredentialRefresher) upsertCredential(
+func (r *IMDSCredentialsRefresher) upsertCredential(
 	task *apitask.Task, cred imds.TaskCredential,
 ) {
 	credentialsID := task.GetCredentialsIDForRoleType(cred.RoleType)
 	if credentialsID == "" {
-		logger.Warn("IMDS credential refresh: no credentials ID for task",
+		logger.Warn("IMDS credentials refresh: no credentials ID for task",
 			logger.Fields{
 				field.TaskID: cred.TaskID,
 				"roleType":   cred.RoleType,
@@ -145,7 +145,7 @@ func (r *IMDSCredentialRefresher) upsertCredential(
 		},
 	})
 	if err != nil {
-		logger.Error("IMDS credential refresh: failed to upsert credential",
+		logger.Error("IMDS credentials refresh: failed to upsert credential",
 			logger.Fields{
 				field.TaskID: cred.TaskID,
 				field.Error:  err,

--- a/agent/imdscreds/refresher_integ_test.go
+++ b/agent/imdscreds/refresher_integ_test.go
@@ -52,8 +52,8 @@ const (
 	credID2Exec = "cred-b-exec"
 )
 
-// TestIMDSCredentialRefresh tests the integration between the IMDS
-// credential refresher, scanner, task engine state, credentials manager,
+// TestIMDSCredentialsRefresh tests the integration between the IMDS
+// credentials refresher, scanner, task engine state, credentials manager,
 // and a mock IMDS HTTP server.
 //
 // Phase 1: Setup the mock IMDS server, task engine, and credentials refresher.
@@ -63,7 +63,7 @@ const (
 //
 // Phase 3: Rotate credentials on the mock server and verify the refresher
 // picks up the new values on the next scan cycle.
-func TestIMDSCredentialRefresh(t *testing.T) {
+func TestIMDSCredentialsRefresh(t *testing.T) {
 	// Phase 1: Setup.
 	//
 	// Start a mock IMDS server.
@@ -78,8 +78,8 @@ func TestIMDSCredentialRefresh(t *testing.T) {
 	scanner := ecsagentimds.NewScanner(newEC2Client(t, mockIMDS.URL()))
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Setup the credential refresher.
-	refresher := NewIMDSCredentialRefresher(
+	// Setup the credentials refresher.
+	refresher := NewIMDSCredentialsRefresher(
 		ctx, scanner, credManager, taskEngine, testScanInterval,
 	)
 

--- a/agent/imdscreds/refresher_test.go
+++ b/agent/imdscreds/refresher_test.go
@@ -318,7 +318,7 @@ func TestRefresh(t *testing.T) {
 					Times(0)
 			}
 
-			refresher := &IMDSCredentialRefresher{
+			refresher := &IMDSCredentialsRefresher{
 				ctx:         context.Background(),
 				scanner:     mockScanner,
 				credManager: mockCredManager,
@@ -426,7 +426,7 @@ func TestUpsertCredential(t *testing.T) {
 					Times(0)
 			}
 
-			refresher := &IMDSCredentialRefresher{
+			refresher := &IMDSCredentialsRefresher{
 				ctx:         context.Background(),
 				credManager: mockCredManager,
 			}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/scanner.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/scanner.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Package imds provides an IMDS credential scanner that retrieves task
+// Package imds provides an IMDS credentials scanner that retrieves task
 // credentials from IMDS.
 package imds
 
@@ -48,7 +48,7 @@ const (
 	// IMDS shares a 1024 packets-per-second (PPS) limit with other
 	// link local services (Route 53 DNS, NTP).
 	// Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-	// The rate limiter keeps credential scanning within ~10% of the total PPS budget
+	// The rate limiter keeps credentials scanning within ~10% of the total PPS budget
 	// to leave headroom for other link-local requests on the instance.
 	//
 	// TODO: this value will be finalized based on load testing.
@@ -75,7 +75,7 @@ type scanner struct {
 	lastUpdated map[string]time.Time
 }
 
-// NewScanner creates a new IMDS credential scanner.
+// NewScanner creates a new IMDS credentials scanner.
 func NewScanner(ec2MetadataClient ec2.EC2MetadataClient) Scanner {
 	return &scanner{
 		ec2MetadataClient: ec2MetadataClient,

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/testutil/mock_imds_server.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/testutil/mock_imds_server.go
@@ -15,7 +15,7 @@
 // permissions and limitations under the License.
 
 // Package testutil provides a mock IMDS HTTP server for integration testing
-// the IMDS credential scanner with agent's refresher.
+// the IMDS credentials scanner with agent's refresher.
 package testutil
 
 import (

--- a/ecs-agent/credentials/imds/scanner.go
+++ b/ecs-agent/credentials/imds/scanner.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Package imds provides an IMDS credential scanner that retrieves task
+// Package imds provides an IMDS credentials scanner that retrieves task
 // credentials from IMDS.
 package imds
 
@@ -48,7 +48,7 @@ const (
 	// IMDS shares a 1024 packets-per-second (PPS) limit with other
 	// link local services (Route 53 DNS, NTP).
 	// Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-	// The rate limiter keeps credential scanning within ~10% of the total PPS budget
+	// The rate limiter keeps credentials scanning within ~10% of the total PPS budget
 	// to leave headroom for other link-local requests on the instance.
 	//
 	// TODO: this value will be finalized based on load testing.
@@ -75,7 +75,7 @@ type scanner struct {
 	lastUpdated map[string]time.Time
 }
 
-// NewScanner creates a new IMDS credential scanner.
+// NewScanner creates a new IMDS credentials scanner.
 func NewScanner(ec2MetadataClient ec2.EC2MetadataClient) Scanner {
 	return &scanner{
 		ec2MetadataClient: ec2MetadataClient,

--- a/ecs-agent/credentials/imds/testutil/mock_imds_server.go
+++ b/ecs-agent/credentials/imds/testutil/mock_imds_server.go
@@ -15,7 +15,7 @@
 // permissions and limitations under the License.
 
 // Package testutil provides a mock IMDS HTTP server for integration testing
-// the IMDS credential scanner with agent's refresher.
+// the IMDS credentials scanner with agent's refresher.
 package testutil
 
 import (


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR renames the IMDSCredentialRefresher to IMDSCredentialsRefresher, while the feature is disabled and being built.

This aligns it with the plural naming used by sibling types in the credentials package (CredentialsManager, IAMRoleCredentials). Single-entity types (TaskCredential) and per-credential methods (upsertCredential, parseCredentialKey, etc.) stay singular per Go entity convention.

This will also align the naming with our sibling containerd-based ECS agent.

### Implementation details
<!-- How are the changes implemented? -->

Self-explainatory, rename-only change, no new functional change.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no, relying on PR checks. rename is also across test files as needed.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement - rename IMDSCredentialRefresher to IMDSCredentialsRefresher

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
