### PR TITLE
MPS GPU sharing: advertise ecs.capability.gpu-sharing-mps

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -275,6 +275,7 @@ func (agent *ecsAgent) capabilities() ([]types.Attribute, error) {
 
 	if agent.cfg.GPUSupportEnabled {
 		capabilities = agent.appendNvidiaDriverVersionAttribute(capabilities)
+		capabilities = agent.appendGpuSharingMpsCapability(capabilities)
 	}
 
 	// ecs agent version 1.22.0 supports sharing PID namespaces and IPC resource namespaces

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -30,8 +30,10 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ecscni"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/capability"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/utils/netconfig"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/gpu"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
@@ -121,6 +123,34 @@ func (agent *ecsAgent) appendNvidiaDriverVersionAttribute(capabilities []types.A
 			})
 		}
 	}
+	return capabilities
+}
+
+// appendGpuSharingMpsCapability advertises ecs.capability.gpu-sharing-mps when the
+// instance can run MPS: a GPU is present, the MPS control binary and its systemd unit
+// are installed and enabled, and the GPU is not a vGPU slice. The facts are gathered by
+// ecs-init and read from the NvidiaGPUManager; the decision itself lives in the shared
+// gpu package so the MI agent reaches the same verdict from the same inputs.
+func (agent *ecsAgent) appendGpuSharingMpsCapability(capabilities []types.Attribute) []types.Attribute {
+	if agent.resourceFields == nil || agent.resourceFields.NvidiaGPUManager == nil {
+		return capabilities
+	}
+	mgr := agent.resourceFields.NvidiaGPUManager
+	inputs := gpu.MpsCapabilityInputs{
+		GPUPresent:        len(mgr.GetDevices()) > 0,
+		MpsBinaryPresent:  mgr.GetMpsControlBinaryPresent(),
+		MpsServiceEnabled: mgr.GetMpsServiceEnabled(),
+		IsVGPU:            mgr.GetHasVGPU(),
+	}
+	advertise, conditions := gpu.ShouldAdvertiseMpsCapability(inputs)
+	if !advertise {
+		for _, c := range gpu.UnmetMpsConditions(conditions) {
+			seelog.Warnf("Not advertising %s: %s", capability.GPUSharingMps, c.UnmetReason())
+		}
+		return capabilities
+	}
+	// TODO: re-enable once the MPS runtime integration is in place:
+	// return appendNameOnlyAttribute(capabilities, capability.GPUSharingMps)
 	return capabilities
 }
 

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	mock_loader "github.com/aws/amazon-ecs-agent/agent/utils/loader/mocks"
 	mock_mobypkgwrapper "github.com/aws/amazon-ecs-agent/agent/utils/mobypkgwrapper/mocks"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/capability"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ipcompatibility"
 	md "github.com/aws/amazon-ecs-agent/ecs-agent/manageddaemon"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/utils/netconfig"
@@ -339,6 +340,61 @@ func TestEmptyNvidiaDriverCapabilitiesUnix(t *testing.T) {
 			Value: expected.Value,
 		})
 	}
