### PR TITLE
Netlib changes and helpers for introspection access control

### DIFF
--- a/ecs-agent/netlib/platform/introspection_firewall_sudo_integ_test.go
+++ b/ecs-agent/netlib/platform/introspection_firewall_sudo_integ_test.go
@@ -1,0 +1,257 @@
+//go:build linux && sudo
+// +build linux,sudo
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package platform
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the introspection firewall against the REAL iptables /
+// ip6tables binaries (no stubbing), asserting the actual netfilter state.
+//
+// The test mutates real kernel netfilter rules, so to avoid touching the host's
+// firewall it first moves into a FRESH, EMPTY network namespace (see
+// enterFreshNetNS). That gives clean, deterministic isolation: the INPUT chain
+// starts empty (no state from a prior run to pre-clean, no leak to tear down),
+// and the kernel reclaims the whole namespace — and every rule in it — when the
+// locked OS thread exits. Nothing here can affect the host or a concurrent test.
+//
+// These tests require root: creating a namespace needs CAP_SYS_ADMIN and
+// modifying netfilter needs CAP_NET_ADMIN. Because the namespace provides the
+// isolation, no container is needed — build the test binary as your normal user
+// (so it uses the module/build cache) and run it under sudo:
+//
+//	go test -tags 'linux sudo' -c -o /tmp/introspect.test ./netlib/platform/
+//	sudo /tmp/introspect.test -test.run Introspection -test.v
+//
+// The rules reference the bridge interface (BridgeInterfaceName) by name;
+// iptables accepts -i on a non-existent interface, so the test does not need the
+// bridge to exist — it asserts on rule presence and ordering in the INPUT chain.
+
+// enterFreshNetNS moves the current goroutine into a new, empty network
+// namespace and keeps it there for the rest of the test. It locks the goroutine
+// to its OS thread and deliberately never unlocks: subprocesses (the exec'd
+// iptables/ip6tables) inherit the thread's namespace, so pinning the thread is
+// what guarantees those commands act on the fresh namespace rather than the
+// host. When the test goroutine exits still locked, the Go runtime terminates
+// the thread, which drops the last reference to the namespace and the kernel
+// tears it (and all its netfilter rules) down — so no explicit cleanup is
+// needed.
+func enterFreshNetNS(t *testing.T) {
+	t.Helper()
+	runtime.LockOSThread() // intentionally never unlocked; see doc comment.
+	if err := syscall.Unshare(syscall.CLONE_NEWNET); err != nil {
+		t.Fatalf("unshare(CLONE_NEWNET) failed (needs CAP_SYS_ADMIN / root): %v", err)
+	}
+}
+
+// iptablesBin returns the iptables binary for the given address family.
+func iptablesBin(useIPv6 bool) string {
+	if useIPv6 {
+		return ipv6Tables
+	}
+	return iptablesExecutable
+}
+
+// daemonAddr returns the daemon namespace's fixed daemon-bridge source address
+// for the given family — the source the ACCEPT rule matches on.
+func daemonAddr(useIPv6 bool) string {
+	if useIPv6 {
+		return DaemonBridgeIPv6
+	}
+	return DaemonBridgeIP
+}
+
+// listINPUT returns the INPUT chain rule specs for the given family via
+// `iptables -S INPUT` (or ip6tables), one rule per element.
+func listINPUT(t *testing.T, useIPv6 bool) []string {
+	t.Helper()
+	bin := iptablesBin(useIPv6)
+	// bin is a fixed iptables/ip6tables constant and the remaining args are
+	// literals; exec.Command runs the binary directly (no shell). Test-only.
+	// nosemgrep: command-injection-exec-variable
+	out, err := exec.Command(bin, "-w", "-S", "INPUT").CombinedOutput()
+	require.NoError(t, err, "%s -S INPUT failed: %s", bin, string(out))
+	var rules []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if strings.TrimSpace(line) != "" {
+			rules = append(rules, line)
+		}
+	}
+	return rules
+}
+
+// isIntrospectionRule reports whether an `iptables -S INPUT` rule spec is one of
+// our introspection rules with the given verdict ("ACCEPT" or "DROP"): it must
+// match the daemon-bridge interface and the introspection port. Matching by
+// these tokens is robust to iptables' canonical formatting/reordering.
+func isIntrospectionRule(rule, verdict string) bool {
+	return strings.Contains(rule, BridgeInterfaceName) &&
+		strings.Contains(rule, introspectionServerPort) &&
+		strings.Contains(rule, verdict)
+}
+
+// dropRuleIndex returns the INPUT-chain position of the baseline DROP rule, or
+// -1 if it is absent.
+func dropRuleIndex(rules []string) int {
+	for i, r := range rules {
+		if isIntrospectionRule(r, "DROP") {
+			return i
+		}
+	}
+	return -1
+}
+
+// acceptRuleIndex returns the INPUT-chain position of the daemon ACCEPT rule for
+// the given family (matched by the daemon source address), or -1 if absent.
+func acceptRuleIndex(rules []string, useIPv6 bool) int {
+	for i, r := range rules {
+		if isIntrospectionRule(r, "ACCEPT") && strings.Contains(r, daemonAddr(useIPv6)) {
+			return i
+		}
+	}
+	return -1
+}
+
+// countDropRules / countAcceptRules count matching rules, used to assert that a
+// repeated setup/allow does not create duplicates.
+func countDropRules(rules []string) int {
+	n := 0
+	for _, r := range rules {
+		if isIntrospectionRule(r, "DROP") {
+			n++
+		}
+	}
+	return n
+}
+
+func countAcceptRules(rules []string, useIPv6 bool) int {
+	n := 0
+	for _, r := range rules {
+		if isIntrospectionRule(r, "ACCEPT") && strings.Contains(r, daemonAddr(useIPv6)) {
+			n++
+		}
+	}
+	return n
+}
+
+func TestIntrospectionFirewall_Integration(t *testing.T) {
+	// Isolate in a fresh, empty network namespace: the INPUT chain starts empty
+	// and the kernel reclaims the namespace (and every rule below) when the test
+	// thread exits, so there is no pre-clean or teardown to get right.
+	enterFreshNetNS(t)
+
+	// 1. Baseline DROP installed for both families.
+	require.NoError(t, SetupIntrospectionFirewall(true))
+	for _, useIPv6 := range []bool{false, true} {
+		rules := listINPUT(t, useIPv6)
+		assert.GreaterOrEqual(t, dropRuleIndex(rules), 0,
+			"baseline DROP should be present (ipv6=%v): %v", useIPv6, rules)
+	}
+
+	// 2. Idempotent: re-running setup does not add a duplicate DROP.
+	require.NoError(t, SetupIntrospectionFirewall(true))
+	for _, useIPv6 := range []bool{false, true} {
+		rules := listINPUT(t, useIPv6)
+		assert.Equal(t, 1, countDropRules(rules),
+			"exactly one DROP after re-setup (ipv6=%v): %v", useIPv6, rules)
+	}
+
+	// 3. allowDaemonIntrospection inserts the ACCEPT AHEAD OF the DROP.
+	require.NoError(t, allowDaemonIntrospection(true))
+	for _, useIPv6 := range []bool{false, true} {
+		rules := listINPUT(t, useIPv6)
+		acceptIdx := acceptRuleIndex(rules, useIPv6)
+		dropIdx := dropRuleIndex(rules)
+		require.GreaterOrEqual(t, acceptIdx, 0, "ACCEPT present (ipv6=%v): %v", useIPv6, rules)
+		require.GreaterOrEqual(t, dropIdx, 0, "DROP present (ipv6=%v): %v", useIPv6, rules)
+		assert.Less(t, acceptIdx, dropIdx,
+			"ACCEPT must be evaluated before DROP (ipv6=%v): %v", useIPv6, rules)
+	}
+
+	// 4. Idempotent: re-running Allow does not add a duplicate ACCEPT.
+	require.NoError(t, allowDaemonIntrospection(true))
+	for _, useIPv6 := range []bool{false, true} {
+		rules := listINPUT(t, useIPv6)
+		assert.Equal(t, 1, countAcceptRules(rules, useIPv6),
+			"exactly one ACCEPT after re-allow (ipv6=%v): %v", useIPv6, rules)
+	}
+
+	// 5. disallowDaemonIntrospection removes ONLY the ACCEPT, leaving the DROP.
+	// Called once per family (it operates on a single family).
+	require.NoError(t, disallowDaemonIntrospection(false))
+	require.NoError(t, disallowDaemonIntrospection(true))
+	for _, useIPv6 := range []bool{false, true} {
+		rules := listINPUT(t, useIPv6)
+		assert.Less(t, acceptRuleIndex(rules, useIPv6), 0,
+			"ACCEPT should be removed (ipv6=%v): %v", useIPv6, rules)
+		assert.GreaterOrEqual(t, dropRuleIndex(rules), 0,
+			"DROP must remain (ipv6=%v): %v", useIPv6, rules)
+	}
+
+	// 6. Idempotent teardown: a second Disallow removes nothing more and does not
+	// error; the DROP still stands and the ACCEPT stays gone.
+	require.NoError(t, disallowDaemonIntrospection(false))
+	require.NoError(t, disallowDaemonIntrospection(true))
+	for _, useIPv6 := range []bool{false, true} {
+		rules := listINPUT(t, useIPv6)
+		assert.Less(t, acceptRuleIndex(rules, useIPv6), 0,
+			"ACCEPT should still be absent after second disallow (ipv6=%v): %v", useIPv6, rules)
+		assert.GreaterOrEqual(t, dropRuleIndex(rules), 0,
+			"DROP must remain after second disallow (ipv6=%v): %v", useIPv6, rules)
+	}
+}
+
+// TestIntrospectionFirewall_IPv4Only_Integration exercises the ipv6Enabled=false
+// path: every setup/allow/disallow call must touch only IPv4 and leave the IPv6
+// (ip6tables) INPUT chain empty. This guards the family gating in each function,
+// which the dual-stack test above never exercises (it always passes true).
+func TestIntrospectionFirewall_IPv4Only_Integration(t *testing.T) {
+	enterFreshNetNS(t)
+
+	// Setup + allow with IPv6 disabled: the IPv4 rules land, the IPv6 chain stays
+	// untouched.
+	require.NoError(t, SetupIntrospectionFirewall(false))
+	require.NoError(t, allowDaemonIntrospection(false))
+
+	v4 := listINPUT(t, false)
+	assert.GreaterOrEqual(t, dropRuleIndex(v4), 0, "IPv4 DROP should be present: %v", v4)
+	assert.GreaterOrEqual(t, acceptRuleIndex(v4, false), 0, "IPv4 ACCEPT should be present: %v", v4)
+
+	v6 := listINPUT(t, true)
+	assert.Equal(t, 0, countDropRules(v6), "no IPv6 DROP should be installed: %v", v6)
+	assert.Equal(t, 0, countAcceptRules(v6, true), "no IPv6 ACCEPT should be installed: %v", v6)
+
+	// Teardown with IPv6 disabled removes the IPv4 ACCEPT and leaves the DROP; the
+	// IPv6 chain remains empty throughout.
+	require.NoError(t, disallowDaemonIntrospection(false))
+
+	v4 = listINPUT(t, false)
+	assert.Less(t, acceptRuleIndex(v4, false), 0, "IPv4 ACCEPT should be removed: %v", v4)
+	assert.GreaterOrEqual(t, dropRuleIndex(v4), 0, "IPv4 DROP must remain: %v", v4)
+
+	v6 = listINPUT(t, true)
+	assert.Equal(t, 0, countDropRules(v6), "IPv6 chain must stay empty: %v", v6)
+	assert.Equal(t, 0, countAcceptRules(v6, true), "IPv6 chain must stay empty: %v", v6)
+}

