### PR TITLE
Add Host type and BuildHosts to populate netNS.Hosts

### DIFF
--- a/ecs-agent/netlib/model/tasknetworkconfig/network_namespace.go
+++ b/ecs-agent/netlib/model/tasknetworkconfig/network_namespace.go
@@ -25,6 +25,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 )
 
+// Host represents a single entry in a hosts file mapping an IP to one or more hostnames.
+type Host struct {
+	IP        string
+	Hostnames []string
+}
+
 // NetworkNamespace is model representing each network namespace.
 type NetworkNamespace struct {
 	Name  string
@@ -43,6 +49,9 @@ type NetworkNamespace struct {
 
 	// ServiceConnectConfig holds ServiceConnect related parameters for the particular netns.
 	ServiceConnectConfig *serviceconnect.ServiceConnectConfig
+
+	// Hosts is the set of IP-to-hostname mappings effective for this network namespace.
+	Hosts []Host
 
 	KnownState   status.NetworkStatus
 	DesiredState status.NetworkStatus

--- a/ecs-agent/netlib/platform/common_linux.go
+++ b/ecs-agent/netlib/platform/common_linux.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"sort"
@@ -435,6 +436,7 @@ func (c *common) createDNSConfig(
 	if primaryIF == nil {
 		return errors.New("unable to find primary interface")
 	}
+
 	if reuseHostDNSConfig {
 		if err := c.generateNetworkConfigFiles(netNS.Name, primaryIF); err != nil {
 			return errors.Wrap(err, "unable to copy dns config files")
@@ -450,7 +452,8 @@ func (c *common) createDNSConfig(
 	if err := c.copyNetworkConfigFilesToTask(taskID, netNS.Name); err != nil {
 		return err
 	}
-	return nil
+
+	return c.populateHostsFromFile(netNS)
 }
 
 // createNetworkConfigFiles gathers DNS config information from a network interface
@@ -654,6 +657,61 @@ func (c *common) createHostsFile(netNSName string, iface *networkinterface.Netwo
 		filepath.Join(networkConfigFileDirectory, netNSName, HostsFileName),
 		contents.Bytes(),
 		networkConfigFileMode)
+}
+
+// parseHosts parses content in the hosts(5) file format into a slice of Host
+// entries.
+//
+//	IP_address canonical_hostname [aliases...]
+//
+// Parsing rules (matching the behavior of glibc nss_files, musl, and Go's
+// net.LookupHost):
+//   - A '#' character starts a comment that extends to end-of-line. Comments
+//     may appear inline after valid fields.
+//   - Fields are separated by any combination of spaces and tabs.
+//   - Blank lines and lines with fewer than two fields (e.g., an IP with no
+//     hostname) are silently skipped.
+//   - Lines whose first field is not a valid IPv4 or IPv6 address are
+//     silently skipped (matching glibc's inet_pton and Go's net.ParseIP
+//     behavior).
+func parseHosts(content []byte) []tasknetworkconfig.Host {
+	var hosts []tasknetworkconfig.Host
+	for _, line := range bytes.Split(content, []byte("\n")) {
+		// Strip inline comments.
+		if idx := bytes.IndexByte(line, '#'); idx >= 0 {
+			line = line[:idx]
+		}
+		// Split on any whitespace.
+		fields := bytes.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		ip := string(fields[0])
+		if net.ParseIP(ip) == nil {
+			continue
+		}
+		var hostnames []string
+		for _, f := range fields[1:] {
+			hostnames = append(hostnames, string(f))
+		}
+		hosts = append(hosts, tasknetworkconfig.Host{IP: ip, Hostnames: hostnames})
+	}
+	if hosts == nil {
+		return []tasknetworkconfig.Host{}
+	}
+	return hosts
+}
+
+// populateHostsFromFile reads the hosts file for the given network namespace
+// from disk and populates netNS.Hosts with the parsed entries.
+func (c *common) populateHostsFromFile(netNS *tasknetworkconfig.NetworkNamespace) error {
+	hostsFilePath := filepath.Join(networkConfigFileDirectory, netNS.Name, HostsFileName)
+	content, err := c.ioutil.ReadFile(hostsFilePath)
+	if err != nil {
+		return errors.Wrapf(err, "unable to read hosts file for netns %s", netNS.Name)
+	}
+	netNS.Hosts = parseHosts(content)
+	return nil
 }
 
 // configureInterface initiates the workflow for setting up a network interface

--- a/ecs-agent/netlib/platform/common_linux_test.go
+++ b/ecs-agent/netlib/platform/common_linux_test.go
@@ -176,9 +176,13 @@ func TestCommon_CreateDNSFiles(t *testing.T) {
 			volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/hosts", "hosts", fs.FileMode(0644)).Return(nil).Times(1),
 			volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/resolv.conf", "resolv.conf", fs.FileMode(0644)).Return(nil).Times(1),
 			volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/hostname", "hostname", fs.FileMode(0644)).Return(nil).Times(1),
+
+			// Read back hosts file to populate netNS.Hosts.
+			ioutil.EXPECT().ReadFile(netNSPath+"/hosts").Return([]byte(cs.expectedHostsData), nil),
 		)
 		err := commonPlatform.createDNSConfig(taskID, false, netns)
 		require.NoError(t, err)
+		require.Equal(t, parseHosts([]byte(cs.expectedHostsData)), netns.Hosts)
 	}
 }
 
@@ -307,16 +311,20 @@ func TestCommon_CreateDNSFilesForDebug(t *testing.T) {
 
 			gomock.InOrder(
 				// Creation of hosts file.
-				ioutil.EXPECT().ReadFile("/etc/hosts"),
+				ioutil.EXPECT().ReadFile("/etc/hosts").Return([]byte("127.0.0.1 localhost\n"), nil),
 				ioutil.EXPECT().WriteFile(netNSPath+"/hosts", gomock.Any(), gomock.Any()),
 
 				// CopyToVolume created files into task volume.
 				volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/hosts", "hosts", fs.FileMode(0644)).Return(nil).Times(1),
 				volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/resolv.conf", "resolv.conf", fs.FileMode(0644)).Return(nil).Times(1),
 				volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/hostname", "hostname", fs.FileMode(0644)).Return(nil).Times(1),
+
+				// Read back hosts file to populate netNS.Hosts.
+				ioutil.EXPECT().ReadFile(netNSPath+"/hosts").Return([]byte("127.0.0.1 localhost\n"), nil),
 			)
 			err := commonPlatform.createDNSConfig(taskID, true, netns)
 			require.NoError(t, err)
+			require.Equal(t, parseHosts([]byte("127.0.0.1 localhost\n")), netns.Hosts)
 		})
 	}
 
