### PR TITLE
Regenerate ECS SDK with gpuInfo on PlatformDevice

### DIFF
--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecs/serializers.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecs/serializers.go
@@ -4627,6 +4627,18 @@ func awsAwsjson11_serializeDocumentFSxWindowsFileServerVolumeConfiguration(v *ty
 	return nil
 }
 
+func awsAwsjson11_serializeDocumentGpuPlatformDeviceInfo(v *types.GpuPlatformDeviceInfo, value smithyjson.Value) error {
+	object := value.Object()
+	defer object.Close()
+
+	if v.MemoryInMiB != nil {
+		ok := object.Key("memoryInMiB")
+		ok.Integer(*v.MemoryInMiB)
+	}
+
+	return nil
+}
+
 func awsAwsjson11_serializeDocumentHealthCheck(v *types.HealthCheck, value smithyjson.Value) error {
 	object := value.Object()
 	defer object.Close()
@@ -5188,6 +5200,13 @@ func awsAwsjson11_serializeDocumentPlacementStrategy(v *types.PlacementStrategy,
 func awsAwsjson11_serializeDocumentPlatformDevice(v *types.PlatformDevice, value smithyjson.Value) error {
 	object := value.Object()
 	defer object.Close()
+
+	if v.GpuInfo != nil {
+		ok := object.Key("gpuInfo")
+		if err := awsAwsjson11_serializeDocumentGpuPlatformDeviceInfo(v.GpuInfo, ok); err != nil {
+			return err
+		}
+	}
 
 	if v.Id != nil {
 		ok := object.Key("id")

--- a/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecs/types/types.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecs/types/types.go
@@ -2294,6 +2294,17 @@ type FSxWindowsFileServerVolumeConfiguration struct {
 	noSmithyDocumentSerde
 }
 
+// GPU-specific platform-device attributes reported by the agent, used by
+// GPU-sharing (MPS).
+type GpuPlatformDeviceInfo struct {
+
+	// Usable per-GPU VRAM (MiB) reported by the agent, used by GPU-sharing (MPS)
+	// memory-based placement.
+	MemoryInMiB *int32
+
+	noSmithyDocumentSerde
+}
+
 // An object representing a container health check. Health check parameters that
 // are specified in a container definition override any Docker health checks that
 // exist in the container image (such as those specified in a parent image or from
@@ -3259,6 +3270,11 @@ type PlatformDevice struct {
 	//
 	// This member is required.
 	Type PlatformDeviceType
+
+	// GPU-specific attributes the agent reports for a GPU platform device at
+	// RegisterContainerInstance; present only when type is GPU. Absent on legacy
+	// agents that do not report it.
+	GpuInfo *GpuPlatformDeviceInfo
 
 	noSmithyDocumentSerde
 }

--- a/aws-sdk-go-v2/aws-models/ecs.json
+++ b/aws-sdk-go-v2/aws-models/ecs.json
@@ -8449,6 +8449,20 @@
                 }
             }
         },
+        "com.amazonaws.ecs#GpuPlatformDeviceInfo": {
+            "type": "structure",
+            "members": {
+                "memoryInMiB": {
+                    "target": "com.amazonaws.ecs#BoxedInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Usable per-GPU VRAM (MiB) reported by the agent, used by GPU-sharing (MPS) memory-based placement.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>GPU-specific platform-device attributes reported by the agent, used by GPU-sharing (MPS).</p>"
+            }
+        },
         "com.amazonaws.ecs#PlatformDevice": {
             "type": "structure",
             "members": {
@@ -8464,6 +8478,12 @@
                     "traits": {
                         "smithy.api#documentation": "<p>The type of device that's available on the container instance. The only supported\n\t\t\tvalue is <code>GPU</code>.</p>",
                         "smithy.api#required": {}
+                    }
+                },
+                "gpuInfo": {
+                    "target": "com.amazonaws.ecs#GpuPlatformDeviceInfo",
+                    "traits": {
+                        "smithy.api#documentation": "<p>GPU-specific attributes the agent reports for a GPU platform device at RegisterContainerInstance; present only when type is GPU. Absent on legacy agents that do not report it.</p>"
                     }
                 }
             },

--- a/aws-sdk-go-v2/service/ecs/request_snapshot_test.go
+++ b/aws-sdk-go-v2/service/ecs/request_snapshot_test.go
@@ -1821,10 +1821,16 @@ func TestCheckRequestSnapshot_RegisterContainerInstance(t *testing.T) {
 			types.PlatformDevice{
 				Id:   ptr.String("__Id__"),
 				Type: types.PlatformDeviceType("GPU"),
+				GpuInfo: &types.GpuPlatformDeviceInfo{
+					MemoryInMiB: ptr.Int32(1),
+				},
 			},
 			types.PlatformDevice{
 				Id:   ptr.String("__Id__"),
 				Type: types.PlatformDeviceType("GPU"),
+				GpuInfo: &types.GpuPlatformDeviceInfo{
+					MemoryInMiB: ptr.Int32(1),
+				},
 			},
 		},
 		Tags: []types.Tag{
@@ -5616,10 +5622,16 @@ func TestUpdateRequestSnapshot_RegisterContainerInstance(t *testing.T) {
 			types.PlatformDevice{
 				Id:   ptr.String("__Id__"),
 				Type: types.PlatformDeviceType("GPU"),
+				GpuInfo: &types.GpuPlatformDeviceInfo{
+					MemoryInMiB: ptr.Int32(1),
+				},
 			},
 			types.PlatformDevice{
 				Id:   ptr.String("__Id__"),
 				Type: types.PlatformDeviceType("GPU"),
+				GpuInfo: &types.GpuPlatformDeviceInfo{
+					MemoryInMiB: ptr.Int32(1),
+				},
 			},
 		},
 		Tags: []types.Tag{

--- a/aws-sdk-go-v2/service/ecs/serializers.go
+++ b/aws-sdk-go-v2/service/ecs/serializers.go
@@ -4627,6 +4627,18 @@ func awsAwsjson11_serializeDocumentFSxWindowsFileServerVolumeConfiguration(v *ty
 	return nil
 }
 
+func awsAwsjson11_serializeDocumentGpuPlatformDeviceInfo(v *types.GpuPlatformDeviceInfo, value smithyjson.Value) error {
+	object := value.Object()
+	defer object.Close()
+
+	if v.MemoryInMiB != nil {
+		ok := object.Key("memoryInMiB")
+		ok.Integer(*v.MemoryInMiB)
+	}
+
+	return nil
+}
+
 func awsAwsjson11_serializeDocumentHealthCheck(v *types.HealthCheck, value smithyjson.Value) error {
 	object := value.Object()
 	defer object.Close()
@@ -5188,6 +5200,13 @@ func awsAwsjson11_serializeDocumentPlacementStrategy(v *types.PlacementStrategy,
 func awsAwsjson11_serializeDocumentPlatformDevice(v *types.PlatformDevice, value smithyjson.Value) error {
 	object := value.Object()
 	defer object.Close()
+
+	if v.GpuInfo != nil {
+		ok := object.Key("gpuInfo")
+		if err := awsAwsjson11_serializeDocumentGpuPlatformDeviceInfo(v.GpuInfo, ok); err != nil {
+			return err
+		}
+	}
 
 	if v.Id != nil {
 		ok := object.Key("id")

--- a/aws-sdk-go-v2/service/ecs/types/types.go
+++ b/aws-sdk-go-v2/service/ecs/types/types.go
@@ -2294,6 +2294,17 @@ type FSxWindowsFileServerVolumeConfiguration struct {
 	noSmithyDocumentSerde
 }
 
+// GPU-specific platform-device attributes reported by the agent, used by
+// GPU-sharing (MPS).
+type GpuPlatformDeviceInfo struct {
+
+	// Usable per-GPU VRAM (MiB) reported by the agent, used by GPU-sharing (MPS)
+	// memory-based placement.
+	MemoryInMiB *int32
+
+	noSmithyDocumentSerde
+}
+
 // An object representing a container health check. Health check parameters that
 // are specified in a container definition override any Docker health checks that
 // exist in the container image (such as those specified in a parent image or from
@@ -3259,6 +3270,11 @@ type PlatformDevice struct {
 	//
 	// This member is required.
 	Type PlatformDeviceType
+
+	// GPU-specific attributes the agent reports for a GPU platform device at
+	// RegisterContainerInstance; present only when type is GPU. Absent on legacy
+	// agents that do not report it.
+	GpuInfo *GpuPlatformDeviceInfo
 
 	noSmithyDocumentSerde
 }

--- a/ecs-agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecs/serializers.go
+++ b/ecs-agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecs/serializers.go
@@ -4627,6 +4627,18 @@ func awsAwsjson11_serializeDocumentFSxWindowsFileServerVolumeConfiguration(v *ty
 	return nil
 }
 
+func awsAwsjson11_serializeDocumentGpuPlatformDeviceInfo(v *types.GpuPlatformDeviceInfo, value smithyjson.Value) error {
+	object := value.Object()
+	defer object.Close()
+
+	if v.MemoryInMiB != nil {
+		ok := object.Key("memoryInMiB")
+		ok.Integer(*v.MemoryInMiB)
+	}
+
+	return nil
+}
+
 func awsAwsjson11_serializeDocumentHealthCheck(v *types.HealthCheck, value smithyjson.Value) error {
 	object := value.Object()
 	defer object.Close()
@@ -5188,6 +5200,13 @@ func awsAwsjson11_serializeDocumentPlacementStrategy(v *types.PlacementStrategy,
 func awsAwsjson11_serializeDocumentPlatformDevice(v *types.PlatformDevice, value smithyjson.Value) error {
 	object := value.Object()
 	defer object.Close()
+
+	if v.GpuInfo != nil {
+		ok := object.Key("gpuInfo")
+		if err := awsAwsjson11_serializeDocumentGpuPlatformDeviceInfo(v.GpuInfo, ok); err != nil {
+			return err
+		}
+	}
 
 	if v.Id != nil {
 		ok := object.Key("id")

--- a/ecs-agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecs/types/types.go
+++ b/ecs-agent/vendor/github.com/aws/aws-sdk-go-v2/service/ecs/types/types.go
@@ -2294,6 +2294,17 @@ type FSxWindowsFileServerVolumeConfiguration struct {
 	noSmithyDocumentSerde
 }
 
+// GPU-specific platform-device attributes reported by the agent, used by
+// GPU-sharing (MPS).
+type GpuPlatformDeviceInfo struct {
+
+	// Usable per-GPU VRAM (MiB) reported by the agent, used by GPU-sharing (MPS)
+	// memory-based placement.
+	MemoryInMiB *int32
+
+	noSmithyDocumentSerde
+}
+
 // An object representing a container health check. Health check parameters that
 // are specified in a container definition override any Docker health checks that
 // exist in the container image (such as those specified in a parent image or from
@@ -3259,6 +3270,11 @@ type PlatformDevice struct {
 	//
 	// This member is required.
 	Type PlatformDeviceType
+
+	// GPU-specific attributes the agent reports for a GPU platform device at
+	// RegisterContainerInstance; present only when type is GPU. Absent on legacy
+	// agents that do not report it.
+	GpuInfo *GpuPlatformDeviceInfo
 
 	noSmithyDocumentSerde
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds gpuInfo to the `PlatformDevice` shape in the ECS model and regenerates the service/ecs SDK client from it. This gives the agent a field to report per-GPU usable memory (memoryInMiB) at `RegisterContainerInstance`.

This PR only introduces the field into the SDK. Populating it from NVML lives in a follow-up agent change.
### Implementation details
<!-- How are the changes implemented? -->
- `aws-sdk-go-v2/aws-models/ecs.json`: added a `GpuPlatformDeviceInfo` structure (memoryInMiB -> BoxedInteger) and a gpuInfo member on PlatformDevice.
- Regenerated `aws-sdk-go-v2/service/ecs` from the model via `make gogenerate-aws-sdk`.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> No

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Regenerate ECS SDK with gpuInfo on PlatformDevice
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->   No

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
