### PR TITLE
Emit failure metrics from IMDS credentials scanner

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -1034,7 +1034,9 @@ func (agent *ecsAgent) getIMDSCredentialsRefresher(
 	taskEngine engine.TaskEngine,
 ) *imdscreds.IMDSCredentialsRefresher {
 	if agent.cfg.IMDSIAMRolesEnabled {
-		imdsScanner := imds.NewScanner(agent.ec2MetadataClient)
+		// The agent passes a no-op metrics factory; scanner-emitted metrics,
+		// like other agent runtime metrics, are not consumed today.
+		imdsScanner := imds.NewScanner(agent.ec2MetadataClient, metricsfactory.NewNopEntryFactory())
 		return imdscreds.NewIMDSCredentialsRefresher(
 			agent.ctx, imdsScanner, credentialsManager,
 			taskEngine, imdscreds.ScanInterval,

--- a/agent/imdscreds/refresher_integ_test.go
+++ b/agent/imdscreds/refresher_integ_test.go
@@ -28,6 +28,7 @@ import (
 	ecsagentimds "github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/testutil"
 	ecsagentec2 "github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
 
 	sdkimds "github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/stretchr/testify/assert"
@@ -75,7 +76,7 @@ func TestIMDSCredentialsRefresh(t *testing.T) {
 	defer cleanup()
 
 	// Setup the IMDS scanner.
-	scanner := ecsagentimds.NewScanner(newEC2Client(t, mockIMDS.URL()))
+	scanner := ecsagentimds.NewScanner(newEC2Client(t, mockIMDS.URL()), metrics.NewNopEntryFactory())
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Setup the credentials refresher.

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/scanner.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/scanner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
 
 	"golang.org/x/time/rate"
 )
@@ -56,6 +57,18 @@ const (
 
 	// imdsQueryBurstSize is the token bucket size for the rate limiter.
 	imdsQueryBurstSize = 1
+
+	// Field names attached to scanner failure metrics.
+	//
+	// metricFieldNamespace identifies the iam-ecs-* namespace this metric entry
+	// pertains to.
+	metricFieldNamespace = "Namespace"
+	// metricFieldTaskID identifies the task whose credential entry caused this
+	// metric emission.
+	metricFieldTaskID = "TaskID"
+	// metricFieldRoleType identifies the role type (e.g., TaskApplication,
+	// TaskExecution) of the credential that failed.
+	metricFieldRoleType = "RoleType"
 )
 
 // Scanner fetches task credentials from IMDS iam-ecs-* namespaces.
@@ -66,21 +79,24 @@ type Scanner interface {
 }
 
 // scanner implements the Scanner interface.
-// TODO: add metricsFactory for operational metrics on scan failures.
 type scanner struct {
 	ec2MetadataClient ec2.EC2MetadataClient
 	// rateLimiter controls the rate of IMDS requests.
 	rateLimiter *rate.Limiter
 	// lastUpdated tracks the LastUpdated timestamp from each namespace's info file.
 	lastUpdated map[string]time.Time
+	// metricsFactory emits metrics for scan operations.
+	metricsFactory metrics.EntryFactory
 }
 
 // NewScanner creates a new IMDS credentials scanner.
-func NewScanner(ec2MetadataClient ec2.EC2MetadataClient) Scanner {
+func NewScanner(ec2MetadataClient ec2.EC2MetadataClient,
+	metricsFactory metrics.EntryFactory) Scanner {
 	return &scanner{
 		ec2MetadataClient: ec2MetadataClient,
 		rateLimiter:       rate.NewLimiter(rate.Limit(imdsQueriesPerSec), imdsQueryBurstSize),
 		lastUpdated:       make(map[string]time.Time),
+		metricsFactory:    metricsFactory,
 	}
 }
 
@@ -94,7 +110,7 @@ func (s *scanner) Scan(ctx context.Context) ([]TaskCredential, error) {
 
 	// No namespaces is expected when IMDS does not have ECS task credentials yet.
 	if len(namespaces) == 0 {
-		logger.Debug("No iam-ecs namespaces found in IMDS")
+		logger.Debug("No iam-ecs namespace found in IMDS")
 		return nil, nil
 	}
 
@@ -108,14 +124,15 @@ func (s *scanner) Scan(ctx context.Context) ([]TaskCredential, error) {
 				field.Error: err,
 			})
 			scanErrors = append(scanErrors, err)
-			// Scanning for a namespace failed; try scanning remaining namespaces before returning.
+			// Scanning for a namespace failed; try scanning remaining
+			// namespaces before returning.
 			continue
 		}
 		creds = append(creds, nsCreds...)
 	}
 
-	// Surface an error when all namespaces failed so the caller doesn't
-	// mistake it for "no credentials yet".
+	// Surface an error when scanning all namespaces failed so
+	// the caller doesn't mistake it for "no credentials yet".
 	if len(creds) == 0 && len(scanErrors) > 0 {
 		return nil, fmt.Errorf("imds scan: all %d namespace(s) failed: %w",
 			len(scanErrors), errors.Join(scanErrors...))
@@ -154,17 +171,29 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 	infoPath := fmt.Sprintf(infoPathFormat, namespace)
 	infoResp, err := s.getMetadata(ctx, infoPath)
 	if err != nil {
+		s.metricsFactory.New(metrics.IMDSCredentialsScannerNamespaceInfoFailureMetricName).
+			WithFields(map[string]any{
+				metricFieldNamespace: namespace,
+			}).Done(err)
 		return nil, fmt.Errorf("fetch info for %s: %w", namespace, err)
 	}
 
 	var info NamespaceInfo
 	if err := json.Unmarshal([]byte(infoResp), &info); err != nil {
+		s.metricsFactory.New(metrics.IMDSCredentialsScannerNamespaceInfoFailureMetricName).
+			WithFields(map[string]any{
+				metricFieldNamespace: namespace,
+			}).Done(err)
 		return nil, fmt.Errorf("parse info for %s: %w", namespace, err)
 	}
 
 	// Skip credential fetches if the namespace hasn't been updated since the last scan.
 	lastUpdated, err := time.Parse(time.RFC3339, info.LastUpdated)
 	if err != nil {
+		s.metricsFactory.New(metrics.IMDSCredentialsScannerNamespaceInfoFailureMetricName).
+			WithFields(map[string]any{
+				metricFieldNamespace: namespace,
+			}).Done(err)
 		return nil, fmt.Errorf("parse LastUpdated for %s: %w", namespace, err)
 	}
 	if cached, ok := s.lastUpdated[namespace]; ok && lastUpdated.Equal(cached) {
@@ -183,7 +212,11 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 				"namespace": namespace,
 				field.Error: err,
 			})
-			// Cannot determine task ID; attempt the next credential.
+			s.metricsFactory.New(metrics.IMDSCredentialsScannerCredentialFailureMetricName).
+				WithFields(map[string]any{
+					metricFieldNamespace: namespace,
+				}).Done(err)
+			// Cannot determine task ID and role type; attempt the next credential.
 			hasErrors = true
 			continue
 		}
@@ -191,24 +224,38 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 		credPath := fmt.Sprintf(credentialPathFormat, namespace, key)
 		credResp, err := s.getMetadata(ctx, credPath)
 		if err != nil {
-			logger.Error("Failed to fetch from IMDS", logger.Fields{
+			logger.Error("Failed to fetch credential from IMDS", logger.Fields{
 				field.TaskID: taskID,
+				"roleType":   roleType,
 				"namespace":  namespace,
 				field.Error:  err,
 			})
-			// Fetch failed; try remaining credentials in this namespace.
+			s.metricsFactory.New(metrics.IMDSCredentialsScannerCredentialFailureMetricName).
+				WithFields(map[string]any{
+					metricFieldNamespace: namespace,
+					metricFieldTaskID:    taskID,
+					metricFieldRoleType:  roleType,
+				}).Done(err)
+			// Error fetching credential; try remaining credentials in this namespace.
 			hasErrors = true
 			continue
 		}
 
 		var imdsCred imdsCredential
 		if err := json.Unmarshal([]byte(credResp), &imdsCred); err != nil {
-			logger.Error("Failed to parse IMDS response", logger.Fields{
+			logger.Error("Failed to parse credential from IMDS", logger.Fields{
 				field.TaskID: taskID,
+				"roleType":   roleType,
 				"namespace":  namespace,
 				field.Error:  err,
 			})
-			// Error parsing response; try remaining credentials in this namespace.
+			s.metricsFactory.New(metrics.IMDSCredentialsScannerCredentialFailureMetricName).
+				WithFields(map[string]any{
+					metricFieldNamespace: namespace,
+					metricFieldTaskID:    taskID,
+					metricFieldRoleType:  roleType,
+				}).Done(err)
+			// Error parsing credential; try remaining credentials in this namespace.
 			hasErrors = true
 			continue
 		}
@@ -224,10 +271,16 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 		})
 	}
 
-	// Only cache LastUpdated if all credentials were fetched successfully,
+	// Only cache LastUpdated if there are no failures recorded,
 	// so that failed fetches are retried on the next scan.
 	if !hasErrors {
 		s.lastUpdated[namespace] = lastUpdated
+	}
+
+	// Surface an error when the namespace yielded no credentials and also had
+	// failures, so callers don't mistake it for "no credentials yet".
+	if len(creds) == 0 && hasErrors {
+		return nil, fmt.Errorf("namespace %s: all credential processing failed", namespace)
 	}
 
 	return creds, nil

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/metrics/constants.go
@@ -90,4 +90,11 @@ const (
 	DeleteNetworkNamespaceMetricName      = networkBuilderNamespace + ".DeleteNetworkNamespace"
 	V2NDestinationPortExhaustedMetricName = networkBuilderNamespace + ".V2NDestinationPortExhausted"
 	ReleaseGeneveDstPortMetricName        = dbClientMetricNamespace + ".ReleaseGeneveDstPort"
+
+	// IMDS credentials scanner metrics
+	imdsCredentialsScannerMetricNamespace                = "IMDSCredentialsScanner"
+	IMDSCredentialsScannerNamespaceInfoFailureMetricName = imdsCredentialsScannerMetricNamespace +
+		".NamespaceInfoFailure"
+	IMDSCredentialsScannerCredentialFailureMetricName = imdsCredentialsScannerMetricNamespace +
+		".CredentialFailure"
 )

--- a/ecs-agent/credentials/imds/scanner.go
+++ b/ecs-agent/credentials/imds/scanner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ec2"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
 
 	"golang.org/x/time/rate"
 )
@@ -56,6 +57,18 @@ const (
 
 	// imdsQueryBurstSize is the token bucket size for the rate limiter.
 	imdsQueryBurstSize = 1
+
+	// Field names attached to scanner failure metrics.
+	//
+	// metricFieldNamespace identifies the iam-ecs-* namespace this metric entry
+	// pertains to.
+	metricFieldNamespace = "Namespace"
+	// metricFieldTaskID identifies the task whose credential entry caused this
+	// metric emission.
+	metricFieldTaskID = "TaskID"
+	// metricFieldRoleType identifies the role type (e.g., TaskApplication,
+	// TaskExecution) of the credential that failed.
+	metricFieldRoleType = "RoleType"
 )
 
 // Scanner fetches task credentials from IMDS iam-ecs-* namespaces.
@@ -66,21 +79,24 @@ type Scanner interface {
 }
 
 // scanner implements the Scanner interface.
-// TODO: add metricsFactory for operational metrics on scan failures.
 type scanner struct {
 	ec2MetadataClient ec2.EC2MetadataClient
 	// rateLimiter controls the rate of IMDS requests.
 	rateLimiter *rate.Limiter
 	// lastUpdated tracks the LastUpdated timestamp from each namespace's info file.
 	lastUpdated map[string]time.Time
+	// metricsFactory emits metrics for scan operations.
+	metricsFactory metrics.EntryFactory
 }
 
 // NewScanner creates a new IMDS credentials scanner.
-func NewScanner(ec2MetadataClient ec2.EC2MetadataClient) Scanner {
+func NewScanner(ec2MetadataClient ec2.EC2MetadataClient,
+	metricsFactory metrics.EntryFactory) Scanner {
 	return &scanner{
 		ec2MetadataClient: ec2MetadataClient,
 		rateLimiter:       rate.NewLimiter(rate.Limit(imdsQueriesPerSec), imdsQueryBurstSize),
 		lastUpdated:       make(map[string]time.Time),
+		metricsFactory:    metricsFactory,
 	}
 }
 
@@ -94,7 +110,7 @@ func (s *scanner) Scan(ctx context.Context) ([]TaskCredential, error) {
 
 	// No namespaces is expected when IMDS does not have ECS task credentials yet.
 	if len(namespaces) == 0 {
-		logger.Debug("No iam-ecs namespaces found in IMDS")
+		logger.Debug("No iam-ecs namespace found in IMDS")
 		return nil, nil
 	}
 
@@ -108,14 +124,15 @@ func (s *scanner) Scan(ctx context.Context) ([]TaskCredential, error) {
 				field.Error: err,
 			})
 			scanErrors = append(scanErrors, err)
-			// Scanning for a namespace failed; try scanning remaining namespaces before returning.
+			// Scanning for a namespace failed; try scanning remaining
+			// namespaces before returning.
 			continue
 		}
 		creds = append(creds, nsCreds...)
 	}
 
-	// Surface an error when all namespaces failed so the caller doesn't
-	// mistake it for "no credentials yet".
+	// Surface an error when scanning all namespaces failed so
+	// the caller doesn't mistake it for "no credentials yet".
 	if len(creds) == 0 && len(scanErrors) > 0 {
 		return nil, fmt.Errorf("imds scan: all %d namespace(s) failed: %w",
 			len(scanErrors), errors.Join(scanErrors...))
@@ -154,17 +171,29 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 	infoPath := fmt.Sprintf(infoPathFormat, namespace)
 	infoResp, err := s.getMetadata(ctx, infoPath)
 	if err != nil {
+		s.metricsFactory.New(metrics.IMDSCredentialsScannerNamespaceInfoFailureMetricName).
+			WithFields(map[string]any{
+				metricFieldNamespace: namespace,
+			}).Done(err)
 		return nil, fmt.Errorf("fetch info for %s: %w", namespace, err)
 	}
 
 	var info NamespaceInfo
 	if err := json.Unmarshal([]byte(infoResp), &info); err != nil {
+		s.metricsFactory.New(metrics.IMDSCredentialsScannerNamespaceInfoFailureMetricName).
+			WithFields(map[string]any{
+				metricFieldNamespace: namespace,
+			}).Done(err)
 		return nil, fmt.Errorf("parse info for %s: %w", namespace, err)
 	}
 
 	// Skip credential fetches if the namespace hasn't been updated since the last scan.
 	lastUpdated, err := time.Parse(time.RFC3339, info.LastUpdated)
 	if err != nil {
+		s.metricsFactory.New(metrics.IMDSCredentialsScannerNamespaceInfoFailureMetricName).
+			WithFields(map[string]any{
+				metricFieldNamespace: namespace,
+			}).Done(err)
 		return nil, fmt.Errorf("parse LastUpdated for %s: %w", namespace, err)
 	}
 	if cached, ok := s.lastUpdated[namespace]; ok && lastUpdated.Equal(cached) {
@@ -183,7 +212,11 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 				"namespace": namespace,
 				field.Error: err,
 			})
-			// Cannot determine task ID; attempt the next credential.
+			s.metricsFactory.New(metrics.IMDSCredentialsScannerCredentialFailureMetricName).
+				WithFields(map[string]any{
+					metricFieldNamespace: namespace,
+				}).Done(err)
+			// Cannot determine task ID and role type; attempt the next credential.
 			hasErrors = true
 			continue
 		}