@@ -511,4 +519,90 @@ func testGeneveInterfaceConfiguration(t *testing.T) {
 		Return(nil).Times(1)
 	err = commonPlatform.configureInterface(ctx, netNSPath, v2nIface, netDAO)
 	require.NoError(t, err)
+}
+
+func TestParseHosts(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []tasknetworkconfig.Host
+	}{
+		{
+			// Canonical example from hosts(5) man page:
+			// https://man7.org/linux/man-pages/man5/hosts.5.html
+			name: "hosts(5) man page example",
+			input: "# The following lines are desirable for IPv4 capable hosts\n" +
+				"127.0.0.1       localhost\n" +
+				"\n" +
+				"# 127.0.1.1 is often used for the FQDN of the machine\n" +
+				"127.0.1.1       thishost.example.org   thishost\n" +
+				"192.168.1.10    foo.example.org        foo\n" +
+				"192.168.1.13    bar.example.org        bar\n" +
+				"146.82.138.7    master.debian.org      master\n" +
+				"209.237.226.90  www.opensource.org\n" +
+				"\n" +
+				"# The following lines are desirable for IPv6 capable hosts\n" +
+				"::1             localhost ip6-localhost ip6-loopback\n" +
+				"ff02::1         ip6-allnodes\n" +
+				"ff02::2         ip6-allrouters\n",
+			expected: []tasknetworkconfig.Host{
+				{IP: "127.0.0.1", Hostnames: []string{"localhost"}},
+				{IP: "127.0.1.1", Hostnames: []string{"thishost.example.org", "thishost"}},
+				{IP: "192.168.1.10", Hostnames: []string{"foo.example.org", "foo"}},
+				{IP: "192.168.1.13", Hostnames: []string{"bar.example.org", "bar"}},
+				{IP: "146.82.138.7", Hostnames: []string{"master.debian.org", "master"}},
+				{IP: "209.237.226.90", Hostnames: []string{"www.opensource.org"}},
+				{IP: "::1", Hostnames: []string{"localhost", "ip6-localhost", "ip6-loopback"}},
+				{IP: "ff02::1", Hostnames: []string{"ip6-allnodes"}},
+				{IP: "ff02::2", Hostnames: []string{"ip6-allrouters"}},
+			},
+		},
+		{
+			name:  "inline comments stripped",
+			input: "192.168.1.1 foo # this is a web server\n10.0.0.1 bar#no space before hash\n",
+			expected: []tasknetworkconfig.Host{
+				{IP: "192.168.1.1", Hostnames: []string{"foo"}},
+				{IP: "10.0.0.1", Hostnames: []string{"bar"}},
+			},
+		},
+		{
+			name:  "tabs as separators",
+			input: "127.0.0.1\tlocalhost\n10.0.0.2\tmy-host\tmy-alias\n",
+			expected: []tasknetworkconfig.Host{
+				{IP: "127.0.0.1", Hostnames: []string{"localhost"}},
+				{IP: "10.0.0.2", Hostnames: []string{"my-host", "my-alias"}},
+			},
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: []tasknetworkconfig.Host{},
+		},
+		{
+			name:     "only comments and blanks",
+			input:    "# comment\n\n  # another\n",
+			expected: []tasknetworkconfig.Host{},
+		},
+		{
+			name:  "line with only IP and no hostname is skipped",
+			input: "192.168.1.1\n10.0.0.1 valid-host\n",
+			expected: []tasknetworkconfig.Host{
+				{IP: "10.0.0.1", Hostnames: []string{"valid-host"}},
+			},
+		},
+		{
+			name:  "invalid IP addresses are skipped",
+			input: "not-an-ip hostname1\n999.999.999.999 hostname2\n10.0.0.1 valid-host\n",
+			expected: []tasknetworkconfig.Host{
+				{IP: "10.0.0.1", Hostnames: []string{"valid-host"}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := parseHosts([]byte(tc.input))
+			assert.Equal(t, tc.expected, result)
+		})
+	}
 }

