### PR TITLE
Backfill host DNS config on isolated platform

### DIFF
--- a/ecs-agent/netlib/platform/isolated_debug_linux.go
+++ b/ecs-agent/netlib/platform/isolated_debug_linux.go
@@ -1,35 +1,5 @@
 package platform
 
-import (
-	"path/filepath"
-
-	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/tasknetworkconfig"
-	"github.com/pkg/errors"
-)
-
 type isolatedDebug struct {
 	isolatedLinux
-}
-
-func (d *isolatedDebug) CreateDNSConfig(taskID string, netNS *tasknetworkconfig.NetworkNamespace) error {
-	if err := d.createDNSConfig(taskID, true, netNS); err != nil {
-		return err
-	}
-
-	// Backfill interface DNS fields from the copied resolv.conf so downstream
-	// consumers can read DNS config from the model.
-	primaryIF := netNS.GetPrimaryInterface()
-	if primaryIF == nil || len(primaryIF.DomainNameServers) > 0 {
-		return nil
-	}
-
-	src := filepath.Join(d.resolvConfPath, ResolveConfFileName)
-	contents, err := d.ioutil.ReadFile(src)
-	if err != nil {
-		return errors.Wrapf(err, "unable to read %s", src)
-	}
-	servers, searches := parseResolvConf(contents)
-	primaryIF.DomainNameServers = servers
-	primaryIF.DomainNameSearchList = searches
-	return nil
 }

--- a/ecs-agent/netlib/platform/isolated_linux.go
+++ b/ecs-agent/netlib/platform/isolated_linux.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/ecscni"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/status"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/tasknetworkconfig"
 
 	cnins "github.com/containernetworking/plugins/pkg/ns"
 	"github.com/pkg/errors"
@@ -212,4 +213,31 @@ func (il *isolatedLinux) resolveHostNeighbor(ip net.IP) (net.HardwareAddr, error
 	}
 
 	return nil, fmt.Errorf("no neighbor entry for %s in host ARP table", ip)
+}
+
+// CreateDNSConfig creates the task DNS config files and backfills the
+// interface DNS fields from the host's resolv.conf.
+func (il *isolatedLinux) CreateDNSConfig(taskID string, netNS *tasknetworkconfig.NetworkNamespace) error {
+	// Create the DNS config files. resolv.conf is built from the ENI
+	// payload's DNS servers when present, otherwise copied from the host.
+	if err := il.managedLinux.CreateDNSConfig(taskID, netNS); err != nil {
+		return err
+	}
+
+	// An empty DomainNameServers means resolv.conf was copied from the
+	// host; backfill the interface's DNS fields from file.
+	primaryIF := netNS.GetPrimaryInterface()
+	if primaryIF == nil || len(primaryIF.DomainNameServers) > 0 {
+		return nil
+	}
+
+	src := filepath.Join(il.resolvConfPath, ResolveConfFileName)
+	contents, err := il.ioutil.ReadFile(src)
+	if err != nil {
+		return errors.Wrapf(err, "unable to read %s", src)
+	}
+	servers, searches := parseResolvConf(contents)
+	primaryIF.DomainNameServers = servers
+	primaryIF.DomainNameSearchList = searches
+	return nil
 }


### PR DESCRIPTION
### Summary

On the isolated platform, guest DNS is provisioned solely from the interface model. When the task payload carries no DNS servers, the guest was left with an empty resolv.conf and all DNS resolution inside the task failed. This change backfills the interface DNS fields from the host's resolv.conf so the guest always receives nameservers.

### Implementation details

The debug variant of the isolated platform (`isolatedDebug`) already contained this backfill in its `CreateDNSConfig` override, so the gap only manifested on the non-debug path. The backfill is moved from `isolatedDebug` to `isolatedLinux.CreateDNSConfig`, which first delegates to `managedLinux.CreateDNSConfig` and then, when the primary interface has no `DomainNameServers`, parses the host's resolv.conf and populates
`DomainNameServers` / `DomainNameSearchList` on the interface model. `isolatedDebug` now inherits the behavior and its override is removed.

### Testing

- Verified end-to-end on the isolated platform: before the change, a   task with a task role could reach the link-local credentials endpoint   but failed all DNS resolution (empty resolv.conf in the guest); with   the change, the same task resolves service endpoints and completes  AWS API calls successfully.

New tests cover the changes: no

### Description for the changelog

Bugfix - Backfill guest DNS config from the host resolv.conf on the isolated platform when the task payload provides no DNS servers

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**

No.

**Does this PR include the addition of new environment variables in the README?**

No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
