### PR TITLE
feat(acs-model): Add LogDriverVolumeConfiguration to ACS Volume shape

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs/api.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs/api.go
@@ -1757,6 +1757,30 @@ func (s *LinuxParameters) Validate() error {
 	return nil
 }
 
+type LogDriverVolumeConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	Driver *string `json:"driver,omitempty" type:"string"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s LogDriverVolumeConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s LogDriverVolumeConfiguration) GoString() string {
+	return s.String()
+}
+
 type ManagedAgent struct {
 	_ struct{} `type:"structure"`
 
@@ -3052,6 +3076,8 @@ type Volume struct {
 	FsxWindowsFileServerVolumeConfiguration *FSxWindowsFileServerVolumeConfiguration `json:"fsxWindowsFileServerVolumeConfiguration,omitempty" type:"structure"`
 
 	Host *HostVolumeProperties `json:"host,omitempty" type:"structure"`
+
+	LogDriverVolumeConfiguration *LogDriverVolumeConfiguration `json:"logDriverVolumeConfiguration,omitempty" type:"structure"`
 
 	Name *string `json:"name,omitempty" type:"string"`
 

--- a/ecs-agent/acs/model/api/api-2.json
+++ b/ecs-agent/acs/model/api/api-2.json
@@ -623,6 +623,12 @@
       "exception":true
     },
     "Long":{"type":"long"},
+    "LogDriverVolumeConfiguration":{
+      "type":"structure",
+      "members":{
+        "driver":{"shape":"String"}
+      }
+    },
     "ManagedAgent":{
       "type":"structure",
       "members":{
@@ -997,7 +1003,8 @@
         "dockerVolumeConfiguration":{"shape":"DockerVolumeConfiguration"},
         "efsVolumeConfiguration":{"shape":"EFSVolumeConfiguration"},
         "fsxWindowsFileServerVolumeConfiguration":{"shape":"FSxWindowsFileServerVolumeConfiguration"},
-        "ebsVolumeConfiguration":{"shape":"EBSVolumeConfiguration"}
+        "ebsVolumeConfiguration":{"shape":"EBSVolumeConfiguration"},
+        "logDriverVolumeConfiguration":{"shape":"LogDriverVolumeConfiguration"}
       }
     },
     "VolumeFrom":{
@@ -1022,7 +1029,8 @@
         "docker",
         "efs",
         "fsxWindowsFileServer",
-        "ebs"
+        "ebs",
+        "logDriverOutput"
       ]
     }
   }

--- a/ecs-agent/acs/model/ecsacs/api.go
+++ b/ecs-agent/acs/model/ecsacs/api.go
@@ -1757,6 +1757,30 @@ func (s *LinuxParameters) Validate() error {
 	return nil
 }
 
+type LogDriverVolumeConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	Driver *string `json:"driver,omitempty" type:"string"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s LogDriverVolumeConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s LogDriverVolumeConfiguration) GoString() string {
+	return s.String()
+}
+
 type ManagedAgent struct {
 	_ struct{} `type:"structure"`
 
@@ -3052,6 +3076,8 @@ type Volume struct {
 	FsxWindowsFileServerVolumeConfiguration *FSxWindowsFileServerVolumeConfiguration `json:"fsxWindowsFileServerVolumeConfiguration,omitempty" type:"structure"`
 
 	Host *HostVolumeProperties `json:"host,omitempty" type:"structure"`
+
+	LogDriverVolumeConfiguration *LogDriverVolumeConfiguration `json:"logDriverVolumeConfiguration,omitempty" type:"structure"`
 
 	Name *string `json:"name,omitempty" type:"string"`
 


### PR DESCRIPTION
 ### Summary

  Add `LogDriverVolumeConfiguration` structure and `logDriverVolumeConfiguration` field to the ACS `Volume` shape. Add `LogDriverOutput` to the `VolumeType` enum.

  ### Implementation details

  - `ecs-agent/acs/model/api/api-2.json`: Added the new shape definition and volume member
  - `ecs-agent/acs/model/ecsacs/api.go`: Regenerated from the updated model JSON

  ### Testing

  Downstream consumer builds and passes unit tests with these model additions.

  New tests cover the changes: no (model-only change; downstream tests validate consumption)

  ### Description for the changelog

  Feature - Add LogDriverVolumeConfiguration to ACS volume model

  ### Additional Information

  **Does this PR include breaking model changes? If so, Have you added transformation functions?**
  No, additive only.

  **Does this PR include the addition of new environment variables in the README?**
  No.

  ### Licensing

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.