### PR TITLE
🧹 Update Makefile, gitignore, and dcgm-init comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ _bin/
 *.zip
 *.swp
 *.orig
+/agent/version/_version.go
 /ecs-agent/daemonimages/csidriver/tarfiles
 .agignore
 *.sublime-*

--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,6 @@ _bin/
 *.zip
 *.swp
 *.orig
-/agent/version/_version.go
-/ecs-agent/daemonimages/csidriver/tarfiles
-/ecs-init/version/version.go
-/dcgm-init/version/version.go
 /ecs-agent/daemonimages/csidriver/tarfiles
 .agignore
 *.sublime-*
@@ -26,7 +22,7 @@ cover.out
 cover.out.tmp
 coverprofile*.out
 /amazon-ecs-init*
-/amazon-dcgm-init
+/amazon-dcgm-init*
 /BUILDROOT/
 /x86_64/
 /sources.tar

--- a/Makefile
+++ b/Makefile
@@ -193,8 +193,15 @@ test-init:
 
 .PHONY: build-dcgm-init test-dcgm-init
 build-dcgm-init:
-	cd dcgm-init && CGO_ENABLED=1 \
-		go build -mod=vendor -ldflags "-s" -o ../amazon-dcgm-init .
+	version=$$(cat VERSION); \
+	git_hash=$$(git rev-parse --short=8 HEAD); \
+	git_dirty=false; \
+	if [ -n "$$(git status --porcelain)" ]; then git_dirty=true; fi; \
+	cd dcgm-init && CGO_ENABLED=1 go build -mod=vendor -ldflags "-s \
+		-X github.com/aws/amazon-ecs-agent/dcgm-init/version.Version=$${version} \
+		-X github.com/aws/amazon-ecs-agent/dcgm-init/version.GitShortHash=$${git_hash} \
+		-X github.com/aws/amazon-ecs-agent/dcgm-init/version.GitDirty=$${git_dirty}" \
+		-o ../amazon-dcgm-init .
 
 test-dcgm-init:
 	cd dcgm-init && GO111MODULE=on ${GOTEST} ${VERBOSE} -tags unit -mod vendor \
@@ -380,7 +387,7 @@ container-health-check-image:
 	$(MAKE) -C misc/container-health $(MFLAGS)
 
 # all .go files in the agent, excluding vendor/, model/ and testutils/ directories, and all *_test.go and *_mocks.go files