--- a/ecs-agent/netlib/platform/firecracker_linux_test.go
+++ b/ecs-agent/netlib/platform/firecracker_linux_test.go
@@ -122,6 +122,9 @@ func TestFirecracker_CreateDNSConfig(t *testing.T) {
 		volumeAccessor.EXPECT().CopyToVolume(taskID, primaryNetNSPath+"/resolv.conf", "resolv.conf", fs.FileMode(0644)).Return(nil).Times(1),
 		volumeAccessor.EXPECT().CopyToVolume(taskID, primaryNetNSPath+"/hostname", "hostname", fs.FileMode(0644)).Return(nil).Times(1),
 
+		// Read back hosts file to populate netNS.Hosts.
+		ioutil.EXPECT().ReadFile(primaryNetNSPath+"/hosts").Return([]byte(primaryHostsData), nil),
+
 		// Creation of secondary netns path.
 		osWrapper.EXPECT().Stat(secondaryNetNSPath).Return(nil, os.ErrNotExist).Times(1),
 		osWrapper.EXPECT().IsNotExist(os.ErrNotExist).Return(true).Times(1),

--- a/ecs-agent/netlib/platform/managed_linux.go
+++ b/ecs-agent/netlib/platform/managed_linux.go
@@ -138,7 +138,11 @@ func (m *managedLinux) createServiceConnectTasksDNSConfig(taskID string,
 
 	// Copy these files into a task volume, which can be used by containers as well, to
 	// configure their network.
-	return m.copyNetworkConfigFilesToTask(taskID, netNSName)
+	if err := m.copyNetworkConfigFilesToTask(taskID, netNSName); err != nil {
+		return err
+	}
+
+	return m.populateHostsFromFile(netNS)
 }
 
 func (m *managedLinux) ConfigureInterface(

--- a/ecs-agent/netlib/platform/managed_linux_test.go
+++ b/ecs-agent/netlib/platform/managed_linux_test.go
@@ -428,13 +428,16 @@ func TestManagedLinux_CreateDNSConfig(t *testing.T) {
 			ioutil.EXPECT().WriteFile(netNSPath+"/resolv.conf", gomock.Any(), gomock.Any()),
 
 			// Copy hosts file from host and append interface mappings
-			ioutil.EXPECT().ReadFile("/etc/hosts"),
+			ioutil.EXPECT().ReadFile("/etc/hosts").Return([]byte("127.0.0.1 localhost\n"), nil),
 			ioutil.EXPECT().WriteFile(netNSPath+"/hosts", gomock.Any(), gomock.Any()),
 
 			// CopyToVolume created files into task volume
 			volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/hosts", "hosts", fs.FileMode(0644)).Return(nil).Times(1),
 			volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/resolv.conf", "resolv.conf", fs.FileMode(0644)).Return(nil).Times(1),
 			volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/hostname", "hostname", fs.FileMode(0644)).Return(nil).Times(1),
+
+			// Read back hosts file to populate netNS.Hosts.
+			ioutil.EXPECT().ReadFile(netNSPath+"/hosts").Return([]byte("127.0.0.1 localhost\n"), nil),
 		)
 
 		err := ml.CreateDNSConfig(taskID, netns)
@@ -497,6 +500,9 @@ func TestManagedLinux_CreateDNSConfig(t *testing.T) {
 			volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/hosts", "hosts", fs.FileMode(0644)).Return(nil).Times(1),
 			volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/resolv.conf", "resolv.conf", fs.FileMode(0644)).Return(nil).Times(1),
 			volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/hostname", "hostname", fs.FileMode(0644)).Return(nil).Times(1),
+
+			// Read back hosts file to populate netNS.Hosts.
+			ioutil.EXPECT().ReadFile(netNSPath+"/hosts").Return([]byte(hostsData), nil),
 		)
 
 		err := ml.CreateDNSConfig(taskID, netns)
@@ -559,6 +565,9 @@ func TestManagedLinux_CreateDNSConfig(t *testing.T) {
 			volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/hosts", "hosts", fs.FileMode(0644)).Return(nil).Times(1),
 			volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/resolv.conf", "resolv.conf", fs.FileMode(0644)).Return(nil).Times(1),
 			volumeAccessor.EXPECT().CopyToVolume(taskID, netNSPath+"/hostname", "hostname", fs.FileMode(0644)).Return(nil).Times(1),
+
+			// Read back hosts file to populate netNS.Hosts.
+			ioutil.EXPECT().ReadFile(netNSPath+"/hosts").Return([]byte(hostsData), nil),
 		)
 
 		err := ml.CreateDNSConfig(taskID, netns)


### PR DESCRIPTION
### Summary

Add a `Host` struct and `Hosts` field on `NetworkNamespace` so that the content of the generated hosts file is available as structured data on the model. This allows downstream consumers to read host entries without parsing the file.

### Implementation details

- Add `Host` struct (`IP`, `Hostnames`) and `Hosts []Host` field on `NetworkNamespace`.
- Add `BuildHosts(iface)` which produces the host entries (localhost, task IP/hostname, Service Connect DNS mappings) from a `NetworkInterface`.
- `createHostsFile` calls `BuildHosts` to generate its content, and `netNS.Hosts` is assigned from the same function in `createDNSConfig` and the managed_linux Service Connect path.
- `Hosts` is only populated when the agent generates the hosts file (not when copying from the host, and not on Windows which does not write one).
- Remove `HostsLocalhostEntryIPv4`/`HostsLocalhostEntryIPv6` constants (superseded by `BuildHosts`).

### Testing

- New unit tests for `BuildHosts`: IPv4, IPv6-only, empty interface, nil interface, and Service Connect mapping scenarios.
- Existing platform tests pass with identical expected file output.
- Full `go test -tags unit ./netlib/...` passes.

New tests cover the changes: yes

### Description for the changelog

Enhancement - Add structured Hosts field to NetworkNamespace

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No.

**Does this PR include the addition of new environment variables in the README?**
No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
