### PR TITLE
Add IsolatedDebugPlatform with DNS field backfill

### DIFF
--- a/ecs-agent/netlib/platform/common_linux.go
+++ b/ecs-agent/netlib/platform/common_linux.go
@@ -134,7 +134,7 @@ func NewPlatform(
 			common: commonPlatform,
 			client: ec2Client,
 		}, nil
-	case IsolatedPlatform, IsolatedDebugPlatform:
+	case IsolatedPlatform:
 		ec2Client, err := ec2.NewEC2MetadataClient(nil)
 		if err != nil {
 			return nil, err
@@ -143,6 +143,19 @@ func NewPlatform(
 			managedLinux: managedLinux{
 				common: commonPlatform,
 				client: ec2Client,
+			},
+		}, nil
+	case IsolatedDebugPlatform:
+		ec2Client, err := ec2.NewEC2MetadataClient(nil)
+		if err != nil {
+			return nil, err
+		}
+		return &isolatedDebug{
+			isolatedLinux: isolatedLinux{
+				managedLinux: managedLinux{
+					common: commonPlatform,
+					client: ec2Client,
+				},
 			},
 		}, nil
 	}
@@ -581,6 +594,39 @@ func (c *common) createResolvConf(netNSDir string,
 	return c.copyFile(filepath.Join(netNSDir, ResolveConfFileName),
 		filepath.Join(c.resolvConfPath, ResolveConfFileName),
 		taskDNSConfigFileMode)
+}
+
+// parseResolvConf extracts nameserver addresses and search domains from content
+// in the resolv.conf(5) format.
+//
+// Parsing rules (matching the behavior of Go's net.dnsReadConfig in
+// src/net/dnsconfig_unix.go and glibc's res_init):
+//   - Lines starting with ';' or '#' are treated as comments and skipped.
+//   - Fields are separated by any combination of spaces and tabs.
+//   - A "nameserver" line contributes one IP address (the second field).
+//   - A "search" line contributes all subsequent fields as search domains;
+//     if multiple search lines appear, only the last is used.
+//   - All other directives are ignored.
+func parseResolvConf(content []byte) (servers, searches []string) {
+	for _, line := range bytes.Split(content, []byte("\n")) {
+		if len(line) == 0 || line[0] == ';' || line[0] == '#' {
+			continue
+		}
+		fields := bytes.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		switch string(fields[0]) {
+		case "nameserver":
+			servers = append(servers, string(fields[1]))
+		case "search":
+			searches = nil
+			for _, f := range fields[1:] {
+				searches = append(searches, string(f))
+			}
+		}
+	}
+	return servers, searches
 }
 
 func (c *common) copyFile(dst, src string, fileMode os.FileMode) error {

--- a/ecs-agent/netlib/platform/common_linux_test.go
+++ b/ecs-agent/netlib/platform/common_linux_test.go
@@ -606,3 +606,78 @@ func TestParseHosts(t *testing.T) {
 		})
 	}
 }
+
+func TestParseResolvConf(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           string
+		expectedServers []string
+		expectedSearch  []string
+	}{
+		{
+			// Test fixture from Go's net package resolv.conf parser tests:
+			// https://github.com/golang/go/blob/master/src/net/testdata/resolv.conf
+			name: "Go stdlib test fixture",
+			input: "# /etc/resolv.conf\n" +
+				"domain localdomain\n" +
+				"nameserver 8.8.8.8\n" +
+				"nameserver 2001:4860:4860::8888\n" +
+				"nameserver fe80::1%lo0\n" +
+				"options ndots:5 timeout:10 attempts:3 rotate\n" +
+				"options attempts 3\n",
+			expectedServers: []string{"8.8.8.8", "2001:4860:4860::8888", "fe80::1%lo0"},
+			expectedSearch:  nil,
+		},
+		{
+			name:            "semicolon comments",
+			input:           "; this is a comment\nnameserver 8.8.8.8\n",
+			expectedServers: []string{"8.8.8.8"},
+			expectedSearch:  nil,
+		},
+		{
+			name:            "tabs as separators",
+			input:           "nameserver\t10.0.0.2\nsearch\tlocal\texample.com\n",
+			expectedServers: []string{"10.0.0.2"},
+			expectedSearch:  []string{"local", "example.com"},
+		},
+		{
+			name:            "multiple spaces between keyword and value",
+			input:           "nameserver   8.8.8.8\nsearch   example.com\n",
+			expectedServers: []string{"8.8.8.8"},
+			expectedSearch:  []string{"example.com"},
+		},
+		{
+			name: "last search directive wins",
+			input: "search first.com\n" +
+				"search second.com third.com\n",
+			expectedServers: nil,
+			expectedSearch:  []string{"second.com", "third.com"},
+		},
+		{
+			name:            "empty input",
+			input:           "",
+			expectedServers: nil,
+			expectedSearch:  nil,
+		},
+		{
+			name:            "only comments and blanks",
+			input:           "# comment\n\n; another\n",
+			expectedServers: nil,
+			expectedSearch:  nil,
+		},
+		{
+			name:            "unknown directives ignored",
+			input:           "options ndots:5\nnameserver 10.0.0.2\ndomain example.com\nsortlist 130.155.160.0\n",
+			expectedServers: []string{"10.0.0.2"},
+			expectedSearch:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			servers, searches := parseResolvConf([]byte(tc.input))
+			assert.Equal(t, tc.expectedServers, servers)
+			assert.Equal(t, tc.expectedSearch, searches)
+		})
+	}
+}

