### PR TITLE
Add TrustedExecutionConfiguration struct to task payload

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs/api.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs/api.go
@@ -2631,6 +2631,8 @@ type Task struct {
 
 	TaskDefinitionAccountId *string `json:"taskDefinitionAccountId,omitempty" type:"string"`
 
+	TrustedExecutionConfiguration *TrustedExecutionConfiguration `json:"trustedExecutionConfiguration,omitempty" type:"structure"`
+
 	Version *string `json:"version,omitempty" type:"string"`
 
 	Volumes []*Volume `json:"volumes,omitempty" type:"list"`
@@ -2905,6 +2907,30 @@ func (s TaskStopVerificationOutput) String() string {
 // be included in the string output. The member name will be present, but the
 // value will be replaced with "sensitive".
 func (s TaskStopVerificationOutput) GoString() string {
+	return s.String()
+}
+
+type TrustedExecutionConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	IsolationMode *string `json:"isolationMode,omitempty" type:"string" enum:"IsolationMode"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s TrustedExecutionConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s TrustedExecutionConfiguration) GoString() string {
 	return s.String()
 }
 

--- a/ecs-agent/acs/model/api/api-2.json
+++ b/ecs-agent/acs/model/api/api-2.json
@@ -600,6 +600,14 @@
       "exception":true
     },
     "Integer":{"type":"integer"},
+    "IsolationMode":{
+      "type":"string",
+      "enum":[
+        "SHARED",
+        "EXCLUSIVE",
+        "ISOLATED_PARTITION"
+      ]
+    },
     "InvalidClusterException":{
       "type":"structure",
       "members":{
@@ -906,7 +914,8 @@
         "networkMode":{"shape":"String"},
         "serviceName":{"shape":"String"},
         "group":{"shape":"String"},
-        "enableFaultInjection":{"shape":"Boolean"}
+        "enableFaultInjection":{"shape":"Boolean"},
+        "trustedExecutionConfiguration":{"shape":"TrustedExecutionConfiguration"}
       }
     },
     "TaskIdentifier":{
@@ -957,6 +966,12 @@
         "tcp",
         "udp"
       ]
+    },
+    "TrustedExecutionConfiguration":{
+      "type":"structure",
+      "members":{
+        "isolationMode":{"shape":"IsolationMode"}
+      }
     },
     "UpdateInfo":{
       "type":"structure",

--- a/ecs-agent/acs/model/ecsacs/api.go
+++ b/ecs-agent/acs/model/ecsacs/api.go
@@ -2631,6 +2631,8 @@ type Task struct {
 
 	TaskDefinitionAccountId *string `json:"taskDefinitionAccountId,omitempty" type:"string"`
 
+	TrustedExecutionConfiguration *TrustedExecutionConfiguration `json:"trustedExecutionConfiguration,omitempty" type:"structure"`
+
 	Version *string `json:"version,omitempty" type:"string"`
 
 	Volumes []*Volume `json:"volumes,omitempty" type:"list"`
@@ -2905,6 +2907,30 @@ func (s TaskStopVerificationOutput) String() string {
 // be included in the string output. The member name will be present, but the
 // value will be replaced with "sensitive".
 func (s TaskStopVerificationOutput) GoString() string {
+	return s.String()
+}
+
+type TrustedExecutionConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	IsolationMode *string `json:"isolationMode,omitempty" type:"string" enum:"IsolationMode"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s TrustedExecutionConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s TrustedExecutionConfiguration) GoString() string {
 	return s.String()
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Add new TrustedExecutionConfiguration struct to task payload model.

### Implementation details
<!-- How are the changes implemented? -->

added model to api-2.json, ran `go generate`, then ran `go mod tidy && go mod vendor`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

N/A

New tests cover the changes: no

### Description for the changelog

[Enhancement] Add TrustedExecutionConfiguration to task payload models

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
