### PR TITLE
Fix flaky TestHostResourceManagerTrickleQueue integ test

### DIFF
--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -1638,16 +1638,21 @@ func TestHostResourceManagerTrickleQueue(t *testing.T) {
 	}()
 
 	// goroutine to verify task accounting
-	// After ~4s, 3rd task should be queued up and will not be dequeued until ~10s, i.e. until 1st task stops and gets dequeued
+	// After tasks 0 and 1 consume all resources, task 2 should be queued.
+	// Once task 0 stops and frees resources, task 2 should be dequeued.
 	go func() {
-		time.Sleep(6 * time.Second)
-		task, err := taskEngine.(*DockerTaskEngine).topTask()
-		assert.NoError(t, err, "one task should be queued up after 6s")
-		assert.Equal(t, task.Arn, tasks[2].Arn, "wrong task at top of queue")
+		// Wait for task 2 to appear in the queue eventually (it's added at ~4s, needs resource check to be queued)
+		// Will be polling every 500ms
+		assert.Eventually(t, func() bool {
+			task, err := taskEngine.(*DockerTaskEngine).topTask()
+			return err == nil && task.Arn == tasks[2].Arn
+		}, 10*time.Second, 500*time.Millisecond, "task 2 should be queued after resources are exhausted")
 
-		time.Sleep(6 * time.Second)
-		_, err = taskEngine.(*DockerTaskEngine).topTask()
-		assert.Error(t, err, "no task should be queued up after 12s")
+		// Wait for task 2 to be dequeued (after task 0 stops and frees resources)
+		assert.Eventually(t, func() bool {
+			_, err := taskEngine.(*DockerTaskEngine).topTask()
+			return err != nil
+		}, 10*time.Second, 500*time.Millisecond, "task 2 should be dequeued after resources are freed")
 	}()
 	waitFinished(t, finished, testTimeout)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
