### PR TITLE
🔀 Add dcgm-init into dependabot and refactoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,13 @@ updates:
     # the bot stuck at trying to upgrade it; (2) sdk change has higher risk of breaking the agent so probably safer to
     # upgrade manually.
     - dependency-name: "github.com/aws/aws-sdk-go"
+- package-ecosystem: gomod
+  directory: "/dcgm-init"
+  schedule:
+    interval: weekly
+    time: "00:00"
+  open-pull-requests-limit: 1
+  target-branch: "dev"
 - package-ecosystem: "github-actions"
   directory: ".github/workflows"
   schedule:

--- a/agent/gpu/dcgm_metrics_reader_linux_test.go
+++ b/agent/gpu/dcgm_metrics_reader_linux_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	gputypes "github.com/aws/amazon-ecs-agent/ecs-agent/gpu/types"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -73,7 +72,7 @@ const (
 	testFractionalUtil    = 0.0
 	testFractionalMemUtil = 7.5
 
-	testStaleTimestamp  = "2026-01-01T00:00:00Z"
+	testTimestamp       = "2026-07-19T00:00:00Z"
 	testUnhealthyReason = "XID_48" // mirrors dcgm/client's fmt.Sprintf("XID_%d")
 
 	testT4GPUUUID   = "GPU-2a95d2f5-c87a-9cb4-52d4-393d7059e8f5"
@@ -87,263 +86,224 @@ const (
 	testT4Xid       = int64(2)
 )
 
-// TestDCGMMetricsReaderValidFile parses a healthy single-GPU snapshot and checks every
-// field round-trips.
+// TestDCGMMetricsReaderValidFile verifies healthy snapshots round-trip through
+// the file: one deep-equal per case asserts the reader returns exactly what was
+// written. Covers a fully populated GPU, four GPUs, a fractional vGPU with absent
+// optional fields, connection-lost, and unhealthy.
 func TestDCGMMetricsReaderValidFile(t *testing.T) {
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "gpu-metrics.json")
-
-	writeMetricsFile(t, filePath, gputypes.GPUMetricsFileData{
-		Timestamp: testT4Timestamp,
-		Healthy:   true,
-		GPUs: []gputypes.GPUMetric{
-			{
-				GPUUUID:            testT4GPUUUID,
-				GPUUtilization:     aws.Float64(testT4Util),
-				MemoryUtilization:  aws.Float64(testT4MemUtil),
-				MemoryTotal:        aws.Uint64(testT4MemTotal),
-				MemoryUsed:         aws.Uint64(testT4MemUsed),
-				PowerDraw:          aws.Float64(testT4PowerDraw),
-				Temperature:        aws.Float64(testT4Temp),
-				RestartAppXidCount: testT4Xid,
+	for _, tc := range []struct {
+		name string
+		data gputypes.GPUMetricsFileData
+	}{
+		{
+			name: "single GPU with all fields populated",
+			data: gputypes.GPUMetricsFileData{
+				Timestamp: testT4Timestamp,
+				Healthy:   true,
+				GPUs: []gputypes.GPUMetric{{
+					GPUUUID:            testT4GPUUUID,
+					GPUUtilization:     aws.Float64(testT4Util),
+					MemoryUtilization:  aws.Float64(testT4MemUtil),
+					MemoryTotal:        aws.Uint64(testT4MemTotal),
+					MemoryUsed:         aws.Uint64(testT4MemUsed),
+					PowerDraw:          aws.Float64(testT4PowerDraw),
+					Temperature:        aws.Float64(testT4Temp),
+					RestartAppXidCount: testT4Xid,
+				}},
 			},
 		},
-	})
-
-	reader := NewDCGMMetricsReader(filePath)
-	result := reader.GetGPUMetrics()
-
-	require.NotNil(t, result)
-	assert.Equal(t, testT4Timestamp, result.Timestamp)
-	assert.True(t, result.Healthy)
-	require.Len(t, result.GPUs, 1)
-	assert.Equal(t, testT4GPUUUID, result.GPUs[0].GPUUUID)
-	assert.Equal(t, testT4Util, *result.GPUs[0].GPUUtilization)
-	assert.Equal(t, testT4MemUtil, *result.GPUs[0].MemoryUtilization)
-	assert.Equal(t, testT4MemTotal, *result.GPUs[0].MemoryTotal)
-	assert.Equal(t, testT4MemUsed, *result.GPUs[0].MemoryUsed)
-	assert.Equal(t, testT4PowerDraw, *result.GPUs[0].PowerDraw)
-	assert.Equal(t, testT4Temp, *result.GPUs[0].Temperature)
-	assert.Equal(t, testT4Xid, result.GPUs[0].RestartAppXidCount)
-}
-
-func TestDCGMMetricsReaderMultipleGPUs(t *testing.T) {
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "gpu-metrics.json")
-
-	expectedGPUs := []gputypes.GPUMetric{
 		{
-			GPUUUID:            testGPUUUID1,
-			GPUUtilization:     aws.Float64(testUtilization1),
-			MemoryUtilization:  aws.Float64(testMemUtil1),
-			MemoryTotal:        aws.Uint64(testMemTotal1),
-			MemoryUsed:         aws.Uint64(testMemUsed1),
-			PowerDraw:          aws.Float64(testPowerDraw1),
-			Temperature:        aws.Float64(testTemp1),
-			RestartAppXidCount: 0,
+			name: "four GPUs",
+			data: gputypes.GPUMetricsFileData{
+				Timestamp: testTimestamp,
+				GPUs: []gputypes.GPUMetric{
+					{
+						GPUUUID:            testGPUUUID1,
+						GPUUtilization:     aws.Float64(testUtilization1),
+						MemoryUtilization:  aws.Float64(testMemUtil1),
+						MemoryTotal:        aws.Uint64(testMemTotal1),
+						MemoryUsed:         aws.Uint64(testMemUsed1),
+						PowerDraw:          aws.Float64(testPowerDraw1),
+						Temperature:        aws.Float64(testTemp1),
+						RestartAppXidCount: 0,
+					},
+					{
+						GPUUUID:            testGPUUUID2,
+						GPUUtilization:     aws.Float64(testUtilization2),
+						MemoryUtilization:  aws.Float64(testMemUtil2),
+						MemoryTotal:        aws.Uint64(testMemTotal2),
+						MemoryUsed:         aws.Uint64(testMemUsed2),
+						PowerDraw:          aws.Float64(testPowerDraw2),
+						Temperature:        aws.Float64(testTemp2),
+						RestartAppXidCount: testRestartXidCount,
+					},
+					{
+						GPUUUID:            testGPUUUID3,
+						GPUUtilization:     aws.Float64(testUtilization3),
+						MemoryUtilization:  aws.Float64(testMemUtil3),
+						MemoryTotal:        aws.Uint64(testMemTotal3),
+						MemoryUsed:         aws.Uint64(testMemUsed3),
+						PowerDraw:          aws.Float64(testPowerDraw3),
+						Temperature:        aws.Float64(testTemp3),
+						RestartAppXidCount: 0,
+					},
+					{
+						GPUUUID:            testGPUUUID4,
+						GPUUtilization:     aws.Float64(testUtilization4),
+						MemoryUtilization:  aws.Float64(testMemUtil4),
+						MemoryTotal:        aws.Uint64(testMemTotal4),
+						MemoryUsed:         aws.Uint64(testMemUsed4),
+						PowerDraw:          aws.Float64(testPowerDraw4),
+						Temperature:        aws.Float64(testTemp4),
+						RestartAppXidCount: 0,
+					},
+				},
+			},
 		},
 		{
-			GPUUUID:            testGPUUUID2,
-			GPUUtilization:     aws.Float64(testUtilization2),
-			MemoryUtilization:  aws.Float64(testMemUtil2),
-			MemoryTotal:        aws.Uint64(testMemTotal2),
-			MemoryUsed:         aws.Uint64(testMemUsed2),
-			PowerDraw:          aws.Float64(testPowerDraw2),
-			Temperature:        aws.Float64(testTemp2),
-			RestartAppXidCount: testRestartXidCount,
+			// PowerDraw and Temperature are left nil: their omitempty tags drop
+			// them from the JSON, exactly as dcgm-init emits on a g6f fractional
+			// vGPU instance. They must parse back as nil, not zero.
+			name: "fractional vGPU with absent power and temperature",
+			data: gputypes.GPUMetricsFileData{
+				Timestamp: testTimestamp,
+				GPUs: []gputypes.GPUMetric{{
+					GPUUUID:           testGPUUUIDFractional,
+					GPUUtilization:    aws.Float64(testFractionalUtil),
+					MemoryUtilization: aws.Float64(testFractionalMemUtil),
+					MemoryTotal:       aws.Uint64(testFractionalMem),
+					MemoryUsed:        aws.Uint64(0),
+				}},
+			},
 		},
 		{
-			GPUUUID:            testGPUUUID3,
-			GPUUtilization:     aws.Float64(testUtilization3),
-			MemoryUtilization:  aws.Float64(testMemUtil3),
-			MemoryTotal:        aws.Uint64(testMemTotal3),
-			MemoryUsed:         aws.Uint64(testMemUsed3),
-			PowerDraw:          aws.Float64(testPowerDraw3),
-			Temperature:        aws.Float64(testTemp3),
-			RestartAppXidCount: 0,
+			// Healthy stays true while disconnected; callers rely on
+			// ConnectionLost, not Healthy, to detect the dropped connection.
+			name: "connection lost",
+			data: gputypes.GPUMetricsFileData{
+				Timestamp:      testTimestamp,
+				Healthy:        true,
+				ConnectionLost: true,
+				GPUs:           []gputypes.GPUMetric{},
+			},
 		},
 		{
-			GPUUUID:            testGPUUUID4,
-			GPUUtilization:     aws.Float64(testUtilization4),
-			MemoryUtilization:  aws.Float64(testMemUtil4),
-			MemoryTotal:        aws.Uint64(testMemTotal4),
-			MemoryUsed:         aws.Uint64(testMemUsed4),
-			PowerDraw:          aws.Float64(testPowerDraw4),
-			Temperature:        aws.Float64(testTemp4),
-			RestartAppXidCount: 0,
+			// Unhealthy GPU: healthy=false with a fault code. "XID_48" mirrors
+			// dcgm/client's fmt.Sprintf("XID_%d").
+			name: "unhealthy with fault reason",
+			data: gputypes.GPUMetricsFileData{
+				Timestamp:       testTimestamp,
+				Healthy:         false,
+				UnhealthyReason: testUnhealthyReason,
+				GPUs:            []gputypes.GPUMetric{},
+			},
 		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			filePath := filepath.Join(t.TempDir(), "gpu-metrics.json")
+			writeMetricsFile(t, filePath, tc.data)
+
+			result := NewDCGMMetricsReader(filePath).GetGPUMetrics()
+			require.NotNil(t, result)
+			assert.Equal(t, &tc.data, result, "parsed struct should match the written file")
+		})
 	}
+}
 
-	data := gputypes.GPUMetricsFileData{
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-		GPUs:      expectedGPUs,
+// TestDCGMMetricsReaderRejectsAbsentFile covers cases where os.ReadFile fails, so
+// the reader returns nil before parsing: missing parent dir, missing file in an
+// existing dir (the common pre-first-write transient), path is a dir (EISDIR),
+// non-dir parent (ENOTDIR), and an unreadable file. Each setup returns the path.
+func TestDCGMMetricsReaderRejectsAbsentFile(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T) string
+	}{
+		{
+			name: "parent directory missing",
+			setup: func(t *testing.T) string {
+				return "/nonexistent/path/gpu-metrics.json"
+			},
+		},
+		{
+			name: "file missing in existing directory",
+			setup: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "gpu-metrics.json")
+			},
+		},
+		{
+			name: "path is a directory",
+			setup: func(t *testing.T) string {
+				filePath := filepath.Join(t.TempDir(), "gpu-metrics.json")
+				require.NoError(t, os.Mkdir(filePath, 0755))
+				return filePath
+			},
+		},
+		{
+			name: "parent path is not a directory",
+			setup: func(t *testing.T) string {
+				notADir := filepath.Join(t.TempDir(), "not-a-dir")
+				require.NoError(t, os.WriteFile(notADir, []byte("x"), 0644))
+				return filepath.Join(notADir, "gpu-metrics.json")
+			},
+		},
+		{
+			// Root bypasses Unix permission checks, so this case cannot be
+			// exercised as root and skips itself.
+			name: "unreadable file",
+			setup: func(t *testing.T) string {
+				if os.Geteuid() == 0 {
+					t.Skip("root bypasses file permission checks; cannot exercise unreadable path")
+				}
+				filePath := filepath.Join(t.TempDir(), "gpu-metrics.json")
+				require.NoError(t, os.WriteFile(filePath, []byte(`{"timestamp":"2026-01-01T00:00:00Z","gpus":[]}`), 0000))
+				return filePath
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := NewDCGMMetricsReader(tc.setup(t)).GetGPUMetrics()
+			assert.Nil(t, result, "an unreadable/absent file should return nil")
+		})
 	}