--- a/ecs-agent/netlib/platform/iptables_linux.go
+++ b/ecs-agent/netlib/platform/iptables_linux.go
@@ -3,7 +3,9 @@ package platform
 import (
 	"fmt"
 	"os/exec"
+	"strconv"
 
+	"github.com/aws/amazon-ecs-agent/ecs-agent/introspection"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ipcompatibility"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	loggerfield "github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
@@ -13,14 +15,24 @@ import (
 type iptablesAction string
 
 const (
-	iptablesExecutable = "iptables"
-	ipv6Tables         = "ip6tables"
-	iptablesTableNat   = "nat"
-	sysctlExecutable   = "sysctl"
+	iptablesExecutable  = "iptables"
+	ipv6Tables          = "ip6tables"
+	iptablesTableNat    = "nat"
+	iptablesTableFilter = "filter"
+	sysctlExecutable    = "sysctl"
 	// iptablesAppend enumerates the 'append' action.
 	iptablesAppend iptablesAction = "-A"
+	// iptablesInsert enumerates the 'insert' action (inserts at the top of the
+	// chain, i.e. before already-appended rules).
+	iptablesInsert iptablesAction = "-I"
 	// iptablesCheck enumerates the 'check' action.
 	iptablesCheck iptablesAction = "-C"
+	// iptablesDelete enumerates the 'delete' action.
+	iptablesDelete iptablesAction = "-D"
+
+	// iptablesWaitFlag makes iptables acquire the xtables lock (waiting rather
+	// than failing) so concurrent iptables invocations don't spuriously error.
+	iptablesWaitFlag = "-w"
 
 	// sysctl configuration keys.
 	ipv4ForwardingKey          = "net.ipv4.ip_forward"
@@ -29,9 +41,27 @@ const (
 	bridgeNetfilterCallIPv6Key = "net.bridge.bridge-nf-call-ip6tables"
 )
 
+// introspectionServerPort is the introspection server's TCP port as a string for
+// iptables --dport args, derived from the canonical introspection.Port so the
+// filter rules always target the same port the server binds.
+var introspectionServerPort = strconv.Itoa(introspection.Port)
+
 // getNetfilterChainArgsFunc defines a function pointer type that returns
 // a slice of arguments for modifying a netfilter chain.
 type getNetfilterChainArgsFunc func() []string
+
+// runIptablesCommand executes the iptables/ip6tables binary with the given args
+// and returns its combined output. It is a package-level var so unit tests can
+// stub iptables execution to exercise error paths without invoking real
+// iptables; production code never reassigns it.
+var runIptablesCommand = func(executable string, args ...string) ([]byte, error) {
+	// executable is a fixed iptables/ip6tables constant and args are built from
+	// internal constants (chain, port, fixed bridge addresses); none are
+	// user-controlled. exec.Command runs the binary directly (no shell), so there
+	// is no shell-injection surface.
+	// nosemgrep: command-injection-exec-variable
+	return exec.Command(executable, args...).CombinedOutput()
+}
 
 // modifyNetfilterEntry modifies an entry in the netfilter table based on
 // the action and the function pointer to get arguments for modifying the chain.
@@ -41,9 +71,7 @@ func modifyNetfilterEntry(table string, action iptablesAction, getNetfilterChain
 		executable = ipv6Tables
 	}
 
-	args := append(getTableArgs(table), string(action))
-	args = append(args, getNetfilterChainArgs()...)
-	cmd := exec.Command(executable, args...)
+	args := buildIptablesArgs(table, action, getNetfilterChainArgs())
 
 	logger.Info("Executing iptables command", logger.Fields{
 		"executable": executable,
@@ -53,7 +81,7 @@ func modifyNetfilterEntry(table string, action iptablesAction, getNetfilterChain
 		"ipv6":       useIPv6,
 	})
 
-	output, err := cmd.CombinedOutput()
+	output, err := runIptablesCommand(executable, args...)
 	if err != nil {
 		logger.Error("iptables command failed", logger.Fields{
 			"executable":      executable,
@@ -77,6 +105,17 @@ func getTableArgs(table string) []string {
 	return []string{"-t", table}
 }
 
+// buildIptablesArgs assembles the full iptables argument list for a command:
+// the -w wait flag, the table selector, the action, then the chain args. -w
+// makes iptables wait for the xtables lock instead of failing when another
+// iptables invocation holds it (this code runs concurrently with NAT setup).
+func buildIptablesArgs(table string, action iptablesAction, chainArgs []string) []string {
+	args := append([]string{iptablesWaitFlag}, getTableArgs(table)...)
+	args = append(args, string(action))
+	args = append(args, chainArgs...)
+	return args
+}
+
 // getDaemonBridgeNATArgs returns arguments for daemon-bridge MASQUERADE rule.
 // The subnet parameter specifies the source network for NAT (e.g., ECSSubNet for IPv4 or ECSSubNetIPv6 for IPv6).
 func getDaemonBridgeNATArgs(subnet string) []string {
@@ -95,6 +134,32 @@ func getSimpleIPv6NATArgs() []string {
 		"POSTROUTING",
 		"-o", "eth0", // Output interface.
 		"-j", "MASQUERADE",
+	}
+}
+
+// getIntrospectionAllowDaemonArgs returns a filter-table INPUT rule that accepts
+// introspection traffic on the daemon bridge from the given source address
+// (daemonAddr, e.g. DaemonBridgeIP for IPv4).
+func getIntrospectionAllowDaemonArgs(daemonAddr string) []string {
+	return []string{
+		"INPUT",
+		"-i", BridgeInterfaceName,
+		"-p", "tcp",
+		"--dport", introspectionServerPort,
+		"-s", daemonAddr,
+		"-j", "ACCEPT",
+	}
+}
+
+// getIntrospectionBridgeDropArgs returns a filter-table INPUT rule that drops
+// introspection traffic on the daemon bridge from any source.
+func getIntrospectionBridgeDropArgs() []string {
+	return []string{
+		"INPUT",
+		"-i", BridgeInterfaceName,
+		"-p", "tcp",
+		"--dport", introspectionServerPort,
+		"-j", "DROP",
 	}
 }
 
@@ -174,6 +239,95 @@ func setupNATRule(getArgs getNetfilterChainArgsFunc, useIPv6 bool, ruleDescripti
 	}
 
 	return nil
+}
+
+// setupFilterRule sets up a filter-table rule using the provided arguments
+// function, using the given action (append or insert). It checks for existence
+// first so it is idempotent, mirroring setupNATRule.
+func setupFilterRule(action iptablesAction, getArgs getNetfilterChainArgsFunc, useIPv6 bool, ruleDescription string) error {
+	if err := modifyNetfilterEntry(iptablesTableFilter, iptablesCheck, getArgs, useIPv6); err != nil {
+		if err := modifyNetfilterEntry(iptablesTableFilter, action, getArgs, useIPv6); err != nil {
+			return fmt.Errorf("failed to add %s: %w", ruleDescription, err)
+		}
+		logger.Info(fmt.Sprintf("%s added successfully", ruleDescription))
+	} else {
+		logger.Info(fmt.Sprintf("%s already exists", ruleDescription))
+	}
+	return nil
+}
+
+// SetupIntrospectionFirewall appends a filter-table INPUT rule that drops all
+// introspection traffic arriving on the daemon bridge. The rule is appended for
+// IPv4, and additionally for IPv6 when ipv6Enabled is true — gating on
+// ipv6Enabled both scopes the rule to hosts that use IPv6 and avoids invoking
+// ip6tables on hosts without an IPv6 stack.
+//
+// The rule matches the bridge interface by name even before that interface
+// exists (iptables allows this); it simply matches no traffic until the bridge
+// is created. Idempotent: the rule is added only if not already present.
+func SetupIntrospectionFirewall(ipv6Enabled bool) error {
+	if err := setupFilterRule(iptablesAppend, getIntrospectionBridgeDropArgs, false, "IPv4 introspection bridge-drop rule"); err != nil {
+		return err
+	}
+	if ipv6Enabled {
+		if err := setupFilterRule(iptablesAppend, getIntrospectionBridgeDropArgs, true, "IPv6 introspection bridge-drop rule"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// allowDaemonIntrospection inserts a filter-table INPUT rule that accepts
+// introspection traffic on the daemon bridge from the daemon namespace's fixed
+// source address. It is inserted at the top of the chain so it takes precedence
+// over lower-priority rules. The rule is added for IPv4, and additionally for
+// IPv6 when ipv6Enabled is true.
+//
+// Idempotent: the rule is added only if not already present.
+func allowDaemonIntrospection(ipv6Enabled bool) error {
+	allowV4 := func() []string { return getIntrospectionAllowDaemonArgs(DaemonBridgeIP) }
+	if err := setupFilterRule(iptablesInsert, allowV4, false, "IPv4 introspection allow-daemon rule"); err != nil {
+		return err
+	}
+	if ipv6Enabled {
+		allowV6 := func() []string { return getIntrospectionAllowDaemonArgs(DaemonBridgeIPv6) }
+		if err := setupFilterRule(iptablesInsert, allowV6, true, "IPv6 introspection allow-daemon rule"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// deleteFilterRule removes a filter-table rule if present, checking existence
+// first so it is idempotent (a -D on a missing rule would error). It is the
+// inverse of setupFilterRule.
+func deleteFilterRule(getArgs getNetfilterChainArgsFunc, useIPv6 bool, ruleDescription string) error {
+	if err := modifyNetfilterEntry(iptablesTableFilter, iptablesCheck, getArgs, useIPv6); err != nil {
+		// Rule not present; nothing to delete.
+		logger.Info(fmt.Sprintf("%s not present, nothing to remove", ruleDescription))
+		return nil
+	}
+	if err := modifyNetfilterEntry(iptablesTableFilter, iptablesDelete, getArgs, useIPv6); err != nil {
+		return fmt.Errorf("failed to remove %s: %w", ruleDescription, err)
+	}
+	logger.Info(fmt.Sprintf("%s removed successfully", ruleDescription))
+	return nil
+}
+
+// disallowDaemonIntrospection removes the filter-table INPUT rule that accepts
+// introspection traffic from the daemon namespace's fixed source address, for a
+// single address family (IPv6 when useIPv6 is true, else IPv4). The caller
+// invokes it once per family so a failure on one family does not prevent the
+// other from being cleaned up.
+//
+// Idempotent: removing an absent rule is a no-op, not an error.
+func disallowDaemonIntrospection(useIPv6 bool) error {
+	addr, description := DaemonBridgeIP, "IPv4 introspection allow-daemon rule"
+	if useIPv6 {
+		addr, description = DaemonBridgeIPv6, "IPv6 introspection allow-daemon rule"
+	}
+	allow := func() []string { return getIntrospectionAllowDaemonArgs(addr) }
+	return deleteFilterRule(allow, useIPv6, description)
 }
 
 // SetupIPv6NAT sets up IPv6 NAT rules for the daemon bridge.

--- a/ecs-agent/netlib/platform/iptables_linux_test.go
+++ b/ecs-agent/netlib/platform/iptables_linux_test.go
@@ -4,6 +4,7 @@
 package platform
 
 import (
+	"errors"
 	"os/exec"
 	"testing"
 
@@ -733,4 +734,80 @@ func TestUnifiedFunctionHandlesBothIPVersions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildIptablesArgs(t *testing.T) {
+	// The -w wait flag must lead, followed by the table selector, the action,
+	// then the chain args — for insert, delete, append alike.
+	allow := getIntrospectionAllowDaemonArgs(DaemonBridgeIP)
+
+	assert.Equal(t,
+		append([]string{"-w", "-t", iptablesTableFilter, "-I"}, allow...),
+		buildIptablesArgs(iptablesTableFilter, iptablesInsert, allow),
+		"insert args should be: -w -t filter -I <chain args>")
+
+	assert.Equal(t,
+		append([]string{"-w", "-t", iptablesTableFilter, "-D"}, allow...),
+		buildIptablesArgs(iptablesTableFilter, iptablesDelete, allow),
+		"delete args should be: -w -t filter -D <chain args>")
+
+	drop := getIntrospectionBridgeDropArgs()
+	assert.Equal(t,
+		append([]string{"-w", "-t", iptablesTableFilter, "-A"}, drop...),
+		buildIptablesArgs(iptablesTableFilter, iptablesAppend, drop),
+		"append args should be: -w -t filter -A <chain args>")
+}
+
+// errStubIptables is the failure returned by the stubbed iptables runner.
+var errStubIptables = errors.New("stub iptables failure")
+
+// stubIptables replaces the package-level iptables runner with fn for the
+// duration of the test, restoring the real one on cleanup. It lets unit tests
+// drive error paths without invoking real iptables (the integration test, which
+// needs root, covers the success paths against the real binaries).
+func stubIptables(t *testing.T, fn func(executable string, args ...string) ([]byte, error)) {
+	t.Helper()
+	orig := runIptablesCommand
+	runIptablesCommand = fn
+	t.Cleanup(func() { runIptablesCommand = orig })
+}
+
+// iptablesActionOf returns the action flag (-A/-I/-C/-D) present in an iptables
+// argument list, or "" if none is found.
+func iptablesActionOf(args []string) iptablesAction {
+	for _, a := range args {
+		switch iptablesAction(a) {
+		case iptablesAppend, iptablesInsert, iptablesCheck, iptablesDelete:
+			return iptablesAction(a)
+		}
+	}
+	return ""
+}
+
+// These unit tests cover only the error paths: that a failed iptables invocation
+// surfaces as a returned error rather than being swallowed. The success paths —
+// rule content, ordering, idempotency, and IPv6 gating — are covered by the
+// integration test against real iptables (which, running in a fresh netns where
+// commands succeed, cannot exercise failures).
+
+func TestSetupIntrospectionFirewall_PropagatesError(t *testing.T) {
+	stubIptables(t, func(string, ...string) ([]byte, error) { return nil, errStubIptables })
+	assert.ErrorIs(t, SetupIntrospectionFirewall(false), errStubIptables)
+}
+
+func TestAllowDaemonIntrospection_PropagatesError(t *testing.T) {
+	stubIptables(t, func(string, ...string) ([]byte, error) { return nil, errStubIptables })
+	assert.ErrorIs(t, allowDaemonIntrospection(false), errStubIptables)
+}
+
+func TestDisallowDaemonIntrospection_PropagatesError(t *testing.T) {
+	// The -C existence check must succeed so the delete is attempted; only the
+	// delete fails. (A failed -C is read as "rule absent" and returns no error.)
+	stubIptables(t, func(_ string, args ...string) ([]byte, error) {
+		if iptablesActionOf(args) == iptablesDelete {
+			return nil, errStubIptables
+		}
+		return nil, nil
+	})
+	assert.ErrorIs(t, disallowDaemonIntrospection(false), errStubIptables)
 }

--- a/ecs-agent/netlib/platform/managed_linux.go
+++ b/ecs-agent/netlib/platform/managed_linux.go
@@ -614,6 +614,18 @@ func (m *managedLinux) addDaemonBridgeNATRule(ipComp ipcompatibility.IPCompatibi
 		}
 	}
 
+	// Grant the daemon namespace access to the introspection server. The baseline
+	// DROP is installed at agent startup (SetupIntrospectionFirewall); the ACCEPT
+	// is added here, only now that a daemon bridge exists and the daemon owns
+	// DaemonBridgeIP, so an awsvpc task can never satisfy it. Best-effort: a
+	// failure here only means the daemon cannot reach introspection, so log and
+	// continue rather than failing daemon-bridge setup.
+	if err := allowDaemonIntrospection(ipComp.IsIPv6Compatible()); err != nil {
+		logger.Warn("Failed to allow daemon introspection access", logger.Fields{
+			loggerfield.Error: err,
+		})
+	}
+
 	return nil
 }
 
@@ -656,6 +668,30 @@ func (m *managedLinux) StopDaemonNetNS(ctx context.Context, netNS *tasknetworkco
 			loggerfield.Error: err,
 		})
 		return err
+	}
+
+	// Remove the daemon-namespace introspection ACCEPT rule added in
+	// addDaemonBridgeNATRule, once per family that was set up. Each family is
+	// attempted independently so a failure on one still cleans up the other.
+	// Best-effort: a removal failure only leaves a stale allow rule (which matches
+	// nothing once the daemon's fixed address is gone), so log and continue rather
+	// than failing teardown.
+	//
+	// This runs BEFORE the CNI DEL below: the DEL releases the daemon's fixed
+	// address (169.254.172.2) back to the shared bridge IPAM, where a subsequent
+	// awsvpc task could be assigned it. Removing the ACCEPT first ensures that
+	// address is never simultaneously reallocatable and still allowed.
+	removeIntrospectionAllow := func(useIPv6 bool) {
+		if err := disallowDaemonIntrospection(useIPv6); err != nil {
+			logger.Warn("Failed to remove daemon introspection access rule", logger.Fields{
+				"ipv6":            useIPv6,
+				loggerfield.Error: err,
+			})
+		}
+	}
+	removeIntrospectionAllow(false)
+	if ipComp.IsIPv6Compatible() {
+		removeIntrospectionAllow(true)
 	}
 
 	var cniNetConf []ecscni.PluginConfig


### PR DESCRIPTION
### Summary

Adds netlib platform helpers that manage filter-table `INPUT` rules for the introspection server on the daemon bridge, so the introspection endpoint is reachable by the daemon namespace while remaining blocked for other tasks that share the bridge.

### Implementation details

`ecs-agent/netlib/platform/iptables_linux.go`:

- `SetupIntrospectionFirewall(ipv6Enabled bool)` — appends a baseline rule that drops introspection traffic arriving on the daemon bridge (IPv4, and IPv6 when `ipv6Enabled`). Idempotent. Exported for the platform startup path, which installs this baseline drop before the introspection server becomes reachable.
- `allowDaemonIntrospection(ipv6Enabled bool)` — inserts a higher-priority rule that accepts introspection traffic from the daemon namespace's source address, ahead of the baseline drop. Wired into daemon-bridge setup in `managed_linux.go`. Idempotent.
- `disallowDaemonIntrospection(useIPv6 bool)` — removes the accept rule for one address family; the teardown caller invokes it per family so a failure on one family does not prevent cleanup of the other.

Teardown removes the accept rule before releasing the daemon bridge address, so the address is never simultaneously reclaimable and still allowed. Rule commands go through a small `runIptablesCommand` seam and pass `-w` so concurrent iptables invocations wait for the xtables lock rather than failing.

### Resulting rules

With a daemon present, the filter `INPUT` chain carries the daemon accept rule ahead of the baseline drop (so the daemon's fixed source address is allowed and everything else on the bridge is dropped):

```
-A INPUT -s 169.254.172.2/32 -i fargate-bridge -p tcp -m tcp --dport 51678 -j ACCEPT
-A INPUT -i fargate-bridge -p tcp -m tcp --dport 51678 -j DROP
```

With no daemon, only the baseline drop is present, so nothing on the bridge can reach introspection:

```
-A INPUT -i fargate-bridge -p tcp -m tcp --dport 51678 -j DROP
```

On IPv6 the rules are identical in shape, using the daemon's ULA address:

```
-A INPUT -s fd00:ec2::172:2/128 -i fargate-bridge -p tcp -m tcp --dport 51678 -j ACCEPT
-A INPUT -i fargate-bridge -p tcp -m tcp --dport 51678 -j DROP
```

### Testing

- `make test` (unit): error-path coverage — each entry point surfaces a failed iptables invocation as a wrapped error (`errors.Is`).
- Sudo integration (`//go:build linux && sudo`, run under `make run-sudo-tests`): runs against the real iptables/ip6tables binaries in a fresh network namespace (`unshare(CLONE_NEWNET)` on a locked OS thread, so no host state is touched and no cleanup is needed) and asserts on the actual `INPUT` chain — baseline drop present for the enabled families, accept rule inserted ahead of it, both idempotent, teardown removes only the accept rule, and the IPv4-only path leaves the IPv6 chain untouched:

  ```
  go test -tags 'linux sudo' -c -o /tmp/introspect.test ./netlib/platform/
  sudo /tmp/introspect.test -test.run Introspection -test.v
  ```

- Validated end-to-end with the platform functional test suite.

New tests cover the changes: yes

### Description for the changelog

Enhancement - Restrict daemon-bridge introspection access to the daemon namespace

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**

No.

**Does this PR include the addition of new environment variables in the README?**

No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