@@ -191,24 +224,38 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 		credPath := fmt.Sprintf(credentialPathFormat, namespace, key)
 		credResp, err := s.getMetadata(ctx, credPath)
 		if err != nil {
-			logger.Error("Failed to fetch from IMDS", logger.Fields{
+			logger.Error("Failed to fetch credential from IMDS", logger.Fields{
 				field.TaskID: taskID,
+				"roleType":   roleType,
 				"namespace":  namespace,
 				field.Error:  err,
 			})
-			// Fetch failed; try remaining credentials in this namespace.
+			s.metricsFactory.New(metrics.IMDSCredentialsScannerCredentialFailureMetricName).
+				WithFields(map[string]any{
+					metricFieldNamespace: namespace,
+					metricFieldTaskID:    taskID,
+					metricFieldRoleType:  roleType,
+				}).Done(err)
+			// Error fetching credential; try remaining credentials in this namespace.
 			hasErrors = true
 			continue
 		}
 
 		var imdsCred imdsCredential
 		if err := json.Unmarshal([]byte(credResp), &imdsCred); err != nil {
-			logger.Error("Failed to parse IMDS response", logger.Fields{
+			logger.Error("Failed to parse credential from IMDS", logger.Fields{
 				field.TaskID: taskID,
+				"roleType":   roleType,
 				"namespace":  namespace,
 				field.Error:  err,
 			})
-			// Error parsing response; try remaining credentials in this namespace.
+			s.metricsFactory.New(metrics.IMDSCredentialsScannerCredentialFailureMetricName).
+				WithFields(map[string]any{
+					metricFieldNamespace: namespace,
+					metricFieldTaskID:    taskID,
+					metricFieldRoleType:  roleType,
+				}).Done(err)
+			// Error parsing credential; try remaining credentials in this namespace.
 			hasErrors = true
 			continue
 		}
@@ -224,10 +271,16 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 		})
 	}
 
-	// Only cache LastUpdated if all credentials were fetched successfully,
+	// Only cache LastUpdated if there are no failures recorded,
 	// so that failed fetches are retried on the next scan.
 	if !hasErrors {
 		s.lastUpdated[namespace] = lastUpdated
+	}
+
+	// Surface an error when the namespace yielded no credentials and also had
+	// failures, so callers don't mistake it for "no credentials yet".
+	if len(creds) == 0 && hasErrors {
+		return nil, fmt.Errorf("namespace %s: all credential processing failed", namespace)
 	}
 
 	return creds, nil

--- a/ecs-agent/credentials/imds/scanner_test.go
+++ b/ecs-agent/credentials/imds/scanner_test.go
@@ -1,3 +1,6 @@
+//go:build unit
+// +build unit
+
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -11,19 +14,20 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-//go:build unit
-
 package imds
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
-	mock_ec2 "github.com/aws/amazon-ecs-agent/ecs-agent/ec2/mocks"
+	mockec2 "github.com/aws/amazon-ecs-agent/ecs-agent/ec2/mocks"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
+	mockmetrics "github.com/aws/amazon-ecs-agent/ecs-agent/metrics/mocks"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/golang/mock/gomock"
@@ -84,13 +88,54 @@ func testCred(taskID, roleType, roleArn, accessKeyID string) TaskCredential {
 	}
 }
 
