### PR TITLE
Report per-GPU memory at container instance registration

### DIFF
--- a/agent/gpu/nvidia_gpu_manager_unix.go
+++ b/agent/gpu/nvidia_gpu_manager_unix.go
@@ -48,6 +48,7 @@ type NvidiaGPUManager struct {
 	DriverVersion           string                 `json:"DriverVersion"`
 	GPUIDs                  []string               `json:"GPUIDs"`
 	GPUDevices              []types.PlatformDevice `json:"-"`
+	GPUMemoryMiB            map[string]uint64      `json:"GPUMemoryMiB,omitempty"`
 	MpsControlBinaryPresent bool                   `json:"MpsControlBinaryPresent"`
 	MpsServiceEnabled       bool                   `json:"MpsServiceEnabled"`
 	HasVGPU                 bool                   `json:"HasVGPU"`
@@ -82,8 +83,10 @@ func (n *NvidiaGPUManager) Initialize() error {
 		n.SetDriverVersion(nvidiaGPUInfo.GetDriverVersion())
 		nvidiaGPUInfo.lock.RLock()
 		gpuIDs := nvidiaGPUInfo.GetGPUIDsUnsafe()
+		gpuMemoryMiB := nvidiaGPUInfo.GetGPUMemoryMiBUnsafe()
 		nvidiaGPUInfo.lock.RUnlock()
 		n.SetGPUIDs(gpuIDs)
+		n.SetGPUMemoryMiB(gpuMemoryMiB)
 		n.SetDevices()
 		n.MpsControlBinaryPresent = nvidiaGPUInfo.GetMpsControlBinaryPresent()
 		n.MpsServiceEnabled = nvidiaGPUInfo.GetMpsServiceEnabled()
@@ -129,6 +132,18 @@ func (n *NvidiaGPUManager) GetGPUIDsUnsafe() []string {
 	return n.GPUIDs
 }
 
+// SetGPUMemoryMiB sets the per-GPU usable memory map
+func (n *NvidiaGPUManager) SetGPUMemoryMiB(gpuMemoryMiB map[string]uint64) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	n.GPUMemoryMiB = gpuMemoryMiB
+}
+
+// GetGPUMemoryMiBUnsafe returns the per-GPU usable memory map
+func (n *NvidiaGPUManager) GetGPUMemoryMiBUnsafe() map[string]uint64 {
+	return n.GPUMemoryMiB
+}
+
 // SetDriverVersion is a setter for nvidia driver version
 func (n *NvidiaGPUManager) SetDriverVersion(version string) {
 	n.lock.Lock()
@@ -149,10 +164,16 @@ func (n *NvidiaGPUManager) SetDevices() {
 	gpuIDs := n.GetGPUIDsUnsafe()
 	devices := make([]types.PlatformDevice, 0)
 	for _, gpuID := range gpuIDs {
-		devices = append(devices, types.PlatformDevice{
+		device := types.PlatformDevice{
 			Id:   aws.String(gpuID),
 			Type: types.PlatformDeviceTypeGpu,
-		})
+		}
+		if memMiB, ok := n.GPUMemoryMiB[gpuID]; ok {
+			device.GpuInfo = &types.GpuPlatformDeviceInfo{
+				MemoryInMiB: aws.Int32(int32(memMiB)),
+			}
+		}
+		devices = append(devices, device)
 	}
 	n.GPUDevices = devices
 }

--- a/agent/gpu/nvidia_gpu_manager_unix_test.go
+++ b/agent/gpu/nvidia_gpu_manager_unix_test.go
@@ -89,3 +89,55 @@ func TestSetGPUDevices(t *testing.T) {
 	nvidiaGPUManager.SetDevices()
 	assert.True(t, reflect.DeepEqual(devices, nvidiaGPUManager.GetDevices()))
 }
+
+// TestSetDevicesWithGPUMemory verifies SetDevices attaches GpuInfo.MemoryInMiB
+// for UUIDs with known usable memory, and leaves GpuInfo nil for UUIDs without
+// it (legacy hosts / partial NVML discovery), so the field is omitted from RCI.
+func TestSetDevicesWithGPUMemory(t *testing.T) {
+	nvidiaGPUManager := NewNvidiaGPUManager().(*NvidiaGPUManager)
+	nvidiaGPUManager.SetGPUIDs([]string{"id1", "id2"})
+	// id1 has known memory; id2 does not.
+	nvidiaGPUManager.SetGPUMemoryMiB(map[string]uint64{"id1": 15872})
+	nvidiaGPUManager.SetDevices()
+
+	got := nvidiaGPUManager.GetDevices()
+	expected := []types.PlatformDevice{
+		{
+			Id:   aws.String("id1"),
+			Type: types.PlatformDeviceTypeGpu,
+			GpuInfo: &types.GpuPlatformDeviceInfo{
+				MemoryInMiB: aws.Int32(15872),
+			},
+		},
+		{
+			Id:   aws.String("id2"),
+			Type: types.PlatformDeviceTypeGpu,
+		},
+	}
+	assert.True(t, reflect.DeepEqual(expected, got), "expected %+v, got %+v", expected, got)
+	assert.Nil(t, got[1].GpuInfo, "GpuInfo must be nil for a UUID without known memory")
+}
+
+// TestInitializeWithGPUMemory verifies GPUMemoryMiB round-trips through the GPU
+// info file and lands on the reported devices.
+func TestInitializeWithGPUMemory(t *testing.T) {
+	nvidiaGPUManager := NewNvidiaGPUManager()
+	GPUInfoFileExists = func() bool {
+		return true
+	}
+	GetGPUInfoJSON = func() ([]byte, error) {
+		return []byte(`{"DriverVersion":"396.44","GPUIDs":["id1","id2"],` +
+			`"GPUMemoryMiB":{"id1":15872,"id2":15872},` +
+			`"MpsControlBinaryPresent":true,"MpsServiceEnabled":true,"HasVGPU":false}`), nil
+	}
+	defer func() {
+		GPUInfoFileExists = CheckForGPUInfoFile
+		GetGPUInfoJSON = GetGPUInfo
+	}()
+	err := nvidiaGPUManager.Initialize()
+	assert.NoError(t, err)
+	for _, device := range nvidiaGPUManager.GetDevices() {
+		assert.NotNil(t, device.GpuInfo, "device %s should carry GpuInfo", aws.ToString(device.Id))
+		assert.Equal(t, int32(15872), aws.ToInt32(device.GpuInfo.MemoryInMiB))
+	}
+}

--- a/ecs-init/gpu/nvidia_gpu_manager.go
+++ b/ecs-init/gpu/nvidia_gpu_manager.go
@@ -43,6 +43,11 @@ type GPUManager interface {
 type NvidiaGPUManager struct {
 	DriverVersion string
 	GPUIDs        []string
+	// GPUMemoryMiB maps a GPU UUID to its usable memory in MiB, computed as
+	// (NVML v2 Total - Reserved). The agent reads this from the saved JSON to
+	// report per-GPU memory at RegisterContainerInstance for the MPS
+	// GPU-sharing feature.
+	GPUMemoryMiB map[string]uint64 `json:"GPUMemoryMiB,omitempty"`
 	// MPS gating facts. The agent reads these from the saved JSON to decide whether
 	// to advertise the gpu-sharing-mps capability at registration.
 	MpsControlBinaryPresent bool `json:"MpsControlBinaryPresent"`
@@ -59,6 +64,8 @@ const (
 	NvidiaGPUInfoFilePath = GPUInfoDirPath + "/nvidia-gpu-info.json"
 	// FilePerm is the file permissions for gpu info json file
 	FilePerm = 0700
+	// bytesPerMiB converts NVML memory (reported in bytes) to MiB.
+	bytesPerMiB = 1024 * 1024
 	// mpsControlBinaryPath is where the NVIDIA MPS control daemon binary lives on the GPU AMI.
 	mpsControlBinaryPath = "/usr/bin/nvidia-cuda-mps-control"
 	// mpsServiceName is the systemd unit that runs the MPS control daemon.
@@ -103,6 +110,9 @@ func (n *NvidiaGPUManager) Setup() error {
 		return errors.Wrapf(err, "setup failed")
 	}
 	n.GPUIDs = gpuIDs
+	// Discover per-GPU usable memory so the agent can report it at
+	// registration for the MPS GPU-sharing feature. 
+	n.GPUMemoryMiB = n.DetectGPUMemory()
 	// Gather the MPS facts once, after devices are known and before we persist state.
 	// HasVGPU is set per-device inside GetGPUDeviceIDs above.
 	n.MpsControlBinaryPresent = detectMpsControlBinary()
@@ -217,6 +227,42 @@ func (n *NvidiaGPUManager) GetGPUDeviceIDs() ([]string, error) {
 		return gpuIDs, errors.New("error initializing GPU devices")
 	}
 	return gpuIDs, nil
+}
+
+// DetectGPUMemory returns a map of GPU UUID to usable memory in MiB. It uses
+// NVML v2 memory (usable = Total - Reserved) so the reported value matches what
+// a workload can actually allocate under MPS.
+func (n *NvidiaGPUManager) DetectGPUMemory() map[string]uint64 {
+	memory := make(map[string]uint64)
+	count, err := NvmlGetDeviceCount()
+	if err != nil {
+		seelog.Errorf("Error getting GPU device count for memory detection: %v", err)
+		return memory
+	}
+	for i := 0; i < count; i++ {
+		device, ret := nvml.DeviceGetHandleByIndex(i)
+		if ret != nvml.SUCCESS {
+			seelog.Errorf("Error initializing device of index %d for memory detection: %v", i, nvml.ErrorString(ret))
+			continue
+		}
+		uuid, ret := nvml.DeviceGetUUID(device)
+		if ret != nvml.SUCCESS {
+			seelog.Errorf("Failed to get UUID for device at index %d during memory detection: %v", i, nvml.ErrorString(ret))
+			continue
+		}
+		// NVML v2 memory: usable = Total - Reserved.
+		mem, ret := nvml.DeviceGetMemoryInfo_v2(device)
+		if ret != nvml.SUCCESS {
+			seelog.Errorf("Failed to get v2 memory info for device %s: %v", uuid, nvml.ErrorString(ret))
+			continue
+		}
+		if mem.Total < mem.Reserved {
+			seelog.Errorf("Unexpected v2 memory for device %s: total %d < reserved %d; skipping", uuid, mem.Total, mem.Reserved)
+			continue
+		}
+		memory[uuid] = (mem.Total - mem.Reserved) / bytesPerMiB
+	}
+	return memory
 }
 
 var NvmlGetDeviceCount = GetDeviceCount

--- a/ecs-init/gpu/nvidia_gpu_manager_test.go
+++ b/ecs-init/gpu/nvidia_gpu_manager_test.go
@@ -321,11 +321,23 @@ func TestGPUSetupSuccessful(t *testing.T) {
 
 	mockDevice1 := mock_gpu.NewMockGPUDevice(ctrl)
 	mockDevice2 := mock_gpu.NewMockGPUDevice(ctrl)
-	mockDevice1.EXPECT().GetUUID().Return("gpu-0123", nvml.SUCCESS)
-	mockDevice2.EXPECT().GetUUID().Return("gpu-1234", nvml.SUCCESS)
+	// Setup walks the devices twice: once in GetGPUDeviceIDs (UUID +
+	// virtualization mode) and once in DetectGPUMemory (UUID + v2 memory).
+	mockDevice1.EXPECT().GetUUID().Return("gpu-0123", nvml.SUCCESS).Times(2)
+	mockDevice2.EXPECT().GetUUID().Return("gpu-1234", nvml.SUCCESS).Times(2)
 	// The device loop now probes virtualization mode to gate MPS; these are not vGPUs.
 	mockDevice1.EXPECT().GetVirtualizationMode().Return(nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS)
 	mockDevice2.EXPECT().GetVirtualizationMode().Return(nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS)
+	// DetectGPUMemory reads NVML v2 memory (usable = Total - Reserved). Use
+	// round numbers: 16 GiB total, 512 MiB reserved -> 16384 - 512 = 15872 MiB.
+	mockDevice1.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{
+		Total:    16384 * bytesPerMiB,
+		Reserved: 512 * bytesPerMiB,
+	}, nvml.SUCCESS)
+	mockDevice2.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{
+		Total:    16384 * bytesPerMiB,
+		Reserved: 512 * bytesPerMiB,
+	}, nvml.SUCCESS)
 
 	// Mock DeviceGetHandleByIndex
 	oldDeviceGetHandleByIndex := nvml.DeviceGetHandleByIndex
@@ -365,10 +377,78 @@ func TestGPUSetupSuccessful(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, driverVersion, nvidiaGPUManager.(*NvidiaGPUManager).DriverVersion)
 	assert.Equal(t, []string{"gpu-0123", "gpu-1234"}, nvidiaGPUManager.(*NvidiaGPUManager).GPUIDs)
+	// Setup must record per-GPU usable memory (v2 Total - Reserved) per UUID.
+	assert.Equal(t, map[string]uint64{"gpu-0123": 15872, "gpu-1234": 15872}, nvidiaGPUManager.(*NvidiaGPUManager).GPUMemoryMiB)
 	// Setup must persist the MPS gating facts gathered from the host and devices.
 	assert.True(t, nvidiaGPUManager.(*NvidiaGPUManager).MpsControlBinaryPresent)
 	assert.True(t, nvidiaGPUManager.(*NvidiaGPUManager).MpsServiceEnabled)
 	assert.False(t, nvidiaGPUManager.(*NvidiaGPUManager).HasVGPU)
+}
+
+// TestDetectGPUMemory covers the happy path plus the fail-open branches: a
+// per-device NVML error skips only that device, and a total < reserved reading
+// is treated as bad data and skipped, so a flaky call never fails discovery.
+func TestDetectGPUMemory(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	nvidiaGPUManager := NewNvidiaGPUManager().(*NvidiaGPUManager)
+
+	NvmlGetDeviceCount = func() (int, error) {
+		return 3, nil
+	}
+
+	good := mock_gpu.NewMockGPUDevice(ctrl)
+	good.EXPECT().GetUUID().Return("gpu-good", nvml.SUCCESS)
+	good.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{
+		Total:    24576 * bytesPerMiB,
+		Reserved: 768 * bytesPerMiB,
+	}, nvml.SUCCESS)
+
+	memErr := mock_gpu.NewMockGPUDevice(ctrl)
+	memErr.EXPECT().GetUUID().Return("gpu-memerr", nvml.SUCCESS)
+	memErr.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{}, nvml.ERROR_UNKNOWN)
+
+	badData := mock_gpu.NewMockGPUDevice(ctrl)
+	badData.EXPECT().GetUUID().Return("gpu-baddata", nvml.SUCCESS)
+	badData.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{
+		Total:    512 * bytesPerMiB,
+		Reserved: 1024 * bytesPerMiB,
+	}, nvml.SUCCESS)
+
+	oldDeviceGetHandleByIndex := nvml.DeviceGetHandleByIndex
+	nvml.DeviceGetHandleByIndex = func(idx int) (nvml.Device, nvml.Return) {
+		switch idx {
+		case 0:
+			return good, nvml.SUCCESS
+		case 1:
+			return memErr, nvml.SUCCESS
+		default:
+			return badData, nvml.SUCCESS
+		}
+	}
+	defer func() {
+		NvmlGetDeviceCount = GetDeviceCount
+		nvml.DeviceGetHandleByIndex = oldDeviceGetHandleByIndex
+	}()
+
+	memory := nvidiaGPUManager.DetectGPUMemory()
+	// Only the good device is reported; the NVML error and bad-data devices are skipped.
+	assert.Equal(t, map[string]uint64{"gpu-good": 23808}, memory)
+}
+
+// TestDetectGPUMemoryCountError verifies a device-count failure yields an empty
+// map (not nil-panic) and never fails discovery.
+func TestDetectGPUMemoryCountError(t *testing.T) {
+	nvidiaGPUManager := NewNvidiaGPUManager().(*NvidiaGPUManager)
+	NvmlGetDeviceCount = func() (int, error) {
+		return 0, errors.New("device count error")
+	}
+	defer func() {
+		NvmlGetDeviceCount = GetDeviceCount
+	}()
+	memory := nvidiaGPUManager.DetectGPUMemory()
+	assert.Empty(t, memory)
 }
 
 func TestSetupNVMLError(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
ecs-init discovers per-GPU usable memory (NVML v2 Total - Reserved) during Setup and persists it as a UUID->MiB map in the GPU info file. The agent loads the map and populates PlatformDevice.GpuInfo.MemoryInMiB when building
the RegisterContainerInstance payload, so the control plane can size GPUs for MPS memory-based placement.
### Implementation details
<!-- How are the changes implemented? -->
* ecs-init (ecs-init/gpu/nvidia_gpu_manager.go): new DetectGPUMemory() iterates over each device and computes usable memory with NVML v2 (DeviceGetMemoryInfo_v2), usable = (Total - Reserved) / MiB. Results are stored as GPUMemoryMiB map[string]uint64 (UUID -> MiB) and serialized to the GPU info file. Called from Setup().
* agent (agent/gpu/nvidia_gpu_manager_unix.go): reads the matching GPUMemoryMiB field from the info file in Initialize(), and SetDevices() sets PlatformDevice.GpuInfo = &GpuPlatformDeviceInfo{MemoryInMiB: ...} when a UUID has a known value. Left nil for GPUs without a value, so legacy hosts are unaffected.

Backward compatible and additive: the field is omitempty on both sides, so older agents/hosts that do not report it send nothing, and the control plane treats it as optional.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
* On host `nvidia-gpu-info.json` GPUMemoryMiB = 22563, matching nvidia-smi (23034 total - 471 reserved).
```
# sudo cat /var/lib/ecs/gpu/nvidia-gpu-info.json
{"DriverVersion":"580.159.03","GPUIDs":["GPU-cc922717-b2bb-b68f-d7da-7e2ac056c6fb"],"GPUMemoryMiB":{"GPU-cc922717-b2bb-b68f-d7da-7e2ac056c6fb":22563},"MpsControlBinaryPresent":true,"MpsServiceEnabled":true,"HasVGPU":false}[root@ip-172-31-37-203 bin]#
```
*  CloudTrail RegisterContainerInstance requestParameters.platformDevices[0] shows gpuInfo.memoryInMiB = 22563 from this agent build, confirming the field reaches the control plane on the wire.
```

"platformDevices": [
--
{
"id": "GPU-cc922717-b2bb-b68f-d7da-7e2ac056c6fb",
"type": "GPU",
"gpuInfo": {
"memoryInMiB": 22563
}
}
]


```
New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Report per-GPU memory at container instance registration for GPU sharing
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
