### PR TITLE
Fix TestClientProxy to obtain available port dynamically

### DIFF
--- a/ecs-agent/wsclient/client_test.go
+++ b/ecs-agent/wsclient/client_test.go
@@ -55,15 +55,19 @@ func (cs *ClientServerImpl) Close() error {
 }
 
 func TestClientProxy(t *testing.T) {
-	proxy_url := "127.0.0.1:1234"
-	os.Setenv("HTTP_PROXY", proxy_url)
+	// Choose the next available port to start the proxy
+	l, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	proxyURL := l.Addr().String()
+	l.Close()
+	os.Setenv("HTTP_PROXY", proxyURL)
 	defer os.Unsetenv("HTTP_PROXY")
 
 	types := []interface{}{ecsacs.AckRequest{}}
 	cs := getTestClientServer("http://www.amazon.com", types, 1)
-	_, err := cs.Connect(mockDisconnectTimeoutMetricName, DisconnectTimeout, DisconnectJitterMax)
+	_, err = cs.Connect(mockDisconnectTimeoutMetricName, DisconnectTimeout, DisconnectJitterMax)
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), proxy_url), "proxy not found: %s", err.Error())
+	assert.True(t, strings.Contains(err.Error(), proxyURL), "proxy not found: %s", err.Error())
 }
 
 // TestConcurrentWritesDontPanic will force a panic in the websocket library if


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Small PR to make `TestClientProxy` to obtain available port dynamically to start the proxy URL on. Without this, it may cause the test to run into the following error locally

```
=== RUN   TestClientProxy
1780951628455425737 [Info] logger=structured msg="Establishing a Websocket connection" url="http://www.amazon.com"
1780951628455503387 [Info] logger=structured msg="NO_PROXY is set: 169.254.169.254,169.254.170.2,/var/run/docker.sock"
    client_test.go:66: 
                Error Trace:    /home/yemike/go/src/github.com/aws/amazon-ecs-agent/ecs-agent/wsclient/client_test.go:66
                Error:          Should be true
                Test:           TestClientProxy
                Messages:       proxy not found: websocket client: unable to dial www.amazon.com response: : Forbidden
--- FAIL: TestClientProxy (0.00s)
```

### Implementation details
<!-- How are the changes implemented? -->

### Testing
* Ran `make test` locally

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
bugfix - Fix TestClientProxy to obtain available port dynamically 

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