+// metricExpectation describes an expected metric emission for use with
+// expectMetricEmission in table-driven tests.
+type metricExpectation struct {
+	name    string
+	fields  map[string]any
+	doneErr any
+}
+
+// errContainsMatcher implements gomock.Matcher for matching errors whose
+// message contains a substring.
+type errContainsMatcher struct {
+	substr string
+}
+
+func (m errContainsMatcher) Matches(x any) bool {
+	err, ok := x.(error)
+	return ok && err != nil && strings.Contains(err.Error(), m.substr)
+}
+
+func (m errContainsMatcher) String() string {
+	return fmt.Sprintf("error containing %q", m.substr)
+}
+
+// errMessageContains returns a gomock matcher that matches errors whose
+// Error() string contains the given substring.
+func errMessageContains(substr string) gomock.Matcher {
+	return errContainsMatcher{substr: substr}
+}
+
+// expectMetricEmission registers gomock expectations for a single metric
+// emission of the form factory.New(name).WithFields(fields).Done(doneErr).
+func expectMetricEmission(
+	mf *mockmetrics.MockEntryFactory,
+	me *mockmetrics.MockEntry,
+	m metricExpectation,
+) {
+	mf.EXPECT().New(m.name).Return(me)
+	me.EXPECT().WithFields(m.fields).Return(me)
+	me.EXPECT().Done(m.doneErr)
+}
+
 func TestDiscoverNamespaces(t *testing.T) {
 	tests := []struct {
-		name      string
-		imdsResp  string
-		imdsErr   error
-		expected  []string
-		expectErr bool
+		name                 string
+		imdsResp             string
+		imdsErr              error
+		expected             []string
+		expectedErrSubstring string
 	}{
 		{
 			name:     "no iam-ecs namespaces",
@@ -123,9 +168,9 @@ func TestDiscoverNamespaces(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name:      "IMDS error",
-			imdsErr:   errors.New("connection refused"),
-			expectErr: true,
+			name:                 "IMDS error",
+			imdsErr:              errors.New("connection refused"),
+			expectedErrSubstring: "connection refused",
 		},
 	}
 
@@ -134,14 +179,15 @@ func TestDiscoverNamespaces(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mock := mock_ec2.NewMockEC2MetadataClient(ctrl)
+			mock := mockec2.NewMockEC2MetadataClient(ctrl)
 			mock.EXPECT().GetMetadata("").Return(tc.imdsResp, tc.imdsErr)
+			mockMetricsFactory := mockmetrics.NewMockEntryFactory(ctrl)
 
-			s := NewScanner(mock).(*scanner)
+			s := NewScanner(mock, mockMetricsFactory).(*scanner)
 			namespaces, err := s.discoverNamespaces(context.Background())
 
-			if tc.expectErr {
-				assert.Error(t, err)
+			if tc.expectedErrSubstring != "" {
+				assert.ErrorContains(t, err, tc.expectedErrSubstring)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expected, namespaces)
@@ -155,18 +201,19 @@ func TestScanNamespace(t *testing.T) {
 	key2 := testTaskID2 + "-" + credentials.ExecutionRoleType
 
 	tests := []struct {
-		name          string
-		setupMock     func(*mock_ec2.MockEC2MetadataClient)
-		lastUpdated   map[string]time.Time
-		expectedCreds []TaskCredential
-		expectErr     bool
+		name                 string
+		setupMock            func(*mockec2.MockEC2MetadataClient)
+		lastUpdated          map[string]time.Time
+		expectedCreds        []TaskCredential
+		expectedErrSubstring string
+		expectedMetrics      []metricExpectation
 		// expectLastUpdatedCached is a pointer to distinguish "don't check" (nil)
 		// from "assert not cached" (false).
 		expectLastUpdatedCached *bool
 	}{
 		{
 			name: "single credential",
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
 					testInfoJSON(map[string]string{key1: testRoleARN}), nil)
 				m.EXPECT().GetMetadata("iam-ecs-1/security-credentials/"+key1).Return(
@@ -179,7 +226,7 @@ func TestScanNamespace(t *testing.T) {
 		},
 		{
 			name: "multiple credentials",
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
 					testInfoJSON(map[string]string{
 						key1: testRoleARN,
@@ -197,32 +244,53 @@ func TestScanNamespace(t *testing.T) {
 		},
 		{
 			name: "info file fetch fails",
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
 					"", errors.New("not found"))
 			},
-			expectErr: true,
+			expectedErrSubstring: "fetch info for",
+			expectedMetrics: []metricExpectation{
+				{
+					name:    metrics.IMDSCredentialsScannerNamespaceInfoFailureMetricName,
+					fields:  map[string]any{metricFieldNamespace: "iam-ecs-1"},
+					doneErr: errMessageContains("not found"),
+				},
+			},
 		},
 		{
 			name: "info file invalid JSON",
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
 					"not json", nil)
 			},
-			expectErr: true,
+			expectedErrSubstring: "parse info for",
+			expectedMetrics: []metricExpectation{
+				{
+					name:    metrics.IMDSCredentialsScannerNamespaceInfoFailureMetricName,
+					fields:  map[string]any{metricFieldNamespace: "iam-ecs-1"},
+					doneErr: errMessageContains("invalid character"),
+				},
+			},
 		},
 		{
 			name: "invalid LastUpdated timestamp",
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
 					testInfoJSONWithTimestamp("not-a-timestamp",
 						map[string]string{key1: testRoleARN}), nil)
 			},
-			expectErr: true,
+			expectedErrSubstring: "parse LastUpdated for",
+			expectedMetrics: []metricExpectation{
+				{
+					name:    metrics.IMDSCredentialsScannerNamespaceInfoFailureMetricName,
+					fields:  map[string]any{metricFieldNamespace: "iam-ecs-1"},
+					doneErr: errMessageContains("parsing time"),
+				},
+			},
 		},
 		{
 			name: "fetch for one credential fails, other succeeds",
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
 					testInfoJSON(map[string]string{
 						key1: testRoleARN,
@@ -236,29 +304,62 @@ func TestScanNamespace(t *testing.T) {
 			expectedCreds: []TaskCredential{
 				testCred(testTaskID2, credentials.ExecutionRoleType, testRoleARN, "AKID2"),
 			},
+			expectedMetrics: []metricExpectation{
+				{
+					name: metrics.IMDSCredentialsScannerCredentialFailureMetricName,
+					fields: map[string]any{
+						metricFieldNamespace: "iam-ecs-1",
+						metricFieldTaskID:    testTaskID1,
+						metricFieldRoleType:  credentials.ApplicationRoleType,
+					},
+					doneErr: errMessageContains("timeout"),
+				},
+			},
 			expectLastUpdatedCached: aws.Bool(false),
 		},
 		{
 			name: "credential response invalid JSON",
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
 					testInfoJSON(map[string]string{key1: testRoleARN}), nil)
 				m.EXPECT().GetMetadata("iam-ecs-1/security-credentials/"+key1).Return(
 					"not json", nil)
 			},
+			expectedErrSubstring: "all credential processing failed",
+			expectedMetrics: []metricExpectation{
+				{
+					name: metrics.IMDSCredentialsScannerCredentialFailureMetricName,
+					fields: map[string]any{
+						metricFieldNamespace: "iam-ecs-1",
+						metricFieldTaskID:    testTaskID1,
+						metricFieldRoleType:  credentials.ApplicationRoleType,
+					},
+					doneErr: errMessageContains("invalid character"),
+				},
+			},
+			expectLastUpdatedCached: aws.Bool(false),
 		},
 		{
 			name: "invalid credential key format",
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
 					testInfoJSON(map[string]string{
 						"nodelimiterkey": testRoleARN,
 					}), nil)
 			},
+			expectedErrSubstring: "all credential processing failed",
+			expectedMetrics: []metricExpectation{
+				{
+					name:    metrics.IMDSCredentialsScannerCredentialFailureMetricName,
+					fields:  map[string]any{metricFieldNamespace: "iam-ecs-1"},
+					doneErr: errMessageContains("unexpected credential key format"),
+				},
+			},
+			expectLastUpdatedCached: aws.Bool(false),
 		},
 		{
 			name: "unchanged LastUpdated skips credential fetches",
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
 					testInfoJSON(map[string]string{key1: testRoleARN}), nil)
 			},
@@ -268,7 +369,7 @@ func TestScanNamespace(t *testing.T) {
 		},
 		{
 			name: "changed LastUpdated re-fetches credentials",
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
 					testInfoJSONWithTimestamp("2026-04-28T01:00:00Z",
 						map[string]string{key1: testRoleARN}), nil)
@@ -289,18 +390,25 @@ func TestScanNamespace(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mock := mock_ec2.NewMockEC2MetadataClient(ctrl)
+			mock := mockec2.NewMockEC2MetadataClient(ctrl)
 			tc.setupMock(mock)
 
-			s := NewScanner(mock).(*scanner)
+			mockMetricsFactory := mockmetrics.NewMockEntryFactory(ctrl)
+
+			for _, m := range tc.expectedMetrics {
+				mockEntry := mockmetrics.NewMockEntry(ctrl)
+				expectMetricEmission(mockMetricsFactory, mockEntry, m)
+			}
+
+			s := NewScanner(mock, mockMetricsFactory).(*scanner)
 			if tc.lastUpdated != nil {
 				s.lastUpdated = tc.lastUpdated
 			}
 
 			creds, err := s.scanNamespace(context.Background(), "iam-ecs-1")
 
-			if tc.expectErr {
-				assert.Error(t, err)
+			if tc.expectedErrSubstring != "" {
+				assert.ErrorContains(t, err, tc.expectedErrSubstring)
 				assert.Nil(t, creds)
 			} else {
 				assert.NoError(t, err)
@@ -369,21 +477,22 @@ func TestParseCredentialKey(t *testing.T) {
 
 func TestScan(t *testing.T) {
 	tests := []struct {
-		name          string
-		ctx           context.Context
-		setupMock     func(*mock_ec2.MockEC2MetadataClient)
-		expectedCreds []TaskCredential
-		expectErr     bool
+		name                 string
+		setupMock            func(*mockec2.MockEC2MetadataClient)
+		ctx                  context.Context
+		expectedCreds        []TaskCredential
+		expectedErrSubstring string
+		expectedMetrics      []metricExpectation
 	}{
 		{
 			name: "no namespaces",
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				m.EXPECT().GetMetadata("").Return("ami-id\niam/", nil)
 			},
 		},
 		{
 			name: "end to end with multiple namespaces",
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				key1 := testTaskID1 + "-" + credentials.ApplicationRoleType
 				key2 := testTaskID2 + "-" + credentials.ExecutionRoleType
 				m.EXPECT().GetMetadata("").Return("iam-ecs-1\niam-ecs-2", nil)
@@ -403,21 +512,33 @@ func TestScan(t *testing.T) {
 		},
 		{
 			name: "namespace discovery fails",
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				m.EXPECT().GetMetadata("").Return("", errors.New("unreachable"))
 			},
-			expectErr: true,
+			expectedErrSubstring: "imds scan: discover namespaces",
 		},
 		{
 			name: "all namespaces fail",
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				m.EXPECT().GetMetadata("").Return("iam-ecs-1\niam-ecs-2", nil)
 				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
 					"", errors.New("timeout"))
 				m.EXPECT().GetMetadata("iam-ecs-2/info").Return(
 					"", errors.New("timeout"))
 			},
-			expectErr: true,
+			expectedErrSubstring: "imds scan: all",
+			expectedMetrics: []metricExpectation{
+				{
+					name:    metrics.IMDSCredentialsScannerNamespaceInfoFailureMetricName,
+					fields:  map[string]any{metricFieldNamespace: "iam-ecs-1"},
+					doneErr: errMessageContains("timeout"),
+				},
+				{
+					name:    metrics.IMDSCredentialsScannerNamespaceInfoFailureMetricName,
+					fields:  map[string]any{metricFieldNamespace: "iam-ecs-2"},
+					doneErr: errMessageContains("timeout"),
+				},
+			},
 		},
 		{
 			name: "cancelled context",
@@ -426,8 +547,8 @@ func TestScan(t *testing.T) {
 				cancel()
 				return ctx
 			}(),
-			setupMock: func(m *mock_ec2.MockEC2MetadataClient) {},
-			expectErr: true,
+			setupMock:            func(m *mockec2.MockEC2MetadataClient) {},
+			expectedErrSubstring: "context canceled",
 		},
 	}
 
@@ -436,19 +557,26 @@ func TestScan(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mock := mock_ec2.NewMockEC2MetadataClient(ctrl)
+			mock := mockec2.NewMockEC2MetadataClient(ctrl)
 			tc.setupMock(mock)
+
+			mockMetricsFactory := mockmetrics.NewMockEntryFactory(ctrl)
+
+			for _, m := range tc.expectedMetrics {
+				mockEntry := mockmetrics.NewMockEntry(ctrl)
+				expectMetricEmission(mockMetricsFactory, mockEntry, m)
+			}
 
 			ctx := tc.ctx
 			if ctx == nil {
 				ctx = context.Background()
 			}
 
-			s := NewScanner(mock)
+			s := NewScanner(mock, mockMetricsFactory)
 			creds, err := s.Scan(ctx)
 
-			if tc.expectErr {
-				assert.Error(t, err)
+			if tc.expectedErrSubstring != "" {
+				assert.ErrorContains(t, err, tc.expectedErrSubstring)
 				assert.Nil(t, creds)
 			} else {
 				assert.NoError(t, err)

--- a/ecs-agent/metrics/constants.go
+++ b/ecs-agent/metrics/constants.go
@@ -90,4 +90,11 @@ const (
 	DeleteNetworkNamespaceMetricName      = networkBuilderNamespace + ".DeleteNetworkNamespace"
 	V2NDestinationPortExhaustedMetricName = networkBuilderNamespace + ".V2NDestinationPortExhausted"
 	ReleaseGeneveDstPortMetricName        = dbClientMetricNamespace + ".ReleaseGeneveDstPort"
+
+	// IMDS credentials scanner metrics
+	imdsCredentialsScannerMetricNamespace                = "IMDSCredentialsScanner"
+	IMDSCredentialsScannerNamespaceInfoFailureMetricName = imdsCredentialsScannerMetricNamespace +
+		".NamespaceInfoFailure"
+	IMDSCredentialsScannerCredentialFailureMetricName = imdsCredentialsScannerMetricNamespace +
+		".CredentialFailure"
 )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR adds failure metric emission to the IMDS credentials scanner in the shared library. The overall feature is disabled by the agents' configurations currently, so these new metrics won't show up in production just yet.

### Implementation details
<!-- How are the changes implemented? -->

- Add a metricsFactory parameter to NewScanner so the scanner can emit metrics.
- Emit IMDSCredentialsScannerNamespaceInfoFailure when fetching or parsing a namespace info file fails.
- Emit IMDSCredentialsScannerCredentialFailure when fetching or parsing an individual credential fails.
- Return an error from scanNamespace when all credentials in a namespace fail.
- Add metric name constants to ecs-agent/metrics/constants.go.
- Update agent/app and agent/imdscreds integ test to pass the new metricsFactory argument.


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes, updated existing unit tests with metric assertions.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement - Emit failure metrics from IMDS credentials scanner in the shared library.

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