--- a/ecs-agent/netlib/platform/isolated_debug_linux.go
+++ b/ecs-agent/netlib/platform/isolated_debug_linux.go
@@ -1,0 +1,35 @@
+package platform
+
+import (
+	"path/filepath"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/tasknetworkconfig"
+	"github.com/pkg/errors"
+)
+
+type isolatedDebug struct {
+	isolatedLinux
+}
+
+func (d *isolatedDebug) CreateDNSConfig(taskID string, netNS *tasknetworkconfig.NetworkNamespace) error {
+	if err := d.createDNSConfig(taskID, true, netNS); err != nil {
+		return err
+	}
+
+	// Backfill interface DNS fields from the copied resolv.conf so downstream
+	// consumers can read DNS config from the model.
+	primaryIF := netNS.GetPrimaryInterface()
+	if primaryIF == nil || len(primaryIF.DomainNameServers) > 0 {
+		return nil
+	}
+
+	src := filepath.Join(d.resolvConfPath, ResolveConfFileName)
+	contents, err := d.ioutil.ReadFile(src)
+	if err != nil {
+		return errors.Wrapf(err, "unable to read %s", src)
+	}
+	servers, searches := parseResolvConf(contents)
+	primaryIF.DomainNameServers = servers
+	primaryIF.DomainNameSearchList = searches
+	return nil
+}


### PR DESCRIPTION
### Summary

When the ACS payload omits DomainNameServers, netlib copies the host's resolv.conf into the task volume but leaves the interface struct fields empty. This adds an IsolatedDebugPlatform that parses the copied resolv.conf back into the interface fields so the model reflects the DNS config that containers actually use. The backfill is scoped to the isolated debug platform.

### Implementation details

Add a new `IsolatedDebugPlatform` constant and `isolatedDebug` struct that embeds `containerd`. Its `CreateDNSConfig` method delegates to `createDNSConfig`, then—when the primary interface has no `DomainNameServers`—reads the resolv.conf that was just copied and backfills the interface fields.

The parser (`parseResolvConf`) is added to `common_linux.go` and follows resolv.conf(5) using the same rules as Go's `net.dnsReadConfig`:
- Lines starting with `;` or `#` are comments
- Fields split on any whitespace
- `nameserver` contributes one IP per line
- Last `search` directive wins

The platform factory in `NewPlatform` routes `IsolatedDebugPlatform` to the new struct.

### Testing

Unit tests for `parseResolvConf` covering:
- Go stdlib test fixture (IPv4, IPv6, zone-scoped nameservers, mixed directives)
- Semicolon and hash comments
- Tabs and multiple spaces as separators
- Last-search-wins semantics
- Empty input and unknown directives

New tests cover the changes: yes

### Description for the changelog

Enhancement - Add IsolatedDebugPlatform with DNS field backfill from host resolv.conf

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**

No. This adds a new platform type. `DomainNameServers` and `DomainNameSearchList` are `[]string` with `json:",omitempty"` — consumers already handle both nil and populated cases.

**Does this PR include the addition of new environment variables in the README?**

No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
