### PR TITLE
Fix flaky TestHostResourceManagerTrickleQueue integration test

### DIFF
--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -1645,9 +1645,10 @@ func TestHostResourceManagerTrickleQueue(t *testing.T) {
 		assert.NoError(t, err, "one task should be queued up after 6s")
 		assert.Equal(t, task.Arn, tasks[2].Arn, "wrong task at top of queue")
 
-		time.Sleep(6 * time.Second)
-		_, err = taskEngine.(*DockerTaskEngine).topTask()
-		assert.Error(t, err, "no task should be queued up after 12s")
+		assert.Eventually(t, func() bool {
+			_, err = taskEngine.(*DockerTaskEngine).topTask()
+			return err != nil
+		}, 30*time.Second, 500*time.Millisecond, "queue should be empty after task-0 stops")
 	}()
 	waitFinished(t, finished, testTimeout)
 }


### PR DESCRIPTION
### Summary

Fix flaky `TestHostResourceManagerTrickleQueue` integration test that intermittently fails on loaded CI hosts.

### Implementation details

Replace the fixed `time.Sleep(6s)` + `assert.Error` queue-empty check with `assert.Eventually`, which polls until the queue drains (with a 30s timeout and 500ms interval).

The test was flaky because it assumed container startup overhead < 2s. The accounting goroutine checks at T+12s that the queue is empty, but task-0's container (running `sleep 10`) only finishes at T = startup_overhead + 10s. On loaded CI hosts, startup overhead can exceed 2s, causing the assertion to fire while task-2 is still queued.

The new approach tests the same invariant (task-2 eventually dequeues after task-0 frees resources) and eliminates the most common source of flakiness. 

### Testing

- Verified the fix passes locally with the normal `sleep 10` container command
- Verified the fix passes with `sleep 12` (deterministic repro of the CI race — previously failed 100% of the time without the fix)
- Confirmed the original failure mode matches CI failures (e.g., PR #5025 run on 2026-06-29)

New tests cover the changes: no (existing test fix)

### Description for the changelog

Housekeeping - Fix flaky TestHostResourceManagerTrickleQueue integration test

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No

**Does this PR include the addition of new environment variables in the README?**
No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
