### PR TITLE
Detect cloud-init failure at startup to prevent silent cluster miscon…

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -357,6 +357,18 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 	imageManager engine.ImageManager,
 	client ecs.ECSClient,
 	execCmdMgr execcmd.Manager) int {
+	// Check for cloud-init failure before proceeding with startup.
+	// If cloud-init fell back to DataSourceNone but userdata exists on IMDS,
+	// userdata was not executed and the agent may have incorrect config.
+	if !agent.cfg.External.Enabled() {
+		if err := config.CheckCloudInitFailure(agent.ec2MetadataClient, config.CloudInitResultFilePath); err != nil {
+			seelog.Criticalf("Cloud-init failure detected: %v. "+
+				"Userdata was not executed during instance boot. "+
+				"Refusing to start with potentially incorrect config.", err)
+			return exitcodes.ExitTerminal
+		}
+	}
+
 	// check docker version >= 1.9.0, exit agent if older
 	if exitcode, ok := agent.verifyRequiredDockerVersion(); !ok {
 		return exitcode

--- a/agent/config/cloudinit_check_linux.go
+++ b/agent/config/cloudinit_check_linux.go
@@ -1,0 +1,81 @@
+//go:build linux
+// +build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
+	"github.com/cihub/seelog"
+)
+
+// CloudInitResultFilePath is the path to cloud-init's result.json file which records
+// the datasource used during instance boot.
+const CloudInitResultFilePath = "/var/lib/cloud/data/result.json"
+
+// cloudInitResult represents the structure of cloud-init's result.json file.
+type cloudInitResult struct {
+	V1 struct {
+		Datasource string `json:"datasource"`
+	} `json:"v1"`
+}
+
+// CheckCloudInitFailure detects if cloud-init failed to execute userdata due to
+// IMDS unavailability during boot. Returns a non-nil error only when both
+// conditions are met: DataSourceNone in result.json AND non-empty userdata on
+// IMDS. Any failure to perform the check returns nil (best-effort, fail-open).
+func CheckCloudInitFailure(ec2Client ec2.EC2MetadataClient, resultFilePath string) error {
+	data, err := os.ReadFile(resultFilePath)
+	if err != nil {
+		seelog.Warnf("Unable to read cloud-init result file at %s, skipping cloud-init check: %v",
+			resultFilePath, err)
+		return nil
+	}
+
+	var result cloudInitResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		seelog.Warnf("Unable to parse cloud-init result file at %s, skipping cloud-init check: %v",
+			resultFilePath, err)
+		return nil
+	}
+
+	if result.V1.Datasource != "DataSourceNone" {
+		seelog.Infof("cloud-init datasource is %s, cloud-init check passed", result.V1.Datasource)
+		return nil
+	}
+
+	userData, err := ec2Client.GetUserData()
+	if err != nil {
+		var statusErr interface{ HTTPStatusCode() int }
+		if errors.As(err, &statusErr) && statusErr.HTTPStatusCode() == http.StatusNotFound {
+			seelog.Infof("cloud-init used DataSourceNone but no userdata is configured for this instance, skipping check")
+		} else {
+			seelog.Infof("cloud-init used DataSourceNone; unable to verify if userdata exists on IMDS, skipping check: %v", err)
+		}
+		return nil
+	}
+	if userData == "" {
+		seelog.Infof("cloud-init used DataSourceNone but userdata is empty, skipping check")
+		return nil
+	}
+
+	return fmt.Errorf("cloud-init used DataSourceNone and userdata exists on IMDS but was never executed")
+}

