### PR TITLE
Fault update sources

### DIFF
--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -323,6 +323,37 @@ func registerFaultHandlers(
 		),
 	).Methods("POST")
 
+	// Setting up add-sources handler endpoints for network latency and packet
+	// loss faults. These let the FIS SSM script push newly resolved IPs into a
+	// running tc fault without restarting it. The endpoints use the same
+	// rate-limiter and telemetry middleware wiring as start/stop/status, and
+	// share the metricsFactory so their metrics land in the same
+	// MetadataServer.* namespace.
+	muxRouter.Handle(
+		fault.NetworkFaultPath(faulttype.LatencyFaultType, faulttype.AddNetworkFaultPostfix),
+		fault.TelemetryMiddleware(
+			tollbooth.LimitFuncHandler(
+				createRateLimiter(),
+				handler.AddSourcesNetworkLatency(),
+			),
+			metricsFactory,
+			faulttype.AddNetworkFaultPostfix,
+			faulttype.LatencyFaultType,
+		),
+	).Methods("POST")
+	muxRouter.Handle(
+		fault.NetworkFaultPath(faulttype.PacketLossFaultType, faulttype.AddNetworkFaultPostfix),
+		fault.TelemetryMiddleware(
+			tollbooth.LimitFuncHandler(
+				createRateLimiter(),
+				handler.AddSourcesNetworkPacketLoss(),
+			),
+			metricsFactory,
+			faulttype.AddNetworkFaultPostfix,
+			faulttype.PacketLossFaultType,
+		),
+	).Methods("POST")
+
 	seelog.Debug("Successfully set up Fault TMDS handlers")
 }
 

--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -324,11 +324,11 @@ func registerFaultHandlers(
 	).Methods("POST")
 
 	// Setting up add-sources handler endpoints for network latency and packet
-	// loss faults. These let the FIS SSM script push newly resolved IPs into a
-	// running tc fault without restarting it. The endpoints use the same
-	// rate-limiter and telemetry middleware wiring as start/stop/status, and
-	// share the metricsFactory so their metrics land in the same
-	// MetadataServer.* namespace.
+	// loss faults. These let callers push newly resolved IPs into a running
+	// tc fault without restarting it. The endpoints use the same rate-limiter
+	// and telemetry middleware wiring as start/stop/status, and share the
+	// metricsFactory so their metrics land in the same MetadataServer.*
+	// namespace.
 	muxRouter.Handle(
 		fault.NetworkFaultPath(faulttype.LatencyFaultType, faulttype.AddNetworkFaultPostfix),
 		fault.TelemetryMiddleware(

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -508,6 +508,15 @@ var (
 		"Sources":         ipSources,
 		"SourcesToFilter": ipSourcesToFilter,
 	}
+
+	// happyAddSourcesReqBody mirrors the shape the SSM script sends when
+	// extending a running fault with newly resolved IPs. Reuses the existing
+	// ipSources/ipSourcesToFilter fixtures; the add-sources endpoint accepts
+	// IPv4 and IPv6 (validated in ecs-agent/tmds/handlers/fault/v1/types).
+	happyAddSourcesReqBody = map[string]interface{}{
+		"Sources":         ipSources,
+		"SourcesToFilter": ipSourcesToFilter,
+	}
 )
 
 func standardTask() *apitask.Task {
@@ -4292,6 +4301,55 @@ func TestRegisterCheckPacketLossFaultHandler(t *testing.T) {
 	testRegisterFaultHandler(t, tcs, faulthandler.NetworkFaultPath(faulttype.PacketLossFaultType, faulttype.CheckNetworkFaultPostfix), faulttype.CheckNetworkFaultPostfix, faulttype.PacketLossFaultType)
 }
 
+// TestRegisterAddSourcesLatencyFaultHandler verifies the router wires
+// POST /fault/v1/network-latency/add-sources to AddSourcesNetworkLatency and
+// that the telemetry middleware fires exactly once. Handler-level behavior
+// (validation, 404 paths, tc filter commands) is covered in the ecs-agent
+// handler package tests; this test intentionally only exercises the happy
+// path against a running latency fault.
+func TestRegisterAddSourcesLatencyFaultHandler(t *testing.T) {
+	setExecExpectations := func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+		mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+		gomock.InOrder(
+			exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+			// checkTCFault: one show command per interface, returns "latency running".
+			exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLatencyFaultExistsCommandOutput), nil),
+		)
+		// One `tc filter add` per IP in SourcesToFilter (1) + Sources (2).
+		// Relax the exact count with AnyTimes to keep the test robust if the
+		// fixture lists grow; gomock still requires the calls to happen or the
+		// handler would fail on the ones it misses.
+		exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(mockCMD)
+		mockCMD.EXPECT().CombinedOutput().AnyTimes().Return([]byte(""), nil)
+	}
+	tcs := generateCommonNetworkFaultInjectionTestCases("add sources latency", "running", setExecExpectations, happyAddSourcesReqBody)
+	testRegisterFaultHandler(t, tcs,
+		faulthandler.NetworkFaultPath(faulttype.LatencyFaultType, faulttype.AddNetworkFaultPostfix),
+		faulttype.AddNetworkFaultPostfix, faulttype.LatencyFaultType)
+}
+
+// TestRegisterAddSourcesPacketLossFaultHandler is the packet-loss twin of the
+// latency add-sources registration test.
+func TestRegisterAddSourcesPacketLossFaultHandler(t *testing.T) {
+	setExecExpectations := func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeoutDuration)
+		mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+		gomock.InOrder(
+			exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+			exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLossFaultExistsCommandOutput), nil),
+		)
+		exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(mockCMD)
+		mockCMD.EXPECT().CombinedOutput().AnyTimes().Return([]byte(""), nil)
+	}
+	tcs := generateCommonNetworkFaultInjectionTestCases("add sources packet loss", "running", setExecExpectations, happyAddSourcesReqBody)
+	testRegisterFaultHandler(t, tcs,
+		faulthandler.NetworkFaultPath(faulttype.PacketLossFaultType, faulttype.AddNetworkFaultPostfix),
+		faulttype.AddNetworkFaultPostfix, faulttype.PacketLossFaultType)
+}
+
 func testRegisterFaultHandler(t *testing.T, tcs []networkFaultTestCase, tmdsEndpoint, faultOperation, faultType string) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -4342,6 +4400,10 @@ func testRegisterFaultHandler(t *testing.T, tcs []networkFaultTestCase, tmdsEndp
 				tmdsAPI = "/api/%s/fault/v1/network-packet-loss/stop"
 			case faulthandler.NetworkFaultPath(faulttype.PacketLossFaultType, faulttype.CheckNetworkFaultPostfix):
 				tmdsAPI = "/api/%s/fault/v1/network-packet-loss/status"
+			case faulthandler.NetworkFaultPath(faulttype.LatencyFaultType, faulttype.AddNetworkFaultPostfix):
+				tmdsAPI = "/api/%s/fault/v1/network-latency/add-sources"
+			case faulthandler.NetworkFaultPath(faulttype.PacketLossFaultType, faulttype.AddNetworkFaultPostfix):
+				tmdsAPI = "/api/%s/fault/v1/network-packet-loss/add-sources"
 			default:
 				t.Error("Unrecognized TMDS Endpoint")
 			}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -48,6 +48,7 @@ const (
 	startFaultRequestType       = "start %s"
 	stopFaultRequestType        = "stop %s"
 	checkStatusFaultRequestType = "check status %s"
+	addSourcesFaultRequestType  = "add sources %s"
 	// Fault injection operation error messages
 	internalError                      = "internal error"
 	invalidNetworkModeError            = "%s mode is not supported. Please use either host or awsvpc mode."
@@ -55,6 +56,10 @@ const (
 	requestTimedOutError               = "%s: request timed out"
 	latencyFaultAlreadyRunningError    = "There is already one network latency fault running"
 	packetLossFaultAlreadyRunningError = "There is already one network packet loss fault running"
+	// add-sources 404 messages. We emit a distinct message per fault type so the
+	// SSM script's logs make it obvious which fault it was trying to extend.
+	latencyFaultNotRunningError    = "no network-latency fault is currently running on the task's network namespace"
+	packetLossFaultNotRunningError = "no network-packet-loss fault is currently running on the task's network namespace"
 	// This is our initial assumption of how much time it would take for the Linux commands used to inject faults
 	// to finish. This will be confirmed/updated after more testing.
 	requestTimeoutSeconds = 5
@@ -1082,6 +1087,170 @@ func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.
 			requestType,
 		)
 	}