+}
+
+func TestAppendGpuSharingMpsCapability(t *testing.T) {
+	mpsCap := types.Attribute{Name: aws.String(capability.GPUSharingMps)}
+
+	// newManager returns a GPU manager with the given MPS facts and one device
+	// present unless gpuPresent is false.
+	newManager := func(gpuPresent, binary, service, vgpu bool) *gpu.NvidiaGPUManager {
+		m := &gpu.NvidiaGPUManager{
+			MpsControlBinaryPresent: binary,
+			MpsServiceEnabled:       service,
+			HasVGPU:                 vgpu,
+		}
+		if gpuPresent {
+			m.SetGPUIDs([]string{"gpu-0"})
+			m.SetDevices()
+		}
+		return m
+	}
+
+	cases := []struct {
+		name          string
+		mgr           *gpu.NvidiaGPUManager
+		wantAdvertise bool
+	}{
+		// Advertisement of gpu-sharing-mps is intentionally disabled until the MPS runtime
+		// integration lands, so the capability must NOT appear in any case.
+		// TODO: flip to true once capability advertisement is enabled
+		{"all conditions met", newManager(true, true, true, false), false},
+		{"no gpu present", newManager(false, true, true, false), false},
+		{"mps binary absent", newManager(true, false, true, false), false},
+		{"mps service disabled", newManager(true, true, false, false), false},
+		{"is vgpu", newManager(true, true, true, true), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := &ecsAgent{
+				resourceFields: &taskresource.ResourceFields{NvidiaGPUManager: tc.mgr},
+			}
+			capabilities := agent.appendGpuSharingMpsCapability(nil)
+			if tc.wantAdvertise {
+				assert.Contains(t, capabilities, mpsCap)
+			} else {
+				assert.NotContains(t, capabilities, mpsCap)
+			}
+		})
+	}
+}
+
+// A nil NvidiaGPUManager must not panic and must not advertise.
+func TestAppendGpuSharingMpsCapabilityNilManager(t *testing.T) {
+	agent := &ecsAgent{resourceFields: &taskresource.ResourceFields{}}
+	capabilities := agent.appendGpuSharingMpsCapability(nil)
+	assert.NotContains(t, capabilities, types.Attribute{Name: aws.String(capability.GPUSharingMps)})
 }
 
 func TestENITrunkingCapabilitiesUnix(t *testing.T) {

--- a/agent/app/agent_capability_unspecified.go
+++ b/agent/app/agent_capability_unspecified.go
@@ -81,6 +81,10 @@ func (agent *ecsAgent) appendNvidiaDriverVersionAttribute(capabilities []types.A
 	return capabilities
 }
 
+func (agent *ecsAgent) appendGpuSharingMpsCapability(capabilities []types.Attribute) []types.Attribute {
+	return capabilities
+}
+
 func (agent *ecsAgent) appendENITrunkingCapabilities(capabilities []types.Attribute) []types.Attribute {
 	return capabilities
 }

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -59,6 +59,10 @@ func (agent *ecsAgent) appendNvidiaDriverVersionAttribute(capabilities []types.A
 	return capabilities
 }
 
+func (agent *ecsAgent) appendGpuSharingMpsCapability(capabilities []types.Attribute) []types.Attribute {
+	return capabilities
+}
+
 func (agent *ecsAgent) appendENITrunkingCapabilities(capabilities []types.Attribute) []types.Attribute {
 	return capabilities
 }

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -656,6 +656,10 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 	imageManager.EXPECT().AddImageToCleanUpExclusionList(gomock.Eq("service_connect_agent:v1")).Times(1)
 	client.EXPECT().GetHostResources().Return(testHostResource, nil).Times(1)
 	mockGPUManager.EXPECT().GetDevices().Return(devices).AnyTimes()
+	// The gpu-sharing-mps capability check reads these MPS facts during registration.
+	mockGPUManager.EXPECT().GetMpsControlBinaryPresent().Return(false).AnyTimes()
+	mockGPUManager.EXPECT().GetMpsServiceEnabled().Return(false).AnyTimes()
+	mockGPUManager.EXPECT().GetHasVGPU().Return(false).AnyTimes()
 
 	gomock.InOrder(
 		mockGPUManager.EXPECT().Initialize().Return(nil),

--- a/agent/gpu/mocks/gpu_manager_mocks.go
+++ b/agent/gpu/mocks/gpu_manager_mocks.go
@@ -90,6 +90,48 @@ func (mr *MockGPUManagerMockRecorder) GetGPUIDsUnsafe() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGPUIDsUnsafe", reflect.TypeOf((*MockGPUManager)(nil).GetGPUIDsUnsafe))
 }
 
+// GetHasVGPU mocks base method.
+func (m *MockGPUManager) GetHasVGPU() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHasVGPU")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetHasVGPU indicates an expected call of GetHasVGPU.
+func (mr *MockGPUManagerMockRecorder) GetHasVGPU() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHasVGPU", reflect.TypeOf((*MockGPUManager)(nil).GetHasVGPU))
+}
+
+// GetMpsControlBinaryPresent mocks base method.
+func (m *MockGPUManager) GetMpsControlBinaryPresent() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMpsControlBinaryPresent")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetMpsControlBinaryPresent indicates an expected call of GetMpsControlBinaryPresent.
+func (mr *MockGPUManagerMockRecorder) GetMpsControlBinaryPresent() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMpsControlBinaryPresent", reflect.TypeOf((*MockGPUManager)(nil).GetMpsControlBinaryPresent))
+}
+
+// GetMpsServiceEnabled mocks base method.
+func (m *MockGPUManager) GetMpsServiceEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMpsServiceEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetMpsServiceEnabled indicates an expected call of GetMpsServiceEnabled.
+func (mr *MockGPUManagerMockRecorder) GetMpsServiceEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMpsServiceEnabled", reflect.TypeOf((*MockGPUManager)(nil).GetMpsServiceEnabled))
+}
+
 // Initialize mocks base method.
 func (m *MockGPUManager) Initialize() error {
 	m.ctrl.T.Helper()

--- a/agent/gpu/nvidia_gpu_manager_unix.go
+++ b/agent/gpu/nvidia_gpu_manager_unix.go
@@ -37,15 +37,21 @@ type GPUManager interface {
 	GetDevices() []types.PlatformDevice
 	SetDriverVersion(string)
 	GetDriverVersion() string
+	GetMpsControlBinaryPresent() bool
+	GetMpsServiceEnabled() bool
+	GetHasVGPU() bool
 }
 
 // NvidiaGPUManager is used as a wrapper for NVML APIs and implements GPUManager
 // interface
 type NvidiaGPUManager struct {
-	DriverVersion string                 `json:"DriverVersion"`
-	GPUIDs        []string               `json:"GPUIDs"`
-	GPUDevices    []types.PlatformDevice `json:"-"`
-	lock          sync.RWMutex
+	DriverVersion           string                 `json:"DriverVersion"`
+	GPUIDs                  []string               `json:"GPUIDs"`
+	GPUDevices              []types.PlatformDevice `json:"-"`
+	MpsControlBinaryPresent bool                   `json:"MpsControlBinaryPresent"`
+	MpsServiceEnabled       bool                   `json:"MpsServiceEnabled"`
+	HasVGPU                 bool                   `json:"HasVGPU"`
+	lock                    sync.RWMutex
 }
 
 const (
@@ -79,6 +85,9 @@ func (n *NvidiaGPUManager) Initialize() error {
 		nvidiaGPUInfo.lock.RUnlock()
 		n.SetGPUIDs(gpuIDs)
 		n.SetDevices()
+		n.MpsControlBinaryPresent = nvidiaGPUInfo.GetMpsControlBinaryPresent()
+		n.MpsServiceEnabled = nvidiaGPUInfo.GetMpsServiceEnabled()
+		n.HasVGPU = nvidiaGPUInfo.GetHasVGPU()
 	} else {
 		seelog.Error("Config for GPU support is enabled, but GPU information is not found; continuing without it")
 	}
@@ -153,4 +162,25 @@ func (n *NvidiaGPUManager) GetDevices() []types.PlatformDevice {
 	n.lock.RLock()
 	defer n.lock.RUnlock()
 	return n.GPUDevices
+}
+
+// GetMpsControlBinaryPresent reports whether ecs-init found the MPS control binary on the host.
+func (n *NvidiaGPUManager) GetMpsControlBinaryPresent() bool {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+	return n.MpsControlBinaryPresent
+}
+
+// GetMpsServiceEnabled reports whether ecs-init found nvidia-mps.service enabled on the host.
+func (n *NvidiaGPUManager) GetMpsServiceEnabled() bool {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+	return n.MpsServiceEnabled
+}
+
+// GetHasVGPU reports whether any device on the instance is an NVIDIA vGPU slice.
+func (n *NvidiaGPUManager) GetHasVGPU() bool {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+	return n.HasVGPU
 }

--- a/agent/gpu/nvidia_gpu_manager_unix_test.go
+++ b/agent/gpu/nvidia_gpu_manager_unix_test.go
@@ -47,7 +47,8 @@ func TestNvidiaGPUManagerInitialize(t *testing.T) {
 		return true
 	}
 	GetGPUInfoJSON = func() ([]byte, error) {
-		return []byte(`{"DriverVersion":"396.44","GPUIDs":["id1","id2","id3"]}`), nil
+		return []byte(`{"DriverVersion":"396.44","GPUIDs":["id1","id2","id3"],` +
+			`"MpsControlBinaryPresent":true,"MpsServiceEnabled":true,"HasVGPU":false}`), nil
 	}
 	defer func() {
 		GPUInfoFileExists = CheckForGPUInfoFile
@@ -58,6 +59,10 @@ func TestNvidiaGPUManagerInitialize(t *testing.T) {
 	assert.Equal(t, []string{"id1", "id2", "id3"}, nvidiaGPUManager.GetGPUIDsUnsafe())
 	assert.Equal(t, "396.44", nvidiaGPUManager.GetDriverVersion())
 	assert.True(t, reflect.DeepEqual(devices, nvidiaGPUManager.GetDevices()))
+	// The MPS gating facts written by ecs-init must round-trip through Initialize.
+	assert.True(t, nvidiaGPUManager.GetMpsControlBinaryPresent())
+	assert.True(t, nvidiaGPUManager.GetMpsServiceEnabled())
+	assert.False(t, nvidiaGPUManager.GetHasVGPU())
 }
 
 func TestNvidiaGPUManagerError(t *testing.T) {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/capability/capability.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/capability/capability.go
@@ -17,4 +17,8 @@ package capability
 const (
 	// IMDSIAMRoles indicates that the agent supports retrieving task credentials via IMDS.
 	IMDSIAMRoles = "ecs.capability.imds-iam-roles"
+
+	// GPUSharingMps indicates that the agent and instance can support GPU container sharing
+	// via NVIDIA MPS under enforced per-container memory and optional compute limits.
+	GPUSharingMps = "ecs.capability.gpu-sharing-mps"
 )

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/gpu/gpu.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/gpu/gpu.go
@@ -1,0 +1,87 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package gpu holds the GPU-sharing capability logic that the agents
+// share, so both decide and report the gpu-sharing-mps capability the same way.
+package gpu
+
+type MpsGateCondition string
+
+const (
+	GPUPresent        MpsGateCondition = "gpu-present"
+	MpsBinaryPresent  MpsGateCondition = "mps-binary-present"
+	MpsServiceEnabled MpsGateCondition = "mps-service-enabled"
+	NotVGPU           MpsGateCondition = "not-vgpu"
+)
+
+// UnmetReason returns the message to log when a condition is not satisfied.
+// The wording lives here so agents report the same reason for the same failure.
+func (c MpsGateCondition) UnmetReason() string {
+	switch c {
+	case GPUPresent:
+		return "no NVIDIA GPU present"
+	case MpsBinaryPresent:
+		return "MPS control binary not present on host"
+	case MpsServiceEnabled:
+		return "nvidia-mps systemd service is not enabled on host"
+	case NotVGPU:
+		return "instance has an NVIDIA vGPU slice, where we do not support MPS"
+	}
+	return string(c)
+}
+
+// MpsCapabilityInputs are the host facts the capability decision is made from.
+type MpsCapabilityInputs struct {
+	// GPUPresent is true when the NVIDIA driver and GPU device injection work.
+	GPUPresent bool
+	// MpsBinaryPresent is true when the MPS control binary exists on the host.
+	MpsBinaryPresent bool
+	// MpsServiceEnabled is true when the nvidia-mps systemd unit is enabled.
+	// This is a static setup check, not daemon liveness.
+	MpsServiceEnabled bool
+	// IsVGPU must be set only on a definite NVML VGPU result. Leaving it false
+	// on an errored or unknown probe keeps the gate fail-open, so a flaky probe
+	// never strips MPS from a real passthrough GPU.
+	IsVGPU bool
+}
+
+// ShouldAdvertiseMpsCapability reports whether ecs.capability.gpu-sharing-mps
+// should be advertised.
+func ShouldAdvertiseMpsCapability(in MpsCapabilityInputs) (advertise bool, conditions map[MpsGateCondition]bool) {
+	conditions = map[MpsGateCondition]bool{
+		GPUPresent:        in.GPUPresent,
+		MpsBinaryPresent:  in.MpsBinaryPresent,
+		MpsServiceEnabled: in.MpsServiceEnabled,
+		NotVGPU:           !in.IsVGPU,
+	}
+	advertise = true
+	for _, satisfied := range conditions {
+		if !satisfied {
+			advertise = false
+			break
+		}
+	}
+	return advertise, conditions
+}
+
+// UnmetMpsConditions returns the unsatisfied conditions in a fixed order
+func UnmetMpsConditions(conditions map[MpsGateCondition]bool) []MpsGateCondition {
+	order := []MpsGateCondition{GPUPresent, MpsBinaryPresent, MpsServiceEnabled, NotVGPU}
+	var unmet []MpsGateCondition
+	for _, c := range order {
+		if !conditions[c] {
+			unmet = append(unmet, c)
+		}
+	}
+	return unmet
+}

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -87,6 +87,7 @@ github.com/aws/amazon-ecs-agent/ecs-agent/utils/cipher
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper/mocks
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/firelens
+github.com/aws/amazon-ecs-agent/ecs-agent/utils/gpu
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/httpproxy
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/net
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper

--- a/ecs-agent/capability/capability.go
+++ b/ecs-agent/capability/capability.go
@@ -17,4 +17,8 @@ package capability
 const (
 	// IMDSIAMRoles indicates that the agent supports retrieving task credentials via IMDS.
 	IMDSIAMRoles = "ecs.capability.imds-iam-roles"
+
+	// GPUSharingMps indicates that the agent and instance can support GPU container sharing
+	// via NVIDIA MPS under enforced per-container memory and optional compute limits.
+	GPUSharingMps = "ecs.capability.gpu-sharing-mps"
 )

--- a/ecs-agent/utils/gpu/gpu.go
+++ b/ecs-agent/utils/gpu/gpu.go
@@ -1,0 +1,87 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package gpu holds the GPU-sharing capability logic that the agents
+// share, so both decide and report the gpu-sharing-mps capability the same way.
+package gpu
+
+type MpsGateCondition string
+
+const (
+	GPUPresent        MpsGateCondition = "gpu-present"
+	MpsBinaryPresent  MpsGateCondition = "mps-binary-present"
+	MpsServiceEnabled MpsGateCondition = "mps-service-enabled"
+	NotVGPU           MpsGateCondition = "not-vgpu"
+)
+
+// UnmetReason returns the message to log when a condition is not satisfied.
+// The wording lives here so agents report the same reason for the same failure.
+func (c MpsGateCondition) UnmetReason() string {
+	switch c {
+	case GPUPresent:
+		return "no NVIDIA GPU present"
+	case MpsBinaryPresent:
+		return "MPS control binary not present on host"
+	case MpsServiceEnabled:
+		return "nvidia-mps systemd service is not enabled on host"
+	case NotVGPU:
+		return "instance has an NVIDIA vGPU slice, where we do not support MPS"
+	}
+	return string(c)
+}
+
+// MpsCapabilityInputs are the host facts the capability decision is made from.
+type MpsCapabilityInputs struct {
+	// GPUPresent is true when the NVIDIA driver and GPU device injection work.
+	GPUPresent bool
+	// MpsBinaryPresent is true when the MPS control binary exists on the host.
+	MpsBinaryPresent bool
+	// MpsServiceEnabled is true when the nvidia-mps systemd unit is enabled.
+	// This is a static setup check, not daemon liveness.
+	MpsServiceEnabled bool
+	// IsVGPU must be set only on a definite NVML VGPU result. Leaving it false
+	// on an errored or unknown probe keeps the gate fail-open, so a flaky probe
+	// never strips MPS from a real passthrough GPU.
+	IsVGPU bool
+}
+
+// ShouldAdvertiseMpsCapability reports whether ecs.capability.gpu-sharing-mps
+// should be advertised.
+func ShouldAdvertiseMpsCapability(in MpsCapabilityInputs) (advertise bool, conditions map[MpsGateCondition]bool) {
+	conditions = map[MpsGateCondition]bool{
+		GPUPresent:        in.GPUPresent,
+		MpsBinaryPresent:  in.MpsBinaryPresent,
+		MpsServiceEnabled: in.MpsServiceEnabled,
+		NotVGPU:           !in.IsVGPU,
+	}
+	advertise = true
+	for _, satisfied := range conditions {
+		if !satisfied {
+			advertise = false
+			break
+		}
+	}
+	return advertise, conditions
+}
+
+// UnmetMpsConditions returns the unsatisfied conditions in a fixed order
+func UnmetMpsConditions(conditions map[MpsGateCondition]bool) []MpsGateCondition {
+	order := []MpsGateCondition{GPUPresent, MpsBinaryPresent, MpsServiceEnabled, NotVGPU}
+	var unmet []MpsGateCondition
+	for _, c := range order {
+		if !conditions[c] {
+			unmet = append(unmet, c)
+		}
+	}
+	return unmet
+}

--- a/ecs-agent/utils/gpu/gpu_test.go
+++ b/ecs-agent/utils/gpu/gpu_test.go
@@ -1,0 +1,113 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package gpu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// allMet returns inputs where every condition is satisfied. This is the only
+// combination that should advertise the capability.
+func allMet() MpsCapabilityInputs {
+	return MpsCapabilityInputs{
+		GPUPresent:        true,
+		MpsBinaryPresent:  true,
+		MpsServiceEnabled: true,
+		IsVGPU:            false, // not a vGPU -> the NotVGPU condition is satisfied
+	}
+}
+
+func TestAllConditionsMetAdvertises(t *testing.T) {
+	advertise, conditions := ShouldAdvertiseMpsCapability(allMet())
+	assert.True(t, advertise)
+	assert.Empty(t, UnmetMpsConditions(conditions))
+}
+
+// TestShouldAdvertiseTruthTable exercises all 16 combinations of the four
+// boolean inputs and checks that the capability is advertised only when every
+// condition holds.
+func TestShouldAdvertiseTruthTable(t *testing.T) {
+	for i := 0; i < 16; i++ {
+		in := MpsCapabilityInputs{
+			GPUPresent:        i&1 != 0,
+			MpsBinaryPresent:  i&2 != 0,
+			MpsServiceEnabled: i&4 != 0,
+			IsVGPU:            i&8 != 0,
+		}
+		want := in.GPUPresent && in.MpsBinaryPresent && in.MpsServiceEnabled && !in.IsVGPU
+		advertise, _ := ShouldAdvertiseMpsCapability(in)
+		assert.Equalf(t, want, advertise, "inputs=%+v", in)
+	}
+}
+
+// TestSingleFailingConditionWithholds flips one condition false at a time and
+// checks the capability is withheld and that exact condition is the only one
+// reported unmet.
+func TestSingleFailingConditionWithholds(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*MpsCapabilityInputs)
+		expect MpsGateCondition
+	}{
+		{"no gpu", func(in *MpsCapabilityInputs) { in.GPUPresent = false }, GPUPresent},
+		{"no binary", func(in *MpsCapabilityInputs) { in.MpsBinaryPresent = false }, MpsBinaryPresent},
+		{"service disabled", func(in *MpsCapabilityInputs) { in.MpsServiceEnabled = false }, MpsServiceEnabled},
+		{"is vgpu", func(in *MpsCapabilityInputs) { in.IsVGPU = true }, NotVGPU},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := allMet()
+			tc.mutate(&in)
+			advertise, conditions := ShouldAdvertiseMpsCapability(in)
+			assert.False(t, advertise)
+			assert.Equal(t, []MpsGateCondition{tc.expect}, UnmetMpsConditions(conditions))
+		})
+	}
+}
+
+// TestUnmetConditionsStableOrder checks that multiple failures are all returned
+// and always in the fixed order, regardless of Go's random map iteration.
+func TestUnmetConditionsStableOrder(t *testing.T) {
+	in := MpsCapabilityInputs{} // all false; IsVGPU false means NotVGPU is satisfied
+	advertise, conditions := ShouldAdvertiseMpsCapability(in)
+	assert.False(t, advertise)
+	assert.Equal(t,
+		[]MpsGateCondition{GPUPresent, MpsBinaryPresent, MpsServiceEnabled},
+		UnmetMpsConditions(conditions))
+}
+
+// TestVGPUFailOpen checks the vGPU gate only withholds on a definite vGPU
+// result. An errored or unknown probe leaves IsVGPU false, which must still
+// advertise so a flaky probe does not strip MPS from a real GPU.
+func TestVGPUFailOpen(t *testing.T) {
+	in := allMet()
+	in.IsVGPU = true
+	advertise, _ := ShouldAdvertiseMpsCapability(in)
+	assert.False(t, advertise)
+
+	in.IsVGPU = false
+	advertise, _ = ShouldAdvertiseMpsCapability(in)
+	assert.True(t, advertise)
+}
+
+func TestUnmetReason(t *testing.T) {
+	assert.Equal(t, "no NVIDIA GPU present", GPUPresent.UnmetReason())
+	assert.Equal(t, "MPS control binary not present on host", MpsBinaryPresent.UnmetReason())
+	assert.Equal(t, "nvidia-mps systemd service is not enabled on host", MpsServiceEnabled.UnmetReason())
+	assert.Equal(t, "instance has an NVIDIA vGPU slice, where we do not support MPS", NotVGPU.UnmetReason())
+	// Unknown condition falls back to its raw string.
+	assert.Equal(t, "some-unknown", MpsGateCondition("some-unknown").UnmetReason())
+}