--- a/agent/config/cloudinit_check_linux_test.go
+++ b/agent/config/cloudinit_check_linux_test.go
@@ -1,0 +1,128 @@
+//go:build linux && unit
+// +build linux,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mock_ec2 "github.com/aws/amazon-ecs-agent/ecs-agent/ec2/mocks"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// httpStatusError implements the HTTPStatusCode() interface for testing.
+type httpStatusError struct {
+	statusCode int
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("http response error StatusCode: %d, request to EC2 IMDS failed", e.statusCode)
+}
+
+func (e *httpStatusError) HTTPStatusCode() int {
+	return e.statusCode
+}
+
+func TestCheckCloudInitFailure(t *testing.T) {
+	tests := []struct {
+		name        string
+		fileContent *string
+		setupMock   func(*mock_ec2.MockEC2MetadataClient)
+		expectError bool
+	}{
+		{
+			name:        "file missing",
+			fileContent: nil,
+		},
+		{
+			name:        "invalid JSON",
+			fileContent: aws.String("not valid json{{{"),
+		},
+		{
+			name:        "datasource is DataSourceEc2Local",
+			fileContent: aws.String(`{"v1": {"datasource": "DataSourceEc2Local"}}`),
+		},
+		{
+			name:        "datasource is DataSourceEc2",
+			fileContent: aws.String(`{"v1": {"datasource": "DataSourceEc2"}}`),
+		},
+		{
+			name:        "DataSourceNone but GetUserData returns error",
+			fileContent: aws.String(`{"v1": {"datasource": "DataSourceNone"}}`),
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetUserData().Return("", errors.New("IMDS error"))
+			},
+		},
+		{
+			name:        "DataSourceNone but GetUserData returns 404 (no userdata configured)",
+			fileContent: aws.String(`{"v1": {"datasource": "DataSourceNone"}}`),
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetUserData().Return("", &httpStatusError{statusCode: http.StatusNotFound})
+			},
+		},
+		{
+			name:        "DataSourceNone but userdata is empty",
+			fileContent: aws.String(`{"v1": {"datasource": "DataSourceNone"}}`),
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetUserData().Return("", nil)
+			},
+		},
+		{
+			name:        "DataSourceNone with non-empty userdata - detection fires",
+			fileContent: aws.String(`{"v1": {"datasource": "DataSourceNone"}}`),
+			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+				m.EXPECT().GetUserData().Return("#!/bin/bash\necho ECS_CLUSTER=my-cluster >> /etc/ecs/ecs.config", nil)
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockEC2 := mock_ec2.NewMockEC2MetadataClient(ctrl)
+
+			var resultFile string
+			if tc.fileContent != nil {
+				tmpDir := t.TempDir()
+				resultFile = filepath.Join(tmpDir, "result.json")
+				require.NoError(t, os.WriteFile(resultFile, []byte(*tc.fileContent), 0644))
+			} else {
+				resultFile = "/nonexistent/path/result.json"
+			}
+
+			if tc.setupMock != nil {
+				tc.setupMock(mockEC2)
+			}
+
+			err := CheckCloudInitFailure(mockEC2, resultFile)
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "DataSourceNone")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/agent/config/cloudinit_check_unsupported.go
+++ b/agent/config/cloudinit_check_unsupported.go
@@ -1,0 +1,27 @@
+//go:build !linux
+// +build !linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import "github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
+
+// CloudInitResultFilePath is empty on non-Linux platforms where cloud-init is not applicable.
+const CloudInitResultFilePath = ""
+
+// CheckCloudInitFailure is a no-op on non-Linux platforms.
+func CheckCloudInitFailure(ec2Client ec2.EC2MetadataClient, resultFilePath string) error {
+	return nil
+}

--- a/ecs-init/docker/docker_config.go
+++ b/ecs-init/docker/docker_config.go
@@ -49,6 +49,7 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 	)
 	binds = append(binds, getNsenterBinds(config.OsStat)...)
 	binds = append(binds, getModInfoBinds(config.OsStat)...)
+	binds = append(binds, getCloudInitResultBinds(config.OsStat)...)
 
 	logConfig := config.AgentDockerLogDriverConfiguration()
 
@@ -122,4 +123,24 @@ func getModInfoBinds(statFn func(string) (os.FileInfo, error)) []string {
 		}
 	}
 	return binds
