### PR TITLE
Add isolated_linux platform for isolated container networking

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper/mocks/netlinkwrapper_mocks_linux.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper/mocks/netlinkwrapper_mocks_linux.go
@@ -122,6 +122,35 @@ func (mr *MockNetLinkMockRecorder) LinkSetUp(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSetUp", reflect.TypeOf((*MockNetLink)(nil).LinkSetUp), arg0)
 }
 
+// NeighList mocks base method.
+func (m *MockNetLink) NeighList(arg0, arg1 int) ([]netlink.Neigh, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NeighList", arg0, arg1)
+	ret0, _ := ret[0].([]netlink.Neigh)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NeighList indicates an expected call of NeighList.
+func (mr *MockNetLinkMockRecorder) NeighList(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeighList", reflect.TypeOf((*MockNetLink)(nil).NeighList), arg0, arg1)
+}
+
+// NeighSet mocks base method.
+func (m *MockNetLink) NeighSet(arg0 *netlink.Neigh) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NeighSet", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// NeighSet indicates an expected call of NeighSet.
+func (mr *MockNetLinkMockRecorder) NeighSet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeighSet", reflect.TypeOf((*MockNetLink)(nil).NeighSet), arg0)
+}
+
 // RouteAdd mocks base method.
 func (m *MockNetLink) RouteAdd(arg0 *netlink.Route) error {
 	m.ctrl.T.Helper()
@@ -163,4 +192,18 @@ func (m *MockNetLink) RouteList(arg0 netlink.Link, arg1 int) ([]netlink.Route, e
 func (mr *MockNetLinkMockRecorder) RouteList(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteList", reflect.TypeOf((*MockNetLink)(nil).RouteList), arg0, arg1)
+}
+
+// RouteReplace mocks base method.
+func (m *MockNetLink) RouteReplace(arg0 *netlink.Route) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RouteReplace", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RouteReplace indicates an expected call of RouteReplace.
+func (mr *MockNetLinkMockRecorder) RouteReplace(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteReplace", reflect.TypeOf((*MockNetLink)(nil).RouteReplace), arg0)
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper/netlink_linux.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper/netlink_linux.go
@@ -28,7 +28,10 @@ type NetLink interface {
 	LinkList() ([]netlink.Link, error)
 	RouteAdd(route *netlink.Route) error
 	RouteDel(route *netlink.Route) error
+	RouteReplace(route *netlink.Route) error
 	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)
+	NeighList(linkIndex, family int) ([]netlink.Neigh, error)
+	NeighSet(neigh *netlink.Neigh) error
 }
 
 type netLink struct{}
@@ -70,4 +73,16 @@ func (nl *netLink) RouteDel(route *netlink.Route) error {
 
 func (nl *netLink) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
 	return netlink.AddrList(link, family)
+}
+
+func (nl *netLink) RouteReplace(route *netlink.Route) error {
+	return netlink.RouteReplace(route)
+}
+
+func (nl *netLink) NeighList(linkIndex, family int) ([]netlink.Neigh, error) {
+	return netlink.NeighList(linkIndex, family)
+}
+
+func (nl *netLink) NeighSet(neigh *netlink.Neigh) error {
+	return netlink.NeighSet(neigh)
 }

--- a/ecs-agent/netlib/platform/common.go
+++ b/ecs-agent/netlib/platform/common.go
@@ -32,6 +32,8 @@ const (
 	FirecrackerPlatform      = "firecracker"
 	ManagedPlatform          = "managed-instance"
 	ManagedDebugPlatform     = "ec2-debug-managed-instance"
+	IsolatedPlatform         = "isolated"
+	IsolatedDebugPlatform    = "ec2-debug-isolated"
 )
 
 // executeCNIPlugin executes CNI plugins with the given network configs and a timeout context.

--- a/ecs-agent/netlib/platform/common_linux.go
+++ b/ecs-agent/netlib/platform/common_linux.go
@@ -134,6 +134,17 @@ func NewPlatform(
 			common: commonPlatform,
 			client: ec2Client,
 		}, nil
+	case IsolatedPlatform, IsolatedDebugPlatform:
+		ec2Client, err := ec2.NewEC2MetadataClient(nil)
+		if err != nil {
+			return nil, err
+		}
+		return &isolatedLinux{
+			managedLinux: managedLinux{
+				common: commonPlatform,
+				client: ec2Client,
+			},
+		}, nil
 	}
 	return nil, errors.New("invalid platform: " + platformConfig.Name)
 }

