### PR TITLE
Skip IPv4 gateway neighbor for IPv6-only ENIs

### DIFF
--- a/ecs-agent/netlib/platform/isolated_linux.go
+++ b/ecs-agent/netlib/platform/isolated_linux.go
@@ -139,11 +139,18 @@ func (il *isolatedLinux) configureBranchENI(ctx context.Context, netNSPath strin
 // addGatewayNeighbor installs a permanent ARP entry and /32 link-scope route
 // for the gateway in the task netns.
 func (il *isolatedLinux) addGatewayNeighbor(netNSPath string, eni *networkinterface.NetworkInterface) error {
+	// IPv6-only interfaces have no IPv4 gateway to pre-resolve, even when the
+	// payload carries a subnet gateway IPv4 address. The guest resolves the
+	// IPv6 gateway via NDP, which the TAP egress filters permit, so no
+	// neighbor entry is needed for IPv6.
+	if eni.IPv6Only() {
+		return nil
+	}
+
 	gwIPStr := eni.GetSubnetGatewayIPv4Address()
 	if gwIPStr == "" {
 		return nil
 	}
-	// TODO: Install equivalent neighbor entry for IPv6 gateway.
 
 	gwIP := net.ParseIP(gwIPStr)
 	if gwIP == nil {


### PR DESCRIPTION
The isolated platform pre-installs a permanent ARP entry for the subnet gateway in the task netns. IPv6-only interfaces have no IPv4 gateway to pre-resolve, even when the payload carries a subnet gateway IPv4 address; the guest resolves its IPv6 gateway via NDP, which the TAP egress filters permit. Installing the IPv4 neighbor entry on such ENIs is at best a no-op and at worst pins a gateway from a foreign subnet.

### Summary

`addGatewayNeighbor` now returns early for IPv6-only network interfaces on the isolated platform, so no IPv4 ARP entry or link-scope route is installed for a task that has no IPv4 addresses.

### Implementation details

`isolatedLinux.configureInterface` calls `addGatewayNeighbor` for every interface it configures on add (`NetworkReadyPull`). `addGatewayNeighbor` reads the subnet gateway IPv4 address from the interface, resolves the gateway MAC from the host neighbor cache, and installs a permanent ARP entry plus a `/32` link-scope route inside the task netns.

The change adds a guard at the top of `addGatewayNeighbor`: if `eni.IPv6Only()` (no IPv4 addresses and at least one IPv6 address), return `nil` immediately. This runs before the `GetSubnetGatewayIPv4Address()` empty check, so an IPv6-only interface is skipped even when the payload does populate a subnet gateway IPv4 address. The pre-existing `TODO` about installing an equivalent IPv6 neighbor entry is removed: IPv6 needs no pre-resolution, because NDP works from inside the task netns.

One file changed: `ecs-agent/netlib/platform/isolated_linux.go`.

### Testing

`go test -tags unit ./netlib/platform/...` passes, including the three existing `addGatewayNeighbor` cases (`TestIsolatedLinux_AddGatewayNeighbor`, `..._NoGateway`, `..._HostNeighborNotFound`), which cover the IPv4 path and confirm no regression.

Validated end to end with an ECS functional test for the isolated platform on an IPv6-only subnet (private subnet with an egress-only internet gateway).

New tests cover the changes: no — the existing unit tests cover the unchanged IPv4 path, and the IPv6-only behavior is covered by the functional test described above.

### Description for the changelog

Bugfix - Skip IPv4 gateway neighbor installation for IPv6-only ENIs on the isolated platform

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**

No.

**Does this PR include the addition of new environment variables in the README?**

No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