+}
+
+// AddSourcesNetworkLatency extends a running network-latency fault with
+// additional IPs supplied by the caller. It does not modify fault parameters
+// (delay, jitter, flows percent); those are locked in at start time. Returns
+// 404 if no latency fault is currently running on the task's network namespace.
+func (h *FaultHandler) AddSourcesNetworkLatency() func(http.ResponseWriter, *http.Request) {
+	// The selector is defined inline so that the rule "this endpoint honors
+	// only the latency flag" lives at the only call site that uses it; the
+	// packet-loss handler has its own mirror below.
+	return h.addSourcesHandler(
+		types.LatencyFaultType,
+		latencyFaultNotRunningError,
+		func(latencyExists, _ bool) bool { return latencyExists },
+	)
+}
+
+// AddSourcesNetworkPacketLoss extends a running network-packet-loss fault
+// with additional IPs. See AddSourcesNetworkLatency for semantics.
+func (h *FaultHandler) AddSourcesNetworkPacketLoss() func(http.ResponseWriter, *http.Request) {
+	return h.addSourcesHandler(
+		types.PacketLossFaultType,
+		packetLossFaultNotRunningError,
+		func(_, packetLossExists bool) bool { return packetLossExists },
+	)
+}
+
+// faultExistsSelector picks which of the two flags returned by checkTCFault
+// should gate the add-sources operation. A latency add-sources call must
+// observe a latency fault (packet-loss running counts as "not running" for
+// the latency endpoint, returning 404), and vice versa.
+type faultExistsSelector func(latencyExists, packetLossExists bool) bool
+
+// addSourcesHandler is the shared implementation behind AddSourcesNetworkLatency
+// and AddSourcesNetworkPacketLoss. Both endpoints share the same decode,
+// validate, lock, check, apply pipeline; only the fault type, not-running
+// error message, and which checkTCFault flag to honor differ.
+func (h *FaultHandler) addSourcesHandler(
+	faultType, notRunningErr string, faultPresent faultExistsSelector,
+) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var request types.NetworkFaultAddSourcesRequest
+		requestType := fmt.Sprintf(addSourcesFaultRequestType, faultType)
+
+		// Parse the request body. decodeRequest logs the request and writes a
+		// 400 if the JSON is malformed or the body is missing.
+		if err := decodeRequest(w, &request, requestType, r); err != nil {
+			return
+		}
+
+		// Validate the request. validateRequest writes a 400 on failure.
+		if err := validateRequest(w, request, requestType); err != nil {
+			return
+		}
+
+		// Obtain the task metadata via the endpoint container ID.
+		taskMetadata, err := validateTaskMetadata(w, h.AgentState, requestType, r)
+		if err != nil {
+			return
+		}
+
+		// Acquire the per-namespace write lock. This is the same lock used by
+		// start and stop so that add-sources cannot race with either: if stop
+		// has already torn down the qdisc hierarchy, checkTCFault below will
+		// observe it and return 404 instead of attempting a filter-add against
+		// a missing qdisc.
+		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
+		rwMu := h.loadLock(networkNSPath)
+		rwMu.Lock()
+		defer rwMu.Unlock()
+
+		var responseBody types.NetworkFaultInjectionResponse
+		var httpStatusCode int
+		stringToBeLogged := "Failed to add sources to fault"
+		// Share a single 5-second context across checkTCFault and every
+		// tc filter add below. The per-request cap of AddSourcesMaxIPs keeps
+		// a well-formed call inside this budget.
+		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(
+			context.Background(), requestTimeoutSeconds*time.Second)
+		defer cancel()
+
+		latencyExists, packetLossExists, err := h.checkTCFault(ctx, taskMetadata)
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			responseBody = types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf(requestTimedOutError, requestType))
+			httpStatusCode = http.StatusInternalServerError
+		} else if err != nil {
+			// Log before overwriting responseBody. Without this, a failing
+			// checkTCFault surfaces as a bare 500 with no breadcrumb for ops.
+			logger.Error("checkTCFault failed", logger.Fields{
+				field.Error:       err,
+				field.RequestType: requestType,
+				field.TaskARN:     taskMetadata.TaskARN,
+			})
+			responseBody = types.NewNetworkFaultInjectionErrorResponse(internalError)
+			httpStatusCode = http.StatusInternalServerError
+		} else if !faultPresent(latencyExists, packetLossExists) {
+			// 404 is the signal to the SSM script that the fault is gone and
+			// the refresh loop should stop. The design calls this out as the
+			// expected behavior after a stop has raced ahead of this update.
+			responseBody = types.NewNetworkFaultInjectionErrorResponse(notRunningErr)
+			httpStatusCode = http.StatusNotFound
+		} else {
+			applyErr := h.addSourcesToFault(ctx, taskMetadata, request)
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				responseBody = types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf(requestTimedOutError, requestType))
+				httpStatusCode = http.StatusInternalServerError
+			} else if applyErr != nil {
+				// No rollback on partial application. Filters already installed
+				// stay in place; the SSM script retries the same IPs on the
+				// next refresh cycle, and tc filter add is idempotent enough
+				// across kernel versions that the retry either succeeds or
+				// fails silently without corrupting the qdisc hierarchy.
+				responseBody = types.NewNetworkFaultInjectionErrorResponse(internalError)
+				httpStatusCode = http.StatusInternalServerError
+			} else {
+				stringToBeLogged = "Successfully added sources to fault"
+				responseBody = types.NewNetworkFaultInjectionSuccessResponse("running")
+				httpStatusCode = http.StatusOK
+			}
+		}
+		logger.Info(stringToBeLogged, logger.Fields{
+			field.RequestType: requestType,
+			field.Request:     request.ToString(),
+			field.Response:    responseBody.ToString(),
+		})
+		handlerutils.WriteJSONResponse(
+			w,
+			httpStatusCode,
+			responseBody,
+			requestType,
+		)
+	}
+}
+
+// addSourcesToFault walks every interface in the task's network namespace and
+// installs new tc filters: SourcesToFilter first (flowid 1:3, allowlist), then
+// Sources (flowid 1:1, impaired). We mirror the start workflow's ordering
+// because SourcesToFilter has a higher-priority tc prio (1 vs 2) and applying
+// it first matches how start builds the filter chain; no functional difference
+// for add-sources, but keeps the two paths visually aligned.
+func (h *FaultHandler) addSourcesToFault(
+	ctx context.Context, taskMetadata *state.TaskResponse,
+	request types.NetworkFaultAddSourcesRequest,
+) error {
+	networkMode := ecstypes.NetworkMode(taskMetadata.TaskNetworkConfig.NetworkMode)
+	nsenterPrefix := ""
+	if networkMode == ecstypes.NetworkModeAwsvpc {
+		nsenterPrefix = fmt.Sprintf(nsenterCommandString, taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path)
+	}
+	for _, netInterface := range taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces {
+		if err := h.addIPAddressesToFilter(
+			ctx, request.SourcesToFilter, taskMetadata, nsenterPrefix,
+			tcAllowlistIPCommandString, netInterface.DeviceName,
+		); err != nil {
+			return err
+		}
+		if err := h.addIPAddressesToFilter(
+			ctx, request.Sources, taskMetadata, nsenterPrefix,
+			tcAddFilterForIPCommandString, netInterface.DeviceName,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // decodeRequest will log the request and then translate/unmarshal an incoming fault injection request into

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -56,10 +56,10 @@ const (
 	requestTimedOutError               = "%s: request timed out"
 	latencyFaultAlreadyRunningError    = "There is already one network latency fault running"
 	packetLossFaultAlreadyRunningError = "There is already one network packet loss fault running"
-	// add-sources 404 messages. We emit a distinct message per fault type so the
-	// SSM script's logs make it obvious which fault it was trying to extend.
-	latencyFaultNotRunningError    = "no network-latency fault is currently running on the task's network namespace"
-	packetLossFaultNotRunningError = "no network-packet-loss fault is currently running on the task's network namespace"
+	// add-sources 404 messages. We emit a distinct message per fault type so
+	// caller logs make it obvious which fault was being extended.
+	latencyFaultNotRunningError    = "no network-latency fault is currently running for the task"
+	packetLossFaultNotRunningError = "no network-packet-loss fault is currently running for the task"
 	// This is our initial assumption of how much time it would take for the Linux commands used to inject faults
 	// to finish. This will be confirmed/updated after more testing.
 	requestTimeoutSeconds = 5
@@ -1092,7 +1092,7 @@ func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.
 // AddSourcesNetworkLatency extends a running network-latency fault with
 // additional IPs supplied by the caller. It does not modify fault parameters
 // (delay, jitter, flows percent); those are locked in at start time. Returns
-// 404 if no latency fault is currently running on the task's network namespace.
+// 404 if no latency fault is currently running for the task.
 func (h *FaultHandler) AddSourcesNetworkLatency() func(http.ResponseWriter, *http.Request) {
 	// The selector is defined inline so that the rule "this endpoint honors
 	// only the latency flag" lives at the only call site that uses it; the
@@ -1183,9 +1183,9 @@ func (h *FaultHandler) addSourcesHandler(
 			responseBody = types.NewNetworkFaultInjectionErrorResponse(internalError)
 			httpStatusCode = http.StatusInternalServerError
 		} else if !faultPresent(latencyExists, packetLossExists) {
-			// 404 is the signal to the SSM script that the fault is gone and
-			// the refresh loop should stop. The design calls this out as the
-			// expected behavior after a stop has raced ahead of this update.
+			// 404 signals to the caller that the fault is gone, e.g. so a
+			// refresh loop can stop. This is the expected behavior after a
+			// stop has raced ahead of this update.
 			responseBody = types.NewNetworkFaultInjectionErrorResponse(notRunningErr)
 			httpStatusCode = http.StatusNotFound
 		} else {
@@ -1195,10 +1195,10 @@ func (h *FaultHandler) addSourcesHandler(
 				httpStatusCode = http.StatusInternalServerError
 			} else if applyErr != nil {
 				// No rollback on partial application. Filters already installed
-				// stay in place; the SSM script retries the same IPs on the
-				// next refresh cycle, and tc filter add is idempotent enough
-				// across kernel versions that the retry either succeeds or
-				// fails silently without corrupting the qdisc hierarchy.
+				// stay in place; callers retry the same IPs on the next call.
+				// `tc filter add` accepts duplicate u32 matches without error,
+				// so the retry is safe. Any duplicates are reaped when the
+				// qdisc is torn down on stop.
 				responseBody = types.NewNetworkFaultInjectionErrorResponse(internalError)
 				httpStatusCode = http.StatusInternalServerError
 			} else {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -30,13 +30,26 @@ const (
 	StartNetworkFaultPostfix = "start"
 	StopNetworkFaultPostfix  = "stop"
 	CheckNetworkFaultPostfix = "status"
-	TrafficTypeIngress       = "ingress"
-	TrafficTypeEgress        = "egress"
+	AddNetworkFaultPostfix   = "add-sources"
+	// AddSourcesMaxIPs caps the total number of entries (Sources + SourcesToFilter)
+	// accepted by a single add-sources request. The cap keeps a well-formed call
+	// inside the shared requestTimeoutSeconds budget and forces callers to keep
+	// one refresh call per domain. Route53 returns at most 8 IPs per answer, so
+	// 16 leaves headroom for two-domain bundles without requiring a split.
+	AddSourcesMaxIPs   = 16
+	TrafficTypeIngress = "ingress"
+	TrafficTypeEgress  = "egress"
 	// Request Payload Errors
 	MissingRequiredFieldError = "required parameter %s is missing"
 	MissingRequestBodyError   = "required request body is missing"
 	ZeroDelayAndJitterError   = "required either DelayMilliseconds or JitterMilliseconds to be non-zero"
 	InvalidValueError         = "invalid value %s for parameter %s"
+	// AddSources-specific errors. "Sources" and "SourcesToFilter" are JSON
+	// field names on NetworkFaultAddSourcesRequest, not English nouns; the
+	// capitalization lets callers grep from error back to field.
+	AddSourcesTooManyIPsError = "Sources and SourcesToFilter together have %d entries, maximum allowed is %d"
+	AddSourcesEmptyError      = "at least one of Sources or SourcesToFilter must be non-empty"
+	AddSourcesOverlapError    = "%s is present in both Sources and SourcesToFilter"
 )
 
 type NetworkFaultRequest interface {
@@ -243,4 +256,61 @@ func requireIPInRequestSource(source string, sourceType string) error {
 	}
 
 	return fmt.Errorf(InvalidValueError, source, sourceType)
+}
+
+// NetworkFaultAddSourcesRequest is the request body for the add-sources endpoint
+// used to push additional IPs into an already-running tc fault. It carries only
+// the IP lists because the fault parameters (delay, jitter, loss percent, flows
+// percent) are locked in at start time and cannot be changed mid-fault.
+type NetworkFaultAddSourcesRequest struct {
+	// Sources is a list of IPv4/IPv6 addresses or IPv4/IPv6 CIDR blocks to add
+	// as tc filters for the impaired flow.
+	Sources []*string `json:"Sources"`
+	// SourcesToFilter is a list of IPv4/IPv6 addresses or IPv4/IPv6 CIDR blocks
+	// to add as allowlist filters that bypass the impairment.
+	SourcesToFilter []*string `json:"SourcesToFilter,omitempty"`
+}
+
+// ValidateRequest enforces the add-sources contract: at least one IP across the
+// two lists, every entry is a valid IPv4/IPv6 address or CIDR block, the two
+// lists are disjoint within this request, and the combined size fits under
+// AddSourcesMaxIPs. Cross-request overlap is the SSM script's responsibility;
+// tracking it here would require per-namespace state and additional tc queries.
+func (request NetworkFaultAddSourcesRequest) ValidateRequest() error {
+	if len(request.Sources) == 0 && len(request.SourcesToFilter) == 0 {
+		return errors.New(AddSourcesEmptyError)
+	}
+	total := len(request.Sources) + len(request.SourcesToFilter)
+	if total > AddSourcesMaxIPs {
+		return fmt.Errorf(AddSourcesTooManyIPsError, total, AddSourcesMaxIPs)
+	}
+	if err := requireIPInRequestSources(request.Sources, "Sources"); err != nil {
+		return err
+	}
+	if err := requireIPInRequestSources(request.SourcesToFilter, "SourcesToFilter"); err != nil {
+		return err
+	}
+	// Reject within-request overlap. Any IP that appears in both lists is
+	// ambiguous: the caller cannot want the same address on both flowid 1:1
+	// (impaired) and flowid 1:3 (allowlist). 400 surfaces the mistake instead
+	// of installing conflicting filters.
+	filterSet := make(map[string]struct{}, len(request.SourcesToFilter))
+	for _, ipPtr := range request.SourcesToFilter {
+		filterSet[aws.ToString(ipPtr)] = struct{}{}
+	}
+	for _, ipPtr := range request.Sources {
+		ip := aws.ToString(ipPtr)
+		if _, found := filterSet[ip]; found {
+			return fmt.Errorf(AddSourcesOverlapError, ip)
+		}
+	}
+	return nil
+}
+
+func (request NetworkFaultAddSourcesRequest) ToString() string {
+	data, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Sprintf("Error: Unable to parse add-sources request with error %v.", err)
+	}
+	return string(data)
 }

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -48,6 +48,7 @@ const (
 	startFaultRequestType       = "start %s"
 	stopFaultRequestType        = "stop %s"
 	checkStatusFaultRequestType = "check status %s"
+	addSourcesFaultRequestType  = "add sources %s"
 	// Fault injection operation error messages
 	internalError                      = "internal error"
 	invalidNetworkModeError            = "%s mode is not supported. Please use either host or awsvpc mode."
@@ -55,6 +56,10 @@ const (
 	requestTimedOutError               = "%s: request timed out"
 	latencyFaultAlreadyRunningError    = "There is already one network latency fault running"
 	packetLossFaultAlreadyRunningError = "There is already one network packet loss fault running"
+	// add-sources 404 messages. We emit a distinct message per fault type so the
+	// SSM script's logs make it obvious which fault it was trying to extend.
+	latencyFaultNotRunningError    = "no network-latency fault is currently running on the task's network namespace"
+	packetLossFaultNotRunningError = "no network-packet-loss fault is currently running on the task's network namespace"
 	// This is our initial assumption of how much time it would take for the Linux commands used to inject faults
 	// to finish. This will be confirmed/updated after more testing.
 	requestTimeoutSeconds = 5
@@ -1082,6 +1087,170 @@ func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.
 			requestType,
 		)
 	}
+}
+
+// AddSourcesNetworkLatency extends a running network-latency fault with
+// additional IPs supplied by the caller. It does not modify fault parameters
+// (delay, jitter, flows percent); those are locked in at start time. Returns
+// 404 if no latency fault is currently running on the task's network namespace.
+func (h *FaultHandler) AddSourcesNetworkLatency() func(http.ResponseWriter, *http.Request) {
+	// The selector is defined inline so that the rule "this endpoint honors
+	// only the latency flag" lives at the only call site that uses it; the
+	// packet-loss handler has its own mirror below.
+	return h.addSourcesHandler(
+		types.LatencyFaultType,
+		latencyFaultNotRunningError,
+		func(latencyExists, _ bool) bool { return latencyExists },
+	)
+}
+
+// AddSourcesNetworkPacketLoss extends a running network-packet-loss fault
+// with additional IPs. See AddSourcesNetworkLatency for semantics.
+func (h *FaultHandler) AddSourcesNetworkPacketLoss() func(http.ResponseWriter, *http.Request) {
+	return h.addSourcesHandler(
+		types.PacketLossFaultType,
+		packetLossFaultNotRunningError,
+		func(_, packetLossExists bool) bool { return packetLossExists },
+	)
+}
+
+// faultExistsSelector picks which of the two flags returned by checkTCFault
+// should gate the add-sources operation. A latency add-sources call must
+// observe a latency fault (packet-loss running counts as "not running" for
+// the latency endpoint, returning 404), and vice versa.
+type faultExistsSelector func(latencyExists, packetLossExists bool) bool
+
+// addSourcesHandler is the shared implementation behind AddSourcesNetworkLatency
+// and AddSourcesNetworkPacketLoss. Both endpoints share the same decode,
+// validate, lock, check, apply pipeline; only the fault type, not-running
+// error message, and which checkTCFault flag to honor differ.
+func (h *FaultHandler) addSourcesHandler(
+	faultType, notRunningErr string, faultPresent faultExistsSelector,
+) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var request types.NetworkFaultAddSourcesRequest
+		requestType := fmt.Sprintf(addSourcesFaultRequestType, faultType)
+
+		// Parse the request body. decodeRequest logs the request and writes a
+		// 400 if the JSON is malformed or the body is missing.
+		if err := decodeRequest(w, &request, requestType, r); err != nil {
+			return
+		}
+
+		// Validate the request. validateRequest writes a 400 on failure.
+		if err := validateRequest(w, request, requestType); err != nil {
+			return
+		}
+
+		// Obtain the task metadata via the endpoint container ID.
+		taskMetadata, err := validateTaskMetadata(w, h.AgentState, requestType, r)
+		if err != nil {
+			return
+		}
+
+		// Acquire the per-namespace write lock. This is the same lock used by
+		// start and stop so that add-sources cannot race with either: if stop
+		// has already torn down the qdisc hierarchy, checkTCFault below will
+		// observe it and return 404 instead of attempting a filter-add against
+		// a missing qdisc.
+		networkNSPath := taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path
+		rwMu := h.loadLock(networkNSPath)
+		rwMu.Lock()
+		defer rwMu.Unlock()
+
+		var responseBody types.NetworkFaultInjectionResponse
+		var httpStatusCode int
+		stringToBeLogged := "Failed to add sources to fault"
+		// Share a single 5-second context across checkTCFault and every
+		// tc filter add below. The per-request cap of AddSourcesMaxIPs keeps
+		// a well-formed call inside this budget.
+		ctx, cancel := h.osExecWrapper.NewExecContextWithTimeout(
+			context.Background(), requestTimeoutSeconds*time.Second)
+		defer cancel()
+
+		latencyExists, packetLossExists, err := h.checkTCFault(ctx, taskMetadata)
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			responseBody = types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf(requestTimedOutError, requestType))
+			httpStatusCode = http.StatusInternalServerError
+		} else if err != nil {
+			// Log before overwriting responseBody. Without this, a failing
+			// checkTCFault surfaces as a bare 500 with no breadcrumb for ops.
+			logger.Error("checkTCFault failed", logger.Fields{
+				field.Error:       err,
+				field.RequestType: requestType,
+				field.TaskARN:     taskMetadata.TaskARN,
+			})
+			responseBody = types.NewNetworkFaultInjectionErrorResponse(internalError)
+			httpStatusCode = http.StatusInternalServerError
+		} else if !faultPresent(latencyExists, packetLossExists) {
+			// 404 is the signal to the SSM script that the fault is gone and
+			// the refresh loop should stop. The design calls this out as the
+			// expected behavior after a stop has raced ahead of this update.
+			responseBody = types.NewNetworkFaultInjectionErrorResponse(notRunningErr)
+			httpStatusCode = http.StatusNotFound
+		} else {
+			applyErr := h.addSourcesToFault(ctx, taskMetadata, request)
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				responseBody = types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf(requestTimedOutError, requestType))
+				httpStatusCode = http.StatusInternalServerError
+			} else if applyErr != nil {
+				// No rollback on partial application. Filters already installed
+				// stay in place; the SSM script retries the same IPs on the
+				// next refresh cycle, and tc filter add is idempotent enough
+				// across kernel versions that the retry either succeeds or
+				// fails silently without corrupting the qdisc hierarchy.
+				responseBody = types.NewNetworkFaultInjectionErrorResponse(internalError)
+				httpStatusCode = http.StatusInternalServerError
+			} else {
+				stringToBeLogged = "Successfully added sources to fault"
+				responseBody = types.NewNetworkFaultInjectionSuccessResponse("running")
+				httpStatusCode = http.StatusOK
+			}
+		}
+		logger.Info(stringToBeLogged, logger.Fields{
+			field.RequestType: requestType,
+			field.Request:     request.ToString(),
+			field.Response:    responseBody.ToString(),
+		})
+		handlerutils.WriteJSONResponse(
+			w,
+			httpStatusCode,
+			responseBody,
+			requestType,
+		)
+	}
+}
+
+// addSourcesToFault walks every interface in the task's network namespace and
+// installs new tc filters: SourcesToFilter first (flowid 1:3, allowlist), then
+// Sources (flowid 1:1, impaired). We mirror the start workflow's ordering
+// because SourcesToFilter has a higher-priority tc prio (1 vs 2) and applying
+// it first matches how start builds the filter chain; no functional difference
+// for add-sources, but keeps the two paths visually aligned.
+func (h *FaultHandler) addSourcesToFault(
+	ctx context.Context, taskMetadata *state.TaskResponse,
+	request types.NetworkFaultAddSourcesRequest,
+) error {
+	networkMode := ecstypes.NetworkMode(taskMetadata.TaskNetworkConfig.NetworkMode)
+	nsenterPrefix := ""
+	if networkMode == ecstypes.NetworkModeAwsvpc {
+		nsenterPrefix = fmt.Sprintf(nsenterCommandString, taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].Path)
+	}
+	for _, netInterface := range taskMetadata.TaskNetworkConfig.NetworkNamespaces[0].NetworkInterfaces {
+		if err := h.addIPAddressesToFilter(
+			ctx, request.SourcesToFilter, taskMetadata, nsenterPrefix,
+			tcAllowlistIPCommandString, netInterface.DeviceName,
+		); err != nil {
+			return err
+		}
+		if err := h.addIPAddressesToFilter(
+			ctx, request.Sources, taskMetadata, nsenterPrefix,
+			tcAddFilterForIPCommandString, netInterface.DeviceName,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // decodeRequest will log the request and then translate/unmarshal an incoming fault injection request into

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go
@@ -56,10 +56,10 @@ const (
 	requestTimedOutError               = "%s: request timed out"
 	latencyFaultAlreadyRunningError    = "There is already one network latency fault running"
 	packetLossFaultAlreadyRunningError = "There is already one network packet loss fault running"
-	// add-sources 404 messages. We emit a distinct message per fault type so the
-	// SSM script's logs make it obvious which fault it was trying to extend.
-	latencyFaultNotRunningError    = "no network-latency fault is currently running on the task's network namespace"
-	packetLossFaultNotRunningError = "no network-packet-loss fault is currently running on the task's network namespace"
+	// add-sources 404 messages. We emit a distinct message per fault type so
+	// caller logs make it obvious which fault was being extended.
+	latencyFaultNotRunningError    = "no network-latency fault is currently running for the task"
+	packetLossFaultNotRunningError = "no network-packet-loss fault is currently running for the task"
 	// This is our initial assumption of how much time it would take for the Linux commands used to inject faults
 	// to finish. This will be confirmed/updated after more testing.
 	requestTimeoutSeconds = 5
@@ -1092,7 +1092,7 @@ func (h *FaultHandler) CheckNetworkPacketLoss() func(http.ResponseWriter, *http.
 // AddSourcesNetworkLatency extends a running network-latency fault with
 // additional IPs supplied by the caller. It does not modify fault parameters
 // (delay, jitter, flows percent); those are locked in at start time. Returns
-// 404 if no latency fault is currently running on the task's network namespace.
+// 404 if no latency fault is currently running for the task.
 func (h *FaultHandler) AddSourcesNetworkLatency() func(http.ResponseWriter, *http.Request) {
 	// The selector is defined inline so that the rule "this endpoint honors
 	// only the latency flag" lives at the only call site that uses it; the
@@ -1183,9 +1183,9 @@ func (h *FaultHandler) addSourcesHandler(
 			responseBody = types.NewNetworkFaultInjectionErrorResponse(internalError)
 			httpStatusCode = http.StatusInternalServerError
 		} else if !faultPresent(latencyExists, packetLossExists) {
-			// 404 is the signal to the SSM script that the fault is gone and
-			// the refresh loop should stop. The design calls this out as the
-			// expected behavior after a stop has raced ahead of this update.
+			// 404 signals to the caller that the fault is gone, e.g. so a
+			// refresh loop can stop. This is the expected behavior after a
+			// stop has raced ahead of this update.
 			responseBody = types.NewNetworkFaultInjectionErrorResponse(notRunningErr)
 			httpStatusCode = http.StatusNotFound
 		} else {
@@ -1195,10 +1195,10 @@ func (h *FaultHandler) addSourcesHandler(
 				httpStatusCode = http.StatusInternalServerError
 			} else if applyErr != nil {
 				// No rollback on partial application. Filters already installed
-				// stay in place; the SSM script retries the same IPs on the
-				// next refresh cycle, and tc filter add is idempotent enough
-				// across kernel versions that the retry either succeeds or
-				// fails silently without corrupting the qdisc hierarchy.
+				// stay in place; callers retry the same IPs on the next call.
+				// `tc filter add` accepts duplicate u32 matches without error,
+				// so the retry is safe. Any duplicates are reaped when the
+				// qdisc is torn down on stop.
 				responseBody = types.NewNetworkFaultInjectionErrorResponse(internalError)
 				httpStatusCode = http.StatusInternalServerError
 			} else {

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_sudo_integ_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_sudo_integ_test.go
@@ -21,9 +21,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -43,11 +47,12 @@ import (
 )
 
 const (
-	endpointId     = "endpoint"
-	taskARN        = "t1"
-	startEndpoint  = "/api/%s/fault/v1/%s/start"
-	stopEndpoint   = "/api/%s/fault/v1/%s/stop"
-	statusEndpoint = "/api/%s/fault/v1/%s/status"
+	endpointId         = "endpoint"
+	taskARN            = "t1"
+	startEndpoint      = "/api/%s/fault/v1/%s/start"
+	stopEndpoint       = "/api/%s/fault/v1/%s/stop"
+	statusEndpoint     = "/api/%s/fault/v1/%s/status"
+	addSourcesEndpoint = "/api/%s/fault/v1/%s/add-sources"
 )
 
 var (
@@ -172,6 +177,16 @@ func startServer(t *testing.T) (*http.Server, int) {
 	router.HandleFunc(
 		fmt.Sprintf(statusEndpoint, endpointId, types.PacketLossFaultType),
 		handler.CheckNetworkPacketLoss(),
+	).Methods(http.MethodPost)
+
+	// Registering the add-sources fault injection handlers for both fault types
+	router.HandleFunc(
+		fmt.Sprintf(addSourcesEndpoint, endpointId, types.LatencyFaultType),
+		handler.AddSourcesNetworkLatency(),
+	).Methods(http.MethodPost)
+	router.HandleFunc(
+		fmt.Sprintf(addSourcesEndpoint, endpointId, types.PacketLossFaultType),
+		handler.AddSourcesNetworkPacketLoss(),
 	).Methods(http.MethodPost)
 
 	server := &http.Server{
@@ -374,4 +389,615 @@ func TestParallelNetworkFaults(t *testing.T) {
 			assert.Equal(t, tc.responseCode2, res2.StatusCode)
 		})
 	}
+}
+
+// ===========================================================================
+// FIS-driven add-sources endpoint integration tests.
+//
+// Covers the happy paths, 404 / 400 contract responses, and the
+// concurrency / idempotency expectations of the add-sources endpoint for
+// both latency and packet-loss fault types.
+//
+// IPv6 rejection cases are intentionally omitted because the implementation
+// accepts IPv6 addresses and CIDR blocks, and a v6 filter is installed
+// successfully end to end. host-vs-awsvpc network mode and
+// multiple-interface permutations are omitted because the sudo-style
+// harness only models a single host-mode interface; those network-mode
+// cases are covered by handler-level unit tests in handlers_test.go. Rate
+// limit and telemetry cases are omitted because this harness wires
+// handlers without the tollbooth limiter or telemetry middleware that
+// would make the observable behavior meaningful.
+// ===========================================================================
+
+// addSourcesRequestBody constructs the JSON shape the SSM script sends to
+// the add-sources endpoint. A nil list is omitted from the encoded JSON
+// entirely; pass an empty []string{} to send the field with a `[]` value
+// (used by the empty-request 400 case). The two arguments are independent.
+func addSourcesRequestBody(sources, sourcesToFilter []string) map[string]interface{} {
+	body := map[string]interface{}{}
+	if sources != nil {
+		body["Sources"] = sources
+	}
+	if sourcesToFilter != nil {
+		body["SourcesToFilter"] = sourcesToFilter
+	}
+	return body
+}
+
+// postFault sends a POST to the named fault endpoint on the test server and
+// returns the status code and response body. body=nil sends an empty
+// request; body=string sends the raw string verbatim (used for the
+// malformed-JSON case); any other value is JSON-marshalled. The response
+// body is fully read and the underlying connection closed before this
+// helper returns.
+func postFault(t *testing.T, port int, urlFormat, faultType string, body interface{}) (int, []byte) {
+	t.Helper()
+	var reader io.Reader
+	switch v := body.(type) {
+	case nil:
+		reader = nil
+	case string:
+		reader = strings.NewReader(v)
+	default:
+		buf, err := json.Marshal(v)
+		require.NoError(t, err)
+		reader = bytes.NewReader(buf)
+	}
+	req, err := http.NewRequest(http.MethodPost,
+		getURL(port, fmt.Sprintf(urlFormat, endpointId, faultType)),
+		reader)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, respBody
+}
+
+// startLatencyFault issues a /start request that brings the latency tc
+// hierarchy up against the host's default interface. The caller is
+// responsible for cleanup (typically via defer cleanupLatencyAndPacketLossFaults).
+func startLatencyFault(t *testing.T, port int) {
+	t.Helper()
+	body := getNetworkLatencyRequestBody(100, 0,
+		[]string{"203.0.113.1"}, nil)
+	status, respBody := postFault(t, port, startEndpoint, types.LatencyFaultType, body)
+	require.Equal(t, http.StatusOK, status,
+		"latency /start failed: %s", string(respBody))
+}
+
+// startPacketLossFault is the packet-loss twin of startLatencyFault.
+func startPacketLossFault(t *testing.T, port int) {
+	t.Helper()
+	body := getNetworkPacketLossRequestBody(50,
+		[]string{"203.0.113.1"}, nil)
+	status, respBody := postFault(t, port, startEndpoint, types.PacketLossFaultType, body)
+	require.Equal(t, http.StatusOK, status,
+		"packet-loss /start failed: %s", string(respBody))
+}
+
+// hostInterface returns the host's default network interface name. Tests
+// that need to introspect real tc state shell out against this device.
+func hostInterface(t *testing.T) string {
+	t.Helper()
+	dev, err := netconfig.DefaultNetInterfaceName(netconfig.NewNetworkConfigClient().NetlinkClient)
+	require.NoError(t, err)
+	require.NotEmpty(t, dev)
+	return dev
+}
+
+// tcShowTimeout caps how long any tc inspection helper waits for a real tc
+// invocation. 5s is the same budget the fault handler uses for tc commands;
+// keeping the test side identical avoids spurious skews between observed
+// behavior and the production timeout.
+const tcShowTimeout = 5 * time.Second
+
+// tcFilterShow runs `tc filter show dev <iface>` and returns its output.
+// Used by tests that assert on which IPs ended up installed by add-sources.
+func tcFilterShow(t *testing.T, iface string) string {
+	t.Helper()
+	cmdCtx, cancel := context.WithTimeout(context.Background(), tcShowTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(cmdCtx, "tc", "filter", "show", "dev", iface).CombinedOutput()
+	require.NoError(t, err, "tc filter show failed: %s", string(out))
+	return string(out)
+}
+
+// tcQdiscShow runs `tc qdisc show dev <iface>` and returns the output.
+// Used by the StopAfterAdd test to assert the qdisc hierarchy is fully gone.
+func tcQdiscShow(t *testing.T, iface string) string {
+	t.Helper()
+	cmdCtx, cancel := context.WithTimeout(context.Background(), tcShowTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(cmdCtx, "tc", "qdisc", "show", "dev", iface).CombinedOutput()
+	require.NoError(t, err, "tc qdisc show failed: %s", string(out))
+	return string(out)
+}
+
+// hexForIPv4 converts a dotted-quad IPv4 address into the lowercase 8-char
+// hex representation tc filter show uses in its `match <hex>/ffffffff at 16`
+// output. tc renders the destination IP as a single 32-bit big-endian word.
+// The test fails fast on a malformed input so callers don't have to guard
+// against silent empty-string returns.
+func hexForIPv4(t *testing.T, ip string) string {
+	t.Helper()
+	parts := strings.Split(ip, ".")
+	require.Lenf(t, parts, 4, "hexForIPv4: %q is not a dotted-quad IPv4 address", ip)
+	out := make([]byte, 0, 8)
+	const hex = "0123456789abcdef"
+	for _, p := range parts {
+		n, err := strconv.Atoi(p)
+		require.NoErrorf(t, err, "hexForIPv4: octet %q in %q is not an integer", p, ip)
+		require.Truef(t, n >= 0 && n <= 255,
+			"hexForIPv4: octet %d in %q out of range", n, ip)
+		out = append(out, hex[(n>>4)&0xf], hex[n&0xf])
+	}
+	return string(out)
+}
+
+// assertFilterContainsIP fails the test with a focused message if the tc
+// filter table doesn't include the hex-encoded form of `ip`. Replaces ad-hoc
+// `assert.Contains(filterOutput, hexForIPv4(t, ip))` calls so failures cite
+// the specific IP that was missing rather than dumping the full tc table
+// with no hint of which assertion failed.
+func assertFilterContainsIP(t *testing.T, filterOutput, ip string) {
+	t.Helper()
+	assert.Containsf(t, filterOutput, hexForIPv4(t, ip),
+		"tc filter table missing %s:\n%s", ip, filterOutput)
+}
+
+// ---------------------------------------------------------------------------
+// Happy-path tests.
+// ---------------------------------------------------------------------------
+
+// TestAddSourcesLatencyHappyPath: with a latency
+// fault running, posting two new IPs to /add-sources returns 200 and both
+// IPs land on the impaired flowid (1:1) in the tc filter table.
+func TestAddSourcesLatencyHappyPath(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+	defer cleanupLatencyAndPacketLossFaults(t, port)
+
+	startLatencyFault(t, port)
+
+	const ip1, ip2 = "203.0.113.10", "203.0.113.11"
+	status, body := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+		addSourcesRequestBody([]string{ip1, ip2}, nil))
+	assert.Equal(t, http.StatusOK, status)
+	assert.JSONEq(t, `{"Status":"running"}`, string(body))
+
+	// Verify the kernel actually installed filters for both IPs on flowid 1:1.
+	filterOutput := tcFilterShow(t, hostInterface(t))
+	assertFilterContainsIP(t, filterOutput, ip1)
+	assertFilterContainsIP(t, filterOutput, ip2)
+	assert.Contains(t, filterOutput, "flowid 1:1",
+		"impaired flow not present in filter table")
+}
+
+// TestAddSourcesPacketLossHappyPath is the packet-loss twin of
+// TestAddSourcesLatencyHappyPath.
+func TestAddSourcesPacketLossHappyPath(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+	defer cleanupLatencyAndPacketLossFaults(t, port)
+
+	startPacketLossFault(t, port)
+
+	const ip = "203.0.113.20"
+	status, body := postFault(t, port, addSourcesEndpoint, types.PacketLossFaultType,
+		addSourcesRequestBody([]string{ip}, nil))
+	assert.Equal(t, http.StatusOK, status)
+	assert.JSONEq(t, `{"Status":"running"}`, string(body))
+
+	filterOutput := tcFilterShow(t, hostInterface(t))
+	assertFilterContainsIP(t, filterOutput, ip)
+}
+
+// TestAddSourcesWithSourcesToFilter: a request
+// mixing Sources (impaired, flowid 1:1) and SourcesToFilter (allowlist,
+// flowid 1:3) installs both filter shapes.
+func TestAddSourcesWithSourcesToFilter(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+	defer cleanupLatencyAndPacketLossFaults(t, port)
+
+	startLatencyFault(t, port)
+
+	const impairedIP = "203.0.113.30"
+	const allowlistIP = "10.0.0.99"
+	status, _ := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+		addSourcesRequestBody([]string{impairedIP}, []string{allowlistIP}))
+	assert.Equal(t, http.StatusOK, status)
+
+	filterOutput := tcFilterShow(t, hostInterface(t))
+	assertFilterContainsIP(t, filterOutput, impairedIP)
+	assertFilterContainsIP(t, filterOutput, allowlistIP)
+	assert.Contains(t, filterOutput, "flowid 1:1")
+	assert.Contains(t, filterOutput, "flowid 1:3")
+}
+
+// TestAddSourcesOnlySourcesToFilter: Sources empty,
+// SourcesToFilter populated. Only the allowlist filter is installed.
+func TestAddSourcesOnlySourcesToFilter(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+	defer cleanupLatencyAndPacketLossFaults(t, port)
+
+	startLatencyFault(t, port)
+
+	// Snapshot the impaired-filter set installed by /start so we can prove
+	// add-sources didn't add another impaired filter on top of it.
+	pre := tcFilterShow(t, hostInterface(t))
+	preFlow11 := strings.Count(pre, "flowid 1:1")
+
+	const allowlistIP = "10.0.0.55"
+	status, _ := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+		addSourcesRequestBody(nil, []string{allowlistIP}))
+	assert.Equal(t, http.StatusOK, status)
+
+	post := tcFilterShow(t, hostInterface(t))
+	assertFilterContainsIP(t, post, allowlistIP)
+	assert.Contains(t, post, "flowid 1:3")
+	assert.Equal(t, preFlow11, strings.Count(post, "flowid 1:1"),
+		"impaired-filter count must not change when only SourcesToFilter is sent")
+}
+
+// TestAddSourcesCIDRBlock: a CIDR block in Sources
+// is accepted and translated into a tc filter for the prefix.
+func TestAddSourcesCIDRBlock(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+	defer cleanupLatencyAndPacketLossFaults(t, port)
+
+	startLatencyFault(t, port)
+
+	// Use a /28 to keep the filter mask distinct from a single-host /32.
+	const cidr = "203.0.113.0/28"
+	status, _ := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+		addSourcesRequestBody([]string{cidr}, nil))
+	assert.Equal(t, http.StatusOK, status)
+
+	filterOutput := tcFilterShow(t, hostInterface(t))
+	// /28 = 0xfffffff0 mask, base 203.0.113.0 = cb007100 in hex.
+	assert.Contains(t, filterOutput, "cb007100/fffffff0",
+		"tc filter table missing CIDR-shaped match: %s", filterOutput)
+}
+
+// ---------------------------------------------------------------------------
+// 404 paths.
+// ---------------------------------------------------------------------------
+
+// TestAddSourcesNoFaultRunningReturns404: with no
+// prior /start, the qdisc hierarchy is absent and add-sources returns 404
+// with the not-running contract message.
+func TestAddSourcesNoFaultRunningReturns404(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+	defer cleanupLatencyAndPacketLossFaults(t, port)
+
+	status, body := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+		addSourcesRequestBody([]string{"203.0.113.10"}, nil))
+	assert.Equal(t, http.StatusNotFound, status)
+	assert.Contains(t, string(body), latencyFaultNotRunningError)
+}
+
+// TestAddSourcesWrongFaultTypeReturns404: latency
+// is running, but the request hits the packet-loss endpoint and
+// faultExistsSelector returns false so the response is 404.
+func TestAddSourcesWrongFaultTypeReturns404(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+	defer cleanupLatencyAndPacketLossFaults(t, port)
+
+	startLatencyFault(t, port)
+
+	status, body := postFault(t, port, addSourcesEndpoint, types.PacketLossFaultType,
+		addSourcesRequestBody([]string{"203.0.113.10"}, nil))
+	assert.Equal(t, http.StatusNotFound, status)
+	assert.Contains(t, string(body), packetLossFaultNotRunningError)
+}
+
+// TestAddSourcesAfterStopReturns404: a /start
+// followed by /stop tears down the qdisc; the next add-sources observes an
+// empty tc state and returns 404.
+func TestAddSourcesAfterStopReturns404(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+	defer cleanupLatencyAndPacketLossFaults(t, port)
+
+	startLatencyFault(t, port)
+	stopStatus, _ := postFault(t, port, stopEndpoint, types.LatencyFaultType, map[string]interface{}{})
+	require.Equal(t, http.StatusOK, stopStatus)
+
+	status, body := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+		addSourcesRequestBody([]string{"203.0.113.10"}, nil))
+	assert.Equal(t, http.StatusNotFound, status)
+	assert.Contains(t, string(body), latencyFaultNotRunningError)
+}
+
+// ---------------------------------------------------------------------------
+// 400 validation paths.
+// ---------------------------------------------------------------------------
+
+// TestAddSourcesEmptyRequestReturns400 verifies that a body with both
+// Sources and SourcesToFilter empty is rejected with 400.
+func TestAddSourcesEmptyRequestReturns400(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+
+	status, body := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+		map[string]interface{}{"Sources": []string{}, "SourcesToFilter": []string{}})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, string(body), types.AddSourcesEmptyError)
+}
+
+// TestAddSourcesOverCapReturns400 verifies that a request exceeding
+// AddSourcesMaxIPs is rejected with 400 and an error citing both counts.
+func TestAddSourcesOverCapReturns400(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+
+	overCap := types.AddSourcesMaxIPs + 1
+	ips := make([]string, overCap)
+	for i := range ips {
+		ips[i] = fmt.Sprintf("10.0.0.%d", i+1)
+	}
+	status, body := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+		addSourcesRequestBody(ips, nil))
+	assert.Equal(t, http.StatusBadRequest, status)
+	// The error message pins both the actual count and the cap.
+	assert.Contains(t, string(body), strconv.Itoa(overCap))
+	assert.Contains(t, string(body), strconv.Itoa(types.AddSourcesMaxIPs))
+}
+
+// TestAddSourcesAtCapBoundary: exactly
+// AddSourcesMaxIPs entries across the two lists is accepted.
+func TestAddSourcesAtCapBoundary(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+	defer cleanupLatencyAndPacketLossFaults(t, port)
+
+	startLatencyFault(t, port)
+
+	// Split the cap evenly between the two lists. types.AddSourcesMaxIPs is
+	// even (16) by design; the test would need updating if the cap moved to
+	// an odd value.
+	half := types.AddSourcesMaxIPs / 2
+	srcs := make([]string, half)
+	filters := make([]string, half)
+	// Start the srcs range at 203.0.113.10 to keep it disjoint from the
+	// 203.0.113.1 filter installed by startLatencyFault; otherwise the
+	// `assertFilterContainsIP(out, srcs[0])` check would pass even if the
+	// boundary add-sources call were a no-op.
+	for i := 0; i < half; i++ {
+		srcs[i] = fmt.Sprintf("203.0.113.%d", i+10)
+		filters[i] = fmt.Sprintf("10.0.0.%d", i+10)
+	}
+	status, body := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+		addSourcesRequestBody(srcs, filters))
+	assert.Equal(t, http.StatusOK, status)
+	assert.JSONEq(t, `{"Status":"running"}`, string(body))
+
+	// All AddSourcesMaxIPs entries should have landed in the filter table.
+	// We verify the first and last of each list to keep the assertion focused.
+	out := tcFilterShow(t, hostInterface(t))
+	assertFilterContainsIP(t, out, srcs[0])
+	assertFilterContainsIP(t, out, srcs[len(srcs)-1])
+	assertFilterContainsIP(t, out, filters[0])
+	assertFilterContainsIP(t, out, filters[len(filters)-1])
+}
+
+// TestAddSourcesWithinRequestOverlap verifies that an IP appearing in both
+// Sources and SourcesToFilter within a single request is rejected with 400.
+func TestAddSourcesWithinRequestOverlap(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+
+	const ip = "203.0.113.10"
+	status, body := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+		addSourcesRequestBody([]string{ip}, []string{ip}))
+	assert.Equal(t, http.StatusBadRequest, status)
+	// Pin to the exact error format so accidental edits to the message
+	// have to update the test alongside the production string.
+	assert.Contains(t, string(body), fmt.Sprintf(types.AddSourcesOverlapError, ip))
+}
+
+// TestAddSourcesInvalidIP verifies that a malformed address in Sources is
+// rejected with 400 and the canonical InvalidValueError message.
+func TestAddSourcesInvalidIP(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+
+	status, body := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+		addSourcesRequestBody([]string{"not-an-ip"}, nil))
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, string(body),
+		fmt.Sprintf(types.InvalidValueError, "not-an-ip", "Sources"))
+}
+
+// TestAddSourcesMalformedJSON sends a truncated
+// JSON object; the decoder fails before validation runs.
+func TestAddSourcesMalformedJSON(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+
+	status, _ := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+		`{"Sources":["1.1.1.1"`)
+	assert.Equal(t, http.StatusBadRequest, status)
+}
+
+// TestAddSourcesMissingBody verifies that a request with no body is
+// rejected with 400 and the MissingRequestBodyError contract message.
+func TestAddSourcesMissingBody(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+
+	status, body := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, string(body), types.MissingRequestBodyError)
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency / idempotency.
+// ---------------------------------------------------------------------------
+
+// TestAddSourcesDuplicateAcrossRequestsIdempotent:
+// two sequential add-sources calls with the same IP both succeed.
+//
+// The handler does not deduplicate; the manual-test "Add same IP twice"
+// observation shows the kernel installs a second filter and both calls
+// return 200, which matches the expectation here.
+func TestAddSourcesDuplicateAcrossRequestsIdempotent(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+	defer cleanupLatencyAndPacketLossFaults(t, port)
+
+	startLatencyFault(t, port)
+
+	body := addSourcesRequestBody([]string{"203.0.113.10"}, nil)
+	status1, _ := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType, body)
+	assert.Equal(t, http.StatusOK, status1)
+	status2, _ := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType, body)
+	assert.Equal(t, http.StatusOK, status2)
+}
+
+// TestAddSourcesConcurrentWithStopSerialized: an
+// add-sources and a stop fired concurrently must both terminate, and the
+// add-sources response must be either 200 (it raced ahead of the stop) or
+// 404 (stop tore down the qdisc first). Neither must produce a 500.
+func TestAddSourcesConcurrentWithStopSerialized(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+	defer cleanupLatencyAndPacketLossFaults(t, port)
+
+	startLatencyFault(t, port)
+
+	var wg sync.WaitGroup
+	var addStatus, stopStatus int
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		addStatus, _ = postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+			addSourcesRequestBody([]string{"203.0.113.10"}, nil))
+	}()
+	go func() {
+		defer wg.Done()
+		stopStatus, _ = postFault(t, port, stopEndpoint, types.LatencyFaultType,
+			map[string]interface{}{})
+	}()
+	wg.Wait()
+
+	assert.Equal(t, http.StatusOK, stopStatus,
+		"stop must complete cleanly even when add-sources is in flight")
+	assert.True(t,
+		addStatus == http.StatusOK || addStatus == http.StatusNotFound,
+		"add-sources concurrent with stop must be 200 or 404, got %d", addStatus)
+	assert.NotEqual(t, http.StatusInternalServerError, addStatus,
+		"add-sources concurrent with stop must not 500")
+}
+
+// TestAddSourcesConcurrentSerialized: two
+// add-sources calls fired concurrently are serialized by the per-namespace
+// lock; both return 200 and every requested filter ends up installed.
+func TestAddSourcesConcurrentSerialized(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+	defer cleanupLatencyAndPacketLossFaults(t, port)
+
+	startLatencyFault(t, port)
+
+	const ipA, ipB = "203.0.113.10", "203.0.113.11"
+	var wg sync.WaitGroup
+	statuses := [2]int{}
+	bodies := [2]map[string]interface{}{
+		addSourcesRequestBody([]string{ipA}, nil),
+		addSourcesRequestBody([]string{ipB}, nil),
+	}
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			statuses[idx], _ = postFault(t, port, addSourcesEndpoint,
+				types.LatencyFaultType, bodies[idx])
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, http.StatusOK, statuses[0])
+	assert.Equal(t, http.StatusOK, statuses[1])
+
+	out := tcFilterShow(t, hostInterface(t))
+	assertFilterContainsIP(t, out, ipA)
+	assertFilterContainsIP(t, out, ipB)
+}
+
+// TestAddSourcesDoesNotMutateFaultParameters: the
+// add-sources handler must not change the qdisc parameters established at
+// /start. We assert by snapshotting `tc qdisc show` before and after.
+func TestAddSourcesDoesNotMutateFaultParameters(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+	defer cleanupLatencyAndPacketLossFaults(t, port)
+
+	startLatencyFault(t, port)
+
+	iface := hostInterface(t)
+	pre := tcQdiscShow(t, iface)
+
+	status, _ := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+		addSourcesRequestBody([]string{"203.0.113.10"}, nil))
+	require.Equal(t, http.StatusOK, status)
+
+	post := tcQdiscShow(t, iface)
+	assert.Equal(t, pre, post,
+		"qdisc state must not change across add-sources:\nbefore: %s\nafter:  %s", pre, post)
+}
+
+// TestAddSourcesStopAfterAddCleansEverything verifies that
+// /add-sources installs new filters; /stop must remove the entire qdisc
+// hierarchy regardless. We verify by snapshotting `tc qdisc show` before
+// any fault and after the stop, and asserting the two are equal.
+func TestAddSourcesStopAfterAddCleansEverything(t *testing.T) {
+	skipForUnsupportedTc(t)
+	server, port := startServer(t)
+	defer shutdownServer(t, server)
+	defer cleanupLatencyAndPacketLossFaults(t, port)
+
+	iface := hostInterface(t)
+	baseline := tcQdiscShow(t, iface)
+
+	startLatencyFault(t, port)
+	addStatus, _ := postFault(t, port, addSourcesEndpoint, types.LatencyFaultType,
+		addSourcesRequestBody([]string{"203.0.113.10", "203.0.113.11"}, nil))
+	require.Equal(t, http.StatusOK, addStatus)
+	stopStatus, _ := postFault(t, port, stopEndpoint, types.LatencyFaultType,
+		map[string]interface{}{})
+	require.Equal(t, http.StatusOK, stopStatus)
+
+	cleaned := tcQdiscShow(t, iface)
+	assert.Equal(t, baseline, cleaned,
+		"qdisc state must return to baseline after stop:\nbaseline: %s\nafter stop: %s",
+		baseline, cleaned)
 }