--- a/ecs-agent/netlib/platform/isolated_linux.go
+++ b/ecs-agent/netlib/platform/isolated_linux.go
@@ -1,0 +1,215 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package platform
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	netlibdata "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/data"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/ecscni"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/status"
+
+	cnins "github.com/containernetworking/plugins/pkg/ns"
+	"github.com/pkg/errors"
+	"github.com/vishvananda/netlink"
+)
+
+// isolatedLinux implements the platform API for containers running inside a
+// micro VM. It extends managedLinux with two differences:
+//
+//  1. No ecs-bridge CNI plugin — TMDS is guest-local, so no bridge is needed
+//     to reach it from the task netns.
+//  2. Permanent ARP neighbor for the VPC gateway — L2 broadcast is unavailable
+//     inside the micro VM, so the gateway MAC must be installed statically.
+type isolatedLinux struct {
+	managedLinux
+}
+
+// ConfigureInterface configures a network interface in the task netns for the
+// isolated platform.
+func (il *isolatedLinux) ConfigureInterface(
+	ctx context.Context,
+	netNSPath string,
+	iface *networkinterface.NetworkInterface,
+	netDAO netlibdata.NetworkDataClient,
+) error {
+	var err error
+
+	switch iface.InterfaceAssociationProtocol {
+	case networkinterface.DefaultInterfaceAssociationProtocol:
+		iface.DeviceName = networkinterface.DefaultTapDeviceName
+		err = il.configureRegularENI(ctx, netNSPath, iface)
+	case networkinterface.VLANInterfaceAssociationProtocol:
+		iface.DeviceName = networkinterface.DefaultTapDeviceName
+		err = il.configureBranchENI(ctx, netNSPath, iface)
+	case networkinterface.V2NInterfaceAssociationProtocol:
+		return il.common.configureGENEVEInterface(ctx, netNSPath, iface, netDAO)
+	case networkinterface.VETHInterfaceAssociationProtocol:
+		return nil
+	default:
+		return errors.New("invalid interface association protocol " + iface.InterfaceAssociationProtocol)
+	}
+
+	// Gateway neighbor is only installed on add (NetworkReadyPull). On delete
+	// the netns is torn down entirely, so the neighbor entry is removed implicitly.
+	if err != nil || iface.DesiredStatus != status.NetworkReadyPull {
+		return err
+	}
+	return il.addGatewayNeighbor(netNSPath, iface)
+}
+
+// configureRegularENI configures a directly-attached ENI (not a branch,
+// GENEVE, or VETH interface).
+func (il *isolatedLinux) configureRegularENI(ctx context.Context, netNSPath string, eni *networkinterface.NetworkInterface) error {
+	logger.Info("Configuring regular ENI", map[string]interface{}{
+		"ENIName":   eni.Name,
+		"NetNSPath": netNSPath,
+	})
+
+	var cniNetConf []ecscni.PluginConfig
+	var add bool
+	var err error
+
+	il.common.os.Setenv(CNIPluginLogFileEnv, ecscni.PluginLogPath)
+	il.common.os.Setenv(IPAMDataPathEnv, filepath.Join(il.common.stateDBDir, IPAMDataFileName))
+
+	switch eni.DesiredStatus {
+	case status.NetworkReadyPull:
+		cniNetConf = append(cniNetConf, createENIPluginConfigs(netNSPath, eni))
+		add = true
+	case status.NetworkDeleted:
+		cniNetConf = append(cniNetConf, createENIPluginConfigs(netNSPath, eni))
+		add = false
+	}
+
+	_, err = il.common.executeCNIPlugin(ctx, add, cniNetConf...)
+	if err != nil {
+		err = errors.Wrap(err, "failed to setup regular eni")
+	}
+
+	return err
+}
+
+// configureBranchENI configures a branch ENI for the isolated platform.
+func (il *isolatedLinux) configureBranchENI(ctx context.Context, netNSPath string, eni *networkinterface.NetworkInterface) error {
+	logger.Info("Configuring branch ENI", map[string]interface{}{
+		"ENIName":   eni.Name,
+		"NetNSPath": netNSPath,
+	})
+
+	il.common.os.Setenv(IPAMDataPathEnv, filepath.Join(il.common.stateDBDir, IPAMDataFileName))
+
+	var cniNetConf []ecscni.PluginConfig
+	var err error
+	add := true
+
+	switch eni.DesiredStatus {
+	case status.NetworkReadyPull:
+		cniNetConf = append(cniNetConf, createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan, blockInstanceMetadataDefault))
+	case status.NetworkDeleted:
+		cniNetConf = append(cniNetConf, createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan, blockInstanceMetadataDefault))
+		add = false
+	}
+
+	_, err = il.common.executeCNIPlugin(ctx, add, cniNetConf...)
+	if err != nil {
+		err = errors.Wrap(err, "failed to setup branch eni")
+	}
+
+	return err
+}
+
+// addGatewayNeighbor installs a permanent ARP entry and /32 link-scope route
+// for the gateway in the task netns.
+func (il *isolatedLinux) addGatewayNeighbor(netNSPath string, eni *networkinterface.NetworkInterface) error {
+	gwIPStr := eni.GetSubnetGatewayIPv4Address()
+	if gwIPStr == "" {
+		return nil
+	}
+	// TODO: Install equivalent neighbor entry for IPv6 gateway.
+
+	gwIP := net.ParseIP(gwIPStr)
+	if gwIP == nil {
+		return fmt.Errorf("failed to parse gateway IP: %s", gwIPStr)
+	}
+
+	// The gateway MAC must be resolved from the host before entering the task
+	// netns, because the ENI has already been moved out of the host namespace.
+	gwMAC, err := il.resolveHostNeighbor(gwIP)
+	if err != nil {
+		return errors.Wrap(err, "gateway MAC not in host neighbor cache")
+	}
+
+	logger.Info("Installing gateway neighbor in task netns", map[string]interface{}{
+		"GatewayIP":  gwIP.String(),
+		"GatewayMAC": gwMAC.String(),
+		"NetNSPath":  netNSPath,
+		"DeviceName": eni.DeviceName,
+	})
+
+	return il.common.nsUtil.ExecInNSPath(netNSPath, func(_ cnins.NetNS) error {
+		link, linkErr := il.common.netlink.LinkByName(eni.DeviceName)
+		if linkErr != nil {
+			return errors.Wrapf(linkErr, "failed to find device %s in task netns", eni.DeviceName)
+		}
+
+		neigh := &netlink.Neigh{
+			LinkIndex:    link.Attrs().Index,
+			State:        netlink.NUD_PERMANENT,
+			IP:           gwIP,
+			HardwareAddr: gwMAC,
+		}
+		if err := il.common.netlink.NeighSet(neigh); err != nil {
+			return errors.Wrapf(err, "failed to set permanent neighbor for %s", gwIP)
+		}
+
+		// A /32 link-scope route marks the gateway as directly reachable,
+		// preventing the kernel from attempting ARP resolution.
+		route := &netlink.Route{
+			LinkIndex: link.Attrs().Index,
+			Dst: &net.IPNet{
+				IP:   gwIP,
+				Mask: net.CIDRMask(32, 32),
+			},
+			Scope: netlink.SCOPE_LINK,
+		}
+		if err := il.common.netlink.RouteReplace(route); err != nil {
+			return errors.Wrapf(err, "failed to add /32 link-scope route for gateway %s", gwIP)
+		}
+
+		return nil
+	})
+}
+
+// resolveHostNeighbor looks up the MAC address for the given IP in the host's
+// neighbor (ARP) table. Returns an error if no entry is found.
+func (il *isolatedLinux) resolveHostNeighbor(ip net.IP) (net.HardwareAddr, error) {
+	neighbors, err := il.common.netlink.NeighList(0, netlink.FAMILY_V4)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list host neighbors")
+	}
+
+	for _, n := range neighbors {
+		if n.IP.Equal(ip) && len(n.HardwareAddr) > 0 {
+			return n.HardwareAddr, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no neighbor entry for %s in host ARP table", ip)
+}

--- a/ecs-agent/netlib/platform/isolated_linux_test.go
+++ b/ecs-agent/netlib/platform/isolated_linux_test.go
@@ -1,0 +1,249 @@
+//go:build !windows && unit
+// +build !windows,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package platform
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+
+	mock_ecscni2 "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/ecscni/mocks_ecscni"
+	mock_ecscni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/ecscni/mocks_nsutil"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/status"
+	mock_netlinkwrapper "github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper/mocks"
+	mock_oswrapper "github.com/aws/amazon-ecs-agent/ecs-agent/utils/oswrapper/mocks"
+
+	cnins "github.com/containernetworking/plugins/pkg/ns"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+)
+
+func newIsolatedLinuxPlatform(ctrl *gomock.Controller) (*isolatedLinux, *mock_oswrapper.MockOS, *mock_ecscni2.MockCNI, *mock_ecscni.MockNetNSUtil, *mock_netlinkwrapper.MockNetLink) {
+	osWrapper := mock_oswrapper.NewMockOS(ctrl)
+	cniClient := mock_ecscni2.NewMockCNI(ctrl)
+	mockNSUtil := mock_ecscni.NewMockNetNSUtil(ctrl)
+	mockNetLink := mock_netlinkwrapper.NewMockNetLink(ctrl)
+
+	mockNSUtil.EXPECT().GetNetNSPath("host-daemon").Return("/var/run/netns/host-daemon").AnyTimes()
+	mockNSUtil.EXPECT().NSExists("/var/run/netns/host-daemon").Return(false, nil).AnyTimes()
+
+	p := &isolatedLinux{
+		managedLinux: managedLinux{
+			common: common{
+				os:         osWrapper,
+				cniClient:  cniClient,
+				nsUtil:     mockNSUtil,
+				netlink:    mockNetLink,
+				stateDBDir: "dummy-db-dir",
+			},
+		},
+	}
+	return p, osWrapper, cniClient, mockNSUtil, mockNetLink
+}
+
+func TestIsolatedLinux_ConfigureInterface_SetsDeviceNameToEth0(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	p, osWrapper, cniClient, _, _ := newIsolatedLinuxPlatform(ctrl)
+	eni := getTestRegularV4ENI()
+	eni.DeviceName = "eth1"
+	// Use NetworkDeleted so addGatewayNeighbor is not invoked.
+	eni.DesiredStatus = status.NetworkDeleted
+
+	osWrapper.EXPECT().Setenv(gomock.Any(), gomock.Any()).AnyTimes()
+	cniClient.EXPECT().Del(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	err := p.ConfigureInterface(context.TODO(), netNSPath, eni, nil)
+	require.NoError(t, err)
+	assert.Equal(t, networkinterface.DefaultTapDeviceName, eni.DeviceName)
+}
+
+func TestIsolatedLinux_ConfigureInterface_RegularENI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	p, osWrapper, cniClient, _, _ := newIsolatedLinuxPlatform(ctrl)
+	eni := getTestRegularV4ENI()
+	eni.DesiredStatus = status.NetworkReadyPull
+
+	eniConfig := createENIPluginConfigs(netNSPath, eni)
+	gomock.InOrder(
+		osWrapper.EXPECT().Setenv(CNIPluginLogFileEnv, gomock.Any()),
+		osWrapper.EXPECT().Setenv(IPAMDataPathEnv, filepath.Join("dummy-db-dir", IPAMDataFileName)),
+		cniClient.EXPECT().Add(gomock.Any(), eniConfig).Return(nil, nil),
+	)
+
+	err := p.configureRegularENI(context.TODO(), netNSPath, eni)
+	require.NoError(t, err)
+}
+
+func TestIsolatedLinux_ConfigureInterface_RegularENI_Delete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	p, osWrapper, cniClient, _, _ := newIsolatedLinuxPlatform(ctrl)
+	eni := getTestRegularV4ENI()
+	eni.DesiredStatus = status.NetworkDeleted
+
+	eniConfig := createENIPluginConfigs(netNSPath, eni)
+	gomock.InOrder(
+		osWrapper.EXPECT().Setenv(CNIPluginLogFileEnv, gomock.Any()),
+		osWrapper.EXPECT().Setenv(IPAMDataPathEnv, filepath.Join("dummy-db-dir", IPAMDataFileName)),
+		cniClient.EXPECT().Del(gomock.Any(), eniConfig).Return(nil),
+	)
+
+	err := p.configureRegularENI(context.TODO(), netNSPath, eni)
+	require.NoError(t, err)
+}
+
+func TestIsolatedLinux_ConfigureInterface_BranchENI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	p, osWrapper, cniClient, _, _ := newIsolatedLinuxPlatform(ctrl)
+	eni := getTestBranchV4ENI()
+	eni.DesiredStatus = status.NetworkReadyPull
+
+	cniConfig := createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan, blockInstanceMetadataDefault)
+	gomock.InOrder(
+		osWrapper.EXPECT().Setenv(IPAMDataPathEnv, filepath.Join("dummy-db-dir", IPAMDataFileName)),
+		cniClient.EXPECT().Add(gomock.Any(), cniConfig).Return(nil, nil),
+	)
+
+	err := p.configureBranchENI(context.TODO(), netNSPath, eni)
+	require.NoError(t, err)
+}
+
+func TestIsolatedLinux_ConfigureInterface_BranchENI_Delete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	p, osWrapper, cniClient, _, _ := newIsolatedLinuxPlatform(ctrl)
+	eni := getTestBranchV4ENI()
+	eni.DesiredStatus = status.NetworkDeleted
+
+	cniConfig := createBranchENIConfig(netNSPath, eni, VPCBranchENIInterfaceTypeVlan, blockInstanceMetadataDefault)
+	gomock.InOrder(
+		osWrapper.EXPECT().Setenv(IPAMDataPathEnv, filepath.Join("dummy-db-dir", IPAMDataFileName)),
+		cniClient.EXPECT().Del(gomock.Any(), cniConfig).Return(nil),
+	)
+
+	err := p.configureBranchENI(context.TODO(), netNSPath, eni)
+	require.NoError(t, err)
+}
+
+func TestIsolatedLinux_ConfigureInterface_VETHDoesNothing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	p, _, _, _, _ := newIsolatedLinuxPlatform(ctrl)
+	eni := &networkinterface.NetworkInterface{
+		InterfaceAssociationProtocol: networkinterface.VETHInterfaceAssociationProtocol,
+		DesiredStatus:                status.NetworkReadyPull,
+	}
+
+	err := p.ConfigureInterface(context.TODO(), netNSPath, eni, nil)
+	require.NoError(t, err)
+}
+
+func TestIsolatedLinux_ConfigureInterface_InvalidProtocol(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	p, _, _, _, _ := newIsolatedLinuxPlatform(ctrl)
+	eni := &networkinterface.NetworkInterface{
+		InterfaceAssociationProtocol: "bogus",
+		DesiredStatus:                status.NetworkReadyPull,
+	}
+
+	err := p.ConfigureInterface(context.TODO(), netNSPath, eni, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid interface association protocol")
+}
+
+func TestIsolatedLinux_AddGatewayNeighbor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	gwMAC, _ := net.ParseMAC("0a:1b:2c:3d:4e:5f")
+	mockLink := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Index: 7, Name: "eth0"}}
+
+	p, _, _, mockNSUtil, mockNetLink := newIsolatedLinuxPlatform(ctrl)
+	eni := getTestRegularV4ENI()
+	eni.DeviceName = "eth0"
+
+	// resolveHostNeighbor: return gateway MAC
+	mockNetLink.EXPECT().NeighList(0, netlink.FAMILY_V4).Return([]netlink.Neigh{
+		{IP: net.ParseIP("10.1.0.1"), HardwareAddr: gwMAC},
+	}, nil)
+
+	// ExecInNSPath: execute the closure
+	mockNSUtil.EXPECT().ExecInNSPath(netNSPath, gomock.Any()).DoAndReturn(
+		func(path string, fn func(cnins.NetNS) error) error {
+			return fn(nil)
+		})
+
+	mockNetLink.EXPECT().LinkByName("eth0").Return(mockLink, nil)
+	mockNetLink.EXPECT().NeighSet(gomock.Any()).DoAndReturn(func(neigh *netlink.Neigh) error {
+		assert.Equal(t, 7, neigh.LinkIndex)
+		assert.Equal(t, netlink.NUD_PERMANENT, neigh.State)
+		assert.True(t, neigh.IP.Equal(net.ParseIP("10.1.0.1")))
+		assert.Equal(t, gwMAC, neigh.HardwareAddr)
+		return nil
+	})
+	mockNetLink.EXPECT().RouteReplace(gomock.Any()).DoAndReturn(func(route *netlink.Route) error {
+		assert.Equal(t, 7, route.LinkIndex)
+		assert.Equal(t, "10.1.0.1/32", route.Dst.String())
+		assert.Equal(t, netlink.SCOPE_LINK, route.Scope)
+		return nil
+	})
+
+	err := p.addGatewayNeighbor(netNSPath, eni)
+	require.NoError(t, err)
+}
+
+func TestIsolatedLinux_AddGatewayNeighbor_NoGateway(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	p, _, _, _, _ := newIsolatedLinuxPlatform(ctrl)
+	eni := getTestRegularV4ENI()
+	eni.SubnetGatewayIPV4Address = ""
+
+	err := p.addGatewayNeighbor(netNSPath, eni)
+	require.NoError(t, err)
+}
+
+func TestIsolatedLinux_AddGatewayNeighbor_HostNeighborNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	p, _, _, _, mockNetLink := newIsolatedLinuxPlatform(ctrl)
+	eni := getTestRegularV4ENI()
+	eni.DeviceName = "eth0"
+
+	mockNetLink.EXPECT().NeighList(0, netlink.FAMILY_V4).Return([]netlink.Neigh{}, nil)
+
+	err := p.addGatewayNeighbor(netNSPath, eni)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "gateway MAC not in host neighbor cache")
+}

