### PR TITLE
🔨 dcgm-init Build and Log to File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ cover.out
 cover.out.tmp
 coverprofile*.out
 /amazon-ecs-init*
+/amazon-dcgm-init
 /BUILDROOT/
 /x86_64/
 /sources.tar
@@ -41,6 +42,7 @@ coverprofile*.out
 /sources.tgz
 ecs-agent-*.tar
 /ecs.service
+/dcgm-init.service
 *.log
 *.DS_Store
 .run/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ _bin/
 /agent/version/_version.go
 /ecs-agent/daemonimages/csidriver/tarfiles
 /ecs-init/version/version.go
+/dcgm-init/version/version.go
 /ecs-agent/daemonimages/csidriver/tarfiles
 .agignore
 *.sublime-*

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ test-init:
 
 .PHONY: build-dcgm-init test-dcgm-init
 build-dcgm-init:
-	cd dcgm-init && CGO_ENABLED=1 CGO_LDFLAGS="-Wl,--unresolved-symbols=ignore-in-object-files" \
+	cd dcgm-init && CGO_ENABLED=1 \
 		go build -mod=vendor -ldflags "-s" -o ../amazon-dcgm-init .
 
 test-dcgm-init:

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,11 @@ test-init:
 		./... && cd ..
 	cd ecs-init && go tool cover -func ../cover.out > ../coverprofile-init.out && cd ..
 
+.PHONY: build-dcgm-init test-dcgm-init
+build-dcgm-init:
+	cd dcgm-init && CGO_ENABLED=1 CGO_LDFLAGS="-Wl,--unresolved-symbols=ignore-in-object-files" \
+		go build -mod=vendor -ldflags "-s" -o ../amazon-dcgm-init .
+
 test-dcgm-init:
 	cd dcgm-init && GO111MODULE=on ${GOTEST} ${VERBOSE} -tags unit -mod vendor \
 		-coverprofile ../cover.out \
@@ -410,7 +415,7 @@ static-check: gocyclo govet importcheck gogenerate-check
 	# use default checks of staticcheck tool, except style checks (-ST*) and depracation checks (-SA1019)
 	# depracation checks have been left out for now; removing their warnings requires error handling for newer suggested APIs, changes in function signatures and their usages.
 	# https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck
-	staticcheck -tests=false -checks "inherit,-ST*,-SA1019,-SA9002,-SA4006" ./agent/... ./ecs-agent/...
+	staticcheck -tests=false -checks "inherit,-ST*,-SA1019,-SA9002,-SA4006" ./agent/... ./ecs-agent/... ./dcgm-init/...
 
 .PHONY: static-check-init
 static-check-init: gocyclo govet importcheck gogenerate-check-init
@@ -458,7 +463,8 @@ amazon-linux-sources.tgz:
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.conf amazon-ecs-volume-plugin.conf
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.service amazon-ecs-volume-plugin.service
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.socket amazon-ecs-volume-plugin.socket
-	tar -czf ./sources.tgz ecs-init scripts misc agent amazon-ecs-cni-plugins amazon-vpc-cni-plugins agent-container Makefile VERSION RELEASE_COMMIT
+	cp packaging/amazon-linux-ami-integrated/dcgm-init.service dcgm-init.service
+	tar -czf ./sources.tgz ecs-init dcgm-init scripts misc agent amazon-ecs-cni-plugins amazon-vpc-cni-plugins agent-container Makefile VERSION RELEASE_COMMIT
 
 .amazon-linux-rpm-integrated-done: amazon-linux-sources.tgz
 	test -e SOURCES || ln -s . SOURCES
@@ -477,7 +483,8 @@ amazon-linux-rpm-integrated: .amazon-linux-rpm-integrated-done
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.conf amazon-ecs-volume-plugin.conf
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.service amazon-ecs-volume-plugin.service
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.socket amazon-ecs-volume-plugin.socket
-	tar -czf ./sources.tgz ecs-init scripts misc agent amazon-ecs-cni-plugins amazon-vpc-cni-plugins agent-container Makefile VERSION GO_VERSION
+	cp packaging/amazon-linux-ami-integrated/dcgm-init.service dcgm-init.service
+	tar -czf ./sources.tgz ecs-init dcgm-init scripts misc agent amazon-ecs-cni-plugins amazon-vpc-cni-plugins agent-container Makefile VERSION GO_VERSION
 	test -e SOURCES || ln -s . SOURCES
 	rpmbuild --define "%_topdir $(PWD)" -bb ecs-agent.spec
 	find RPMS/ -type f -exec cp {} . \;
