### PR TITLE
Remove stale ISO+DualStack endpoint tests from ECS model

### DIFF
--- a/aws-sdk-go-v2/aws-models/ecs.json
+++ b/aws-sdk-go-v2/aws-models/ecs.json
@@ -1125,17 +1125,6 @@
                             }
                         },
                         {
-                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
-                            },
-                            "params": {
-                                "Region": "us-iso-east-1",
-                                "UseFIPS": true,
-                                "UseDualStack": true
-                            }
-                        },
-                        {
                             "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
@@ -1146,17 +1135,6 @@
                                 "Region": "us-iso-east-1",
                                 "UseFIPS": true,
                                 "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "error": "DualStack is enabled but this partition does not support DualStack"
-                            },
-                            "params": {
-                                "Region": "us-iso-east-1",
-                                "UseFIPS": false,
-                                "UseDualStack": true
                             }
                         },
                         {
@@ -1173,17 +1151,6 @@
                             }
                         },
                         {
-                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
-                            },
-                            "params": {
-                                "Region": "us-isob-east-1",
-                                "UseFIPS": true,
-                                "UseDualStack": true
-                            }
-                        },
-                        {
                             "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
@@ -1194,17 +1161,6 @@
                                 "Region": "us-isob-east-1",
                                 "UseFIPS": true,
                                 "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "error": "DualStack is enabled but this partition does not support DualStack"
-                            },
-                            "params": {
-                                "Region": "us-isob-east-1",
-                                "UseFIPS": false,
-                                "UseDualStack": true
                             }
                         },
                         {


### PR DESCRIPTION
### Summary
Removes 4 stale endpoint test cases from the checked-in ECS smithy model so `make gogenerate-aws-sdk` runs against the current (unpinned) codegen toolchain.

### Implementation details
`aws-sdk-go-v2/aws-models/ecs.json` carried 4 endpoint test cases for`us-iso-east-1` and `us-isob-east-1` with `UseDualStack=true`, each expecting a "partition does not support DualStack" error. Upstream `aws-sdk-go-v2` has since removed these invalid ISO/ISO-B DualStack combinations. Current smithy's stricter `RuleSetTestCase` validator rejects them:

```
RuleSetTestCase: Expected StringType but was EndpointType
  (url: https://ecs.us-iso-east-1.c2s.ic.gov ...)
```

which fails the `ecs.2014-11-13` projection and breaks `make gogenerate-aws-sdk`.

This drops only those 4 obsolete cases (53 -> 49 endpoint tests), matching upstream, and restores codegen on the current toolchain without pinning it. The change is confined to the `smithy.rules#endpointTests` trait; no operations,
shapes, or endpoint rules are modified.

#### Upstream reference
The current upstream ECS model no longer contains these cases. In
[`codegen/sdk-codegen/aws-models/ecs.json`](https://github.com/aws/aws-sdk-go-v2/blob/main/codegen/sdk-codegen/aws-models/ecs.json) (aws-sdk-go-v2 `main`), the `smithy.rules#endpointTests` for `us-iso-east-1` / `us-isob-east-1` only include the `UseDualStack=false` cases ("...with FIPS disabled and DualStack disabled" / "...FIPS enabled and DualStack disabled"); the four `UseDualStack=true` variants this PR removes are absent. Verified against
aws-sdk-go-v2 `main` @ 1b06657f (2026-07-23): a grep for the DualStack-enabled ISO test-case documentation strings returns zero matches upstream, while all four are present in our snapshot.

### Testing
Ran `make gogenerate-aws-sdk` before/after on the current (unpinned) toolchain: before, the ECS projection failed with the `RuleSetTestCase` errors above; after, it completes successfully (`Completed projection ecs.2014-11-13`, exit 0). The only regenerated diff is the removal of the 4 corresponding cases from the generated `endpoints_test.go`; no other generated output changes.

New tests cover the changes: no

### Description for the changelog
Housekeeping - Remove stale ISO/DualStack endpoint test cases from the ECS model to unblock code generation

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No.

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 licens