--- a/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/handlers/handlers_test.go
@@ -464,12 +464,14 @@ func TestFaultLatencyFaultPath(t *testing.T) {
 	assert.Equal(t, "/api/{endpointContainerIDMuxName:[^/]*}/fault/v1/network-latency/start", NetworkFaultPath(types.LatencyFaultType, types.StartNetworkFaultPostfix))
 	assert.Equal(t, "/api/{endpointContainerIDMuxName:[^/]*}/fault/v1/network-latency/stop", NetworkFaultPath(types.LatencyFaultType, types.StopNetworkFaultPostfix))
 	assert.Equal(t, "/api/{endpointContainerIDMuxName:[^/]*}/fault/v1/network-latency/status", NetworkFaultPath(types.LatencyFaultType, types.CheckNetworkFaultPostfix))
+	assert.Equal(t, "/api/{endpointContainerIDMuxName:[^/]*}/fault/v1/network-latency/add-sources", NetworkFaultPath(types.LatencyFaultType, types.AddNetworkFaultPostfix))
 }
 
 func TestFaultPacketLossFaultPath(t *testing.T) {
 	assert.Equal(t, "/api/{endpointContainerIDMuxName:[^/]*}/fault/v1/network-packet-loss/start", NetworkFaultPath(types.PacketLossFaultType, types.StartNetworkFaultPostfix))
 	assert.Equal(t, "/api/{endpointContainerIDMuxName:[^/]*}/fault/v1/network-packet-loss/stop", NetworkFaultPath(types.PacketLossFaultType, types.StopNetworkFaultPostfix))
 	assert.Equal(t, "/api/{endpointContainerIDMuxName:[^/]*}/fault/v1/network-packet-loss/status", NetworkFaultPath(types.PacketLossFaultType, types.CheckNetworkFaultPostfix))
+	assert.Equal(t, "/api/{endpointContainerIDMuxName:[^/]*}/fault/v1/network-packet-loss/add-sources", NetworkFaultPath(types.PacketLossFaultType, types.AddNetworkFaultPostfix))
 }
 
 // testNetworkFaultInjectionCommon will be used by unit tests for all 9 fault injection Network Fault APIs.
