### PR TITLE
Update SSM Agent version to 3.3.4624.0 for ECS exec

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -735,7 +735,7 @@ find-copy-certs-exec() {
 }
 
 download-ssm-binaries-exec() {
-    BINARY_VERSION="3.3.4108.0"
+    BINARY_VERSION="3.3.4624.0"
     BINARY_PATH="/var/lib/ecs/deps/execute-command/bin/${BINARY_VERSION}"
     BINARY_DOWNLOAD_PATH="ssm-binaries"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Update Amazon SSM Agent version to[ 3.3.4624.0](https://github.com/aws/amazon-ssm-agent/releases/tag/3.3.4624.0) to address CVEs listed below:
- https://alas.aws.amazon.com/AL2023/ALAS2023-2026-1952.html
- https://alas.aws.amazon.com/AL2023/ALAS2023-2026-1879.html
- https://alas.aws.amazon.com/AL2/ALAS2-2026-3378.html


### Implementation details
Update SSM Agent binary version to 3.3.4624.0 in scripts/ecs-anywhere-install.sh.


### Testing
Run end-to-end SSM/exec functional tests using the updated ecs-anywhere-install.sh on the following ECS Anywhere platforms, both on IPv4 and IPv6 Only networks:
  - al2023generic-amd64/arm64
  - al2generic-amd64/arm64
  - centos9-amd64/arm64
  - debian10-amd64/arm64/gpu (IPv6 not supported)
  - debian11-amd64/arm64/gpu (IPv6 not supported)
  - debian12-amd64/arm64
  - sles15-amd64 (IPv6 not supported)
  - ubuntu18-amd64/arm64/gpu (IPv6 not supported)
  - ubuntu20-amd64/arm64/gpu (IPv6 not supported)
  - ubuntu22-amd64/arm64/gpu
  - ubuntu24-amd64/arm64

New tests cover the changes: no

### Description for the changelog
Enhancement: Update SSM Agent version to 3.3.4624.0 for ECS exec

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