-
-	writeMetricsFile(t, filePath, data)
-
-	reader := NewDCGMMetricsReader(filePath)
-	result := reader.GetGPUMetrics()
-
-	require.NotNil(t, result)
-	require.Len(t, result.GPUs, len(expectedGPUs))
-
-	for i, expected := range expectedGPUs {
-		actual := result.GPUs[i]
-		assert.Equal(t, expected.GPUUUID, actual.GPUUUID, "GPU %d UUID mismatch", i)
-		assert.Equal(t, *expected.GPUUtilization, *actual.GPUUtilization, "GPU %d utilization mismatch", i)
-		assert.Equal(t, *expected.MemoryUtilization, *actual.MemoryUtilization, "GPU %d memory utilization mismatch", i)
-		assert.Equal(t, *expected.MemoryTotal, *actual.MemoryTotal, "GPU %d memory total mismatch", i)
-		assert.Equal(t, *expected.MemoryUsed, *actual.MemoryUsed, "GPU %d memory used mismatch", i)
-		assert.Equal(t, *expected.PowerDraw, *actual.PowerDraw, "GPU %d power draw mismatch", i)
-		assert.Equal(t, *expected.Temperature, *actual.Temperature, "GPU %d temperature mismatch", i)
-		assert.Equal(t, expected.RestartAppXidCount, actual.RestartAppXidCount, "GPU %d XID count mismatch", i)
-	}
 }
 