@@ -529,6 +531,12 @@ func testNetworkFaultInjectionCommon(t *testing.T,
 			case NetworkFaultPath(types.PacketLossFaultType, types.CheckNetworkFaultPostfix):
 				tmdsAPI = "/api/%s/fault/v1/network-packet-loss/status"
 				handleMethod = handler.CheckNetworkPacketLoss()
+			case NetworkFaultPath(types.LatencyFaultType, types.AddNetworkFaultPostfix):
+				tmdsAPI = "/api/%s/fault/v1/network-latency/add-sources"
+				handleMethod = handler.AddSourcesNetworkLatency()
+			case NetworkFaultPath(types.PacketLossFaultType, types.AddNetworkFaultPostfix):
+				tmdsAPI = "/api/%s/fault/v1/network-packet-loss/add-sources"
+				handleMethod = handler.AddSourcesNetworkPacketLoss()
 			default:
 				t.Error("Unrecognized TMDS Endpoint")
 			}
@@ -3680,4 +3688,484 @@ func TestCheckTCFault(t *testing.T) {
 			assert.Equal(t, tc.expectedPacketLoss, packetLossExists)
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Add-sources tests (network-latency and network-packet-loss)
+// ---------------------------------------------------------------------------
+
+var (
+	happyAddSourcesReqBody = map[string]interface{}{
+		"Sources":         []string{"203.0.113.10", "203.0.113.11"},
+		"SourcesToFilter": []string{"10.0.0.2"},
+	}
+
+	addSourcesNetworkLatencyTestPrefix    = fmt.Sprintf(addSourcesFaultRequestType, types.LatencyFaultType)
+	addSourcesNetworkPacketLossTestPrefix = fmt.Sprintf(addSourcesFaultRequestType, types.PacketLossFaultType)
+)
+
+// setAddSourcesExpectations wires up the canonical happy-path exec mocks for
+// an add-sources call: one context setup, one checkTCFault call per interface
+// returning `checkOutput`, then the allowlist and impaired tc filter add
+// commands for each (interface, ip) pair.
+func setAddSourcesExpectations(
+	exec *mock_execwrapper.MockExec,
+	ctrl *gomock.Controller,
+	interfaces []string,
+	checkOutput string,
+	sourcesToFilter []string,
+	sources []string,
+	nsenterPrefix string,
+) {
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+	mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+
+	expectations := []*gomock.Call{
+		exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+	}
+
+	// checkTCFault runs once per interface.
+	checkCommands := make([]string, 0, len(interfaces))
+	for _, iface := range interfaces {
+		checkCommands = append(checkCommands, fmt.Sprintf("tc -j q show dev %s parent 100:1", iface))
+	}
+	expectations = addExpectedCommandsWithOutput(exec, nsenterPrefix, checkCommands, expectations, mockCMD, checkOutput)
+
+	// For each interface, install SourcesToFilter (prio 1, allowlist) then
+	// Sources (prio 2, impaired). Matches addSourcesToFault's ordering.
+	for _, iface := range interfaces {
+		filterCommands := []string{}
+		for _, src := range sourcesToFilter {
+			proto := ip4
+			if !isIPv4(src) {
+				proto = ip6
+			}
+			filterCommands = append(filterCommands, fmt.Sprintf(
+				"tc filter add dev %s protocol all parent 1:0 prio 1 u32 match %s dst %s flowid 1:3",
+				iface, proto, src))
+		}
+		for _, src := range sources {
+			proto := ip4
+			if !isIPv4(src) {
+				proto = ip6
+			}
+			filterCommands = append(filterCommands, fmt.Sprintf(
+				"tc filter add dev %s protocol all parent 1:0 prio 2 u32 match %s dst %s flowid 1:1",
+				iface, proto, src))
+		}
+		expectations = addExpectedCommandsWithOutput(exec, nsenterPrefix, filterCommands, expectations, mockCMD, "")
+	}
+
+	gomock.InOrder(expectations...)
+}
+
+// addExpectedCommandsWithOutput is a variant of addExpectedCommandsWithPrefix
+// that lets the caller control the CombinedOutput bytes per command batch.
+// The existing helper hardcodes tcCommandEmptyOutput which does not fit the
+// add-sources check-then-apply flow.
+func addExpectedCommandsWithOutput(
+	exec *mock_execwrapper.MockExec, nsenterPrefix string, commands []string,
+	expectations []*gomock.Call, mockCMD *mock_execwrapper.MockCmd, output string,
+) []*gomock.Call {
+	for _, cmd := range commands {
+		if nsenterPrefix != "" {
+			cmd = nsenterPrefix + cmd
+		}
+		parts := strings.Split(cmd, " ")
+		expectations = append(expectations,
+			exec.EXPECT().CommandContext(gomock.Any(), parts[0], parts[1:]).Return(mockCMD),
+			mockCMD.EXPECT().CombinedOutput().Return([]byte(output), nil),
+		)
+	}
+	return expectations
+}
+
+// generateCommonAddSourcesTestCases returns test cases that exercise the
+// validation layer shared by both add-sources endpoints (latency, packet loss)
+// and the task metadata error paths.
+func generateCommonAddSourcesTestCases(name, notRunningErr string) []networkFaultInjectionTestCase {
+	return []networkFaultInjectionTestCase{
+		{
+			name:                 fmt.Sprintf("%s no request body", name),
+			expectedStatusCode:   400,
+			requestBody:          nil,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(types.MissingRequestBodyError),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Times(0)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, types.MissingRequestBodyError),
+		},
+		{
+			name:               fmt.Sprintf("%s both lists empty", name),
+			expectedStatusCode: 400,
+			requestBody: map[string]interface{}{
+				"Sources":         []string{},
+				"SourcesToFilter": []string{},
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(types.AddSourcesEmptyError),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Times(0)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, types.AddSourcesEmptyError),
+		},
+		{
+			name:               fmt.Sprintf("%s exceeds max IPs", name),
+			expectedStatusCode: 400,
+			requestBody: map[string]interface{}{
+				"Sources": func() []string {
+					s := make([]string, 17)
+					for i := range s {
+						s[i] = fmt.Sprintf("10.0.0.%d", i+1)
+					}
+					return s
+				}(),
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf(types.AddSourcesTooManyIPsError, 17, types.AddSourcesMaxIPs)),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Times(0)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, fmt.Sprintf(types.AddSourcesTooManyIPsError, 17, types.AddSourcesMaxIPs)),
+		},
+		{
+			name:               fmt.Sprintf("%s invalid ip rejected", name),
+			expectedStatusCode: 400,
+			requestBody: map[string]interface{}{
+				"Sources": []string{"not-an-ip"},
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf(types.InvalidValueError, "not-an-ip", "Sources")),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Times(0)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, fmt.Sprintf(types.InvalidValueError, "not-an-ip", "Sources")),
+		},
+		{
+			name:               fmt.Sprintf("%s overlap rejected", name),
+			expectedStatusCode: 400,
+			requestBody: map[string]interface{}{
+				"Sources":         []string{"1.2.3.4"},
+				"SourcesToFilter": []string{"1.2.3.4"},
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf(types.AddSourcesOverlapError, "1.2.3.4")),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Times(0)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, fmt.Sprintf(types.AddSourcesOverlapError, "1.2.3.4")),
+		},
+		{
+			name:                 fmt.Sprintf("%s task lookup fail", name),
+			expectedStatusCode:   404,
+			requestBody:          happyAddSourcesReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(taskLookupFailError),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).
+					Return(state.TaskResponse{}, state.NewErrorLookupFailure(taskLookupFailError)).
+					Times(1)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, taskLookupFailError),
+		},
+		{
+			name:                 fmt.Sprintf("%s fault injection disabled", name),
+			expectedStatusCode:   400,
+			requestBody:          happyAddSourcesReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf(faultInjectionEnabledError, taskARN)),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(state.TaskResponse{
+					TaskResponse:          &v2.TaskResponse{TaskARN: taskARN},
+					FaultInjectionEnabled: false,
+				}, nil).Times(1)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, fmt.Sprintf(faultInjectionEnabledError, taskARN)),
+		},
+	}
+}
+
+func generateAddSourcesNetworkLatencyTestCases() []networkFaultInjectionTestCase {
+	commonTcs := generateCommonAddSourcesTestCases(addSourcesNetworkLatencyTestPrefix, latencyFaultNotRunningError)
+	specificTcs := []networkFaultInjectionTestCase{
+		{
+			name:                 "no fault running returns 404",
+			expectedStatusCode:   404,
+			requestBody:          happyAddSourcesReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(latencyFaultNotRunningError),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+				gomock.InOrder(
+					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
+				)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, latencyFaultNotRunningError),
+		},
+		{
+			// Design calls this out explicitly: latency add-sources must only
+			// honor the latency flag. A running packet-loss fault does not
+			// satisfy the latency endpoint.
+			name:                 "packet-loss running but not latency returns 404",
+			expectedStatusCode:   404,
+			requestBody:          happyAddSourcesReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(latencyFaultNotRunningError),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+				gomock.InOrder(
+					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLossFaultExistsCommandOutput), nil),
+				)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, latencyFaultNotRunningError),
+		},
+		{
+			name:                 "latency running, single interface, happy",
+			expectedStatusCode:   200,
+			requestBody:          happyAddSourcesReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				setAddSourcesExpectations(exec, ctrl,
+					[]string{deviceName}, tcLatencyFaultExistsCommandOutput,
+					[]string{"10.0.0.2"}, []string{"203.0.113.10", "203.0.113.11"},
+					fmt.Sprintf(nsenterCommandString, nspath))
+			},
+			expectedResponseJSON: happyFaultRunningResponse,
+		},
+		{
+			// IPv6 and dual-stack sources flow through the same v4/v6 switch
+			// in addIPAddressesToFilter; this test pins the tc filter command
+			// shape to "match ip6 dst <addr>" for v6 entries.
+			name:               "latency running, dual-stack add-sources, happy",
+			expectedStatusCode: 200,
+			requestBody: map[string]interface{}{
+				"Sources":         []string{"203.0.113.10", "2001:db8::1"},
+				"SourcesToFilter": []string{"10.0.0.2", "2001:db8:1::/48"},
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				setAddSourcesExpectations(exec, ctrl,
+					[]string{deviceName}, tcLatencyFaultExistsCommandOutput,
+					[]string{"10.0.0.2", "2001:db8:1::/48"},
+					[]string{"203.0.113.10", "2001:db8::1"},
+					fmt.Sprintf(nsenterCommandString, nspath))
+			},
+			expectedResponseJSON: happyFaultRunningResponse,
+		},
+		{
+			name:                 "latency running, two interfaces (host mode), happy",
+			expectedStatusCode:   200,
+			requestBody:          happyAddSourcesReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().
+					GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).
+					Return(happyTaskResponseTwoInterfaces, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				// host mode does not add nsenter prefix.
+				setAddSourcesExpectations(exec, ctrl,
+					[]string{"eth0", "eth1"}, tcLatencyFaultExistsCommandOutput,
+					[]string{"10.0.0.2"}, []string{"203.0.113.10", "203.0.113.11"},
+					"")
+			},
+			expectedResponseJSON: happyFaultRunningResponse,
+		},
+		{
+			name:                 "tc filter add fails returns 500",
+			expectedStatusCode:   500,
+			requestBody:          happyAddSourcesReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(internalError),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+				gomock.InOrder(
+					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+					// checkTCFault returns "latency running"
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLatencyFaultExistsCommandOutput), nil),
+					// First filter add fails (simulating the kernel rejecting a dup filter).
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte("RTNETLINK answers: File exists"), errors.New("exit status 2")),
+				)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, internalError),
+		},
+		{
+			// checkTCFault returning a non-timeout error must surface as 500
+			// "internal error", not as a 404 (the zero values of the returned
+			// flags would otherwise route the request into the "not running"
+			// branch).
+			name:                 "checkTCFault error returns 500",
+			expectedStatusCode:   500,
+			requestBody:          happyAddSourcesReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(internalError),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+				gomock.InOrder(
+					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+					// Non-parseable output + non-nil error from the tc show
+					// command makes checkTCFault return an error while the
+					// context is still alive.
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte("boom"), errors.New("exit status 1")),
+				)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, internalError),
+		},
+		{
+			// Context deadline exceeded during checkTCFault must map to the
+			// request-timed-out 500, not the generic internal-error 500.
+			name:                 "checkTCFault deadline exceeded returns 500 timed out",
+			expectedStatusCode:   500,
+			requestBody:          happyAddSourcesReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(fmt.Sprintf(requestTimedOutError, addSourcesNetworkLatencyTestPrefix)),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				// A negative timeout yields a context whose Err() is already
+				// DeadlineExceeded, matching how the existing request-timed-out
+				// tests in this file simulate the deadline branch.
+				ctx, cancel := context.WithTimeout(context.Background(), -1*time.Second)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+				gomock.InOrder(
+					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte{}, errors.New("signal: killed")),
+				)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, fmt.Sprintf(requestTimedOutError, addSourcesNetworkLatencyTestPrefix)),
+		},
+	}
+	return append(specificTcs, commonTcs...)
+}
+
+func generateAddSourcesNetworkPacketLossTestCases() []networkFaultInjectionTestCase {
+	commonTcs := generateCommonAddSourcesTestCases(addSourcesNetworkPacketLossTestPrefix, packetLossFaultNotRunningError)
+	specificTcs := []networkFaultInjectionTestCase{
+		{
+			name:                 "no fault running returns 404",
+			expectedStatusCode:   404,
+			requestBody:          happyAddSourcesReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(packetLossFaultNotRunningError),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+				gomock.InOrder(
+					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcCommandEmptyOutput), nil),
+				)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, packetLossFaultNotRunningError),
+		},
+		{
+			name:                 "latency running but not packet-loss returns 404",
+			expectedStatusCode:   404,
+			requestBody:          happyAddSourcesReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionErrorResponse(packetLossFaultNotRunningError),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutDuration)
+				mockCMD := mock_execwrapper.NewMockCmd(ctrl)
+				gomock.InOrder(
+					exec.EXPECT().NewExecContextWithTimeout(gomock.Any(), gomock.Any()).Times(1).Return(ctx, cancel),
+					exec.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(mockCMD),
+					mockCMD.EXPECT().CombinedOutput().Times(1).Return([]byte(tcLatencyFaultExistsCommandOutput), nil),
+				)
+			},
+			expectedResponseJSON: fmt.Sprintf(errorResponse, packetLossFaultNotRunningError),
+		},
+		{
+			name:                 "packet-loss running, single interface, happy",
+			expectedStatusCode:   200,
+			requestBody:          happyAddSourcesReqBody,
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				setAddSourcesExpectations(exec, ctrl,
+					[]string{deviceName}, tcLossFaultExistsCommandOutput,
+					[]string{"10.0.0.2"}, []string{"203.0.113.10", "203.0.113.11"},
+					fmt.Sprintf(nsenterCommandString, nspath))
+			},
+			expectedResponseJSON: happyFaultRunningResponse,
+		},
+		{
+			// IPv6 and dual-stack sources flow through the same v4/v6 switch
+			// in addIPAddressesToFilter; this test pins the tc filter command
+			// shape to "match ip6 dst <addr>" for v6 entries.
+			name:               "packet-loss running, dual-stack add-sources, happy",
+			expectedStatusCode: 200,
+			requestBody: map[string]interface{}{
+				"Sources":         []string{"203.0.113.10", "2001:db8::1"},
+				"SourcesToFilter": []string{"10.0.0.2", "2001:db8:1::/48"},
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				setAddSourcesExpectations(exec, ctrl,
+					[]string{deviceName}, tcLossFaultExistsCommandOutput,
+					[]string{"10.0.0.2", "2001:db8:1::/48"},
+					[]string{"203.0.113.10", "2001:db8::1"},
+					fmt.Sprintf(nsenterCommandString, nspath))
+			},
+			expectedResponseJSON: happyFaultRunningResponse,
+		},
+		{
+			name:               "Sources only (no SourcesToFilter), happy",
+			expectedStatusCode: 200,
+			requestBody: map[string]interface{}{
+				"Sources": []string{"203.0.113.10"},
+			},
+			expectedResponseBody: types.NewNetworkFaultInjectionSuccessResponse("running"),
+			setAgentStateExpectations: func(agentState *mock_state.MockAgentState, netConfigClient *netconfig.NetworkConfigClient) {
+				agentState.EXPECT().GetTaskMetadataWithTaskNetworkConfig(endpointId, netConfigClient).Return(happyTaskResponse, nil)
+			},
+			setExecExpectations: func(exec *mock_execwrapper.MockExec, ctrl *gomock.Controller) {
+				setAddSourcesExpectations(exec, ctrl,
+					[]string{deviceName}, tcLossFaultExistsCommandOutput,
+					nil, []string{"203.0.113.10"},
+					fmt.Sprintf(nsenterCommandString, nspath))
+			},
+			expectedResponseJSON: happyFaultRunningResponse,
+		},
+	}
+	return append(specificTcs, commonTcs...)
+}
+
+func TestAddSourcesNetworkLatency(t *testing.T) {
+	tcs := generateAddSourcesNetworkLatencyTestCases()
+	testNetworkFaultInjectionCommon(t, tcs, NetworkFaultPath(types.LatencyFaultType, types.AddNetworkFaultPostfix))
+}
+
+func TestAddSourcesNetworkPacketLoss(t *testing.T) {
+	tcs := generateAddSourcesNetworkPacketLossTestCases()
+	testNetworkFaultInjectionCommon(t, tcs, NetworkFaultPath(types.PacketLossFaultType, types.AddNetworkFaultPostfix))
 }

