### PR TITLE
Add FailureTracker for DiscoverPollEndpoint + ACS/TCS connect workflows

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/session.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/session.go
@@ -102,6 +102,23 @@ type session struct {
 	lastConnectedTime              time.Time
 	lastDisconnectedTime           time.Time
 	firstACSConnectionTime         time.Time
+	dpeFailureTracker              *metrics.FailureTracker
+	acsConnFailureTracker          *metrics.FailureTracker
+}
+
+// SessionOption configures optional behavior on the ACS session.
+type SessionOption func(*session)
+
+// WithDPEFailureTracker sets the FailureTracker used to track
+// DiscoverPollEndpoint failures across retry attempts.
+func WithDPEFailureTracker(dpeFailureTracker *metrics.FailureTracker) SessionOption {
+	return func(s *session) { s.dpeFailureTracker = dpeFailureTracker }
+}
+
+// WithACSConnFailureTracker sets the FailureTracker used to track ACS
+// connection failures across retry attempts.
+func WithACSConnFailureTracker(acsConnFailureTracker *metrics.FailureTracker) SessionOption {
+	return func(s *session) { s.acsConnFailureTracker = acsConnFailureTracker }
 }
 
 // NewSession creates a new Session.
@@ -127,10 +144,11 @@ func NewSession(containerInstanceARN string,
 	taskStopper TaskStopper,
 	resourceHandler ResourceHandler,
 	addUpdateRequestHandlers func(wsclient.ClientServer),
+	opts ...SessionOption,
 ) Session {
 	backoff := retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax,
 		connectionBackoffJitter, connectionBackoffMultiplier)