-GOFILES:=$(shell go list -f '{{$$p := .}}{{range $$f := .GoFiles}}{{$$p.Dir}}/{{$$f}} {{end}}' ./agent/... ./ecs-agent/... \
+GOFILES:=$(shell go list -f '{{$$p := .}}{{range $$f := .GoFiles}}{{$$p.Dir}}/{{$$f}} {{end}}' ./agent/... ./ecs-agent/... ./dcgm-init/... \
 		| grep -v /testutils/ | grep -v _test\.go$ | grep -v _mocks\.go$ | grep -v /model)
 
 .PHONY: gocyclo
@@ -391,9 +398,9 @@ gocyclo:
 # same as gofiles above, but without the `-f`
 .PHONY: govet
 govet:
-	go vet $(shell go list ./agent/... ./ecs-agent/... | grep -v /testutils/ | grep -v _test\.go$ | grep -v /mocks | grep -v /model)
+	go vet $(shell go list ./agent/... ./ecs-agent/... ./dcgm-init/... | grep -v /testutils/ | grep -v _test\.go$ | grep -v /mocks | grep -v /model)
 
-GOFMTFILES:=$(shell find ./agent ./ecs-agent -not -path './agent/vendor/*' -not -path './ecs-agent/vendor/*' -not -path './ecs-agent/daemonimages/csidriver/vendor/*' -type f -iregex '.*\.go')
+GOFMTFILES:=$(shell find ./agent ./ecs-agent ./dcgm-init -not -path './agent/vendor/*' -not -path './ecs-agent/vendor/*' -not -path './ecs-agent/daemonimages/csidriver/vendor/*' -not -path './dcgm-init/vendor/*' -type f -iregex '.*\.go')
 
 .PHONY: importcheck
 importcheck:
@@ -567,7 +574,7 @@ clean:
 	-rm -rf ./BUILDROOT BUILD RPMS SRPMS SOURCES SPECS
 	-rm -rf ./x86_64
 	-rm -f ./amazon-ecs-init_${VERSION}*
-	-rm -f .srpm-done .rpm-done .generic-rpm-done .generic-deb-integrated-done
+	-rm -f .srpm-done .rpm-done .generic-rpm-done .generic-deb-integrated-done .amazon-linux-rpm-codebuild-done
 	-rm -f .deb-done
 	-rm -f .amazon-linux-rpm-integrated-done
 	-rm -f .generic-rpm-integrated-done

--- a/Makefile
+++ b/Makefile
@@ -194,14 +194,16 @@ test-init:
 .PHONY: build-dcgm-init test-dcgm-init
 build-dcgm-init:
 	version=$$(cat VERSION); \
-	git_hash=$$(git rev-parse --short=8 HEAD); \
-	git_dirty=false; \
-	if [ -n "$$(git status --porcelain)" ]; then git_dirty=true; fi; \
-	cd dcgm-init && CGO_ENABLED=1 go build -mod=vendor -ldflags "-s \
-		-X github.com/aws/amazon-ecs-agent/dcgm-init/version.Version=$${version} \
-		-X github.com/aws/amazon-ecs-agent/dcgm-init/version.GitShortHash=$${git_hash} \
-		-X github.com/aws/amazon-ecs-agent/dcgm-init/version.GitDirty=$${git_dirty}" \
-		-o ../amazon-dcgm-init .
+	ldflags="-s -X github.com/aws/amazon-ecs-agent/dcgm-init/version.Version=$${version}"; \
+	if [ -d .git ]; then \
+		git_hash=$$(git rev-parse --short=8 HEAD); \
+		git_dirty=false; \
+		if [ -n "$$(git status --porcelain)" ]; then git_dirty=true; fi; \
+		ldflags="$${ldflags} \
+			-X github.com/aws/amazon-ecs-agent/dcgm-init/version.GitShortHash=$${git_hash} \
+			-X github.com/aws/amazon-ecs-agent/dcgm-init/version.GitDirty=$${git_dirty}"; \
+	fi; \
+	cd dcgm-init && CGO_ENABLED=1 go build -mod=vendor -ldflags "$${ldflags}" -o ../amazon-dcgm-init .
 
 test-dcgm-init:
 	cd dcgm-init && GO111MODULE=on ${GOTEST} ${VERBOSE} -tags unit -mod vendor \

--- a/dcgm-init/engine/engine.go
+++ b/dcgm-init/engine/engine.go
@@ -31,8 +31,7 @@ import (
 )
 
 const (
-	// DefaultInitErrorExitCode is used for recoverable init errors (retried by
-	// Restart=always).
+	// DefaultInitErrorExitCode is the default error exit code
 	DefaultInitErrorExitCode = -1
 )
 

--- a/dcgm-init/main.go
+++ b/dcgm-init/main.go
@@ -86,8 +86,9 @@ func configureLogging() {
 	logger.SetConfigLogFile(logFile)
 	logger.SetRolloverType("date")
 
-	// The file level defaults to "off" under ECS_LOG_DRIVER, so force it from
-	// ECS_LOGLEVEL (info when unset/invalid) so the file is always written.
+	// When ECS_LOG_DRIVER is set, the instance (file) log level defaults to
+	// "off", which writes nothing to logFile. Force it from ECS_LOGLEVEL (info
+	// when unset/invalid) so the file is always written.
 	logger.SetInstanceLogLevel(logger.DEFAULT_LOGLEVEL)
 	if level := os.Getenv(logger.LOGLEVEL_ENV_VAR); level != "" {
 		logger.SetInstanceLogLevel(level)

--- a/dcgm-init/main.go
+++ b/dcgm-init/main.go
@@ -86,9 +86,8 @@ func configureLogging() {
 	logger.SetConfigLogFile(logFile)
 	logger.SetRolloverType("date")
 
-	// When ECS_LOG_DRIVER is set, the instance (file) log level defaults to
-	// "off", which writes nothing to logFile. Force it from ECS_LOGLEVEL (info
-	// when unset/invalid) so the file is always written.
+	// The file level defaults to "off" under ECS_LOG_DRIVER, so force it from
+	// ECS_LOGLEVEL (info when unset/invalid) so the file is always written.
 	logger.SetInstanceLogLevel(logger.DEFAULT_LOGLEVEL)
 	if level := os.Getenv(logger.LOGLEVEL_ENV_VAR); level != "" {
 		logger.SetInstanceLogLevel(level)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Update files due to `dcgm-init` build comments mentioned in this PR: https://github.com/aws/amazon-ecs-agent/pull/5040. 

### Implementation details
<!-- How are the changes implemented? -->

- `.gitignore`: Remove some files. We are removing the `version.go` files since we are tracking them in the git history and they are committed in the repository. 
- `Makefile`: Update `build-dcgm-init` Makefile target to update the version, following the same procedure for how `ecs-init` is doing it. Update `staticcheck` Makefile target dependencies to also check `dcgm-init` module. 
- `dcgm-init/engine/engine.go`: Update comment on exit code based on comment from previous PR: https://github.com/aws/amazon-ecs-agent/pull/5040#discussion_r3590650409

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Confirmed the `build-dcgm-init` Makefile target works as intended by running: 
`make build-dcgm-init && ./amazon-dcgm-init version`

Got a response of: 
```
dcgm-init version 1.104.0 (*aded218c)
```

And confirmed the Git hash matched what I had in my local branch and is different from the current `version.go` file (ran `cat dcgm-init/version/version.go`): 
```
...
// Package version contains constants to indicate the current version of the
// dcgm-init. It is autogenerated.
package version

// Version is the version of the dcgm-init
var Version string = "1.104.0"

// GitDirty indicates the cleanliness of the git repo when this dcgm-init was built
var GitDirty string = "true"

// GitShortHash is the short hash of this dcgm-init build
var GitShortHash string = "79a79f87"
```

The other `Makefile` commands run as part of the `static-check` target which is run in the GitHub CI workflow (see `static.yml`). 

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Housekeeping - Add dcgm-init to Makefile static-check target dependencies and update gitignore. 

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No.

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.