### PR TITLE
Removed cloudwatch from windows agent capabilities

### DIFF
--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -32,7 +32,6 @@ var (
 	capabilityDepsRootDir  = filepath.Join(config.AmazonECSProgramFiles, "managed-agents")
 	ssmPluginDir           = filepath.Join(config.AmazonProgramFiles, "SSM", "Plugins")
 	sessionManagerShellDir = filepath.Join(ssmPluginDir, "SessionManagerShell")
-	awsCloudWatchDir       = filepath.Join(ssmPluginDir, "awsCloudWatch")
 	awsDomainJoin          = filepath.Join(ssmPluginDir, "awsDomainJoin")
 
 	capabilityExecRequiredBinaries = []string{
@@ -47,7 +46,6 @@ var (
 		configDir:              []string{},
 		ssmPluginDir:           []string{},
 		sessionManagerShellDir: []string{},
-		awsCloudWatchDir:       []string{},
 		awsDomainJoin:          []string{},
 	}
 )

--- a/misc/exec-command-agent-test/build.ps1
+++ b/misc/exec-command-agent-test/build.ps1
@@ -36,11 +36,6 @@ if(!(Test-Path -path $SIMULATED_SSM_PLUGINS_DIR\SessionManagerShell))
     New-Item -Path $SIMULATED_SSM_PLUGINS_DIR\SessionManagerShell -ItemType directory -Force
 }
 
-if(!(Test-Path -path $SIMULATED_SSM_PLUGINS_DIR\awsCloudWatch))
-{
-    New-Item -Path $SIMULATED_SSM_PLUGINS_DIR\awsCloudWatch -ItemType directory -Force
-}
-
 if(!(Test-Path -path $SIMULATED_SSM_PLUGINS_DIR\awsDomainJoin))
 {
     New-Item -Path $SIMULATED_SSM_PLUGINS_DIR\awsDomainJoin -ItemType directory -Force


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
- CloudWatch was deprecate from SSM agent on May 4 - https://github.com/aws/amazon-ssm-agent/commit/0421963b5ad118a7afb5cce11b0566faa4d96fe0
- In order to not to break the windows ECS functionality, removing the aws cloudwatch capabilities from the ECS Windows agent.

### Implementation details
- The SSM agent commit [`0421963`](https://github.com/aws/amazon-ssm-agent/commit/0421963b5ad118a7afb5cce11b0566faa4d96fe0) (May 4) __removed the `awsCloudWatch` plugin__ from the SSM agent. This plugin previously lived at:

```javascript
C:\Program Files\Amazon\SSM\Plugins\awsCloudWatch\
```

- The SSM agent no longer ships or installs this directory.

---

### How This Affected the ECS Windows Agent

The ECS Windows agent's __Execute Command (ECS Exec) capability__ relies on checking that a set of required SSM plugin directories exist on the host before advertising `ecs.capability.execute-command` to the ECS control plane. This check happens in `appendExecCapabilities()` via `dependenciesExist(dependencies)` in `agent/app/agent_capability.go`.


### Testing
make test
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes:

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement - Remove "awsCloudWatch" from ECS exec capability check for Windows

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