--- a/ecs-agent/tmds/handlers/fault/v1/types/types.go
+++ b/ecs-agent/tmds/handlers/fault/v1/types/types.go
@@ -30,13 +30,26 @@ const (
 	StartNetworkFaultPostfix = "start"
 	StopNetworkFaultPostfix  = "stop"
 	CheckNetworkFaultPostfix = "status"
-	TrafficTypeIngress       = "ingress"
-	TrafficTypeEgress        = "egress"
+	AddNetworkFaultPostfix   = "add-sources"
+	// AddSourcesMaxIPs caps the total number of entries (Sources + SourcesToFilter)
+	// accepted by a single add-sources request. The cap keeps a well-formed call
+	// inside the shared requestTimeoutSeconds budget and forces callers to keep
+	// one refresh call per domain. Route53 returns at most 8 IPs per answer, so
+	// 16 leaves headroom for two-domain bundles without requiring a split.
+	AddSourcesMaxIPs   = 16
+	TrafficTypeIngress = "ingress"
+	TrafficTypeEgress  = "egress"
 	// Request Payload Errors
 	MissingRequiredFieldError = "required parameter %s is missing"
 	MissingRequestBodyError   = "required request body is missing"
 	ZeroDelayAndJitterError   = "required either DelayMilliseconds or JitterMilliseconds to be non-zero"
 	InvalidValueError         = "invalid value %s for parameter %s"
+	// AddSources-specific errors. "Sources" and "SourcesToFilter" are JSON
+	// field names on NetworkFaultAddSourcesRequest, not English nouns; the
+	// capitalization lets callers grep from error back to field.
+	AddSourcesTooManyIPsError = "Sources and SourcesToFilter together have %d entries, maximum allowed is %d"
+	AddSourcesEmptyError      = "at least one of Sources or SourcesToFilter must be non-empty"
+	AddSourcesOverlapError    = "%s is present in both Sources and SourcesToFilter"
 )
 
 type NetworkFaultRequest interface {
@@ -243,4 +256,61 @@ func requireIPInRequestSource(source string, sourceType string) error {
 	}
 
 	return fmt.Errorf(InvalidValueError, source, sourceType)
+}
+
+// NetworkFaultAddSourcesRequest is the request body for the add-sources endpoint
+// used to push additional IPs into an already-running tc fault. It carries only
+// the IP lists because the fault parameters (delay, jitter, loss percent, flows
+// percent) are locked in at start time and cannot be changed mid-fault.
+type NetworkFaultAddSourcesRequest struct {
+	// Sources is a list of IPv4/IPv6 addresses or IPv4/IPv6 CIDR blocks to add
+	// as tc filters for the impaired flow.
+	Sources []*string `json:"Sources"`
+	// SourcesToFilter is a list of IPv4/IPv6 addresses or IPv4/IPv6 CIDR blocks
+	// to add as allowlist filters that bypass the impairment.
+	SourcesToFilter []*string `json:"SourcesToFilter,omitempty"`
+}
+
+// ValidateRequest enforces the add-sources contract: at least one IP across the
+// two lists, every entry is a valid IPv4/IPv6 address or CIDR block, the two
+// lists are disjoint within this request, and the combined size fits under
+// AddSourcesMaxIPs. Cross-request overlap is the SSM script's responsibility;
+// tracking it here would require per-namespace state and additional tc queries.
+func (request NetworkFaultAddSourcesRequest) ValidateRequest() error {
+	if len(request.Sources) == 0 && len(request.SourcesToFilter) == 0 {
+		return errors.New(AddSourcesEmptyError)
+	}
+	total := len(request.Sources) + len(request.SourcesToFilter)
+	if total > AddSourcesMaxIPs {
+		return fmt.Errorf(AddSourcesTooManyIPsError, total, AddSourcesMaxIPs)
+	}
+	if err := requireIPInRequestSources(request.Sources, "Sources"); err != nil {
+		return err
+	}
+	if err := requireIPInRequestSources(request.SourcesToFilter, "SourcesToFilter"); err != nil {
+		return err
+	}
+	// Reject within-request overlap. Any IP that appears in both lists is
+	// ambiguous: the caller cannot want the same address on both flowid 1:1
+	// (impaired) and flowid 1:3 (allowlist). 400 surfaces the mistake instead
+	// of installing conflicting filters.
+	filterSet := make(map[string]struct{}, len(request.SourcesToFilter))
+	for _, ipPtr := range request.SourcesToFilter {
+		filterSet[aws.ToString(ipPtr)] = struct{}{}
+	}
+	for _, ipPtr := range request.Sources {
+		ip := aws.ToString(ipPtr)
+		if _, found := filterSet[ip]; found {
+			return fmt.Errorf(AddSourcesOverlapError, ip)
+		}
+	}
+	return nil
+}
+
+func (request NetworkFaultAddSourcesRequest) ToString() string {
+	data, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Sprintf("Error: Unable to parse add-sources request with error %v.", err)
+	}
+	return string(data)
 }