@@ -538,6 +545,7 @@ clean:
 	-rm -rf coverprofile.out
 	-rm -rf coverprofile-init.out
 	-rm -rf coverprofile-ecs-agent.out
+	-rm -rf coverprofile-dcgm-init.out
 	# ecs-init & rpm cleanup
 	-rm -f ecs-init.spec
 	-rm -f amazon-ecs-init.spec
@@ -549,6 +557,8 @@ clean:
 	-rm -rf ./bin
 	-rm -f ./sources.tgz
 	-rm -f ./amazon-ecs-init
+	-rm -f ./amazon-dcgm-init
+	-rm -f ./dcgm-init.service
 	-rm -f ./ecs-init/ecs-init
 	-rm -f ./amazon-ecs-init-*.rpm
 	-rm -f ./ecs-agent-*.tar

--- a/dcgm-init/engine/engine.go
+++ b/dcgm-init/engine/engine.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// DefaultInitErrorExitCode is used for recoverable init errors (retried by
-	// Restart=on-failure).
+	// Restart=always).
 	DefaultInitErrorExitCode = -1
 )
 

--- a/dcgm-init/engine/engine.go
+++ b/dcgm-init/engine/engine.go
@@ -37,13 +37,6 @@ const (
 )
 
 const (
-	MetricsFileDir = "/var/run/ecs"
-
-	// MetricsFilePath is the shared file dcgm-init writes GPU metrics to and the
-	// agent reads. Start() creates the parent dir and an empty file on demand;
-	// it is first populated on the initial collection tick.
-	MetricsFilePath = MetricsFileDir + "/gpu-metrics.json"
-
 	// metricsFilePermission is the permission for the metrics file and its
 	// staging temp file. 0644 keeps it world-readable so the agent can consume
 	// it, while only dcgm-init writes it.
@@ -82,7 +75,7 @@ type Engine struct {
 func New() (*Engine, error) {
 	return &Engine{
 		client:             dcgm.NewClient(dcgm.Config{}),
-		outputPath:         MetricsFilePath,
+		outputPath:         gputypes.GPUMetricsFilePath,
 		collectionInterval: metricsCollectionInterval,
 	}, nil
 }
@@ -101,6 +94,7 @@ func (e *Engine) Start() error {
 	if err := os.MkdirAll(outputDir, metricsDirPermission); err != nil {
 		return fmt.Errorf("dcgm-init cannot create metrics directory %s: %w", outputDir, err)
 	}
+
 	// Fail fast if either file can't be written, rather than spin a loop whose
 	// writes fail every tick. Both are created on demand, so only an existing
 	// unwritable file (or unwritable directory) is fatal.

--- a/dcgm-init/engine/engine_test.go
+++ b/dcgm-init/engine/engine_test.go
@@ -102,9 +102,9 @@ func TestNewEngine(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, eng)
 			assert.NotNil(t, eng.client)
-			assert.Equal(t, MetricsFilePath, eng.outputPath)
+			assert.Equal(t, gputypes.GPUMetricsFilePath, eng.outputPath)
 			assert.Equal(t, metricsCollectionInterval, eng.collectionInterval)
-			assert.Equal(t, MetricsFilePath+".tmp", eng.tempPath())
+			assert.Equal(t, gputypes.GPUMetricsFilePath+".tmp", eng.tempPath())
 		})
 	}
 }
