### PR TITLE
Add retries for TCS publish requests

### DIFF
--- a/ecs-agent/tcs/client/client.go
+++ b/ecs-agent/tcs/client/client.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/wsclient"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -45,6 +46,8 @@ const (
 	// DefaultContainerMetricsPublishInterval is the default interval that we publish
 	// metrics to the ECS telemetry backend (TACS)
 	DefaultContainerMetricsPublishInterval = 20 * time.Second
+	tcsPublishRetryAttempts                = 3
+	tcsPublishRetryBackoff                 = 100 * time.Millisecond
 )
 
 var (
@@ -196,7 +199,7 @@ func (cs *tcsClientServer) publishMetricsOnce(message ecstcs.TelemetryMessage) e
 	// Make the publish metrics request to the backend.
 	for _, request := range requests {
 		logger.Debug("making publish metrics request")
-		err = cs.MakeRequest(request)
+		err = cs.makeRequestWithRetry(request)
 		if err != nil {
 			return err
 		}
@@ -214,12 +217,22 @@ func (cs *tcsClientServer) publishHealthOnce(health ecstcs.HealthMessage) error 
 	// Make the publish metrics request to the backend.
 	for _, request := range requests {
 		logger.Debug("making publish health metrics request")
-		err = cs.MakeRequest(request)
+		err = cs.makeRequestWithRetry(request)
 		if err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (cs *tcsClientServer) makeRequestWithRetry(request interface{}) error {
+	return retry.RetryNWithBackoff(
+		retry.NewConstantBackoff(tcsPublishRetryBackoff),
+		tcsPublishRetryAttempts,
+		func() error {
+			return cs.MakeRequest(request)
+		},
+	)
 }
 
 // metricsToPublishMetricRequests gets task metrics and converts them to a list of PublishMetricRequest

--- a/ecs-agent/tcs/client/client_test.go
+++ b/ecs-agent/tcs/client/client_test.go
@@ -24,6 +24,7 @@ package tcsclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -413,6 +414,72 @@ func TestPublishMetricsRequest(t *testing.T) {
 	}
 }
 
+func TestPublishMetricsOnceRetriesTransientPublishErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	conn := mock_wsconn.NewMockWebsocketConn(ctrl)
+	conn.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil).Times(tcsPublishRetryAttempts)
+	gomock.InOrder(
+		conn.EXPECT().WriteMessage(gomock.Any(), gomock.Any()).Return(errors.New("temporary publish failure")),
+		conn.EXPECT().WriteMessage(gomock.Any(), gomock.Any()).Return(errors.New("temporary publish failure")),
+		conn.EXPECT().WriteMessage(gomock.Any(), gomock.Any()).Return(nil),
+	)
+	conn.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil)
+	conn.EXPECT().Close()
+
+	cs := testCS(conn, nil, nil).(*tcsClientServer)
+	defer cs.Close()
+	message := createIdleTelemetryMessage()
+
+	err := cs.publishMetricsOnce(message)
+
+	assert.NoError(t, err)
+}
+
+func TestPublishMetricsOnceReturnsLastRetryError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	expectedErr := errors.New("temporary publish failure")
+	conn := mock_wsconn.NewMockWebsocketConn(ctrl)
+	conn.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil).Times(tcsPublishRetryAttempts)
+	conn.EXPECT().WriteMessage(gomock.Any(), gomock.Any()).Return(expectedErr).Times(tcsPublishRetryAttempts)
+	conn.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil)
+	conn.EXPECT().Close()
+
+	cs := testCS(conn, nil, nil).(*tcsClientServer)
+	defer cs.Close()
+	message := createIdleTelemetryMessage()
+
+	err := cs.publishMetricsOnce(message)
+
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestPublishHealthOnceRetriesTransientPublishErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	conn := mock_wsconn.NewMockWebsocketConn(ctrl)
+	conn.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil).Times(tcsPublishRetryAttempts)
+	gomock.InOrder(
+		conn.EXPECT().WriteMessage(gomock.Any(), gomock.Any()).Return(errors.New("temporary publish failure")),
+		conn.EXPECT().WriteMessage(gomock.Any(), gomock.Any()).Return(errors.New("temporary publish failure")),
+		conn.EXPECT().WriteMessage(gomock.Any(), gomock.Any()).Return(nil),
+	)
+	conn.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil)
+	conn.EXPECT().Close()
+
+	cs := testCS(conn, nil, nil).(*tcsClientServer)
+	defer cs.Close()
+	message := createHealthMessage()
+
+	err := cs.publishHealthOnce(message)
+
+	assert.NoError(t, err)
+}
+
 func TestMetricsToPublishMetricRequestsIdleStatsSource(t *testing.T) {
 	cs := tcsClientServer{}
 	statsSource := idleStatsSource{}
@@ -430,6 +497,40 @@ func TestMetricsToPublishMetricRequestsIdleStatsSource(t *testing.T) {
 	lastRequest := requests[0]
 	if !*lastRequest.Metadata.Fin {
 		t.Error("Fin not set to true in Last request")
+	}
+}
+
+func createIdleTelemetryMessage() ecstcs.TelemetryMessage {
+	statsSource := idleStatsSource{}
+	metadata, taskMetrics, _ := statsSource.GetInstanceMetrics(testNotIncludeScStats)
+	return ecstcs.TelemetryMessage{
+		Metadata:    metadata,
+		TaskMetrics: taskMetrics,
+	}
+}
+
+func createHealthMessage() ecstcs.HealthMessage {
+	return ecstcs.HealthMessage{
+		Metadata: &ecstcs.HealthMetadata{
+			Cluster:           aws.String("TestCreatePublishHealthRequests"),
+			ContainerInstance: aws.String("container_instance"),
+			Fin:               aws.Bool(true),
+			MessageId:         aws.String("message_id"),
+		},
+		HealthMetrics: []*ecstcs.TaskHealth{
+			{
+				Containers: []*ecstcs.ContainerHealth{
+					{
+						ContainerName: aws.String("container1"),
+						HealthStatus:  aws.String("HEALTHY"),
+						StatusSince:   (*utils.Timestamp)(aws.Time(time.Now())),
+					},
+				},
+				TaskArn:               aws.String("t1"),
+				TaskDefinitionFamily:  aws.String("tdf1"),
+				TaskDefinitionVersion: aws.String("1"),
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
### Summary

Fixes #4105.

Adds retry handling around individual TCS publish requests for telemetry metrics and task health messages. If a transient websocket publish failure occurs, the agent now retries the generated request before giving up and returning the last error to the existing caller/logging path.

### Testing

- `gofmt -w ecs-agent/tcs/client/client.go ecs-agent/tcs/client/client_test.go`
- `go test -tags unit ./tcs/client` from the `ecs-agent` module

Note: I saw another contributor had commented interest on the issue, but I did not find an open PR referencing #4105 before opening this one.