--- a/ecs-agent/tmds/handlers/fault/v1/types/types_test.go
+++ b/ecs-agent/tmds/handlers/fault/v1/types/types_test.go
@@ -71,3 +71,111 @@ func TestRequireIPInRequestSources(t *testing.T) {
 		})
 	}
 }
+
+func TestNetworkFaultAddSourcesRequestValidateRequest(t *testing.T) {
+	ip := func(s string) *string { return aws.String(s) }
+
+	// many16 builds a slice of 16 distinct IPv4 addresses for cap tests.
+	many16 := make([]*string, 16)
+	for i := 0; i < 16; i++ {
+		many16[i] = aws.String(fmt.Sprintf("10.0.0.%d", i+1))
+	}
+	many17 := append([]*string{}, many16...)
+	many17 = append(many17, aws.String("10.0.0.17"))
+
+	tcs := []struct {
+		name    string
+		request NetworkFaultAddSourcesRequest
+		wantErr string // empty means no error expected
+	}{
+		{
+			name:    "both lists empty",
+			request: NetworkFaultAddSourcesRequest{},
+			wantErr: AddSourcesEmptyError,
+		},
+		{
+			name: "Sources only, valid IPv4",
+			request: NetworkFaultAddSourcesRequest{
+				Sources: []*string{ip("1.2.3.4")},
+			},
+		},
+		{
+			name: "SourcesToFilter only, valid IPv4 CIDR",
+			request: NetworkFaultAddSourcesRequest{
+				SourcesToFilter: []*string{ip("10.0.0.0/24")},
+			},
+		},
+		{
+			name: "both lists, disjoint, valid",
+			request: NetworkFaultAddSourcesRequest{
+				Sources:         []*string{ip("1.2.3.4"), ip("5.6.7.8")},
+				SourcesToFilter: []*string{ip("10.0.0.1")},
+			},
+		},
+		{
+			name: "total exactly at cap",
+			request: NetworkFaultAddSourcesRequest{
+				Sources: many16,
+			},
+		},
+		{
+			name: "total exceeds cap",
+			request: NetworkFaultAddSourcesRequest{
+				Sources: many17,
+			},
+			wantErr: fmt.Sprintf(AddSourcesTooManyIPsError, 17, AddSourcesMaxIPs),
+		},
+		{
+			name: "IPv6 in Sources accepted",
+			request: NetworkFaultAddSourcesRequest{
+				Sources: []*string{ip("2001:db8::1")},
+			},
+		},
+		{
+			name: "IPv6 CIDR in SourcesToFilter accepted",
+			request: NetworkFaultAddSourcesRequest{
+				SourcesToFilter: []*string{ip("::1/128")},
+			},
+		},
+		{
+			name: "dual-stack mix across both lists accepted",
+			request: NetworkFaultAddSourcesRequest{
+				Sources:         []*string{ip("1.2.3.4"), ip("2001:db8::1")},
+				SourcesToFilter: []*string{ip("10.0.0.0/24"), ip("2001:db8:1::/48")},
+			},
+		},
+		{
+			name: "non-IP garbage in Sources rejected",
+			request: NetworkFaultAddSourcesRequest{
+				Sources: []*string{ip("not-an-ip")},
+			},
+			wantErr: fmt.Sprintf(InvalidValueError, "not-an-ip", "Sources"),
+		},
+		{
+			name: "Sources and SourcesToFilter overlap",
+			request: NetworkFaultAddSourcesRequest{
+				Sources:         []*string{ip("1.2.3.4")},
+				SourcesToFilter: []*string{ip("1.2.3.4")},
+			},
+			wantErr: fmt.Sprintf(AddSourcesOverlapError, "1.2.3.4"),
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.request.ValidateRequest()
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestNetworkFaultAddSourcesRequestToString(t *testing.T) {
+	req := NetworkFaultAddSourcesRequest{
+		Sources:         []*string{aws.String("1.2.3.4")},
+		SourcesToFilter: []*string{aws.String("5.6.7.8")},
+	}
+	require.Equal(t, `{"Sources":["1.2.3.4"],"SourcesToFilter":["5.6.7.8"]}`, req.ToString())
+}


### PR DESCRIPTION
### Summary
FIS network faults target traffic between an ECS task and a network destination. Customers identify the destination by IP, CIDR, or DNS name; for DNS names FIS resolves to IPs at fault start and hands the resulting set to the ECS Agent, which installs tc rules against it and never revisits the resolution. The set may go stale on long-running faults: resolvers may return only a subset of IPs per lookup, and DNS records rotate over time, so traffic to later-resolved IPs is unimpaired.

### Implementation details
Add `POST /fault/v1/{network-latency|network-packet-loss}/add-sources`. The handler installs additional `tc` filters against a running fault without touching the `qdisc`, returns 404 if no fault of the matching type is running, and caps combined `Sources`+`SourcesToFilter` at 16 IPs per call to fit the 5s `requestTimeoutSeconds` budget.

Touched files: request/response types in `ecs-agent/tmds/handlers/fault/v1/types/types.go`, handlers in `ecs-agent/tmds/handlers/fault/v1/handlers/handlers.go` (and its `agent/vendor/...` mirror), and route registration in `agent/handlers/task_server_setup.go`.

### Testing
Unit tests in `handlers_test.go` and `types_test.go` cover validation, the 16-IP cap, missing/wrong/stopped fault states, and routing.

18 sudo-tagged integration tests issue real `tc` commands on EC2 Linux (`go test -tags sudo -run TestAddSources ./tmds/handlers/fault/v1/handlers/`): happy path for latency and packet loss with `Sources`/`SourcesToFilter`/CIDR; 404 on no fault, wrong type, after stop; 400 on empty/over-cap/overlap/invalid IP/malformed/missing body; 200 at the 16-IP cap; duplicate IPs idempotent; concurrent add+stop and add+add serialized; `qdisc` params unchanged; stop after add cleans everything. All pass.

Manual tests on EC2 against TMDS from a task container, all passing: latency and packet-loss happy paths with mid-fault `add-sources` (verified via `ping`); IPv6 source installs v6 match keys; duplicate IP re-add returns 200 without `qdisc` corruption; add before start, wrong fault type, and add after stop return 404 with the expected error; empty body, `Sources=[]`, and invalid IP return 400 with the expected error.

New tests cover the changes: yes

### Description for the changelog
Feature - Add FIS-driven DNS refresh add-sources endpoint for network-latency and network-packet-loss faults

### Additional Information
**Does this PR include breaking model changes? If so, Have you added transformation functions?**
No. New endpoints and types only; existing types and routes are unchanged.

**Does this PR include the addition of new environment variables in the README?**
No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