--- a/ecs-agent/utils/netlinkwrapper/mocks/netlinkwrapper_mocks_linux.go
+++ b/ecs-agent/utils/netlinkwrapper/mocks/netlinkwrapper_mocks_linux.go
@@ -122,6 +122,35 @@ func (mr *MockNetLinkMockRecorder) LinkSetUp(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSetUp", reflect.TypeOf((*MockNetLink)(nil).LinkSetUp), arg0)
 }
 
+// NeighList mocks base method.
+func (m *MockNetLink) NeighList(arg0, arg1 int) ([]netlink.Neigh, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NeighList", arg0, arg1)
+	ret0, _ := ret[0].([]netlink.Neigh)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NeighList indicates an expected call of NeighList.
+func (mr *MockNetLinkMockRecorder) NeighList(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeighList", reflect.TypeOf((*MockNetLink)(nil).NeighList), arg0, arg1)
+}
+
+// NeighSet mocks base method.
+func (m *MockNetLink) NeighSet(arg0 *netlink.Neigh) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NeighSet", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// NeighSet indicates an expected call of NeighSet.
+func (mr *MockNetLinkMockRecorder) NeighSet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeighSet", reflect.TypeOf((*MockNetLink)(nil).NeighSet), arg0)
+}
+
 // RouteAdd mocks base method.
 func (m *MockNetLink) RouteAdd(arg0 *netlink.Route) error {
 	m.ctrl.T.Helper()
@@ -163,4 +192,18 @@ func (m *MockNetLink) RouteList(arg0 netlink.Link, arg1 int) ([]netlink.Route, e
 func (mr *MockNetLinkMockRecorder) RouteList(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteList", reflect.TypeOf((*MockNetLink)(nil).RouteList), arg0, arg1)
+}
+
+// RouteReplace mocks base method.
+func (m *MockNetLink) RouteReplace(arg0 *netlink.Route) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RouteReplace", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RouteReplace indicates an expected call of RouteReplace.
+func (mr *MockNetLinkMockRecorder) RouteReplace(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteReplace", reflect.TypeOf((*MockNetLink)(nil).RouteReplace), arg0)
 }

--- a/ecs-agent/utils/netlinkwrapper/netlink_linux.go
+++ b/ecs-agent/utils/netlinkwrapper/netlink_linux.go
@@ -28,7 +28,10 @@ type NetLink interface {
 	LinkList() ([]netlink.Link, error)
 	RouteAdd(route *netlink.Route) error
 	RouteDel(route *netlink.Route) error
+	RouteReplace(route *netlink.Route) error
 	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)
+	NeighList(linkIndex, family int) ([]netlink.Neigh, error)
+	NeighSet(neigh *netlink.Neigh) error
 }
 
 type netLink struct{}
@@ -70,4 +73,16 @@ func (nl *netLink) RouteDel(route *netlink.Route) error {
 
 func (nl *netLink) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
 	return netlink.AddrList(link, family)
+}
+
+func (nl *netLink) RouteReplace(route *netlink.Route) error {
+	return netlink.RouteReplace(route)
+}
+
+func (nl *netLink) NeighList(linkIndex, family int) ([]netlink.Neigh, error) {
+	return netlink.NeighList(linkIndex, family)
+}
+
+func (nl *netLink) NeighSet(neigh *netlink.Neigh) error {
+	return netlink.NeighSet(neigh)
 }

--- a/ecs-init/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper/mocks/netlinkwrapper_mocks_linux.go
+++ b/ecs-init/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper/mocks/netlinkwrapper_mocks_linux.go
@@ -122,6 +122,35 @@ func (mr *MockNetLinkMockRecorder) LinkSetUp(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSetUp", reflect.TypeOf((*MockNetLink)(nil).LinkSetUp), arg0)
 }
 
+// NeighList mocks base method.
+func (m *MockNetLink) NeighList(arg0, arg1 int) ([]netlink.Neigh, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NeighList", arg0, arg1)
+	ret0, _ := ret[0].([]netlink.Neigh)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NeighList indicates an expected call of NeighList.
+func (mr *MockNetLinkMockRecorder) NeighList(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeighList", reflect.TypeOf((*MockNetLink)(nil).NeighList), arg0, arg1)
+}
+
+// NeighSet mocks base method.
+func (m *MockNetLink) NeighSet(arg0 *netlink.Neigh) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NeighSet", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// NeighSet indicates an expected call of NeighSet.
+func (mr *MockNetLinkMockRecorder) NeighSet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeighSet", reflect.TypeOf((*MockNetLink)(nil).NeighSet), arg0)
+}
+
 // RouteAdd mocks base method.
 func (m *MockNetLink) RouteAdd(arg0 *netlink.Route) error {
 	m.ctrl.T.Helper()
@@ -163,4 +192,18 @@ func (m *MockNetLink) RouteList(arg0 netlink.Link, arg1 int) ([]netlink.Route, e
 func (mr *MockNetLinkMockRecorder) RouteList(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteList", reflect.TypeOf((*MockNetLink)(nil).RouteList), arg0, arg1)
+}
+
+// RouteReplace mocks base method.
+func (m *MockNetLink) RouteReplace(arg0 *netlink.Route) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RouteReplace", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RouteReplace indicates an expected call of RouteReplace.
+func (mr *MockNetLinkMockRecorder) RouteReplace(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteReplace", reflect.TypeOf((*MockNetLink)(nil).RouteReplace), arg0)
 }

--- a/ecs-init/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper/netlink_linux.go
+++ b/ecs-init/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper/netlink_linux.go
@@ -28,7 +28,10 @@ type NetLink interface {
 	LinkList() ([]netlink.Link, error)
 	RouteAdd(route *netlink.Route) error
 	RouteDel(route *netlink.Route) error
+	RouteReplace(route *netlink.Route) error
 	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)
+	NeighList(linkIndex, family int) ([]netlink.Neigh, error)
+	NeighSet(neigh *netlink.Neigh) error
 }
 
 type netLink struct{}
@@ -70,4 +73,16 @@ func (nl *netLink) RouteDel(route *netlink.Route) error {
 
 func (nl *netLink) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
 	return netlink.AddrList(link, family)
+}
+
+func (nl *netLink) RouteReplace(route *netlink.Route) error {
+	return netlink.RouteReplace(route)
+}
+
+func (nl *netLink) NeighList(linkIndex, family int) ([]netlink.Neigh, error) {
+	return netlink.NeighList(linkIndex, family)
+}
+
+func (nl *netLink) NeighSet(neigh *netlink.Neigh) error {
+	return netlink.NeighSet(neigh)
 }


### PR DESCRIPTION
### Summary

Adds the `isolated` platform to netlib for containers running inside micro VMs (e.g., Firecracker). On this platform, TMDS runs guest-locally so the ecs-bridge CNI plugin is unnecessary. The new platform skips the bridge, sets the ENI as `eth0` in the task netns, and installs a permanent ARP neighbor entry for the VPC gateway so the VM shim can configure guest-side networking without relying on L2 broadcast.

### Implementation details

**New platform type (`isolated_linux.go`):**
- `isolatedLinux` struct embeds `managedLinux` and overrides `ConfigureInterface`.
- For regular and branch ENIs, sets `DeviceName` to `eth0` (the default TAP device name) and runs the ENI/branch-ENI CNI plugins without the bridge plugin.
- After successful interface configuration (ADD path), calls `addGatewayNeighbor` to install a `NUD_PERMANENT` ARP entry and a `/32 link-scope` route for the subnet gateway in the task netns. This allows the VM shim to read the permanent neighbor and configure the guest without ARP broadcast.

**Gateway neighbor resolution (`addGatewayNeighbor` / `resolveHostNeighbor`):**
- Resolves the gateway MAC from the host's ARP table before entering the task netns.
- Enters the task netns, looks up the ENI by device name, and installs both the permanent neighbor entry and the /32 link-scope route.

**NetLink wrapper extensions:**
- Adds `RouteReplace`, `NeighList`, and `NeighSet` to the `NetLink` interface and its mock, enabling neighbor table and route manipulation from platform code.

**Platform registration (`common.go` / `common_linux.go`):**
- Registers `isolated` and `ec2-debug-isolated` platform names in the factory.

### Testing

Unit tests in `isolated_linux_test.go` cover:
- `ConfigureInterface` sets device name to `eth0` for both regular and branch ENIs.
- Regular ENI add/delete paths invoke the correct CNI operations without the bridge plugin.
- Branch ENI add/delete paths invoke the correct CNI operations.
- VETH interfaces are no-ops; invalid protocols return errors.
- `addGatewayNeighbor` installs a `NUD_PERMANENT` neighbor and `/32 link-scope` route with correct parameters.
- `addGatewayNeighbor` is a no-op when no gateway IP is configured.
- `addGatewayNeighbor` returns an error when the host neighbor cache has no entry for the gateway.

New tests cover the changes: yes

### Description for the changelog

Feature - Add isolated platform to netlib for micro VM networking with static gateway neighbor installation

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No.

**Does this PR include the addition of new environment variables in the README?**
No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
