### PR TITLE
engine/serviceconnect: read image digest from metadata json

### DIFF
--- a/agent/engine/serviceconnect/manager.go
+++ b/agent/engine/serviceconnect/manager.go
@@ -27,6 +27,7 @@ type Manager interface {
 	loader.Loader
 
 	GetLoadedImageName() string
+	GetLoadedImageDigest() string
 	AugmentTaskContainer(
 		task *apitask.Task,
 		container *apicontainer.Container,

--- a/agent/engine/serviceconnect/manager_linux.go
+++ b/agent/engine/serviceconnect/manager_linux.go
@@ -82,9 +82,10 @@ const (
 	defaultAdminStatsRequest = httpRequestPrefix + "/stats/prometheus?usedonly&filter=metrics_extension&delta"
 	defaultAdminDrainRequest = httpRequestPrefix + "/drain_listeners?inboundonly"
 
-	defaultAgentContainerImageName         = "ecs-service-connect-agent"
-	defaultAgentContainerTagFormat         = "interface-%s"
-	defaultAgentContainerTarballPathFormat = "/managed-agents/serviceconnect/ecs-service-connect-agent.interface-%s.tar"
+	defaultAgentContainerImageName          = "ecs-service-connect-agent"
+	defaultAgentContainerTagFormat          = "interface-%s"
+	defaultAgentContainerTarballPathFormat  = "/managed-agents/serviceconnect/ecs-service-connect-agent.interface-%s.tar"
+	defaultAgentContainerMetadataPathFormat = "/managed-agents/serviceconnect/ecs-service-connect-agent.interface-%s.metadata.json"
 
 	ecsAgentLogFileENV              = "ECS_LOGFILE"
 	defaultECSAgentLogPathContainer = "/log"
@@ -128,6 +129,7 @@ type manager struct {
 	agentContainerImageName string
 	agentContainerTag       string
 	appnetInterfaceVersion  string
+	appnetImageDigest       string
 
 	ecsClient            ecs.ECSClient
 	containerInstanceARN string
@@ -181,6 +183,9 @@ func (m *manager) augmentAgentContainer(
 
 	task.PopulateServiceConnectRuntimeConfig(config)
 	container.Image = m.GetLoadedImageName()
+	if d := m.GetLoadedImageDigest(); d != "" {
+		container.SetImageDigest(d)
+	}
 	return nil
 }
 
@@ -458,6 +463,38 @@ func (agent *manager) setLoadedAppnetVerion(appnetInterfaceVersion string) {
 	agent.appnetInterfaceVersion = appnetInterfaceVersion
 }
 
+// readMetadataFile is overridden in tests to inject metadata.json contents.
+var readMetadataFile = os.ReadFile
+
+// readLoadedImageDigest reads the Appnet agent container image metadata.json
+// that ships alongside the tarball and returns the registry manifest digest.
+// Returns "" (with a warning logged) if the file is missing or malformed;
+// older RPMs do not ship this file, and the Appnet agent container must
+// still launch in that case.
+func (agent *manager) readLoadedImageDigest(version string) string {
+	imageMetadataPath := fmt.Sprintf(defaultAgentContainerMetadataPathFormat, version)
+	raw, err := readMetadataFile(imageMetadataPath)
+	if err != nil {
+		logger.Warn("Appnet agent container image metadata unavailable", logger.Fields{
+			field.Error: err,
+			"path":      imageMetadataPath,
+		})
+		return ""
+	}
+	var md struct {
+		SchemaVersion int    `json:"schemaVersion"`
+		Digest        string `json:"digest"`
+	}
+	if err := json.Unmarshal(raw, &md); err != nil {
+		logger.Warn("Appnet agent container image metadata malformed", logger.Fields{
+			field.Error: err,
+			"path":      imageMetadataPath,
+		})
+		return ""
+	}
+	return md.Digest
+}
+
 // LoadImage helps load the AppNetAgent container image for the agent latest supported
 // AppNet interface version by looking for the AppNet agent tar name from supported list
 // of AppNet versions from highest to lowest version when loading AppNet image
@@ -480,10 +517,12 @@ func (agent *manager) LoadImage(ctx context.Context, _ *config.Config, dockerCli
 			continue
 		}
 		agent.setLoadedAppnetVerion(supportedAppnetInterfaceVersion)
+		agent.appnetImageDigest = agent.readLoadedImageDigest(supportedAppnetInterfaceVersion)
 		imageName := agent.GetLoadedImageName()
 		logger.Info(fmt.Sprintf("Successfully loaded Appnet agent container tarball: %s", agentContainerTarballPath),
 			logger.Fields{
-				field.Image: imageName,
+				field.Image:         imageName,
+				"appnetImageDigest": agent.appnetImageDigest,
 			})
 		return loader.GetContainerImage(imageName, dockerClient)
 	}
@@ -497,6 +536,14 @@ func (agent *manager) IsLoaded(dockerClient dockerapi.DockerClient) (bool, error
 func (agent *manager) GetLoadedImageName() string {
 	agent.agentContainerTag = fmt.Sprintf(defaultAgentContainerTagFormat, agent.appnetInterfaceVersion)
 	return fmt.Sprintf("%s:%s", agent.agentContainerImageName, agent.agentContainerTag)
+}
+
+// GetLoadedImageDigest returns the registry manifest digest of the loaded
+// Appnet agent container image, sourced from the metadata.json file that
+// ships alongside the tarball. Returns "" if the metadata file was missing
+// or malformed at LoadImage time; callers must tolerate empty digest.
+func (agent *manager) GetLoadedImageDigest() string {
+	return agent.appnetImageDigest
 }
 
 func (agent *manager) GetLoadedAppnetVersion() (string, error) {

--- a/agent/engine/serviceconnect/manager_linux_test.go
+++ b/agent/engine/serviceconnect/manager_linux_test.go
@@ -360,3 +360,105 @@ func TestAugmentTaskContainerError(t *testing.T) {
 		assert.EqualError(t, namedErr, "instance is IPv6-only but no IPv6 address found for container 'web'")
 	})
 }
+
+// Verifies the metadata.json reader: happy path, missing file, malformed JSON.
+// Failures must degrade gracefully (return "" + warn) so older RPMs without
+// metadata.json do not break AppNet container launch.
+func TestReadLoadedImageDigest(t *testing.T) {
+	const expectedDigest = "sha256:8bdb42f6a48b7422f5eee379a6522a446850269001e9432cea58296f5fbb1169"
+
+	tt := []struct {
+		name     string
+		readFn   func(string) ([]byte, error)
+		expected string
+	}{
+		{
+			name: "valid metadata.json returns digest",
+			readFn: func(string) ([]byte, error) {
+				return []byte(`{"schemaVersion":1,"digest":"` + expectedDigest + `"}`), nil
+			},
+			expected: expectedDigest,
+		},
+		{
+			name: "missing file returns empty digest",
+			readFn: func(string) ([]byte, error) {
+				return nil, os.ErrNotExist
+			},
+			expected: "",
+		},
+		{
+			name: "malformed JSON returns empty digest",
+			readFn: func(string) ([]byte, error) {
+				return []byte(`{not valid json`), nil
+			},
+			expected: "",
+		},
+		{
+			name: "empty digest field returns empty",
+			readFn: func(string) ([]byte, error) {
+				return []byte(`{"schemaVersion":1,"digest":""}`), nil
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			origRead := readMetadataFile
+			readMetadataFile = tc.readFn
+			defer func() { readMetadataFile = origRead }()
+
+			m := &manager{}
+			got := m.readLoadedImageDigest("v1")
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// Verifies augmentAgentContainer plumbs the cached digest onto the AppNet
+// container via SetImageDigest. The non-empty branch is the load-bearing
+// behavior (it makes ImageDigest flow to control plane); the empty branch
+// guards against overwriting when an older RPM ships no metadata.json.
+func TestAugmentTaskContainerSetsImageDigest(t *testing.T) {
+	const testDigest = "sha256:8bdb42f6a48b7422f5eee379a6522a446850269001e9432cea58296f5fbb1169"
+
+	tt := []struct {
+		name           string
+		managerDigest  string
+		expectedDigest string
+	}{
+		{
+			name:           "manager has digest, container gets it",
+			managerDigest:  testDigest,
+			expectedDigest: testDigest,
+		},
+		{
+			name:           "manager has empty digest, container untouched",
+			managerDigest:  "",
+			expectedDigest: "",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			origMkdir := mkdirAllAndChown
+			mkdirAllAndChown = func(path string, perm fs.FileMode, uid, gid int) error {
+				return nil
+			}
+			defer func() { mkdirAllAndChown = origMkdir }()
+
+			scTask, _, serviceConnectContainer := getAWSVPCTask(t)
+
+			scManager := &manager{
+				agentContainerImageName: "container_image",
+				agentContainerTag:       "tag",
+				appnetImageDigest:       tc.managerDigest,
+			}
+
+			err := scManager.AugmentTaskContainer(scTask, serviceConnectContainer,
+				&dockercontainer.HostConfig{}, ipcompatibility.NewIPv4OnlyCompatibility())
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedDigest, serviceConnectContainer.GetImageDigest())
+		})
+	}
+}

--- a/agent/engine/serviceconnect/manager_other.go
+++ b/agent/engine/serviceconnect/manager_other.go
@@ -69,6 +69,10 @@ func (*manager) GetLoadedImageName() string {
 	return ""
 }
 
+func (*manager) GetLoadedImageDigest() string {
+	return ""
+}
+
 func (*manager) GetLoadedAppnetVersion() (string, error) {
 	return "", loader.NewUnsupportedPlatformError(fmt.Errorf(
 		"appnetAgent container get loaded appnet version: unsupported platform: %s/%s",

--- a/agent/engine/serviceconnect/mock/manager.go
+++ b/agent/engine/serviceconnect/mock/manager.go
@@ -143,6 +143,20 @@ func (mr *MockManagerMockRecorder) GetLoadedAppnetVersion() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadedAppnetVersion", reflect.TypeOf((*MockManager)(nil).GetLoadedAppnetVersion))
 }
 
+// GetLoadedImageDigest mocks base method.
+func (m *MockManager) GetLoadedImageDigest() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLoadedImageDigest")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetLoadedImageDigest indicates an expected call of GetLoadedImageDigest.
+func (mr *MockManagerMockRecorder) GetLoadedImageDigest() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadedImageDigest", reflect.TypeOf((*MockManager)(nil).GetLoadedImageDigest))
+}
+
 // GetLoadedImageName mocks base method.
 func (m *MockManager) GetLoadedImageName() string {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
The Service Connect sidecar container is loaded from a tarball at `/managed-agents/serviceconnect/ecs-service-connect-agent.interface-v1.tar`. Because it never gets pulled from a registry, Docker has no `RepoDigests` for it, so the agent reports an empty `ImageDigest` in `SubmitContainerStateChange`. This means consumers downstream to the ECS controlplane cannot consume them.

This change makes the agent read a sidecar JSON file at `/managed-agents/serviceconnect/ecs-service-connect-agent.interface-v1.metadata.json` containing `{"schemaVersion":1,"digest":"sha256:..."}`, cache the digest on the manager struct at `LoadImage` time, and stamp it on the SC container in `augmentAgentContainer`. The existing state change pipeline carries it the rest of the way to control plane.

The metadata.json is shipped by the SC RPM (the file is produced upstream in the SC release pipeline that pushes the image to ECR, captured via `docker inspect --format '{{index .RepoDigests 0}}'` right after pull, and bundled into the RPM next to the tarball).

### Implementation details
<!-- How are the changes implemented? -->
* `manager.go`: one new method on the interface, `GetLoadedImageDigest() string`.
* `manager_linux.go`: a constant for the metadata path, a struct field `appnetImageDigest`, a helper `readLoadedImageDigest` with graceful failure, the call site in `LoadImage`, the public getter, and the `SetImageDigest` call inside `augmentAgentContainer`.
* `manager_other.go`: a no-op stub returning `""` for non-Linux. SC is Linux only anyway.
* `mock/manager.go`: gomock entries for the new method (manually edited to match what `mockgen` would produce, the existing `go:generate` directive in `generate_mocks.go` regenerates it identically).
* `manager_linux_test.go`: two new tests covering the read fn (4 subcases including missing file and malformed JSON) and the augment plumbing (digest set when present, untouched when empty).

### Backward compatibility

If the file is absent (older RPM that predates this work), malformed, or has an empty `digest` field,`readLoadedImageDigest` logs a warning and returns `""`. The `if d != ""` guard in `augmentAgentContainer` then skips the `SetImageDigest` call entirely. SC sidecar still launches normally, just with empty digest, which is the existing behavior on those AMIs.

The metadata file is consumer-facing but optional. Agent works the same as today on hosts that don't have it.

### Testing

Unit tests:

* `TestReadLoadedImageDigest` covers the four shapes of metadata.json (valid, missing, malformed, empty digest field).
* `TestAugmentTaskContainerSetsImageDigest` verifies the plumbing both when the manager has a cached digest and when it doesn't.
* Full SC manager test suite passes (`go test -tags "linux unit" ./engine/serviceconnect/...`).
* `go build ./...` clean across the whole agent module.
* `gofmt`, `go vet` clean.

End to end on a real EC2:

**1. Install the SC RPM that ships metadata.json alongside the tarball** on a fresh `amazon-ecs-optimized-amazon-linux-2` AMI host. After install, `/var/lib/ecs/deps/serviceconnect/` contains the tar, the metadata.json (`{"schemaVersion":1,"digest":"sha256:..."}`), and the `ecs-service-connect-agent.tar` symlink.

**2. Build the patched agent** with the linker flags the release pipeline uses. Without these the binary panics at startup because `DefaultPauseContainerImageName` and `DefaultPauseContainerTag` are blank:

```sh
go build -ldflags '\
  -X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerTag=0.1.0 \
  -X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerImageName=amazon/amazon-ecs-pause' \
  -o out/amazon-ecs-agent ./
```

**3. Swap the agent binary on EC2.**

**4. Agent log on first load** confirms the new `appnetImageDigest` field is populated, matching what `docker inspect --format '{{index .RepoDigests 0}}'` returns for the same tag in ECR:

```
level=info msg="Successfully loaded Appnet agent container tarball: /managed-agents/serviceconnect/ecs-service-connect-agent.interface-v1.tar"
  appnetImageDigest="sha256:8bdb42f6a48b7422f5eee379a6522a446850269001e9432cea58296f5fbb1169"
  image="ecs-service-connect-agent:interface-v1"
```

**5. Launch a real SC-enabled task.** Once the task transitions to RUNNING:

```sh
aws ecs describe-tasks --cluster default --tasks <task-id> \
  --query 'tasks[0].containers[].[name,imageDigest,lastStatus]'
```

```
web                            sha256:c9001ce8...   RUNNING
ecs-service-connect-XXXXXX     sha256:8bdb42f6...   RUNNING   ← was empty before this change
```

The SC sidecar reports the registry manifest digest from metadata.json end to end through the agent into the ECS API.


With metadata.json present (sidecar shipped by current RPM):
```
    level=info msg="Successfully loaded Appnet agent container tarball: ..."
      image="ecs-service-connect-agent:interface-v1"
appnetImageDigest="sha256:8bdb42f6a48b7422f5eee379a6522a446850269001e9432cea58296f5fbb1169"
```
 

  Without metadata.json (older RPM):
```
    level=warn msg="AppNet metadata sidecar unavailable"
      error="open /managed-agents/serviceconnect/ecs-service-connect-agent.interface-v1.metadata.json: no such file or directory"
    level=info msg="Successfully loaded Appnet agent container tarball: ..."
      image="ecs-service-connect-agent:interface-v1"
      appnetImageDigest=""
```

New tests cover the changes: yes

### Description for the changelog
Enhancement - Populate ImageDigest for Service Connect sidecar containers.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No

**Does this PR include the addition of new environment variables in the README?**
No
<!--
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