--- a/ecs-init/gpu/nvidia_gpu_manager.go
+++ b/ecs-init/gpu/nvidia_gpu_manager.go
@@ -16,7 +16,9 @@ package gpu
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/cihub/seelog"
@@ -41,6 +43,11 @@ type GPUManager interface {
 type NvidiaGPUManager struct {
 	DriverVersion string
 	GPUIDs        []string
+	// MPS gating facts. The agent reads these from the saved JSON to decide whether
+	// to advertise the gpu-sharing-mps capability at registration.
+	MpsControlBinaryPresent bool `json:"MpsControlBinaryPresent"`
+	MpsServiceEnabled       bool `json:"MpsServiceEnabled"`
+	HasVGPU                 bool `json:"HasVGPU"`
 }
 
 const (
@@ -52,6 +59,10 @@ const (
 	NvidiaGPUInfoFilePath = GPUInfoDirPath + "/nvidia-gpu-info.json"
 	// FilePerm is the file permissions for gpu info json file
 	FilePerm = 0700
+	// mpsControlBinaryPath is where the NVIDIA MPS control daemon binary lives on the GPU AMI.
+	mpsControlBinaryPath = "/usr/bin/nvidia-cuda-mps-control"
+	// mpsServiceName is the systemd unit that runs the MPS control daemon.
+	mpsServiceName = "nvidia-mps.service"
 	// nvidiaEULAAgreementInfo is the EULA agreement that we want to show to the customers when using
 	// Nvidia products
 	nvidiaEULAAgreementInfo = "By using the GPU Optimized AMI, you agree to Nvidia’s End User License Agreement: " +
@@ -92,6 +103,10 @@ func (n *NvidiaGPUManager) Setup() error {
 		return errors.Wrapf(err, "setup failed")
 	}
 	n.GPUIDs = gpuIDs
+	// Gather the MPS facts once, after devices are known and before we persist state.
+	// HasVGPU is set per-device inside GetGPUDeviceIDs above.
+	n.MpsControlBinaryPresent = detectMpsControlBinary()
+	n.MpsServiceEnabled = detectMpsServiceEnabled()
 	err = n.SaveGPUState()
 	if err != nil {
 		return errors.Wrapf(err, "setup failed")
@@ -192,6 +207,10 @@ func (n *NvidiaGPUManager) GetGPUDeviceIDs() ([]string, error) {
 			seelog.Errorf("Failed to get UUID for device at index %d: %v", i, nvml.ErrorString(ret))
 			continue
 		}
+		if detectVGPU(device) {
+			// Any vGPU slice on the instance disqualifies MPS
+			n.HasVGPU = true
+		}
 		gpuIDs = append(gpuIDs, uuid)
 	}
 	if len(gpuIDs) == 0 {
@@ -209,6 +228,38 @@ func GetDeviceCount() (int, error) {
 		return 0, errors.New(nvml.ErrorString(ret))
 	}
 	return count, nil
+}
+
+// statFile and execCommand are indirections so unit tests can stub host access.
+var statFile = os.Stat
+var execCommand = exec.Command
+
+// detectMpsControlBinary reports whether the MPS control daemon binary is installed.
+func detectMpsControlBinary() bool {
+	_, err := statFile(mpsControlBinaryPath)
+	return err == nil
+}
+
+// detectMpsServiceEnabled reports whether nvidia-mps.service is enabled to start on boot.
+// systemctl is-enabled exits non-zero for a known-but-disabled unit while still printing
+// its state, so we key off the printed word rather than the exit code.
+func detectMpsServiceEnabled() bool {
+	out, err := execCommand("systemctl", "is-enabled", mpsServiceName).Output()
+	state := strings.TrimSpace(string(out))
+	if err != nil {
+		seelog.Debugf("Checking nvidia-mps.service enablement: 'systemctl is-enabled %s' returned state %q, err: %v", mpsServiceName, state, err)
+	}
+	return state == "enabled" || state == "enabled-runtime"
+}
+
+// detectVGPU reports whether a device is running as an NVIDIA vGPU slice. It fails open:
+// only a definite VGPU result counts, so an NVML error or unknown mode leaves MPS enabled.
+func detectVGPU(device nvml.Device) bool {
+	mode, ret := nvml.DeviceGetVirtualizationMode(device)
+	if ret != nvml.SUCCESS {
+		return false
+	}
+	return mode == nvml.GPU_VIRTUALIZATION_MODE_VGPU
 }
 
 // SaveGPUState saves gpu state info on the disk

--- a/ecs-init/gpu/nvidia_gpu_manager_test.go
+++ b/ecs-init/gpu/nvidia_gpu_manager_test.go
@@ -15,7 +15,9 @@ package gpu
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 	"testing"
 
 	mock_gpu "github.com/aws/amazon-ecs-agent/ecs-init/gpu/mocks"
@@ -104,6 +106,9 @@ func TestGetGPUDeviceIDs(t *testing.T) {
 
 	mockDevice1.EXPECT().GetUUID().Return("gpu-0123", nvml.SUCCESS)
 	mockDevice2.EXPECT().GetUUID().Return("gpu-1234", nvml.SUCCESS)
+	// The device loop now probes virtualization mode to gate MPS; these are not vGPUs.
+	mockDevice1.EXPECT().GetVirtualizationMode().Return(nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS)
+	mockDevice2.EXPECT().GetVirtualizationMode().Return(nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS)
 
 	defer func() {
 		nvml.DeviceGetHandleByIndex = oldDeviceGetHandleByIndex
@@ -318,6 +323,9 @@ func TestGPUSetupSuccessful(t *testing.T) {
 	mockDevice2 := mock_gpu.NewMockGPUDevice(ctrl)
 	mockDevice1.EXPECT().GetUUID().Return("gpu-0123", nvml.SUCCESS)
 	mockDevice2.EXPECT().GetUUID().Return("gpu-1234", nvml.SUCCESS)
+	// The device loop now probes virtualization mode to gate MPS; these are not vGPUs.
+	mockDevice1.EXPECT().GetVirtualizationMode().Return(nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS)
+	mockDevice2.EXPECT().GetVirtualizationMode().Return(nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS)
 
 	// Mock DeviceGetHandleByIndex
 	oldDeviceGetHandleByIndex := nvml.DeviceGetHandleByIndex
@@ -336,6 +344,11 @@ func TestGPUSetupSuccessful(t *testing.T) {
 		return nil
 	}
 
+	// Stub the host probes so Setup records deterministic MPS facts.
+	oldStatFile := statFile
+	statFile = func(string) (os.FileInfo, error) { return nil, nil } // binary present
+	restoreExec := stubExec("enabled\n")                             // service enabled
+
 	defer func() {
 		MatchFilePattern = FilePatternMatch
 		InitializeNVML = InitNVML
@@ -344,12 +357,18 @@ func TestGPUSetupSuccessful(t *testing.T) {
 		nvml.DeviceGetHandleByIndex = oldDeviceGetHandleByIndex
 		WriteContentToFile = WriteToFile
 		ShutdownNVML = ShutdownNVMLib
+		statFile = oldStatFile
+		restoreExec()
 	}()
 
 	err := nvidiaGPUManager.Setup()
 	assert.NoError(t, err)
 	assert.Equal(t, driverVersion, nvidiaGPUManager.(*NvidiaGPUManager).DriverVersion)
 	assert.Equal(t, []string{"gpu-0123", "gpu-1234"}, nvidiaGPUManager.(*NvidiaGPUManager).GPUIDs)
+	// Setup must persist the MPS gating facts gathered from the host and devices.
+	assert.True(t, nvidiaGPUManager.(*NvidiaGPUManager).MpsControlBinaryPresent)
+	assert.True(t, nvidiaGPUManager.(*NvidiaGPUManager).MpsServiceEnabled)
+	assert.False(t, nvidiaGPUManager.(*NvidiaGPUManager).HasVGPU)
 }
 
 func TestSetupNVMLError(t *testing.T) {
@@ -370,4 +389,80 @@ func TestSetupNVMLError(t *testing.T) {
 	}()
 	err := nvidiaGPUManager.Setup()
 	assert.Error(t, err)
+}
+
+// stubExec makes execCommand return a process whose stdout is the given text.
+// It re-execs the test binary running TestHelperProcess, the standard Go idiom
+// for faking exec.Command output without a real systemctl.
+func stubExec(output string) func() {
+	orig := execCommand
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		cs := []string{"-test.run=TestHelperProcess", "--", output}
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+		return cmd
+	}
+	return func() { execCommand = orig }
+}
+
+// TestHelperProcess is not a real test; it is the fake subprocess stubExec spawns.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	// Last arg is the stdout to emit.
+	args := os.Args
+	fmt.Fprint(os.Stdout, args[len(args)-1])
+	os.Exit(0)
+}
+
+func TestDetectMPSControlBinary(t *testing.T) {
+	orig := statFile
+	defer func() { statFile = orig }()
+
+	statFile = func(string) (os.FileInfo, error) { return nil, nil }
+	assert.True(t, detectMpsControlBinary(), "binary present -> true")
+
+	statFile = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+	assert.False(t, detectMpsControlBinary(), "binary absent -> false")
+}
+
+func TestDetectMpsServiceEnabled(t *testing.T) {
+	cases := []struct {
+		out  string
+		want bool
+	}{
+		{"enabled\n", true},
+		{"enabled-runtime\n", true},
+		{"disabled\n", false},
+		{"static\n", false},
+		{"", false}, // unit not found: no output
+	}
+	for _, tc := range cases {
+		t.Run(tc.out, func(t *testing.T) {
+			restore := stubExec(tc.out)
+			defer restore()
+			assert.Equal(t, tc.want, detectMpsServiceEnabled())
+		})
+	}
+}
+
+func TestDetectVGPU(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// A regular passthrough/bare-metal GPU is not a vGPU.
+	notVGPU := mock_gpu.NewMockGPUDevice(ctrl)
+	notVGPU.EXPECT().GetVirtualizationMode().Return(nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS)
+	assert.False(t, detectVGPU(notVGPU))
+
+	// A vGPU slice must be detected so MPS is gated off.
+	isVGPU := mock_gpu.NewMockGPUDevice(ctrl)
+	isVGPU.EXPECT().GetVirtualizationMode().Return(nvml.GPU_VIRTUALIZATION_MODE_VGPU, nvml.SUCCESS)
+	assert.True(t, detectVGPU(isVGPU))
+
+	// An NVML error must fail open (false) so a flaky probe never strips MPS.
+	errDevice := mock_gpu.NewMockGPUDevice(ctrl)
+	errDevice.EXPECT().GetVirtualizationMode().Return(nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.ERROR_UNKNOWN)
+	assert.False(t, detectVGPU(errDevice))
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
#### TODO:
* The capability advertisement to control plane has been commented out and will be added in once the rest of the MPS implementation is done.

### Summary
<!-- What does this pull request do? -->
Adds a new container instance capability, ecs.capability.gpu-sharing-mps, which the agent advertises when the instance is able to run GPU workloads sharing a single physical GPU through the NVIDIA Multi-Process Service (MPS) control daemon.

The agent advertises the capability only when all of the following hold:
- an NVIDIA GPU is present,
- the MPS control binary (/usr/bin/nvidia-cuda-mps-control) is installed,
- the nvidia-mps.service systemd unit is enabled, and
- the GPU is not an NVIDIA vGPU slice (vGPU does not support MPS).

If any condition is unmet the capability is withheld and the agent logs the specific reason. This pairs with the AL2023 GPU AMI change (https://github.com/aws/amazon-ecs-ami/pull/744) that ships and enables nvidia-mps.service.
### Implementation details
<!-- How are the changes implemented? -->
The facts are gathered on the host by ecs-init and consumed by the agent, mirroring how the existing NVIDIA driver version already flows:

- ecs-init: `ecs-init/gpu/nvidia_gpu_manager.go` gathers three new facts during GPU setup and persists them in `/var/lib/ecs/gpu/nvidia-gpu-info.json`:
  - MPSControlBinaryPresent - stat of the MPS control binary,
  - MPSServiceEnabled - `systemctl is-enabled nvidia-mps.service` (keys off the printed state, since is-enabled exits non-zero for a known-but-disabled unit),
  - HasVGPU - NVML DeviceGetVirtualizationMode, folded into the existing device loop; fails open (only a definite VGPU result counts, so a probe error never strips MPS from a real GPU).
- Shared decision (ecs-agent/utils/gpu/gpu.go) - a new  package that takes the four boolean inputs and returns whether to advertise, plus the unmet conditions with failure reasons. Keeping the decision in the shared library lets agent variants reach the same verdict from the same inputs.
- Agent - `agent/gpu/nvidia_gpu_manager_unix.go` reads the three new fields from the JSON and exposes them via getters; `agent/app/agent_capability_unix.go` builds the inputs (GPU-present derived from discovered devices), calls the shared decider, and appends capability.GPUSharingMps on success or logs each unmet reason otherwise. No-op stubs are added for the windows/unspecified builds.
- The capability name constant lives in `ecs-agent/capability/capability.go`.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes 

Verified end-to-end on  g6.xlarge, covering all four gate conditions via DescribeContainerInstances and the agent log:

* All conditions met (daemon enabled + active) - ecs.capability.gpu-sharing-mps advertised via DescribeContainerInstances
* nvidia-mps.service not enabled - withheld - nvidia-mps systemd service is not enabled on host
* MPS control binary absent - withheld - MPS control binary not present on host
* vGPU instance -withheld - instance has an NVIDIA vGPU slice, where we do not support MPS

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Feature - Add ecs.capability.gpu-sharing-mps capability for NVIDIA MPS GPU sharing
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  
**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66

-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