-	return &session{
+	s := &session{
 		containerInstanceARN:           containerInstanceARN,
 		cluster:                        cluster,
 		ecsClient:                      ecsClient,
@@ -164,6 +182,10 @@ func NewSession(containerInstanceARN string,
 		lastDisconnectedTime:           time.Time{},
 		firstACSConnectionTime:         time.Time{},
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // Start starts the session. It'll forever keep trying to connect to ACS unless
@@ -242,12 +264,15 @@ func (s *session) Start(ctx context.Context) error {
 func (s *session) startSessionOnce(ctx context.Context) error {
 	acsEndpoint, err := s.ecsClient.DiscoverPollEndpoint(s.containerInstanceARN)
 	if err != nil {
+		s.dpeFailureTracker.RecordFailure()
+		s.acsConnFailureTracker.RecordFailure()
 		logger.Error("ACS: Unable to discover poll endpoint", logger.Fields{
 			"containerInstanceARN": s.containerInstanceARN,
 			field.Error:            err,
 		})
 		return err
 	}
+	s.dpeFailureTracker.RecordSuccess()
 
 	client := s.clientFactory.New(
 		s.acsURL(acsEndpoint),
@@ -266,6 +291,7 @@ func (s *session) startSessionOnce(ctx context.Context) error {
 	// Metric created for determining whether ACS connection is successful or not
 	s.metricsFactory.New(metrics.ACSSessionFailureCallName).Done(err)
 	if err != nil {
+		s.acsConnFailureTracker.RecordFailure()
 		logger.Error("Failed to connect to ACS", logger.Fields{
 			"containerInstanceARN": s.containerInstanceARN,
 			field.Error:            err,
@@ -288,6 +314,7 @@ func (s *session) startSessionOnce(ctx context.Context) error {
 
 	// Connection to ACS was successful. Moving forward, rely on ACS to send credentials to Agent at its own cadence
 	// and make sure Agent does not force ACS to send credentials for any subsequent reconnects to ACS.
+	s.acsConnFailureTracker.RecordSuccess()
 	logger.Info("Connected to ACS endpoint",
 		logger.Fields{
 			"containerInstanceARN": s.containerInstanceARN,

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/field/constants.go
@@ -75,4 +75,5 @@ const (
 	Region                  = "region"
 	DockerVersion           = "dockerVersion"
 	NetworkInterface        = "networkInterface"
+	MetricName              = "metricName"
 )

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
@@ -49,6 +49,11 @@ const (
 	CredentialsRefreshFailure = credsRefreshNamespace + ".Failure"
 	CredentialsRefreshSuccess = credsRefreshNamespace + ".Success"
 
+	// ECS Control Plane Connectivity
+	DPEConnectivityFailureMetricName = "DPEConnectivityFailure"
+	ACSConnectivityFailureMetricName = "ACSConnectivityFailure"
+	TCSConnectivityFailureMetricName = "TCSConnectivityFailure"
+
 	// Agent Availability
 	agentAvailabilityNamespace     = "Availability"
 	ACSDisconnectTimeoutMetricName = agentAvailabilityNamespace + ".ACSDisconnectTimeout"

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/failure_tracker.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/failure_tracker.go
@@ -1,0 +1,133 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+)
+
+const (
+	// emitInterval is how much time the metric emission loop should wait
+	// between each metric emission.
+	emitInterval = 1 * time.Minute
+
+	// emitThreshold is the duration of time that must elapse after failingSince
+	// before metric can be emitted.
+	emitThreshold = 1 * time.Minute
+)
+
+// FailureTracker tracks whether an operation has been in a failure state
+// continuously for more than emitThreshold and, if so, emits a metric every
+// emitInterval.
+type FailureTracker struct {
+	failingSince   time.Time
+	isFailing      bool
+	metricName     string
+	metricsFactory EntryFactory
+	mu             sync.Mutex
+}
+
+// NewFailureTracker creates a new FailureTracker.
+func NewFailureTracker(metricName string, metricsFactory EntryFactory) *FailureTracker {
+	return &FailureTracker{
+		metricName:     metricName,
+		metricsFactory: metricsFactory,
+	}
+}
+
+// RecordSuccess marks a successful operation and resets the failure state.
+func (ft *FailureTracker) RecordSuccess() {
+	if ft == nil {
+		return
+	}
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	ft.isFailing = false
+}
+
+// RecordFailure marks the start of a failure period if not already failing.
+func (ft *FailureTracker) RecordFailure() {
+	if ft == nil {
+		return
+	}
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	if !ft.isFailing {
+		ft.isFailing = true
+		ft.failingSince = time.Now()
+	}
+}
+
+// StartEmitLoop runs emitIfFailing once every emitInterval until ctx is cancelled.
+// This function is meant to be called by the entity creating the FailureTracker itself.
+func (ft *FailureTracker) StartEmitLoop(ctx context.Context) {
+	if ft == nil {
+		return
+	}
+	logger.Debug("FailureTracker emit loop started", logger.Fields{
+		field.MetricName: ft.metricName,
+	})
+	ticker := time.NewTicker(emitInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			ft.emitIfFailing()
+		case <-ctx.Done():
+			logger.Debug("FailureTracker emit loop stopping (context closed)", logger.Fields{
+				field.MetricName: ft.metricName,
+			})
+			return
+		}
+	}
+}
+
+// IsFailing returns whether the operation being tracked is currently failing.
+func (ft *FailureTracker) IsFailing() bool {
+	if ft == nil {
+		return false
+	}
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	return ft.isFailing
+}
+
+// emitIfFailing emits metric if its associated operation has been
+// continuously failing for an amount of time greater than emitThreshold.
+func (ft *FailureTracker) emitIfFailing() {
+	if ft == nil {
+		return
+	}
+	ft.mu.Lock()
+	isFailing := ft.isFailing
+	failingSince := ft.failingSince
+	ft.mu.Unlock()
+
+	if !isFailing {
+		return
+	}
+	if time.Since(failingSince) <= emitThreshold {
+		return
+	}
+	ft.metricsFactory.New(ft.metricName).Done(
+		fmt.Errorf("operation associated with metric %s"+
+			" has been failing for more than %v", ft.metricName, emitThreshold),
+	)
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
@@ -76,6 +76,23 @@ type telemetrySession struct {
 	doctor                        *doctor.Doctor
 	ecsClient                     TcsEcsClient
 	lastDisconnectedTime          time.Time
+	dpeFailureTracker             *metrics.FailureTracker
+	tcsConnFailureTracker         *metrics.FailureTracker
+}
+
+// TelemetrySessionOption configures optional behavior on the TCS session.
+type TelemetrySessionOption func(*telemetrySession)
+
+// WithDPEFailureTracker sets the FailureTracker used to track
+// DiscoverPollEndpoint failures across retry attempts.
+func WithDPEFailureTracker(dpeFailureTracker *metrics.FailureTracker) TelemetrySessionOption {
+	return func(session *telemetrySession) { session.dpeFailureTracker = dpeFailureTracker }
+}
+
+// WithTCSConnFailureTracker sets the FailureTracker used to track TCS
+// connection failures across retry attempts.
+func WithTCSConnFailureTracker(tcsConnFailureTracker *metrics.FailureTracker) TelemetrySessionOption {
+	return func(session *telemetrySession) { session.tcsConnFailureTracker = tcsConnFailureTracker }
 }
 
 func NewTelemetrySession(
@@ -98,8 +115,9 @@ func NewTelemetrySession(
 	instanceStatusChannel <-chan ecstcs.InstanceStatusMessage,
 	doctor *doctor.Doctor,
 	ecsClient TcsEcsClient,
+	opts ...TelemetrySessionOption,
 ) TelemetrySession {
-	return &telemetrySession{
+	session := &telemetrySession{
 		containerInstanceArn:          containerInstanceArn,
 		cluster:                       cluster,
 		agentVersion:                  agentVersion,
@@ -121,6 +139,10 @@ func NewTelemetrySession(
 		ecsClient:                     ecsClient,
 		lastDisconnectedTime:          time.Time{},
 	}
+	for _, opt := range opts {
+		opt(session)
+	}
+	return session
 }
 
 // Start runs in for loop to start telemetry session with exponential backoff
@@ -161,8 +183,11 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context) erro
 
 	endpoint, err := session.getTelemetryEndpoint()
 	if err != nil {
+		session.dpeFailureTracker.RecordFailure()
+		session.tcsConnFailureTracker.RecordFailure()
 		return err
 	}
+	session.dpeFailureTracker.RecordSuccess()
 
 	tcsEndpointUrl := formatURL(endpoint, session.cluster, session.containerInstanceArn, session.agentVersion,
 		session.agentHash, containerRuntime, session.containerRuntimeVersion)
@@ -173,6 +198,7 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context) erro
 	if session.deregisterInstanceEventStream != nil {
 		err := session.deregisterInstanceEventStream.Subscribe(deregisterContainerInstanceHandler, client.Disconnect)
 		if err != nil {
+			session.tcsConnFailureTracker.RecordFailure()
 			return err
 		}
 		defer session.deregisterInstanceEventStream.Unsubscribe(deregisterContainerInstanceHandler)
@@ -183,6 +209,7 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context) erro
 		session.disconnectTimeout,
 		session.disconnectJitterMax)
 	if err != nil {
+		session.tcsConnFailureTracker.RecordFailure()
 		logger.Error("Error connecting to TCS", logger.Fields{
 			field.Error: err,
 		})
@@ -195,6 +222,7 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context) erro
 			session.GetLastDisconnectedTime()).Milliseconds()).Done(nil)
 	}
 	defer disconnectTimer.Stop()
+	session.tcsConnFailureTracker.RecordSuccess()
 	logger.Info("Connected to TCS endpoint")
 	// start a timer and listens for tcs heartbeats/acks. The timer is reset when
 	// we receive a heartbeat from the server or when a published metrics message

--- a/ecs-agent/acs/session/session.go
+++ b/ecs-agent/acs/session/session.go
@@ -102,6 +102,23 @@ type session struct {
 	lastConnectedTime              time.Time
 	lastDisconnectedTime           time.Time
 	firstACSConnectionTime         time.Time
+	dpeFailureTracker              *metrics.FailureTracker
+	acsConnFailureTracker          *metrics.FailureTracker
+}
+
+// SessionOption configures optional behavior on the ACS session.
+type SessionOption func(*session)
+
+// WithDPEFailureTracker sets the FailureTracker used to track
+// DiscoverPollEndpoint failures across retry attempts.
+func WithDPEFailureTracker(dpeFailureTracker *metrics.FailureTracker) SessionOption {
+	return func(s *session) { s.dpeFailureTracker = dpeFailureTracker }
+}
+
+// WithACSConnFailureTracker sets the FailureTracker used to track ACS
+// connection failures across retry attempts.
+func WithACSConnFailureTracker(acsConnFailureTracker *metrics.FailureTracker) SessionOption {
+	return func(s *session) { s.acsConnFailureTracker = acsConnFailureTracker }
 }
 
 // NewSession creates a new Session.
@@ -127,10 +144,11 @@ func NewSession(containerInstanceARN string,
 	taskStopper TaskStopper,
 	resourceHandler ResourceHandler,
 	addUpdateRequestHandlers func(wsclient.ClientServer),
+	opts ...SessionOption,
 ) Session {
 	backoff := retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax,
 		connectionBackoffJitter, connectionBackoffMultiplier)
-	return &session{
+	s := &session{
 		containerInstanceARN:           containerInstanceARN,
 		cluster:                        cluster,
 		ecsClient:                      ecsClient,
@@ -164,6 +182,10 @@ func NewSession(containerInstanceARN string,
 		lastDisconnectedTime:           time.Time{},
 		firstACSConnectionTime:         time.Time{},
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // Start starts the session. It'll forever keep trying to connect to ACS unless
@@ -242,12 +264,15 @@ func (s *session) Start(ctx context.Context) error {
 func (s *session) startSessionOnce(ctx context.Context) error {
 	acsEndpoint, err := s.ecsClient.DiscoverPollEndpoint(s.containerInstanceARN)
 	if err != nil {
+		s.dpeFailureTracker.RecordFailure()
+		s.acsConnFailureTracker.RecordFailure()
 		logger.Error("ACS: Unable to discover poll endpoint", logger.Fields{
 			"containerInstanceARN": s.containerInstanceARN,
 			field.Error:            err,
 		})
 		return err
 	}
+	s.dpeFailureTracker.RecordSuccess()
 
 	client := s.clientFactory.New(
 		s.acsURL(acsEndpoint),
@@ -266,6 +291,7 @@ func (s *session) startSessionOnce(ctx context.Context) error {
 	// Metric created for determining whether ACS connection is successful or not
 	s.metricsFactory.New(metrics.ACSSessionFailureCallName).Done(err)
 	if err != nil {
+		s.acsConnFailureTracker.RecordFailure()
 		logger.Error("Failed to connect to ACS", logger.Fields{
 			"containerInstanceARN": s.containerInstanceARN,
 			field.Error:            err,
@@ -288,6 +314,7 @@ func (s *session) startSessionOnce(ctx context.Context) error {
 
 	// Connection to ACS was successful. Moving forward, rely on ACS to send credentials to Agent at its own cadence
 	// and make sure Agent does not force ACS to send credentials for any subsequent reconnects to ACS.
+	s.acsConnFailureTracker.RecordSuccess()
 	logger.Info("Connected to ACS endpoint",
 		logger.Fields{
 			"containerInstanceARN": s.containerInstanceARN,

--- a/ecs-agent/acs/session/session_test.go
+++ b/ecs-agent/acs/session/session_test.go
@@ -1491,6 +1491,93 @@ func TestSessionCallsAddUpdateRequestHandlers(t *testing.T) {
 	assert.True(t, addUpdateRequestHandlersCalled)
 }
 
+func TestDPEAndACSConnFailureTrackerTracking(t *testing.T) {
+	testCases := []struct {
+		name             string
+		setupMocks       func(*mock_ecs.MockECSClient, *mock_wsclient.MockClientFactory, *mock_wsclient.MockClientServer)
+		expectDPEFailing bool
+		expectACSFailing bool
+		expectErr        bool
+	}{
+		{
+			name: "DPE error records both DPE and ACS connectivity failure",
+			setupMocks: func(ecsClient *mock_ecs.MockECSClient, _ *mock_wsclient.MockClientFactory, _ *mock_wsclient.MockClientServer) {
+				ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return("", errors.New("endpoint not found"))
+			},
+			expectDPEFailing: true,
+			expectACSFailing: true,
+			expectErr:        true,
+		},
+		{
+			name: "DPE success and ACS connect error records ACS connectivity failure only",
+			setupMocks: func(ecsClient *mock_ecs.MockECSClient, factory *mock_wsclient.MockClientFactory, wsClient *mock_wsclient.MockClientServer) {
+				ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil)
+				factory.EXPECT().New(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(wsClient)
+				wsClient.EXPECT().Connect(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("connection refused"))
+				wsClient.EXPECT().Close().Return(nil)
+			},
+			expectDPEFailing: false,
+			expectACSFailing: true,
+			expectErr:        true,
+		},
+		{
+			name: "DPE success and ACS connect success records both DPE and ACS connectivity success",
+			setupMocks: func(ecsClient *mock_ecs.MockECSClient, factory *mock_wsclient.MockClientFactory, wsClient *mock_wsclient.MockClientServer) {
+				ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil)
+				factory.EXPECT().New(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(wsClient)
+				wsClient.EXPECT().Connect(gomock.Any(), gomock.Any(), gomock.Any()).Return(time.NewTimer(wsclient.DisconnectTimeout), nil)
+				wsClient.EXPECT().SetAnyRequestHandler(gomock.Any())
+				wsClient.EXPECT().AddRequestHandler(gomock.Any()).AnyTimes()
+				wsClient.EXPECT().Serve(gomock.Any()).Return(nil)
+				wsClient.EXPECT().Close().Return(nil).AnyTimes()
+				wsClient.EXPECT().WriteCloseMessage().Return(nil).AnyTimes()
+			},
+			expectDPEFailing: false,
+			expectACSFailing: false,
+			expectErr:        false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ecsClient := mock_ecs.NewMockECSClient(ctrl)
+			mockClientFactory := mock_wsclient.NewMockClientFactory(ctrl)
+			mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
+			tc.setupMocks(ecsClient, mockClientFactory, mockWsClient)
+
+			dpeFailureTracker := metricsfactory.NewFailureTracker(
+				metricsfactory.DPEConnectivityFailureMetricName,
+				metricsfactory.NewNopEntryFactory(),
+			)
+			acsConnFailureTracker := metricsfactory.NewFailureTracker(
+				metricsfactory.ACSConnectivityFailureMetricName,
+				metricsfactory.NewNopEntryFactory(),
+			)
+
+			s := session{
+				containerInstanceARN:  testconst.ContainerInstanceARN,
+				ecsClient:             ecsClient,
+				clientFactory:         mockClientFactory,
+				metricsFactory:        metricsfactory.NewNopEntryFactory(),
+				dpeFailureTracker:     dpeFailureTracker,
+				acsConnFailureTracker: acsConnFailureTracker,
+			}
+
+			err := s.startSessionOnce(context.Background())
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectDPEFailing, dpeFailureTracker.IsFailing())
+			assert.Equal(t, tc.expectACSFailing, acsConnFailureTracker.IsFailing())
+		})
+	}
+}
+
 func startFakeACSServer(closeWS <-chan bool) (*httptest.Server, chan<- string, <-chan string, <-chan error, error) {
 	serverChan := make(chan string, 1)
 	requestsChan := make(chan string, 1)

--- a/ecs-agent/logger/field/constants.go
+++ b/ecs-agent/logger/field/constants.go
@@ -75,4 +75,5 @@ const (
 	Region                  = "region"
 	DockerVersion           = "dockerVersion"
 	NetworkInterface        = "networkInterface"
+	MetricName              = "metricName"
 )

--- a/ecs-agent/metrics/constants.go
+++ b/ecs-agent/metrics/constants.go
@@ -49,6 +49,11 @@ const (
 	CredentialsRefreshFailure = credsRefreshNamespace + ".Failure"
 	CredentialsRefreshSuccess = credsRefreshNamespace + ".Success"
 
+	// ECS Control Plane Connectivity
+	DPEConnectivityFailureMetricName = "DPEConnectivityFailure"
+	ACSConnectivityFailureMetricName = "ACSConnectivityFailure"
+	TCSConnectivityFailureMetricName = "TCSConnectivityFailure"
+
 	// Agent Availability
 	agentAvailabilityNamespace     = "Availability"
 	ACSDisconnectTimeoutMetricName = agentAvailabilityNamespace + ".ACSDisconnectTimeout"

--- a/ecs-agent/metrics/failure_tracker.go
+++ b/ecs-agent/metrics/failure_tracker.go
@@ -1,0 +1,133 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+)
+
+const (
+	// emitInterval is how much time the metric emission loop should wait
+	// between each metric emission.
+	emitInterval = 1 * time.Minute
+
+	// emitThreshold is the duration of time that must elapse after failingSince
+	// before metric can be emitted.
+	emitThreshold = 1 * time.Minute
+)
+
+// FailureTracker tracks whether an operation has been in a failure state
+// continuously for more than emitThreshold and, if so, emits a metric every
+// emitInterval.
+type FailureTracker struct {
+	failingSince   time.Time
+	isFailing      bool
+	metricName     string
+	metricsFactory EntryFactory
+	mu             sync.Mutex
+}
+
+// NewFailureTracker creates a new FailureTracker.
+func NewFailureTracker(metricName string, metricsFactory EntryFactory) *FailureTracker {
+	return &FailureTracker{
+		metricName:     metricName,
+		metricsFactory: metricsFactory,
+	}
+}
+
+// RecordSuccess marks a successful operation and resets the failure state.
+func (ft *FailureTracker) RecordSuccess() {
+	if ft == nil {
+		return
+	}
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	ft.isFailing = false
+}
+
+// RecordFailure marks the start of a failure period if not already failing.
+func (ft *FailureTracker) RecordFailure() {
+	if ft == nil {
+		return
+	}
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	if !ft.isFailing {
+		ft.isFailing = true
+		ft.failingSince = time.Now()
+	}
+}
+
+// StartEmitLoop runs emitIfFailing once every emitInterval until ctx is cancelled.
+// This function is meant to be called by the entity creating the FailureTracker itself.
+func (ft *FailureTracker) StartEmitLoop(ctx context.Context) {
+	if ft == nil {
+		return
+	}
+	logger.Debug("FailureTracker emit loop started", logger.Fields{
+		field.MetricName: ft.metricName,
+	})
+	ticker := time.NewTicker(emitInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			ft.emitIfFailing()
+		case <-ctx.Done():
+			logger.Debug("FailureTracker emit loop stopping (context closed)", logger.Fields{
+				field.MetricName: ft.metricName,
+			})
+			return
+		}
+	}
+}
+
+// IsFailing returns whether the operation being tracked is currently failing.
+func (ft *FailureTracker) IsFailing() bool {
+	if ft == nil {
+		return false
+	}
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	return ft.isFailing
+}
+
+// emitIfFailing emits metric if its associated operation has been
+// continuously failing for an amount of time greater than emitThreshold.
+func (ft *FailureTracker) emitIfFailing() {
+	if ft == nil {
+		return
+	}
+	ft.mu.Lock()
+	isFailing := ft.isFailing
+	failingSince := ft.failingSince
+	ft.mu.Unlock()
+
+	if !isFailing {
+		return
+	}
+	if time.Since(failingSince) <= emitThreshold {
+		return
+	}
+	ft.metricsFactory.New(ft.metricName).Done(
+		fmt.Errorf("operation associated with metric %s"+
+			" has been failing for more than %v", ft.metricName, emitThreshold),
+	)
+}

--- a/ecs-agent/metrics/failure_tracker_test.go
+++ b/ecs-agent/metrics/failure_tracker_test.go
@@ -1,0 +1,133 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//go:build unit
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFailureTrackerMetricsFactory is a minimal EntryFactory that counts
+// Done(non-nil) calls.
+type fakeFailureTrackerMetricsFactory struct{ numEmissions int }
+
+func (f *fakeFailureTrackerMetricsFactory) New(_ string) Entry {
+	return &fakeFailureTrackerMetricsEntry{f: f}
+}
+func (f *fakeFailureTrackerMetricsFactory) Flush() {}
+
+type fakeFailureTrackerMetricsEntry struct {
+	f *fakeFailureTrackerMetricsFactory
+}
+
+func (e *fakeFailureTrackerMetricsEntry) WithFields(_ map[string]interface{}) Entry { return e }
+func (e *fakeFailureTrackerMetricsEntry) WithCount(_ int) Entry                     { return e }
+func (e *fakeFailureTrackerMetricsEntry) WithGauge(_ interface{}) Entry             { return e }
+func (e *fakeFailureTrackerMetricsEntry) Done(err error) {
+	if err != nil {
+		e.f.numEmissions++
+	}
+}
+
+func TestFailureTracker(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                 string
+		actions              func(ft *FailureTracker)
+		expectedNumEmissions int
+	}{
+		{
+			name: "no emission when not failing",
+			actions: func(ft *FailureTracker) {
+				ft.emitIfFailing()
+			},
+			expectedNumEmissions: 0,
+		},
+		{
+			name: "no emission when failing for less than emitThreshold",
+			actions: func(ft *FailureTracker) {
+				ft.RecordFailure()
+				ft.emitIfFailing()
+			},
+			expectedNumEmissions: 0,
+		},
+		{
+			name: "emits when failing for more than emitThreshold",
+			actions: func(ft *FailureTracker) {
+				ft.RecordFailure()
+				ft.failingSince = time.Now().Add(-2 * emitThreshold)
+				ft.emitIfFailing()
+			},
+			expectedNumEmissions: 1,
+		},
+		{
+			name: "emits on every call while stuck",
+			actions: func(ft *FailureTracker) {
+				ft.RecordFailure()
+				ft.failingSince = time.Now().Add(-2 * emitThreshold)
+				ft.emitIfFailing()
+				ft.emitIfFailing()
+			},
+			expectedNumEmissions: 2,
+		},
+		{
+			name: "stops emitting after success",
+			actions: func(ft *FailureTracker) {
+				ft.RecordFailure()
+				ft.failingSince = time.Now().Add(-2 * emitThreshold)
+				ft.emitIfFailing()
+				ft.RecordSuccess()
+				ft.emitIfFailing()
+			},
+			expectedNumEmissions: 1,
+		},
+		{
+			name: "resets timer on new failure after success",
+			actions: func(ft *FailureTracker) {
+				ft.RecordFailure()
+				ft.failingSince = time.Now().Add(-2 * emitThreshold)
+				ft.emitIfFailing()
+				ft.RecordSuccess()
+				ft.RecordFailure()
+				// New streak just started, so less than emitThreshold elapsed.
+				ft.emitIfFailing()
+			},
+			expectedNumEmissions: 1,
+		},
+		{
+			name: "repeated RecordFailure does not reset timer",
+			actions: func(ft *FailureTracker) {
+				ft.RecordFailure()
+				ft.failingSince = time.Now().Add(-2 * emitThreshold)
+				ft.RecordFailure()
+				ft.emitIfFailing()
+			},
+			expectedNumEmissions: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeMetricsFactory := &fakeFailureTrackerMetricsFactory{}
+			testFailureTracker := NewFailureTracker("TestFailureTrackerMetric", fakeMetricsFactory)
+			tc.actions(testFailureTracker)
+			require.Equal(t, tc.expectedNumEmissions, fakeMetricsFactory.numEmissions)
+		})
+	}
+}

--- a/ecs-agent/tcs/handler/handler.go
+++ b/ecs-agent/tcs/handler/handler.go
@@ -76,6 +76,23 @@ type telemetrySession struct {
 	doctor                        *doctor.Doctor
 	ecsClient                     TcsEcsClient
 	lastDisconnectedTime          time.Time
+	dpeFailureTracker             *metrics.FailureTracker
+	tcsConnFailureTracker         *metrics.FailureTracker
+}
+
+// TelemetrySessionOption configures optional behavior on the TCS session.
+type TelemetrySessionOption func(*telemetrySession)
+
+// WithDPEFailureTracker sets the FailureTracker used to track
+// DiscoverPollEndpoint failures across retry attempts.
+func WithDPEFailureTracker(dpeFailureTracker *metrics.FailureTracker) TelemetrySessionOption {
+	return func(session *telemetrySession) { session.dpeFailureTracker = dpeFailureTracker }
+}
+
+// WithTCSConnFailureTracker sets the FailureTracker used to track TCS
+// connection failures across retry attempts.
+func WithTCSConnFailureTracker(tcsConnFailureTracker *metrics.FailureTracker) TelemetrySessionOption {
+	return func(session *telemetrySession) { session.tcsConnFailureTracker = tcsConnFailureTracker }
 }
 
 func NewTelemetrySession(
@@ -98,8 +115,9 @@ func NewTelemetrySession(
 	instanceStatusChannel <-chan ecstcs.InstanceStatusMessage,
 	doctor *doctor.Doctor,
 	ecsClient TcsEcsClient,
+	opts ...TelemetrySessionOption,
 ) TelemetrySession {
-	return &telemetrySession{
+	session := &telemetrySession{
 		containerInstanceArn:          containerInstanceArn,
 		cluster:                       cluster,
 		agentVersion:                  agentVersion,
@@ -121,6 +139,10 @@ func NewTelemetrySession(
 		ecsClient:                     ecsClient,
 		lastDisconnectedTime:          time.Time{},
 	}
+	for _, opt := range opts {
+		opt(session)
+	}
+	return session
 }
 
 // Start runs in for loop to start telemetry session with exponential backoff
@@ -161,8 +183,11 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context) erro
 
 	endpoint, err := session.getTelemetryEndpoint()
 	if err != nil {
+		session.dpeFailureTracker.RecordFailure()
+		session.tcsConnFailureTracker.RecordFailure()
 		return err
 	}
+	session.dpeFailureTracker.RecordSuccess()
 
 	tcsEndpointUrl := formatURL(endpoint, session.cluster, session.containerInstanceArn, session.agentVersion,
 		session.agentHash, containerRuntime, session.containerRuntimeVersion)
@@ -173,6 +198,7 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context) erro
 	if session.deregisterInstanceEventStream != nil {
 		err := session.deregisterInstanceEventStream.Subscribe(deregisterContainerInstanceHandler, client.Disconnect)
 		if err != nil {
+			session.tcsConnFailureTracker.RecordFailure()
 			return err
 		}
 		defer session.deregisterInstanceEventStream.Unsubscribe(deregisterContainerInstanceHandler)
@@ -183,6 +209,7 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context) erro
 		session.disconnectTimeout,
 		session.disconnectJitterMax)
 	if err != nil {
+		session.tcsConnFailureTracker.RecordFailure()
 		logger.Error("Error connecting to TCS", logger.Fields{
 			field.Error: err,
 		})
@@ -195,6 +222,7 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context) erro
 			session.GetLastDisconnectedTime()).Milliseconds()).Done(nil)
 	}
 	defer disconnectTimer.Stop()
+	session.tcsConnFailureTracker.RecordSuccess()
 	logger.Info("Connected to TCS endpoint")
 	// start a timer and listens for tcs heartbeats/acks. The timer is reset when
 	// we receive a heartbeat from the server or when a published metrics message

--- a/ecs-agent/tcs/handler/handler_test.go
+++ b/ecs-agent/tcs/handler/handler_test.go
@@ -58,6 +58,7 @@ const (
 	testAgentVersion                      = "testAgentVersion"
 	testAgentHash                         = "testAgentHash"
 	testContainerRuntimeVersion           = "testContainerRuntimeVersion"
+	testInvalidURL                        = "invalid-url"
 	testHeartbeatTimeout                  = 1 * time.Minute
 	testHeartbeatJitter                   = 1 * time.Minute
 	testDisconnectionTimeout              = 30 * time.Minute
@@ -482,7 +483,7 @@ func TestTACSConnectionFailureMetric(t *testing.T) {
 
 	// Create a test ECS client that will cause StartTelemetrySession to fail
 	testecsclient := &wsmock.TestECSClient{
-		TCSurl: "invalid-url", // This will cause an error
+		TCSurl: testInvalidURL, // This will cause an error
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -797,4 +798,137 @@ func TestPeriodicDisconnectonTCSClient(t *testing.T) {
 		"Expected normal closure code message to be received on server side after periodic disconnect.")
 
 	closeSocket(closeWS)
+}
+
+func TestDPEAndTCSConnFailureTrackingRecordFailure(t *testing.T) {
+	testCases := []struct {
+		name             string
+		tcsURL           string
+		expectDPEFailing bool
+		expectTCSFailing bool
+	}{
+		{
+			name: "DPE error records both DPE and TCS connectivity failure",
+			// Empty TCS URL will cause DPE call via test ECS client to fail.
+			tcsURL:           "",
+			expectDPEFailing: true,
+			expectTCSFailing: true,
+		},
+		{
+			name: "DPE success and TCS connect error records TCS connectivity failure only",
+			// Invalid TCS URL returned by test ECS client will cause TCS connect to fail.
+			tcsURL:           testInvalidURL,
+			expectDPEFailing: false,
+			expectTCSFailing: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dpeFailureTracker := metrics.NewFailureTracker(
+				metrics.DPEConnectivityFailureMetricName,
+				metrics.NewNopEntryFactory(),
+			)
+			tcsConnFailureTracker := metrics.NewFailureTracker(
+				metrics.TCSConnectivityFailureMetricName,
+				metrics.NewNopEntryFactory(),
+			)
+
+			testecsclient := &wsmock.TestECSClient{TCSurl: tc.tcsURL}
+			telemetryMessages := make(chan ecstcs.TelemetryMessage, testTelemetryChannelDefaultBufferSize)
+			healthMessages := make(chan ecstcs.HealthMessage, testTelemetryChannelDefaultBufferSize)
+			instanceStatusMessages := make(chan ecstcs.InstanceStatusMessage, testTelemetryChannelDefaultBufferSize)
+
+			session := NewTelemetrySession(
+				testInstanceArn,
+				testClusterArn,
+				testAgentVersion,
+				testAgentHash,
+				testContainerRuntimeVersion,
+				false,
+				aws.NewCredentialsCache(testCreds),
+				testCfg,
+				nil,
+				testHeartbeatTimeout,
+				testHeartbeatJitter,
+				testDisconnectionTimeout,
+				testDisconnectionJitter,
+				metrics.NewNopEntryFactory(),
+				telemetryMessages,
+				healthMessages,
+				instanceStatusMessages,
+				emptyDoctor,
+				testecsclient,
+				WithDPEFailureTracker(dpeFailureTracker),
+				WithTCSConnFailureTracker(tcsConnFailureTracker),
+			)
+
+			err := session.StartTelemetrySession(context.Background())
+			assert.Error(t, err)
+			assert.Equal(t, tc.expectDPEFailing, dpeFailureTracker.IsFailing())
+			assert.Equal(t, tc.expectTCSFailing, tcsConnFailureTracker.IsFailing())
+		})
+	}
+}
+
+func TestDPEAndTCSConnFailureTrackersRecordSuccess(t *testing.T) {
+	closeWS := make(chan []byte)
+	server, _, _, _, err := wsmock.GetMockServer(closeWS)
+	assert.NoError(t, err)
+	server.StartTLS()
+	defer server.Close()
+	defer close(closeWS)
+
+	dpeFailureTracker := metrics.NewFailureTracker(
+		metrics.DPEConnectivityFailureMetricName,
+		metrics.NewNopEntryFactory(),
+	)
+	tcsConnFailureTracker := metrics.NewFailureTracker(
+		metrics.TCSConnectivityFailureMetricName,
+		metrics.NewNopEntryFactory(),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start in a failing state to verify later that RecordSuccess resets it.
+	dpeFailureTracker.RecordFailure()
+	tcsConnFailureTracker.RecordFailure()
+
+	// Call cancel upfront to ensure that TCS client does not serve traffic
+	// indefinitely once TCS connection is successful.
+	cancel()
+
+	testecsclient := &wsmock.TestECSClient{TCSurl: server.URL}
+	telemetryMessages := make(chan ecstcs.TelemetryMessage, testTelemetryChannelDefaultBufferSize)
+	healthMessages := make(chan ecstcs.HealthMessage, testTelemetryChannelDefaultBufferSize)
+	instanceStatusMessages := make(chan ecstcs.InstanceStatusMessage, testTelemetryChannelDefaultBufferSize)
+
+	session := NewTelemetrySession(
+		testInstanceArn,
+		testClusterArn,
+		testAgentVersion,
+		testAgentHash,
+		testContainerRuntimeVersion,
+		false,
+		aws.NewCredentialsCache(testCreds),
+		testCfg,
+		nil,
+		testHeartbeatTimeout,
+		testHeartbeatJitter,
+		testDisconnectionTimeout,
+		testDisconnectionJitter,
+		metrics.NewNopEntryFactory(),
+		telemetryMessages,
+		healthMessages,
+		instanceStatusMessages,
+		emptyDoctor,
+		testecsclient,
+		WithDPEFailureTracker(dpeFailureTracker),
+		WithTCSConnFailureTracker(tcsConnFailureTracker),
+	)
+
+	err = session.StartTelemetrySession(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.False(t, dpeFailureTracker.IsFailing())
+	assert.False(t, tcsConnFailureTracker.IsFailing())
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add to the ecs-agent module a new type `FailureTracker`, which is used to:
- track whether an operation has been in a failure state continuously for longer than a specified time threshold (i.e., 1 minute), and
- if so, emit a metric at a specified cadence (i.e., every 1 minute)

Use this new type to monitor failures in:
- resolving ECS endpoints
- establishing connection with ACS
- establishing connection with TCS

### Implementation details
<!-- How are the changes implemented? -->
- Define `FailureTracker` and its functions
- For each `FailureTracker`, record success upon each successful operation and record failure upon each terminal failure mode
- Use functional options pattern to supply `FailureTracker` to structs which manage calling `DiscoverPollEndpoint` ECS API, connecting to ACS, and connecting to TCS (making supplying `FailureTracker` optional by design)

### Out of scope
The following is out of scope of this pull request:
- Updating ECS Agent (i.e., agent module) to supply `FailureTracker` when initializing its ACS session and TCS session and kick off metric emission logic
- Adding support for other functional options to ACS session and TCS session besides newly added `WithDPEFailureTracker`, `WithACSConnFailureTracker`, and `WithTCSConnFailureTracker`
- Removing any metrics already defined in `ecs-agent/metrics/constants.go` which may contain overlap with the newly added `DPEConnectivityFailure`, `ACSConnectivityFailure`, and `TCSConnectivityFailure`


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->
No

**Does this PR include the addition of new environment variables in the README?**
<!--
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.