-// TestDCGMMetricsReaderParentDirMissing covers a missing containing directory: the
-// read fails with os.IsNotExist, so the reader returns nil. The
-// dir-exists/file-missing case is covered by TestDCGMMetricsReaderFileMissingInExistingDir.
-func TestDCGMMetricsReaderParentDirMissing(t *testing.T) {
-	reader := NewDCGMMetricsReader("/nonexistent/path/gpu-metrics.json")
-	result := reader.GetGPUMetrics()
-	assert.Nil(t, result, "a missing parent directory should return nil")
-}
-
-func TestDCGMMetricsReaderInvalidJSON(t *testing.T) {
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "gpu-metrics.json")
-	require.NoError(t, os.WriteFile(filePath, []byte("not valid json{{{"), 0644))
-
-	reader := NewDCGMMetricsReader(filePath)
-	result := reader.GetGPUMetrics()
-	assert.Nil(t, result)
-}
-
-// TestDCGMMetricsReaderEmptyFile covers an empty or whitespace-only file, which
-// dcgm-init creates before its first write. json.Unmarshal rejects it with
-// "unexpected end of JSON input", so it returns nil via the parse-error branch.
-func TestDCGMMetricsReaderEmptyFile(t *testing.T) {
+// TestDCGMMetricsReaderRejectsCorruptFile covers files that read but whose
+// contents are rejected: non-JSON bytes, empty/whitespace (dcgm-init's
+// pre-first-write state), a wrong-typed field, a top-level array, literal null,
+// and an unparseable timestamp. All must return nil, not a partial result.
+func TestDCGMMetricsReaderRejectsCorruptFile(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		content string
 	}{
+		{"invalid json", "not valid json{{{"},
 		{"zero bytes", ""},
 		{"whitespace only", "   \n\t  \n"},
+		{"wrong field type", `{"timestamp":"2026-01-01T00:00:00Z","gpus":[{"gpu_utilization_percent":"not-a-number"}]}`},
+		{"top-level array", "[]"},
+		{"json null", "null"},
+		{"unparseable timestamp", `{"timestamp":"not-a-timestamp","healthy":true,"gpus":[]}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			filePath := filepath.Join(t.TempDir(), "gpu-metrics.json")
 			require.NoError(t, os.WriteFile(filePath, []byte(tc.content), 0644))
 
 			result := NewDCGMMetricsReader(filePath).GetGPUMetrics()
-			assert.Nil(t, result, "empty/whitespace file should return nil (pre-first-write state)")
+			assert.Nil(t, result, "corrupt file contents should return nil")
 		})
 	}
 }
 
-// TestDCGMMetricsReaderUnreadableFile verifies that when the metrics file exists but
-// the agent process cannot read it (no read permission), the reader treats it
-// as no metrics yet and returns nil rather than erroring. Root bypasses Unix
-// permission checks, so the test is skipped when running as root.
-func TestDCGMMetricsReaderUnreadableFile(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("root bypasses file permission checks; cannot exercise unreadable path")
-	}
-
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "gpu-metrics.json")
-	require.NoError(t, os.WriteFile(filePath, []byte(`{"timestamp":"2026-01-01T00:00:00Z","gpus":[]}`), 0000))
-
-	reader := NewDCGMMetricsReader(filePath)
-	result := reader.GetGPUMetrics()
-	assert.Nil(t, result, "Unreadable file should return nil (no read permission)")
-}
-
-func TestDCGMMetricsReaderConnectionLost(t *testing.T) {
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "gpu-metrics.json")
-	writeMetricsFile(t, filePath, gputypes.GPUMetricsFileData{
-		Timestamp:      testStaleTimestamp,
-		Healthy:        true,
-		ConnectionLost: true,
-		GPUs:           []gputypes.GPUMetric{},
-	})
-
-	reader := NewDCGMMetricsReader(filePath)
-	result := reader.GetGPUMetrics()
-	require.NotNil(t, result)
-	assert.True(t, result.ConnectionLost, "connection_lost should be parsed and propagated")
-	assert.True(t, result.Healthy, "healthy stays true when disconnected; caller uses ConnectionLost")
-}
-
-// TestDCGMMetricsReaderUnhealthyReason covers an unhealthy GPU: healthy=false with a
-// fault code. "XID_48" mirrors dcgm/client's fmt.Sprintf("XID_%d").
-func TestDCGMMetricsReaderUnhealthyReason(t *testing.T) {
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "gpu-metrics.json")
-	writeMetricsFile(t, filePath, gputypes.GPUMetricsFileData{
-		Timestamp:       testStaleTimestamp,
-		Healthy:         false,
-		UnhealthyReason: testUnhealthyReason,
-		GPUs:            []gputypes.GPUMetric{},
-	})
-
-	reader := NewDCGMMetricsReader(filePath)
-	result := reader.GetGPUMetrics()
-	require.NotNil(t, result)
-	assert.False(t, result.Healthy, "healthy should be parsed as false")
-	assert.Equal(t, testUnhealthyReason, result.UnhealthyReason, "unhealthy_reason should be parsed and propagated")
-	assert.False(t, result.ConnectionLost, "connection_lost absent -> false")
-}
-
-// TestDCGMMetricsReaderFractionalGPUMissingFields verifies that absent power_draw_watts
-// and temperature_celsius fields (as on g6f fractional vGPU instances) parse as
-// nil, not zero values.
-func TestDCGMMetricsReaderFractionalGPUMissingFields(t *testing.T) {
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "gpu-metrics.json")
-
-	// Leave PowerDraw and Temperature nil: their omitempty tags drop them from the
-	// marshaled JSON, exactly as dcgm-init emits on a g6f instance (fields absent).
-	writeMetricsFile(t, filePath, gputypes.GPUMetricsFileData{
-		Timestamp: testStaleTimestamp,
-		GPUs: []gputypes.GPUMetric{
-			{
-				GPUUUID:           testGPUUUIDFractional,
-				GPUUtilization:    aws.Float64(testFractionalUtil),
-				MemoryUtilization: aws.Float64(testFractionalMemUtil),
-				MemoryTotal:       aws.Uint64(testFractionalMem),
-				MemoryUsed:        aws.Uint64(0),
-			},
-		},
-	})
-
-	reader := NewDCGMMetricsReader(filePath)
-	result := reader.GetGPUMetrics()
-
-	require.NotNil(t, result)
-	require.Len(t, result.GPUs, 1)
-	assert.Equal(t, testGPUUUIDFractional, result.GPUs[0].GPUUUID)
-	assert.NotNil(t, result.GPUs[0].GPUUtilization)
-	assert.Equal(t, testFractionalUtil, *result.GPUs[0].GPUUtilization)
-	assert.NotNil(t, result.GPUs[0].MemoryUtilization)
-	assert.Equal(t, testFractionalMemUtil, *result.GPUs[0].MemoryUtilization)
-	assert.NotNil(t, result.GPUs[0].MemoryTotal)
-	assert.Equal(t, testFractionalMem, *result.GPUs[0].MemoryTotal)
-	assert.Nil(t, result.GPUs[0].PowerDraw,
-		"PowerDraw should be nil when field is absent from JSON (not zero)")
-	assert.Nil(t, result.GPUs[0].Temperature,
-		"Temperature should be nil when field is absent from JSON (not zero)")
-	assert.Equal(t, int64(0), result.GPUs[0].RestartAppXidCount)
-}
-
-// TestDCGMMetricsReaderReturnsTimestamp verifies that the reader returns the timestamp
-// from the file so callers can detect stale data.
+// TestDCGMMetricsReaderReturnsTimestamp verifies the reader returns the file's
+// timestamp (so callers can detect stale data) and that repeated calls return
+// the same data (the reader tracks no staleness itself).
 func TestDCGMMetricsReaderReturnsTimestamp(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "gpu-metrics.json")
 
 	data := gputypes.GPUMetricsFileData{
-		Timestamp: testStaleTimestamp,
+		Timestamp: testTimestamp,
 		GPUs: []gputypes.GPUMetric{
 			{GPUUUID: testGPUUUID0, GPUUtilization: aws.Float64(testUtilization0)},
 		},
@@ -355,7 +315,7 @@ func TestDCGMMetricsReaderReturnsTimestamp(t *testing.T) {
 	// Reader always returns data with the timestamp — no staleness logic
 	result1 := reader.GetGPUMetrics()
 	require.NotNil(t, result1)
-	assert.Equal(t, testStaleTimestamp, result1.Timestamp)
+	assert.Equal(t, testTimestamp, result1.Timestamp)
 	require.Len(t, result1.GPUs, 1)
 
 	// Second call returns the same data (reader doesn't track staleness)
@@ -368,102 +328,6 @@ func TestDCGMMetricsReaderReturnsTimestamp(t *testing.T) {
 func TestDCGMMetricsReaderDefaultFilePath(t *testing.T) {
 	reader := NewDCGMMetricsReader("")
 	assert.Equal(t, gputypes.GPUMetricsFilePath, reader.filePath)
-}
-
-// TestDCGMMetricsReaderFileMissingInExistingDir covers the common runtime transient:
-// the /var/run/ecs directory exists (bind mount present) but dcgm-init has not
-// written the metrics file yet. The reader must return nil.
-func TestDCGMMetricsReaderFileMissingInExistingDir(t *testing.T) {
-	tmpDir := t.TempDir()
-	// Point at a file that does not exist inside a directory that does.
-	filePath := filepath.Join(tmpDir, "gpu-metrics.json")
-
-	reader := NewDCGMMetricsReader(filePath)
-	result := reader.GetGPUMetrics()
-	assert.Nil(t, result, "Missing file in an existing directory should return nil")
-}
-
-// TestDCGMMetricsReaderPathIsDirectory covers the case where the metrics file path is
-// itself a directory: os.ReadFile fails (EISDIR), so the reader returns nil.
-func TestDCGMMetricsReaderPathIsDirectory(t *testing.T) {
-	tmpDir := t.TempDir()
-	// Create a directory where the metrics file is expected.
-	filePath := filepath.Join(tmpDir, "gpu-metrics.json")
-	require.NoError(t, os.Mkdir(filePath, 0755))
-
-	reader := NewDCGMMetricsReader(filePath)
-	result := reader.GetGPUMetrics()
-	assert.Nil(t, result, "A directory in place of the metrics file should return nil")
-}
-
-// TestDCGMMetricsReaderDirPathNotADirectory covers a non-directory path component: the
-// parent path exists but is a regular file, so os.ReadFile fails (ENOTDIR) and
-// the reader returns nil.
-func TestDCGMMetricsReaderDirPathNotADirectory(t *testing.T) {
-	tmpDir := t.TempDir()
-	// Create a regular file, then treat it as the containing directory by
-	// requesting a metrics file "inside" it.
-	notADir := filepath.Join(tmpDir, "not-a-dir")
-	require.NoError(t, os.WriteFile(notADir, []byte("x"), 0644))
-	filePath := filepath.Join(notADir, "gpu-metrics.json")
-
-	reader := NewDCGMMetricsReader(filePath)
-	result := reader.GetGPUMetrics()
-	assert.Nil(t, result, "A non-directory parent path should return nil")
-}
-
-// TestDCGMMetricsReaderInvalidTimestamp covers the timestamp-validation branch: valid
-// JSON but a timestamp that is not RFC3339 is rejected as corrupt.
-func TestDCGMMetricsReaderInvalidTimestamp(t *testing.T) {
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "gpu-metrics.json")
-	writeMetricsFile(t, filePath, gputypes.GPUMetricsFileData{
-		Timestamp: "not-a-timestamp",
-		Healthy:   true,
-		GPUs:      []gputypes.GPUMetric{},
-	})
-
-	reader := NewDCGMMetricsReader(filePath)
-	result := reader.GetGPUMetrics()
-	assert.Nil(t, result, "Unparseable timestamp should return nil (treated as corrupt)")
-}
-
-// TestDCGMMetricsReaderJSONTypeMismatch verifies that structurally valid JSON with a
-// wrong field type (string where a number is expected) is rejected as corrupt
-// (unmarshal error), returning nil rather than panicking.
-func TestDCGMMetricsReaderJSONTypeMismatch(t *testing.T) {
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "gpu-metrics.json")
-	require.NoError(t, os.WriteFile(filePath, []byte(`{
-		"timestamp": "2026-01-01T00:00:00Z",
-		"gpus": [{"gpu_utilization_percent": "not-a-number"}]
-	}`), 0644))
-
-	reader := NewDCGMMetricsReader(filePath)
-	assert.Nil(t, reader.GetGPUMetrics(), "wrong-typed field should return nil (parse error)")
-}
-
-// TestDCGMMetricsReaderTopLevelArray verifies a JSON array where an object is expected
-// is rejected as corrupt, returning nil.
-func TestDCGMMetricsReaderTopLevelArray(t *testing.T) {
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "gpu-metrics.json")
-	require.NoError(t, os.WriteFile(filePath, []byte(`[]`), 0644))
-
-	reader := NewDCGMMetricsReader(filePath)
-	assert.Nil(t, reader.GetGPUMetrics(), "top-level array should return nil (parse error)")
-}
-
-// TestDCGMMetricsReaderJSONNull verifies a literal JSON null (which unmarshals without
-// error into a zero-value struct) is rejected via the empty-timestamp path,
-// returning nil rather than a zero-value result.
-func TestDCGMMetricsReaderJSONNull(t *testing.T) {
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "gpu-metrics.json")
-	require.NoError(t, os.WriteFile(filePath, []byte(`null`), 0644))
-
-	reader := NewDCGMMetricsReader(filePath)
-	assert.Nil(t, reader.GetGPUMetrics(), "JSON null should return nil (empty timestamp)")
 }
 
 func writeMetricsFile(t *testing.T, path string, data gputypes.GPUMetricsFileData) {

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -153,7 +153,7 @@ func (resolver *IntegContainerMetadataResolver) ResolveContainer(containerID str
 }
 
 func validateInstanceMetrics(t *testing.T, engine *DockerStatsEngine, includeServiceConnectStats bool) {
-	metadata, taskMetrics, _, err := engine.GetInstanceMetrics(includeServiceConnectStats, false)
+	metadata, taskMetrics, _, err := engine.GetPublishMetrics(includeServiceConnectStats, false)
 	assert.NoError(t, err, "gettting instance metrics failed")
 	assert.NoError(t, validateMetricsMetadata(metadata), "validating metadata failed")
 	assert.Len(t, taskMetrics, 1, "incorrect number of tasks")
@@ -168,7 +168,7 @@ func validateInstanceMetrics(t *testing.T, engine *DockerStatsEngine, includeSer
 }
 
 func validateInstanceMetricsWithDisabledMetrics(t *testing.T, engine *DockerStatsEngine, includeServiceConnectStats bool) {
-	metadata, taskMetrics, _, err := engine.GetInstanceMetrics(includeServiceConnectStats, false)
+	metadata, taskMetrics, _, err := engine.GetPublishMetrics(includeServiceConnectStats, false)
 	assert.NoError(t, err, "gettting instance metrics failed")
 	assert.NoError(t, validateMetricsMetadata(metadata), "validating metadata failed")
 	assert.Len(t, taskMetrics, 1, "incorrect number of tasks")
@@ -222,7 +222,7 @@ func validateServiceConnectMetrics(serviceConnectMetrics []*ecstcs.GeneralMetric
 }
 
 func validateIdleContainerMetrics(t *testing.T, engine *DockerStatsEngine) {
-	metadata, taskMetrics, _, err := engine.GetInstanceMetrics(false, false)
+	metadata, taskMetrics, _, err := engine.GetPublishMetrics(false, false)
 	assert.NoError(t, err, "getting instance metrics failed")
 	assert.NoError(t, validateMetricsMetadata(metadata), "validating metadata failed")
 

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -154,7 +154,7 @@ func (resolver *IntegContainerMetadataResolver) ResolveContainer(containerID str
 
 func validateInstanceMetrics(t *testing.T, engine *DockerStatsEngine, includeServiceConnectStats bool) {
 	metadata, taskMetrics, _, err := engine.GetPublishMetrics(includeServiceConnectStats, false)
-	assert.NoError(t, err, "gettting instance metrics failed")
+	assert.NoError(t, err, "getting instance metrics failed")
 	assert.NoError(t, validateMetricsMetadata(metadata), "validating metadata failed")
 	assert.Len(t, taskMetrics, 1, "incorrect number of tasks")
 
@@ -169,7 +169,7 @@ func validateInstanceMetrics(t *testing.T, engine *DockerStatsEngine, includeSer
 
 func validateInstanceMetricsWithDisabledMetrics(t *testing.T, engine *DockerStatsEngine, includeServiceConnectStats bool) {
 	metadata, taskMetrics, _, err := engine.GetPublishMetrics(includeServiceConnectStats, false)
-	assert.NoError(t, err, "gettting instance metrics failed")
+	assert.NoError(t, err, "getting instance metrics failed")
 	assert.NoError(t, validateMetricsMetadata(metadata), "validating metadata failed")
 	assert.Len(t, taskMetrics, 1, "incorrect number of tasks")
 

--- a/agent/stats/container_test.go
+++ b/agent/stats/container_test.go
@@ -103,7 +103,7 @@ func TestContainerStatsCollection(t *testing.T) {
 	container.StopStatsCollection()
 	cpuStatsSet, err := container.statsQueue.GetCPUStatsSet()
 	if err != nil {
-		t.Fatal("Error gettting cpu stats set:", err)
+		t.Fatal("Error getting cpu stats set:", err)
 	}
 	if *cpuStatsSet.Min == math.MaxFloat64 || math.IsNaN(*cpuStatsSet.Min) {
 		t.Error("Min value incorrectly set: ", *cpuStatsSet.Min)
@@ -120,7 +120,7 @@ func TestContainerStatsCollection(t *testing.T) {
 
 	memStatsSet, err := container.statsQueue.GetMemoryStatsSet()
 	if err != nil {
-		t.Error("Error gettting cpu stats set:", err)
+		t.Error("Error getting cpu stats set:", err)
 	}
 	if *memStatsSet.Min == math.MaxFloat64 {
 		t.Error("Min value incorrectly set: ", *memStatsSet.Min)

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -136,7 +136,7 @@ func (c *gpuMetricsCollector) setReaderUnsafe(reader gpuMetricsReader) {
 // Engine defines methods to be implemented by the engine struct. It is
 // defined to make testing easier.
 type Engine interface {
-	GetInstanceMetrics(includeServiceConnectStats bool, includeGPUMetrics bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, *ecstcs.InstanceMetrics, error)
+	GetPublishMetrics(includeServiceConnectStats bool, includeGPUMetrics bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, *ecstcs.InstanceMetrics, error)
 	ContainerDockerStats(taskARN string, containerID string) (*types.StatsJSON, *stats.NetworkStatsPerSec, error)
 	GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error)
 	GetPublishServiceConnectTickerInterval() int32
@@ -520,22 +520,7 @@ func (engine *DockerStatsEngine) StartMetricsPublish() {
 	engine.publishHealth()
 
 	for {
-		var includeServiceConnectStats bool
-		serviceConnectCounter := engine.GetPublishServiceConnectTickerInterval()
-		serviceConnectCounter++
-		if serviceConnectCounter == defaultPublishServiceConnectTicker {
-			includeServiceConnectStats = true
-			serviceConnectCounter = 0
-		}
-		engine.SetPublishServiceConnectTickerInterval(serviceConnectCounter)
-		var includeGPUMetrics bool
-		gpuMetricCounter := engine.GetPublishGPUMetricsTickerInterval()
-		gpuMetricCounter++
-		if gpuMetricCounter == defaultPublishGPUMetricsTicker {
-			includeGPUMetrics = true
-			gpuMetricCounter = 0
-		}
-		engine.SetPublishGPUMetricsTickerInterval(gpuMetricCounter)
+		includeServiceConnectStats, includeGPUMetrics := engine.advancePublishTickers()
 		select {
 		case <-engine.publishMetricsTicker.C:
 			seelog.Debugf("publishMetricsTicker triggered. Sending telemetry messages to tcsClient through channel")
@@ -553,10 +538,38 @@ func (engine *DockerStatsEngine) StartMetricsPublish() {
 	}
 }
 
+// advancePublishTickers advances the Service Connect and GPU publish counters
+// by one tick and reports whether this tick should include each metric. Each
+// counter is incremented and, on reaching its interval, wraps back to 0 with
+// its include flag set true; otherwise the incremented counter is persisted and
+// the flag is false.
+func (engine *DockerStatsEngine) advancePublishTickers() (includeServiceConnectStats, includeGPUMetrics bool) {
+	serviceConnectCounter, includeServiceConnectStats := advancePublishCounter(
+		engine.GetPublishServiceConnectTickerInterval(), defaultPublishServiceConnectTicker)
+	engine.SetPublishServiceConnectTickerInterval(serviceConnectCounter)
+
+	gpuCounter, includeGPUMetrics := advancePublishCounter(
+		engine.GetPublishGPUMetricsTickerInterval(), defaultPublishGPUMetricsTicker)
+	engine.SetPublishGPUMetricsTickerInterval(gpuCounter)
+
+	return includeServiceConnectStats, includeGPUMetrics
+}
+
+// advancePublishCounter advances a publish counter one tick: on reaching limit
+// it wraps to 0 and returns include=true, else returns the incremented counter
+// with include=false.
+func advancePublishCounter(counter, limit int32) (next int32, include bool) {
+	counter++
+	if counter == limit {
+		return 0, true
+	}
+	return counter, false
+}
+
 func (engine *DockerStatsEngine) publishMetrics(includeServiceConnectStats bool, includeGPUMetrics bool) {
 	publishMetricsCtx, cancel := context.WithTimeout(engine.ctx, publishMetricsTimeout)
 	defer cancel()
-	metricsMetadata, taskMetrics, instanceMetrics, metricsErr := engine.GetInstanceMetrics(includeServiceConnectStats, includeGPUMetrics)
+	metricsMetadata, taskMetrics, instanceMetrics, metricsErr := engine.GetPublishMetrics(includeServiceConnectStats, includeGPUMetrics)
 	if metricsErr == nil {
 		metricsMessage := ecstcs.TelemetryMessage{
 			InstanceMetrics: instanceMetrics,
@@ -594,8 +607,8 @@ func (engine *DockerStatsEngine) publishHealth() {
 	}
 }
 
-// GetInstanceMetrics gets all task metrics, instance metadata, and instance metrics from stats engine.
-func (engine *DockerStatsEngine) GetInstanceMetrics(includeServiceConnectStats bool, includeGPUMetrics bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, *ecstcs.InstanceMetrics, error) {
+// GetPublishMetrics gets all task metrics, instance metadata, and instance metrics from stats engine.
+func (engine *DockerStatsEngine) GetPublishMetrics(includeServiceConnectStats bool, includeGPUMetrics bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, *ecstcs.InstanceMetrics, error) {
 	var instanceMetrics *ecstcs.InstanceMetrics
 	idle := engine.isIdle()
 	metricsMetadata := &ecstcs.MetricsMetadata{
@@ -918,7 +931,7 @@ func (engine *DockerStatsEngine) taskContainerMetricsUnsafe(taskArn string, gpuM
 		// Check if the container is terminal. If it is, make sure that it is
 		// cleaned up properly. We might sometimes miss events from docker task
 		// engine and this helps in reconciling the state. The tcs client's
-		// GetInstanceMetrics probe is used as the trigger for this.
+		// GetPublishMetrics probe is used as the trigger for this.
 		if engine.stopTrackingContainerUnsafe(container, taskArn) {
 			continue
 		}

--- a/agent/stats/engine_gpu_test.go
+++ b/agent/stats/engine_gpu_test.go
@@ -16,7 +16,7 @@
 
 package stats
 
-// GPU metrics emission tests. Exercises GetInstanceMetrics GPU contract:
+// GPU metrics emission tests. Exercises GetPublishMetrics GPU contract:
 //
 //  1. Reader seam: gpuMetricsReader injected via SetGPUMetricsReader.
 //  2. 3-tick cadence: includeGPUMetrics=true every 3rd tick.
@@ -85,7 +85,7 @@ func setupGPUStatsEngine(t *testing.T, mockCtrl *gomock.Controller, gpuIDs []str
 }
 
 // feedFakeStats loads two CPU/memory samples into every watched container's
-// queue. Call before each GetInstanceMetrics (resetStatsUnsafe drains them).
+// queue. Call before each GetPublishMetrics (resetStatsUnsafe drains them).
 func feedFakeStats(engine *DockerStatsEngine) {
 	containerStats := createFakeContainerStats()
 	for _, containers := range engine.tasksToContainers {
@@ -189,11 +189,11 @@ func requireNoContainerGPUPayload(t *testing.T, taskMetrics []*ecstcs.TaskMetric
 	}
 }
 
-// TestGetInstanceMetricsEmitsInstanceGPUMetrics: an emitting tick with fresh
+// TestGetPublishMetricsEmitsInstanceGPUMetrics: an emitting tick with fresh
 // data emits both scopes — the instance payload (limit = GPUs on host,
 // usage = unique assigned GPU IDs) and a container payload restricted to the
 // container's assigned devices.
-func TestGetInstanceMetricsEmitsInstanceGPUMetrics(t *testing.T) {
+func TestGetPublishMetricsEmitsInstanceGPUMetrics(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -213,7 +213,7 @@ func TestGetInstanceMetricsEmitsInstanceGPUMetrics(t *testing.T) {
 
 	feedFakeStats(engine)
 
-	metadata, taskMetrics, instanceMetrics, err := engine.GetInstanceMetrics(false, true)
+	metadata, taskMetrics, instanceMetrics, err := engine.GetPublishMetrics(false, true)
 	require.NoError(t, err)
 	require.NotNil(t, metadata)
 	require.Len(t, taskMetrics, 1)
@@ -233,12 +233,12 @@ func TestGetInstanceMetricsEmitsInstanceGPUMetrics(t *testing.T) {
 	assert.GreaterOrEqual(t, fake.reads, 1, "engine should have queried the DCGM metrics reader")
 }
 
-// TestGetInstanceMetricsSkipsStaleGPUMetrics: an unchanged reader Timestamp
+// TestGetPublishMetricsSkipsStaleGPUMetrics: an unchanged reader Timestamp
 // means stale data — suppressed at both scopes, resuming once the Timestamp
 // changes. The stale tick asserts on containers too: checking only
 // instanceMetrics would miss leaked container wrappers or a dropped
 // container.
-func TestGetInstanceMetricsSkipsStaleGPUMetrics(t *testing.T) {
+func TestGetPublishMetricsSkipsStaleGPUMetrics(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -255,7 +255,7 @@ func TestGetInstanceMetricsSkipsStaleGPUMetrics(t *testing.T) {
 
 	// Emitting tick #1: fresh data -> emitted at both scopes.
 	feedFakeStats(engine)
-	_, taskMetrics, instanceMetrics, err := engine.GetInstanceMetrics(false, true)
+	_, taskMetrics, instanceMetrics, err := engine.GetPublishMetrics(false, true)
 	require.NoError(t, err)
 	requireInstanceGPUPayload(t, instanceMetrics, 1, 1)
 	require.Len(t, taskMetrics, 1)
@@ -265,7 +265,7 @@ func TestGetInstanceMetricsSkipsStaleGPUMetrics(t *testing.T) {
 	// Emitting tick #2: same timestamp -> stale. Both scopes suppressed
 	// (tick #1's GPU-1 wrapper must not reappear); CPU/memory keep flowing.
 	feedFakeStats(engine)
-	_, taskMetrics, instanceMetrics, err = engine.GetInstanceMetrics(false, true)
+	_, taskMetrics, instanceMetrics, err = engine.GetPublishMetrics(false, true)
 	require.NoError(t, err)
 	assert.Nil(t, instanceMetrics, "stale GPU data (unchanged timestamp) must not be re-emitted")
 	requireNoContainerGPUPayload(t, taskMetrics)
@@ -273,7 +273,7 @@ func TestGetInstanceMetricsSkipsStaleGPUMetrics(t *testing.T) {
 	// Emitting tick #3: new snapshot -> emission resumes at both scopes.
 	fake.data.Timestamp = "2026-07-19T00:01:00Z"
 	feedFakeStats(engine)
-	_, taskMetrics, instanceMetrics, err = engine.GetInstanceMetrics(false, true)
+	_, taskMetrics, instanceMetrics, err = engine.GetPublishMetrics(false, true)
 	require.NoError(t, err)
 	requireInstanceGPUPayload(t, instanceMetrics, 1, 1)
 	require.Len(t, taskMetrics, 1)
@@ -305,7 +305,7 @@ func TestGPUMetricsEmittedOnlyWhenFlagSet(t *testing.T) {
 
 		// Simulate StartMetricsPublish: pass true on every 3rd tick.
 		includeGPU := tick%defaultPublishGPUMetricsTicker == 0
-		_, taskMetrics, instanceMetrics, err := engine.GetInstanceMetrics(false, includeGPU)
+		_, taskMetrics, instanceMetrics, err := engine.GetPublishMetrics(false, includeGPU)
 		require.NoError(t, err, "tick %d", tick)
 
 		if includeGPU {
@@ -321,10 +321,10 @@ func TestGPUMetricsEmittedOnlyWhenFlagSet(t *testing.T) {
 	}
 }
 
-// TestGetInstanceMetricsContainerGPUMetricsFiltering pins the container-scope
+// TestGetPublishMetricsContainerGPUMetricsFiltering pins the container-scope
 // filtering: one wrapper per assigned device in reader order; assigned
 // devices absent from the snapshot are skipped silently (no empty wrapper).
-func TestGetInstanceMetricsContainerGPUMetricsFiltering(t *testing.T) {
+func TestGetPublishMetricsContainerGPUMetricsFiltering(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -345,7 +345,7 @@ func TestGetInstanceMetricsContainerGPUMetricsFiltering(t *testing.T) {
 
 	feedFakeStats(engine)
 
-	_, taskMetrics, instanceMetrics, err := engine.GetInstanceMetrics(false, true)
+	_, taskMetrics, instanceMetrics, err := engine.GetPublishMetrics(false, true)
 	require.NoError(t, err)
 	require.Len(t, taskMetrics, 1)
 	require.Len(t, taskMetrics[0].ContainerMetrics, 1)
@@ -367,9 +367,9 @@ func TestGetInstanceMetricsContainerGPUMetricsFiltering(t *testing.T) {
 	requireInstanceGPUPayload(t, instanceMetrics, 3, 3)
 }
 
-// TestGetInstanceMetricsNoContainerGPUPayloadWithoutAssignment: a container
+// TestGetPublishMetricsNoContainerGPUPayloadWithoutAssignment: a container
 // with no assigned GPUs carries no payload even when the host has GPUs.
-func TestGetInstanceMetricsNoContainerGPUPayloadWithoutAssignment(t *testing.T) {
+func TestGetPublishMetricsNoContainerGPUPayloadWithoutAssignment(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -385,7 +385,7 @@ func TestGetInstanceMetricsNoContainerGPUPayloadWithoutAssignment(t *testing.T) 
 
 	feedFakeStats(engine)
 
-	_, taskMetrics, instanceMetrics, err := engine.GetInstanceMetrics(false, true)
+	_, taskMetrics, instanceMetrics, err := engine.GetPublishMetrics(false, true)
 	require.NoError(t, err)
 
 	// Instance scope still emits: the host has a GPU, none assigned.
@@ -394,12 +394,12 @@ func TestGetInstanceMetricsNoContainerGPUPayloadWithoutAssignment(t *testing.T) 
 	requireNoContainerGPUPayload(t, taskMetrics)
 }
 
-// TestGetInstanceMetricsSuppressesGPUForUnusableSnapshot verifies that GPU
+// TestGetPublishMetricsSuppressesGPUForUnusableSnapshot verifies that GPU
 // metrics are suppressed at both scopes when the reader's snapshot is unusable
 // (connection lost, nil, or no GPU entries) and emitted normally when it is
 // healthy. Every subtest is an emitting tick, so the reader's snapshot is the
 // only variable.
-func TestGetInstanceMetricsSuppressesGPUForUnusableSnapshot(t *testing.T) {
+func TestGetPublishMetricsSuppressesGPUForUnusableSnapshot(t *testing.T) {
 	testCases := []struct {
 		name          string
 		reader        gpuMetricsReader
@@ -456,7 +456,7 @@ func TestGetInstanceMetricsSuppressesGPUForUnusableSnapshot(t *testing.T) {
 			engine.SetGPUMetricsReader(tc.reader)
 
 			feedFakeStats(engine)
-			_, taskMetrics, instanceMetrics, err := engine.GetInstanceMetrics(false, true)
+			_, taskMetrics, instanceMetrics, err := engine.GetPublishMetrics(false, true)
 			require.NoError(t, err)
 
 			if tc.expectGPUEmit {

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -594,7 +594,7 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 
 	time.Sleep(checkPointSleep)
 
-	_, _, _, err = statsEngine.GetInstanceMetrics(false, false)
+	_, _, _, err = statsEngine.GetPublishMetrics(false, false)
 	assert.Error(t, err, "expect error 'no task metrics to report' when getting instance metrics")
 
 	// Should not contain any metrics after cleanup.
@@ -662,7 +662,7 @@ func testNetworkModeStatsInteg(t *testing.T, networkMode string, statsEmpty bool
 
 	// Wait for the stats collection go routine to start.
 	time.Sleep(checkPointSleep)
-	_, taskMetrics, _, err := engine.GetInstanceMetrics(false, false)
+	_, taskMetrics, _, err := engine.GetPublishMetrics(false, false)
 	assert.NoError(t, err, "getting instance metrics failed")
 	taskMetric := taskMetrics[0]
 	for _, containerMetric := range taskMetric.ContainerMetrics {
@@ -759,7 +759,7 @@ func TestStorageStats(t *testing.T) {
 
 	// Wait for the stats collection go routine to start.
 	time.Sleep(checkPointSleep)
-	_, taskMetrics, _, err := engine.GetInstanceMetrics(false, false)
+	_, taskMetrics, _, err := engine.GetPublishMetrics(false, false)
 	assert.NoError(t, err, "getting instance metrics failed")
 	taskMetric := taskMetrics[0]
 	for _, containerMetric := range taskMetric.ContainerMetrics {

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -135,7 +135,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 		t.Errorf("Error validating container metrics: %v", err)
 	}
 
-	metadata, taskMetrics, _, err := engine.GetInstanceMetrics(false, false)
+	metadata, taskMetrics, _, err := engine.GetPublishMetrics(false, false)
 	if err != nil {
 		t.Errorf("Error gettting instance metrics: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 		t.Errorf("Error validating container metrics: %v", err)
 	}
 
-	metadata, taskMetrics, _, err = engine.GetInstanceMetrics(true, false)
+	metadata, taskMetrics, _, err = engine.GetPublishMetrics(true, false)
 	if err != nil {
 		t.Errorf("Error gettting instance metrics: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 		t.Error("Container c3 not found in engine")
 	}
 
-	_, _, _, err = engine.GetInstanceMetrics(false, false)
+	_, _, _, err = engine.GetPublishMetrics(false, false)
 	if err == nil {
 		t.Error("Expected non-empty error for empty stats.")
 	}
@@ -296,7 +296,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 			statsContainer.statsQueue.setLastStat(dockerStats[i])
 		}
 	}
-	metadata, taskMetrics, _, err := engine.GetInstanceMetrics(false, false)
+	metadata, taskMetrics, _, err := engine.GetPublishMetrics(false, false)
 	if err != nil {
 		t.Errorf("Error gettting instance metrics: %v", err)
 	}
@@ -600,12 +600,12 @@ func TestStartMetricsPublish(t *testing.T) {
 	}
 }
 
-func TestGetInstanceMetricsNonIdleEmptyError(t *testing.T) {
+func TestGetPublishMetricsNonIdleEmptyError(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
 	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetInstanceMetrics"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetPublishMetrics"), nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -619,7 +619,7 @@ func TestGetInstanceMetricsNonIdleEmptyError(t *testing.T) {
 	}
 
 	engine.resolver = resolver
-	_, taskMetric, _, err := engine.GetInstanceMetrics(false, false)
+	_, taskMetric, _, err := engine.GetPublishMetrics(false, false)
 	assert.Len(t, taskMetric, 0)
 	assert.Equal(t, err, EmptyMetricsError)
 }
@@ -893,7 +893,7 @@ func testNetworkModeStats(t *testing.T, netMode string, enis []*ni.NetworkInterf
 			statsContainer.statsQueue.setLastStat(dockerStats[i])
 		}
 	}
-	_, taskMetrics, _, err := engine.GetInstanceMetrics(false, false)
+	_, taskMetrics, _, err := engine.GetPublishMetrics(false, false)
 	assert.NoError(t, err)
 	assert.Len(t, taskMetrics, 1)
 	for _, containerMetric := range taskMetrics[0].ContainerMetrics {

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -137,7 +137,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 
 	metadata, taskMetrics, _, err := engine.GetPublishMetrics(false, false)
 	if err != nil {
-		t.Errorf("Error gettting instance metrics: %v", err)
+		t.Errorf("Error getting instance metrics: %v", err)
 	}
 
 	err = validateMetricsMetadata(metadata)
@@ -167,7 +167,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 
 	metadata, taskMetrics, _, err = engine.GetPublishMetrics(true, false)
 	if err != nil {
-		t.Errorf("Error gettting instance metrics: %v", err)
+		t.Errorf("Error getting instance metrics: %v", err)
 	}
 
 	err = validateMetricsMetadata(metadata)
@@ -298,7 +298,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	}
 	metadata, taskMetrics, _, err := engine.GetPublishMetrics(false, false)
 	if err != nil {
-		t.Errorf("Error gettting instance metrics: %v", err)
+		t.Errorf("Error getting instance metrics: %v", err)
 	}
 	if len(taskMetrics) != 1 {
 		t.Fatalf("Incorrect number of tasks. Expected: 1, got: %d", len(taskMetrics))

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -116,7 +116,7 @@ func TestNetworkModeStatsAWSVPCMode(t *testing.T) {
 			taskContainers.StatsQueue.add(containerStats[i])
 		}
 	}
-	_, taskMetrics, _, err := engine.GetInstanceMetrics(false, false)
+	_, taskMetrics, _, err := engine.GetPublishMetrics(false, false)
 	assert.NoError(t, err)
 	assert.Len(t, taskMetrics, 1)
 	for _, containerMetric := range taskMetrics[0].ContainerMetrics {

--- a/agent/stats/mock/engine.go
+++ b/agent/stats/mock/engine.go
@@ -67,10 +67,10 @@ func (mr *MockEngineMockRecorder) ContainerDockerStats(arg0, arg1 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerDockerStats", reflect.TypeOf((*MockEngine)(nil).ContainerDockerStats), arg0, arg1)
 }
 
-// GetInstanceMetrics mocks base method.
-func (m *MockEngine) GetInstanceMetrics(arg0, arg1 bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, *ecstcs.InstanceMetrics, error) {
+// GetPublishMetrics mocks base method.
+func (m *MockEngine) GetPublishMetrics(arg0, arg1 bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, *ecstcs.InstanceMetrics, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInstanceMetrics", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetPublishMetrics", arg0, arg1)
 	ret0, _ := ret[0].(*ecstcs.MetricsMetadata)
 	ret1, _ := ret[1].([]*ecstcs.TaskMetric)
 	ret2, _ := ret[2].(*ecstcs.InstanceMetrics)
@@ -78,10 +78,10 @@ func (m *MockEngine) GetInstanceMetrics(arg0, arg1 bool) (*ecstcs.MetricsMetadat
 	return ret0, ret1, ret2, ret3
 }
 
-// GetInstanceMetrics indicates an expected call of GetInstanceMetrics.
-func (mr *MockEngineMockRecorder) GetInstanceMetrics(arg0, arg1 interface{}) *gomock.Call {
+// GetPublishMetrics indicates an expected call of GetPublishMetrics.
+func (mr *MockEngineMockRecorder) GetPublishMetrics(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceMetrics", reflect.TypeOf((*MockEngine)(nil).GetInstanceMetrics), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublishMetrics", reflect.TypeOf((*MockEngine)(nil).GetPublishMetrics), arg0, arg1)
 }
 
 // GetPublishMetricsTicker mocks base method.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Address nits that were mentioned in prior PRs: 
- refactor GetInstanceMetrics to GetPublishMetrics: https://github.com/aws/amazon-ecs-agent/pull/5052#discussion_r3624966666
- refactor ticker for GPU metrics and SC metrics: https://github.com/aws/amazon-ecs-agent/pull/5052#discussion_r3624488341
- consolidate DCGM metrics reader test cases to be more table-driven: https://github.com/aws/amazon-ecs-agent/pull/5044#discussion_r3599627825
- add dcgm-init into dependabot.yml: https://github.com/aws/amazon-ecs-agent/pull/5043/changes/BASE..3a188b067e608ce083c6174487ef521c611a4002#r3593294177
- fix "gettting" typo in test cases: https://github.com/aws/amazon-ecs-agent/pull/5067#discussion_r3669648980

### Implementation details
<!-- How are the changes implemented? -->

#### `.github/`
- `dependabot.yml`: add `dcgm-init` module to dependabot

#### `agent/gpu/`
- `dcgm_metrics_reader_linux_test.go`: refactor test cases to be table-driven

#### `agent/stats/mock`
- `engine.go`: refactor `GetInstanceMetrics` to be `GetPublishMetrics`

#### `agent/stats/`
- `common_test.go`: refactor `GetInstanceMetrics` to be `GetPublishMetrics`, fix "gettting" typo
- `container_test.go`: fix "gettting" typo
- `engine.go`: refactor `GetInstanceMetrics` to be `GetPublishMetrics`, refactor SC and GPU ticker logic
- `engine_gpu_test.go`: refactor `GetInstanceMetrics` to be `GetPublishMetrics`
- `engine_integ_test.go`: refactor `GetInstanceMetrics` to be `GetPublishMetrics`
- `engine_test.go`: refactor `GetInstanceMetrics` to be `GetPublishMetrics`, fix "gettting" typo
- `engine_unix_test.go`: refactor `GetInstanceMetrics` to be `GetPublishMetrics`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Housekeeping - refactor GPU metrics from prior PR comments

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

No

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