@@ -264,7 +264,6 @@ func TestEngine_PeriodicCollection(t *testing.T) {
 				getMetricsCalls *atomic.Int64,
 				cancel context.CancelFunc,
 			) {
-				// Wait for at least one collection tick.
 				assert.Eventually(t, func() bool {
 					return getMetricsCalls.Load() >= 1
 				}, 200*time.Millisecond, 5*time.Millisecond,
@@ -281,13 +280,11 @@ func TestEngine_PeriodicCollection(t *testing.T) {
 				getMetricsCalls *atomic.Int64,
 				cancel context.CancelFunc,
 			) {
-				// Wait for at least one tick to confirm the loop is running.
 				assert.Eventually(t, func() bool {
 					return reconcileCalls.Load() >= 1
 				}, 200*time.Millisecond, 5*time.Millisecond,
 					"Expected at least one Reconcile call")
 
-				// Cancel the context to stop the loop.
 				cancel()
 
 				// Record the call count after cancellation.
@@ -326,7 +323,6 @@ func TestEngine_PeriodicCollection(t *testing.T) {
 			}).AnyTimes()
 			expectStatus(mockClient, true, "", false)
 
-			// Short interval so the ticker fires many times within the test window.
 			eng := newTestEngine(mockClient, outputPath, 5*time.Millisecond)
 
 			done := make(chan struct{})
@@ -334,11 +330,11 @@ func TestEngine_PeriodicCollection(t *testing.T) {
 
 			tc.testFunc(t, eng, mockClient, &reconcileCalls, &getMetricsCalls, cancel)
 
-			// Cancel (idempotent) and confirm the loop returns cleanly.
+			// Cancel and confirm the loop returns cleanly.
 			cancel()
 			select {
 			case <-done:
-				// run() returned cleanly after context cancellation.
+				// run() returned after context cancellation.
 			case <-time.After(2 * time.Second):
 				t.Fatal("run() did not return after context cancellation")
 			}

--- a/dcgm-init/main.go
+++ b/dcgm-init/main.go
@@ -86,8 +86,9 @@ func configureLogging() {
 	logger.SetConfigLogFile(logFile)
 	logger.SetRolloverType("date")
 
-	// The file level defaults to "off" under ECS_LOG_DRIVER, so force it from
-	// ECS_LOGLEVEL (info when unset/invalid) so the file is always written.
+	// When ECS_LOG_DRIVER is set, the instance (file) log level defaults to
+	// "off", which writes nothing to logFile. Force it from ECS_LOGLEVEL (info
+	// when unset/invalid) so the file is always written.
 	logger.SetInstanceLogLevel(logger.DEFAULT_LOGLEVEL)
 	if level := os.Getenv(logger.LOGLEVEL_ENV_VAR); level != "" {
 		logger.SetInstanceLogLevel(level)

--- a/dcgm-init/main.go
+++ b/dcgm-init/main.go
@@ -19,12 +19,19 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/aws/amazon-ecs-agent/dcgm-init/engine"
 	"github.com/aws/amazon-ecs-agent/dcgm-init/version"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 
 	"github.com/cihub/seelog"
+)
+
+// log config
+const (
+	logFile                      = "/var/log/ecs/dcgm-init.log"
+	logDirPermission os.FileMode = 0755
 )
 
 // all supported commands
@@ -42,12 +49,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	logger.InitSeelog()
+	configureLogging()
 	defer seelog.Flush()
+
 	if args[0] == VERSION {
-		err := version.PrintVersion()
-		if err != nil {
-			seelog.Errorf("failed print version info, err: %v", err)
+		if err := version.PrintVersion(); err != nil {
+			seelog.Errorf("failed to print version info: %v", err)
 		}
 		return
 	}
@@ -61,12 +68,36 @@ func main() {
 	action, ok := actions[args[0]]
 	if !ok {
 		usage(actions)
+		seelog.Flush()
 		os.Exit(1)
 	}
 	err = action.function()
 
 	if err != nil {
 		die(err, engine.DefaultInitErrorExitCode)
+	}
+}
+
+// configureLogging sets up dcgm-init's file logging to logFile.
+func configureLogging() {
+	logger.InitSeelog()
+
+	// Set our file first to override any ECS_LOGFILE from the environment.
+	logger.SetConfigLogFile(logFile)
+	logger.SetRolloverType("date")
+
+	// The file level defaults to "off" under ECS_LOG_DRIVER, so force it from
+	// ECS_LOGLEVEL (info when unset/invalid) so the file is always written.
+	logger.SetInstanceLogLevel(logger.DEFAULT_LOGLEVEL)
+	if level := os.Getenv(logger.LOGLEVEL_ENV_VAR); level != "" {
+		logger.SetInstanceLogLevel(level)
+	}
+
+	// Best-effort: seelog also creates the dir lazily; this just warns clearly
+	// on failure and applies our mode.
+	logDir := filepath.Dir(logFile)
+	if err := os.MkdirAll(logDir, logDirPermission); err != nil {
+		seelog.Warnf("dcgm-init could not create log directory %s: %v", logDir, err)
 	}
 }
 

--- a/dcgm-init/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/gpu/types/types.go
+++ b/dcgm-init/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/gpu/types/types.go
@@ -15,6 +15,12 @@
 
 package types
 
+const (
+	gpuMetricsDirPath  = "/var/run/ecs"
+	gpuMetricsFileName = "gpu-metrics.json"
+	GPUMetricsFilePath = gpuMetricsDirPath + "/" + gpuMetricsFileName
+)
+
 // GPUMetric holds per-device GPU telemetry. This struct is used by both
 // dcgm-init (for collection) and the agent (for TACS conversion).
 type GPUMetric struct {

--- a/ecs-agent/gpu/types/types.go
+++ b/ecs-agent/gpu/types/types.go
@@ -15,6 +15,12 @@
 
 package types
 
+const (
+	gpuMetricsDirPath  = "/var/run/ecs"
+	gpuMetricsFileName = "gpu-metrics.json"
+	GPUMetricsFilePath = gpuMetricsDirPath + "/" + gpuMetricsFileName
+)
+
 // GPUMetric holds per-device GPU telemetry. This struct is used by both
 // dcgm-init (for collection) and the agent (for TACS conversion).
 type GPUMetric struct {

--- a/packaging/amazon-linux-ami-integrated/dcgm-init.service
+++ b/packaging/amazon-linux-ami-integrated/dcgm-init.service
@@ -2,6 +2,7 @@
 Description=Amazon Elastic Container Service - DCGM Go bindings
 Wants=nvidia-dcgm.service
 After=nvidia-dcgm.service
+After=cloud-final.service
 ConditionPathExists=/usr/bin/nv-hostengine
 
 [Service]

--- a/packaging/amazon-linux-ami-integrated/dcgm-init.service
+++ b/packaging/amazon-linux-ami-integrated/dcgm-init.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Amazon Elastic Container Service - DCGM Go bindings
+Wants=nvidia-dcgm.service
+After=nvidia-dcgm.service
+ConditionPathExists=/usr/bin/nv-hostengine
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=10s
+EnvironmentFile=-/etc/ecs/ecs.config
+ExecStart=/usr/libexec/dcgm-init start
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -41,6 +41,7 @@ Source4:        amazon-ecs-volume-plugin.socket
 Source5:        amazon-ecs-volume-plugin.conf
 Source6:        ebs-csi-driver-arm64-v%{version}.tar
 Source7:        ebs-csi-driver-v%{version}.tar
+Source8:        dcgm-init.service
 
 BuildRequires:  golang >= 1.25.0
 %if %{with systemd}
@@ -275,10 +276,12 @@ required routes among its preparation steps.
 # each of these should build for arm and amd arch
 make release-agent-internal
 ./scripts/gobuild.sh %{gobuild_tag}
+make build-dcgm-init
 
 %install
 install -D amazon-ecs-init %{buildroot}%{_libexecdir}/amazon-ecs-init
 install -D amazon-ecs-volume-plugin %{buildroot}%{_libexecdir}/amazon-ecs-volume-plugin
+install -D amazon-dcgm-init %{buildroot}%{_libexecdir}/dcgm-init
 install -m %{no_exec_perm} -D scripts/amazon-ecs-init.1 %{buildroot}%{_mandir}/man1/amazon-ecs-init.1
 
 mkdir -p %{buildroot}%{_sysconfdir}/ecs
@@ -303,6 +306,7 @@ mkdir -p %{buildroot}%{_sharedstatedir}/ecs/data
 install -m %{no_exec_perm} -D %{SOURCE2} $RPM_BUILD_ROOT/%{_unitdir}/ecs.service
 install -m %{no_exec_perm} -D %{SOURCE3} $RPM_BUILD_ROOT/%{_unitdir}/amazon-ecs-volume-plugin.service
 install -m %{no_exec_perm} -D %{SOURCE4} $RPM_BUILD_ROOT/%{_unitdir}/amazon-ecs-volume-plugin.socket
+install -m %{no_exec_perm} -D %{SOURCE8} $RPM_BUILD_ROOT/%{_unitdir}/dcgm-init.service
 %else
 install -m %{no_exec_perm} -D %{SOURCE1} %{buildroot}%{_sysconfdir}/init/ecs.conf
 install -m %{no_exec_perm} -D %{SOURCE5} %{buildroot}%{_sysconfdir}/init/amazon-ecs-volume-plugin.conf
@@ -312,6 +316,7 @@ install -m %{no_exec_perm} -D %{SOURCE5} %{buildroot}%{_sysconfdir}/init/amazon-
 %{_libexecdir}/amazon-ecs-init
 %{_mandir}/man1/amazon-ecs-init.1*
 %{_libexecdir}/amazon-ecs-volume-plugin
+%{_libexecdir}/dcgm-init
 %dir %{_sysconfdir}/ecs
 %config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config
 %config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config.json
@@ -326,6 +331,7 @@ install -m %{no_exec_perm} -D %{SOURCE5} %{buildroot}%{_sysconfdir}/init/amazon-
 %{_unitdir}/ecs.service
 %{_unitdir}/amazon-ecs-volume-plugin.service
 %{_unitdir}/amazon-ecs-volume-plugin.socket
+%{_unitdir}/dcgm-init.service
 %else
 %{_sysconfdir}/init/ecs.conf
 %{_sysconfdir}/init/amazon-ecs-volume-plugin.conf
@@ -337,10 +343,12 @@ ln -sf %{basename:%{agent_image}} %{_cachedir}/ecs/ecs-agent.tar
 %if %{with systemd}
 %systemd_post ecs
 %systemd_post amazon-ecs-volume-plugin.service
+%systemd_post dcgm-init.service
 
 %postun
 %systemd_postun ecs
 %systemd_postun_with_restart amazon-ecs-volume-plugin
+%systemd_postun_with_restart dcgm-init
 
 %else
 %triggerun -- docker

--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -61,7 +61,7 @@ Requires:       procps
 # You can use this to generate a list of the appropriate Provides
 # statements by reading out the vendor directory:
 #
-# find ../../ecs-init/vendor -name \*.go -exec dirname {} \; | sort | uniq | sed 's,^.*ecs-init/vendor/,,; s/^/bundled(golang(/; s/$/))/;' | sed 's/^/Provides:\t/' | expand -
+# find ../../ecs-init/vendor ../../dcgm-init/vendor -name \*.go -exec dirname {} \; | sed 's,^.*ecs-init/vendor/,,; s,^.*dcgm-init/vendor/,,' | sort | uniq | sed 's/^/bundled(golang(/; s/$/))/;' | sed 's/^/Provides:\t/' | expand -
 Provides:       bundled(golang(github.com/Azure/go-ansiterm))
 Provides:       bundled(golang(github.com/Azure/go-ansiterm/winterm))
 Provides:       bundled(golang(github.com/Microsoft/go-winio))
@@ -69,9 +69,13 @@ Provides:       bundled(golang(github.com/Microsoft/go-winio/internal/fs))
 Provides:       bundled(golang(github.com/Microsoft/go-winio/internal/socket))
 Provides:       bundled(golang(github.com/Microsoft/go-winio/internal/stringbuffer))
 Provides:       bundled(golang(github.com/Microsoft/go-winio/pkg/guid))
+Provides:       bundled(golang(github.com/NVIDIA/go-dcgm/pkg/dcgm))
 Provides:       bundled(golang(github.com/NVIDIA/go-nvml/pkg/dl))
 Provides:       bundled(golang(github.com/NVIDIA/go-nvml/pkg/nvml))
 Provides:       bundled(golang(github.com/aws/amazon-ecs-agent/ecs-agent/awsrulesfn))
+Provides:       bundled(golang(github.com/aws/amazon-ecs-agent/ecs-agent/gpu/dcgm))
+Provides:       bundled(golang(github.com/aws/amazon-ecs-agent/ecs-agent/gpu/dcgm/mocks))
+Provides:       bundled(golang(github.com/aws/amazon-ecs-agent/ecs-agent/gpu/types))
 Provides:       bundled(golang(github.com/aws/amazon-ecs-agent/ecs-agent/ipcompatibility))
 Provides:       bundled(golang(github.com/aws/amazon-ecs-agent/ecs-agent/logger))
 Provides:       bundled(golang(github.com/aws/amazon-ecs-agent/ecs-agent/utils))
@@ -187,6 +191,7 @@ Provides:       bundled(golang(github.com/aws/smithy-go/tracing))
 Provides:       bundled(golang(github.com/aws/smithy-go/transport/http))
 Provides:       bundled(golang(github.com/aws/smithy-go/transport/http/internal/io))
 Provides:       bundled(golang(github.com/aws/smithy-go/waiter))
+Provides:       bundled(golang(github.com/bits-and-blooms/bitset))
 Provides:       bundled(golang(github.com/cihub/seelog))
 Provides:       bundled(golang(github.com/cihub/seelog/archive))
 Provides:       bundled(golang(github.com/cihub/seelog/archive/gzip))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Adds the build process for `dcgm-init` binary and incorporating it into the Amazon Linux RPMs. 

### Implementation details
<!-- How are the changes implemented? -->

#### `dcgm-init/`
- `main.go`: Configure logger to emit to `/var/log/ecs/dcgm-init.log`

#### `dcgm-init/engine/`
- `engine.go`: Refactored out metrics file location to `types.go` file and cleaned up comments.
- `engine_test.go`: Refactoring changes from moving shared file path from `engine` package to `types` package and cleaned up comments.

#### `ecs-agent/gpu/types/`
- `types.go`: add GPU metrics file paths

#### `packaging/amazon-linux-ami-integrated/`
- `dcgm-init.service`: systemd unit file. 
- `ecs-agent.spec`: add `dcgm-init` into the build script.

`Makefile`: Added make commands for Amazon Linux RPMs.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Sample `dcgm-init.log`: 
```
sh-5.2$ cat /var/log/ecs/dcgm-init.log
level=info time=2026-07-15T18:00:55Z msg="reconciling DCGM connection" connected=true hasViolation=false
level=info time=2026-07-15T18:00:55Z msg="DCGM connection healthy, no reconnection needed"
level=debug time=2026-07-15T18:00:55Z msg="collecting metrics for GPU devices" deviceCount=1
level=debug time=2026-07-15T18:00:55Z msg="collected GPU metrics" deviceCount=1 metricsWatchActive=true
level=debug time=2026-07-15T18:00:55Z msg="checking GPU health status" connected=true hasViolation=false
level=warn time=2026-07-15T18:00:55Z msg="health check returned WARN status (non-critical)" overallHealth=10
level=debug time=2026-07-15T18:00:55Z msg="dcgm-init collected GPU metrics" path="/var/run/ecs/gpu-metrics.json" gpuCount=1
level=debug time=2026-07-15T18:00:55Z msg="dcgm-init wrote GPU metrics"
level=info time=2026-07-15T18:01:55Z msg="reconciling DCGM connection" connected=true hasViolation=false
level=info time=2026-07-15T18:01:55Z msg="DCGM connection healthy, no reconnection needed"
level=debug time=2026-07-15T18:01:55Z msg="collecting metrics for GPU devices" deviceCount=1
level=debug time=2026-07-15T18:01:55Z msg="collected GPU metrics" deviceCount=1 metricsWatchActive=true
level=debug time=2026-07-15T18:01:55Z msg="checking GPU health status" connected=true hasViolation=false
level=warn time=2026-07-15T18:01:55Z msg="health check returned WARN status (non-critical)" overallHealth=10
level=debug time=2026-07-15T18:01:55Z msg="dcgm-init collected GPU metrics" path="/var/run/ecs/gpu-metrics.json" gpuCount=1
level=debug time=2026-07-15T18:01:55Z msg="dcgm-init wrote GPU metrics"
level=info time=2026-07-15T18:02:55Z msg="reconciling DCGM connection" connected=true hasViolation=false
level=info time=2026-07-15T18:02:55Z msg="DCGM connection healthy, no reconnection needed"
level=debug time=2026-07-15T18:02:55Z msg="collecting metrics for GPU devices" deviceCount=1
level=debug time=2026-07-15T18:02:55Z msg="collected GPU metrics" deviceCount=1 metricsWatchActive=true
level=debug time=2026-07-15T18:02:55Z msg="checking GPU health status" connected=true hasViolation=false
level=warn time=2026-07-15T18:02:55Z msg="health check returned WARN status (non-critical)" overallHealth=10
level=debug time=2026-07-15T18:02:55Z msg="dcgm-init collected GPU metrics" path="/var/run/ecs/gpu-metrics.json" gpuCount=1
level=debug time=2026-07-15T18:02:55Z msg="dcgm-init wrote GPU metrics"
level=info time=2026-07-15T18:03:55Z msg="reconciling DCGM connection" connected=true hasViolation=false
level=info time=2026-07-15T18:03:55Z msg="DCGM connection healthy, no reconnection needed"
level=debug time=2026-07-15T18:03:55Z msg="collecting metrics for GPU devices" deviceCount=1
level=debug time=2026-07-15T18:03:55Z msg="collected GPU metrics" deviceCount=1 metricsWatchActive=true
level=debug time=2026-07-15T18:03:55Z msg="checking GPU health status" connected=true hasViolation=false
level=warn time=2026-07-15T18:03:55Z msg="health check returned WARN status (non-critical)" overallHealth=10
level=debug time=2026-07-15T18:03:55Z msg="dcgm-init collected GPU metrics" path="/var/run/ecs/gpu-metrics.json" gpuCount=1
level=debug time=2026-07-15T18:03:55Z msg="dcgm-init wrote GPU metrics"
level=info time=2026-07-15T18:04:55Z msg="reconciling DCGM connection" hasViolation=false connected=true
level=info time=2026-07-15T18:04:55Z msg="DCGM connection healthy, no reconnection needed"
level=debug time=2026-07-15T18:04:55Z msg="collecting metrics for GPU devices" deviceCount=1
level=debug time=2026-07-15T18:04:55Z msg="collected GPU metrics" deviceCount=1 metricsWatchActive=true
level=debug time=2026-07-15T18:04:55Z msg="checking GPU health status" connected=true hasViolation=false
level=warn time=2026-07-15T18:04:55Z msg="health check returned WARN status (non-critical)" overallHealth=10
level=debug time=2026-07-15T18:04:55Z msg="dcgm-init collected GPU metrics" path="/var/run/ecs/gpu-metrics.json" gpuCount=1
level=debug time=2026-07-15T18:04:55Z msg="dcgm-init wrote GPU metrics"
```

Ran command to create custom Amazon Linux RPM: `make amazon-linux-rpm-codebuild`

Ref: https://github.com/aws/amazon-ecs-agent/tree/dev/packaging/amazon-linux-ami-integrated

Moved the custom RPM into the AMI repository and ran the GPU AMI build script: `make al2023gpu`. 

Verified that the metrics were being written into the file and that we could start and stop `dcgm-init`. 

**Testing to confirm that the systemd `start` and `stop` commands work.** 

What happens when I run the following commands?

Initial state of the system:
`ps aux | grep dcgm-init` yields a response of:
```
root        8770  0.0  0.1 1924300 27944 ?       Ssl  02:16   0:00 /usr/libexec/dcgm-init start
```

`sudo systemctl stop dcgm-init` followed by `cat /var/run/ecs/gpu-metrics.json`
```
...
"timestamp": "2026-07-10T22:41:56Z",
...
```

**Wait for 1 minute to elapse**
`cat /var/run/ecs/gpu-metrics.json`

```
...
"timestamp": "2026-07-10T22:41:56Z",
...
```

Same timestamp as before. 

`sudo systemctl start dcgm-init` followed by `cat /var/run/ecs/gpu-metrics.json`

```
...
"timestamp": "2026-07-10T22:45:17Z",
...
```

Different timestamp, which is good.

New tests cover the changes: <!-- yes|no -->

yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Feature - Add dcgm-init build process

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.