### PR TITLE
Fix flaky TestDPEAndACSConnFailureTrackerTracking nil pointer panic

### DIFF
--- a/ecs-agent/acs/session/session_test.go
+++ b/ecs-agent/acs/session/session_test.go
@@ -1564,6 +1564,12 @@ func TestDPEAndACSConnFailureTrackerTracking(t *testing.T) {
 				metricsFactory:        metricsfactory.NewNopEntryFactory(),
 				dpeFailureTracker:     dpeFailureTracker,
 				acsConnFailureTracker: acsConnFailureTracker,
+				heartbeatTimeout:      20 * time.Millisecond,
+				heartbeatJitter:       10 * time.Millisecond,
+				disconnectTimeout:     30 * time.Millisecond,
+				disconnectJitter:      10 * time.Millisecond,
+				backoff: retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax,
+					connectionBackoffJitter, connectionBackoffMultiplier),
 			}
 
 			err := s.startSessionOnce(context.Background())


### PR DESCRIPTION
### Summary

Fix flaky `TestDPEAndACSConnFailureTrackerTracking` that intermittently panics with nil pointer dereference in CI.

### Implementation details

The test's session struct was missing `backoff` and timeout fields. In the "DPE success and ACS connect success" subcase, `startSessionOnce` reaches `startACSSession`, which creates a `backoffResetTimer` via `time.AfterFunc(AddJitter(s.heartbeatTimeout, s.heartbeatJitter), ...)`. With both timeout fields at zero, the timer fires immediately in a separate goroutine. If that goroutine runs before the deferred `cancel()`, it calls `s.backoff.Reset()` on a nil pointer — crashing the test binary.

The fix adds `heartbeatTimeout`, `heartbeatJitter`, `disconnectTimeout`, `disconnectJitter`, and `backoff` to the session struct in the test, matching the pattern used by all other tests in the file.

### Testing

- Reproduced the panic locally with `-count=500` (hit within ~100 iterations)
- Verified fix passes 500 iterations without panic
- Verified fix passes 500 iterations with `-race` detector
- Full ACS session test suite passes

New tests cover the changes: no (this fixes an existing test)

### Description for the changelog

- Bugfix - Fix flaky TestDPEAndACSConnFailureTrackerTracking nil pointer panic caused by missing session fields

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No

**Does this PR include the addition of new environment variables in the README?**
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
