### PR TITLE
taskresource/volume: add nos3readcache S3 Files mount option

### DIFF
--- a/agent/taskresource/volume/dockervolume_s3files.go
+++ b/agent/taskresource/volume/dockervolume_s3files.go
@@ -123,6 +123,9 @@ func (cfg *S3FilesVolumeConfig) GetVolumePluginDriverOptions(credsRelativeURI st
 	if cfg.S3FilesAccessPointId != "" {
 		mntOpt.AddOption("accesspoint", cfg.S3FilesAccessPointId)
 	}
+	// nos3readcache prevents efs-utils from using application memory as an in-memory
+	// read cache, so that customer requested task memory won't be taken away by the cache.
+	mntOpt.AddOption("nos3readcache", "")
 
 	return map[string]string{
 		"type":   s3filesVolumePluginDriverType,

--- a/agent/taskresource/volume/dockervolume_s3files_test.go
+++ b/agent/taskresource/volume/dockervolume_s3files_test.go
@@ -147,6 +147,7 @@ func TestGetVolumePluginDriverOptions_Basic(t *testing.T) {
 	assert.Contains(t, options["o"], "tls")
 	assert.Contains(t, options["o"], "iam")
 	assert.Contains(t, options["o"], "awscredsuri=/creds")
+	assert.Contains(t, options["o"], "nos3readcache")
 }
 
 func TestGetVolumePluginDriverOptions_WithAccessPoint(t *testing.T) {


### PR DESCRIPTION
### Summary

Adds the `nos3readcache` mount option to S3 Files volume mounts. This option
prevents efs-utils from using application memory as an in-memory read cache,
so that customer requested task memory is not taken away by the cache.

This brings the EC2 agent's S3 Files mount behavior in line with ECS/Fargate.

### Implementation details

- `agent/taskresource/volume/dockervolume_s3files.go`:
  `GetVolumePluginDriverOptions` now appends `nos3readcache` to the mount
  options (`o`) passed to the ECS volume plugin, after the existing
  `tls`/`tlsport`/`iam`/`awscredsuri`/`accesspoint` options. The plugin's
  `ECSVolumeDriver` passes the option string through to the mount command
  unchanged, so no ecs-init changes are required.

### Testing

- `go build ./...` in the `agent` module
- `go test -tags unit ./taskresource/volume/... ./api/task/...` — all pass
- `gofmt` clean

New tests cover the changes: yes
(`TestGetVolumePluginDriverOptions_Basic` now asserts `nos3readcache` is
present in the driver options.)

### Description for the changelog

Enhancement - Add nos3readcache mount option to S3 Files volumes

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**

No.

**Does this PR include the addition of new environment variables in the README?**

No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.