### PR TITLE
Migrate EBS CSI Driver image to AL2023

### DIFF
--- a/ecs-agent/daemonimages/csidriver/Dockerfile
+++ b/ecs-agent/daemonimages/csidriver/Dockerfile
@@ -20,7 +20,7 @@ ADD . /go/src/
 RUN make bin/ebs-csi-driver
 
 # use minimal eks base for csi driver image to add required mount utils
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest-al2
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest-al23
 
 MAINTAINER Amazon Web Services, Inc.
 COPY --from=build /go/src/bin/ebs-csi-driver /bin/ebs-csi-driver

--- a/ecs-agent/daemonimages/csidriver/driver/node.go
+++ b/ecs-agent/daemonimages/csidriver/driver/node.go
@@ -229,6 +229,14 @@ func (d *nodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if len(numInodes) > 0 {
 		formatOptions = append(formatOptions, "-N", numInodes)
 	}
+
+	// This is needed as there's an issue with older kernel versions where newer features in xfsprogs are not available
+	// which is being used in the EBS CSI driver AL2023 image.
+	// Ref: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/faq.md#xfs-on-older-kernels-eg-amazon-linux-2
+	if fsType == FSTypeXfs {
+		formatOptions = append(formatOptions, "-m", "bigtime=0,inobtcount=0,reflink=0", "-i", "nrext64=0")
+	}
+
 	err = d.mounter.FormatAndMountSensitiveWithFormatOptions(source, target, fsType, mountOptions, nil, formatOptions)
 	if err != nil {
 		klog.V(4).InfoS("NodeStageVolume: format mount fail", "error", err)

--- a/ecs-agent/daemonimages/csidriver/driver/node_linux_test.go
+++ b/ecs-agent/daemonimages/csidriver/driver/node_linux_test.go
@@ -94,7 +94,7 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
 				successExpectMock(mockMounter, mockDeviceIdentifier)
-				mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq(devicePath), gomock.Eq(targetPath), gomock.Eq(defaultFsType), gomock.Any(), gomock.Nil(), gomock.Len(0))
+				mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq(devicePath), gomock.Eq(targetPath), gomock.Eq(defaultFsType), gomock.Any(), gomock.Nil(), gomock.Eq([]string{"-m", "bigtime=0,inobtcount=0,reflink=0", "-i", "nrext64=0"}))
 			},
 			expectPermissionCall: true,
 		},
@@ -183,7 +183,7 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
 				successExpectMock(mockMounter, mockDeviceIdentifier)
-				mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq(devicePath), gomock.Eq(targetPath), gomock.Eq(FSTypeXfs), gomock.Any(), gomock.Nil(), gomock.Len(0))
+				mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq(devicePath), gomock.Eq(targetPath), gomock.Eq(FSTypeXfs), gomock.Any(), gomock.Nil(), gomock.Eq([]string{"-m", "bigtime=0,inobtcount=0,reflink=0", "-i", "nrext64=0"}))
 			},
 			expectPermissionCall: true,
 		},
@@ -328,7 +328,7 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
 				successExpectMock(mockMounter, mockDeviceIdentifier)
-				mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq(devicePath), gomock.Eq(targetPath), gomock.Eq(defaultFsType), gomock.Any(), gomock.Nil(), gomock.Len(0))
+				mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq(devicePath), gomock.Eq(targetPath), gomock.Eq(defaultFsType), gomock.Any(), gomock.Nil(), gomock.Eq([]string{"-m", "bigtime=0,inobtcount=0,reflink=0", "-i", "nrext64=0"}))
 			},
 			setupPermissionMocks: func() {
 				// Mock chown failure


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will look to migrate the base image of the EBS CSI Driver to use the AL2023-based image of `eks-distro-minimal-base-csi-ebs` as AL2 will be EOL on 6/30/2026 ([ref](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-20260526.html#announcements-20260526))

As part of the migration, the AL2023-based image upgraded `xfsprogs` from version 5.x to 6.x which enables the `nrext64` XFS feature by default when formatting new volumes. The AL2 kernel (4.14 and 5.10) does not support `nrext64` and rejects the mount. This is a known upstream issue documented in the [EBS CSI Driver CHANGELOG v1.49+](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md#v1490).

How upstream is setting these flags: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/c54d08d90e3c0fffa5f64ad2688048c18f49b46f/pkg/driver/node.go#L292-L294

### Implementation details
* Use the `latest-al23` tag
* For XFS, we will pass in `"-m", "bigtime=0,inobtcount=0,reflink=0", "-i", "nrext64=0"` as format options so that both older and newer kernel versions will be compatible. What this will do is it will disable the features that are enabled by default in the AL2023 image so that the EBS CSI Driver will remain compatible with hosts on older kernel versions that may not support the features

### Testing
* Manually built custom AL2, AL2 ARM, AL2023, and AL2023 ARM AMIs. Ran our functional tests against them.

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
enhancement: Migrate EBS CSI Driver image to AL2023

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