+}
+
+// cloudInitResultFile is the path to cloud-init's result.json file which records
+// the datasource used during instance boot.
+const cloudInitResultFile = "/var/lib/cloud/data/result.json"
+
+// getCloudInitResultBinds returns a read-only bind mount for cloud-init's result.json
+// if the file exists on the host. Returns an empty slice if the file is missing or
+// if running in external (non-EC2) mode where cloud-init is not applicable.
+func getCloudInitResultBinds(statFn func(string) (os.FileInfo, error)) []string {
+	if config.RunningInExternal() {
+		return []string{}
+	}
+	if _, err := statFn(cloudInitResultFile); err == nil {
+		return []string{cloudInitResultFile + ":" + cloudInitResultFile + readOnly}
+	} else {
+		seelog.Infof("cloud-init result file not found at %s, skip binding it to Agent container: %v",
+			cloudInitResultFile, err)
+	}
+	return []string{}
 }

--- a/ecs-init/docker/docker_config_test.go
+++ b/ecs-init/docker/docker_config_test.go
@@ -50,3 +50,17 @@ func TestGetModinfoBinds(t *testing.T) {
 		assert.Equal(t, "/sbin/modinfo:/sbin/modinfo", binds[0])
 	})
 }
+
+func TestGetCloudInitResultBinds(t *testing.T) {
+	t.Run("result file not found", func(t *testing.T) {
+		binds := getCloudInitResultBinds(
+			func(s string) (os.FileInfo, error) { return nil, errors.New("not found") })
+		assert.Empty(t, binds)
+	})
+	t.Run("result file is found", func(t *testing.T) {
+		binds := getCloudInitResultBinds(
+			func(s string) (os.FileInfo, error) { return nil, nil })
+		require.Len(t, binds, 1)
+		assert.Equal(t, "/var/lib/cloud/data/result.json:/var/lib/cloud/data/result.json:ro", binds[0])
+	})
+}


### PR DESCRIPTION
## Summary

When IMDS is transiently unreachable during instance boot (e.g., ENI initialization failure), cloud-init falls back to DataSourceNone and skips userdata execution. The ECS agent then starts with default config which is undesirable.

This adds a best-effort check at agent startup that detects this condition and terminally exits (code 5) so Agent does not run with default configuration.

## Implementation details

**Detection logic:**
1. Read `/var/lib/cloud/data/result.json` (bind-mounted by ecs-init)
2. If datasource is `DataSourceNone` AND IMDS `/latest/user-data` returns non-empty content → cloud-init failed to execute userdata
3. Agent logs CRITICAL and exits with code 5 (terminal, no restart)

**Fail-open design:** Any failure to read or parse the file causes the check to be skipped. The check can never incorrectly prevent the agent from starting.

**Changes:**
- `ecs-init/docker/docker_config.go`: Optional read-only bind mount of `/var/lib/cloud/data/result.json` (skipped in External mode, logs warning if file missing)
- `agent/config/cloudinit_check_linux.go`: `CheckCloudInitFailure()` function with fail-open semantics
- `agent/config/cloudinit_check_unsupported.go`: No-op stub for non-Linux
- `agent/app/agent.go`: Call the check in `doStart()` before Docker version verification (skipped in External mode)

## Testing

- Unit tests cover all branches: file missing, invalid JSON, DataSourceEc2, DataSourceNone + IMDS error, DataSourceNone + empty userdata, DataSourceNone + non-empty userdata (detection fires)
- E2E test (MACIS): two-phase instance test — install agent on first boot, cloud-init clean + IMDS disable on second boot, verify agent exits 5 with "Cloud-init failure detected" in logs
- Verified on AL2023 ECS-Optimized AMI
- Verified detection does NOT fire on normally-booted instances

New tests cover the changes: yes

## Description for the changelog

Feature - Detect cloud-init failure at startup to prevent silent cluster misconfiguration when IMDS is transiently unreachable during boot

## Additional Information

**Does this PR include breaking model changes?** No

**Does this PR include the addition of new environment variables in the README?** No

## Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
