### PR TITLE
fail agent bootstrap when per-GPU memory cannot be read

### DIFF
--- a/agent/gpu/nvidia_gpu_manager_unix.go
+++ b/agent/gpu/nvidia_gpu_manager_unix.go
@@ -168,10 +168,8 @@ func (n *NvidiaGPUManager) SetDevices() {
 			Id:   aws.String(gpuID),
 			Type: types.PlatformDeviceTypeGpu,
 		}
-		if memMiB, ok := n.GPUMemoryMiB[gpuID]; ok {
-			device.GpuInfo = &types.GpuPlatformDeviceInfo{
-				MemoryInMiB: aws.Int32(int32(memMiB)),
-			}
+		device.GpuInfo = &types.GpuPlatformDeviceInfo{
+			MemoryInMiB: aws.Int32(int32(n.GPUMemoryMiB[gpuID])),
 		}
 		devices = append(devices, device)
 	}

--- a/agent/gpu/nvidia_gpu_manager_unix_test.go
+++ b/agent/gpu/nvidia_gpu_manager_unix_test.go
@@ -30,14 +30,23 @@ var devices = []types.PlatformDevice{
 	{
 		Id:   aws.String("id1"),
 		Type: types.PlatformDeviceTypeGpu,
+		GpuInfo: &types.GpuPlatformDeviceInfo{
+			MemoryInMiB: aws.Int32(15872),
+		},
 	},
 	{
 		Id:   aws.String("id2"),
 		Type: types.PlatformDeviceTypeGpu,
+		GpuInfo: &types.GpuPlatformDeviceInfo{
+			MemoryInMiB: aws.Int32(15872),
+		},
 	},
 	{
 		Id:   aws.String("id3"),
 		Type: types.PlatformDeviceTypeGpu,
+		GpuInfo: &types.GpuPlatformDeviceInfo{
+			MemoryInMiB: aws.Int32(15872),
+		},
 	},
 }
 
@@ -47,7 +56,10 @@ func TestNvidiaGPUManagerInitialize(t *testing.T) {
 		return true
 	}
 	GetGPUInfoJSON = func() ([]byte, error) {
+		// ecs-init writes memory for every GPU (all-or-none), so the saved state
+		// always carries a full GPUMemoryMiB map alongside the GPU IDs.
 		return []byte(`{"DriverVersion":"396.44","GPUIDs":["id1","id2","id3"],` +
+			`"GPUMemoryMiB":{"id1":15872,"id2":15872,"id3":15872},` +
 			`"MpsControlBinaryPresent":true,"MpsServiceEnabled":true,"HasVGPU":false}`), nil
 	}
 	defer func() {
@@ -84,20 +96,20 @@ func TestNvidiaGPUManagerError(t *testing.T) {
 }
 
 func TestSetGPUDevices(t *testing.T) {
-	nvidiaGPUManager := NewNvidiaGPUManager()
+	nvidiaGPUManager := NewNvidiaGPUManager().(*NvidiaGPUManager)
 	nvidiaGPUManager.SetGPUIDs([]string{"id1", "id2", "id3"})
+	nvidiaGPUManager.SetGPUMemoryMiB(map[string]uint64{"id1": 15872, "id2": 15872, "id3": 15872})
 	nvidiaGPUManager.SetDevices()
 	assert.True(t, reflect.DeepEqual(devices, nvidiaGPUManager.GetDevices()))
 }
 
-// TestSetDevicesWithGPUMemory verifies SetDevices attaches GpuInfo.MemoryInMiB
-// for UUIDs with known usable memory, and leaves GpuInfo nil for UUIDs without
-// it (legacy hosts / partial NVML discovery), so the field is omitted from RCI.
+// TestSetDevicesWithGPUMemory verifies SetDevices attaches GpuInfo.MemoryInMiB for
+// every discovered GPU UUID. ecs-init detects memory all-or-none and fails setup
+// otherwise, so by the time the agent reads the state every GPU has a memory entry.
 func TestSetDevicesWithGPUMemory(t *testing.T) {
 	nvidiaGPUManager := NewNvidiaGPUManager().(*NvidiaGPUManager)
 	nvidiaGPUManager.SetGPUIDs([]string{"id1", "id2"})
-	// id1 has known memory; id2 does not.
-	nvidiaGPUManager.SetGPUMemoryMiB(map[string]uint64{"id1": 15872})
+	nvidiaGPUManager.SetGPUMemoryMiB(map[string]uint64{"id1": 15872, "id2": 23808})
 	nvidiaGPUManager.SetDevices()
 
 	got := nvidiaGPUManager.GetDevices()
@@ -112,10 +124,12 @@ func TestSetDevicesWithGPUMemory(t *testing.T) {
 		{
 			Id:   aws.String("id2"),
 			Type: types.PlatformDeviceTypeGpu,
+			GpuInfo: &types.GpuPlatformDeviceInfo{
+				MemoryInMiB: aws.Int32(23808),
+			},
 		},
 	}
 	assert.True(t, reflect.DeepEqual(expected, got), "expected %+v, got %+v", expected, got)
-	assert.Nil(t, got[1].GpuInfo, "GpuInfo must be nil for a UUID without known memory")
 }
 
 // TestInitializeWithGPUMemory verifies GPUMemoryMiB round-trips through the GPU

--- a/ecs-init/gpu/nvidia_gpu_manager.go
+++ b/ecs-init/gpu/nvidia_gpu_manager.go
@@ -111,8 +111,12 @@ func (n *NvidiaGPUManager) Setup() error {
 	}
 	n.GPUIDs = gpuIDs
 	// Discover per-GPU usable memory so the agent can report it at
-	// registration for the MPS GPU-sharing feature. 
-	n.GPUMemoryMiB = n.DetectGPUMemory()
+	// registration for the MPS GPU-sharing feature. All-or-none: if any GPU's
+	// memory cannot be read we fail setup rather than register with partial data.
+	n.GPUMemoryMiB, err = n.DetectGPUMemory()
+	if err != nil {
+		return errors.Wrapf(err, "setup failed")
+	}
 	// Gather the MPS facts once, after devices are known and before we persist state.
 	// HasVGPU is set per-device inside GetGPUDeviceIDs above.
 	n.MpsControlBinaryPresent = detectMpsControlBinary()
@@ -231,38 +235,26 @@ func (n *NvidiaGPUManager) GetGPUDeviceIDs() ([]string, error) {
 
 // DetectGPUMemory returns a map of GPU UUID to usable memory in MiB. It uses
 // NVML v2 memory (usable = Total - Reserved) so the reported value matches what
-// a workload can actually allocate under MPS.
-func (n *NvidiaGPUManager) DetectGPUMemory() map[string]uint64 {
+// a workload can actually allocate under MPS. It iterates the GPU UUIDs already
+// discovered by GetGPUDeviceIDs (n.GPUIDs).
+func (n *NvidiaGPUManager) DetectGPUMemory() (map[string]uint64, error) {
 	memory := make(map[string]uint64)
-	count, err := NvmlGetDeviceCount()
-	if err != nil {
-		seelog.Errorf("Error getting GPU device count for memory detection: %v", err)
-		return memory
-	}
-	for i := 0; i < count; i++ {
-		device, ret := nvml.DeviceGetHandleByIndex(i)
+	for _, uuid := range n.GPUIDs {
+		device, ret := nvml.DeviceGetHandleByUUID(uuid)
 		if ret != nvml.SUCCESS {
-			seelog.Errorf("Error initializing device of index %d for memory detection: %v", i, nvml.ErrorString(ret))
-			continue
-		}
-		uuid, ret := nvml.DeviceGetUUID(device)
-		if ret != nvml.SUCCESS {
-			seelog.Errorf("Failed to get UUID for device at index %d during memory detection: %v", i, nvml.ErrorString(ret))
-			continue
+			return nil, errors.Errorf("memory detection: failed to get device handle for UUID %s: %v", uuid, nvml.ErrorString(ret))
 		}
 		// NVML v2 memory: usable = Total - Reserved.
 		mem, ret := nvml.DeviceGetMemoryInfo_v2(device)
 		if ret != nvml.SUCCESS {
-			seelog.Errorf("Failed to get v2 memory info for device %s: %v", uuid, nvml.ErrorString(ret))
-			continue
+			return nil, errors.Errorf("memory detection: failed to get v2 memory info for device %s: %v", uuid, nvml.ErrorString(ret))
 		}
 		if mem.Total < mem.Reserved {
-			seelog.Errorf("Unexpected v2 memory for device %s: total %d < reserved %d; skipping", uuid, mem.Total, mem.Reserved)
-			continue
+			return nil, errors.Errorf("memory detection: unexpected v2 memory for device %s: total %d < reserved %d", uuid, mem.Total, mem.Reserved)
 		}
 		memory[uuid] = (mem.Total - mem.Reserved) / bytesPerMiB
 	}
-	return memory
+	return memory, nil
 }
 
 var NvmlGetDeviceCount = GetDeviceCount

--- a/ecs-init/gpu/nvidia_gpu_manager_test.go
+++ b/ecs-init/gpu/nvidia_gpu_manager_test.go
@@ -321,15 +321,15 @@ func TestGPUSetupSuccessful(t *testing.T) {
 
 	mockDevice1 := mock_gpu.NewMockGPUDevice(ctrl)
 	mockDevice2 := mock_gpu.NewMockGPUDevice(ctrl)
-	// Setup walks the devices twice: once in GetGPUDeviceIDs (UUID +
-	// virtualization mode) and once in DetectGPUMemory (UUID + v2 memory).
-	mockDevice1.EXPECT().GetUUID().Return("gpu-0123", nvml.SUCCESS).Times(2)
-	mockDevice2.EXPECT().GetUUID().Return("gpu-1234", nvml.SUCCESS).Times(2)
+	// GetGPUDeviceIDs derives each UUID (once) and probes virtualization mode.
+	mockDevice1.EXPECT().GetUUID().Return("gpu-0123", nvml.SUCCESS)
+	mockDevice2.EXPECT().GetUUID().Return("gpu-1234", nvml.SUCCESS)
 	// The device loop now probes virtualization mode to gate MPS; these are not vGPUs.
 	mockDevice1.EXPECT().GetVirtualizationMode().Return(nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS)
 	mockDevice2.EXPECT().GetVirtualizationMode().Return(nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS)
-	// DetectGPUMemory reads NVML v2 memory (usable = Total - Reserved). Use
-	// round numbers: 16 GiB total, 512 MiB reserved -> 16384 - 512 = 15872 MiB.
+	// DetectGPUMemory then looks each discovered UUID back up and reads NVML v2
+	// memory (usable = Total - Reserved).
+	// reserved -> 16384 - 512 = 15872 MiB.
 	mockDevice1.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{
 		Total:    16384 * bytesPerMiB,
 		Reserved: 512 * bytesPerMiB,
@@ -339,10 +339,17 @@ func TestGPUSetupSuccessful(t *testing.T) {
 		Reserved: 512 * bytesPerMiB,
 	}, nvml.SUCCESS)
 
-	// Mock DeviceGetHandleByIndex
+	// GetGPUDeviceIDs enumerates by index; DetectGPUMemory resolves handles by UUID.
 	oldDeviceGetHandleByIndex := nvml.DeviceGetHandleByIndex
 	nvml.DeviceGetHandleByIndex = func(idx int) (nvml.Device, nvml.Return) {
 		if idx == 0 {
+			return mockDevice1, nvml.SUCCESS
+		}
+		return mockDevice2, nvml.SUCCESS
+	}
+	oldDeviceGetHandleByUUID := nvml.DeviceGetHandleByUUID
+	nvml.DeviceGetHandleByUUID = func(uuid string) (nvml.Device, nvml.Return) {
+		if uuid == "gpu-0123" {
 			return mockDevice1, nvml.SUCCESS
 		}
 		return mockDevice2, nvml.SUCCESS
@@ -367,6 +374,7 @@ func TestGPUSetupSuccessful(t *testing.T) {
 		NvmlGetDriverVersion = GetNvidiaDriverVersion
 		NvmlGetDeviceCount = GetDeviceCount
 		nvml.DeviceGetHandleByIndex = oldDeviceGetHandleByIndex
+		nvml.DeviceGetHandleByUUID = oldDeviceGetHandleByUUID
 		WriteContentToFile = WriteToFile
 		ShutdownNVML = ShutdownNVMLib
 		statFile = oldStatFile
@@ -385,70 +393,114 @@ func TestGPUSetupSuccessful(t *testing.T) {
 	assert.False(t, nvidiaGPUManager.(*NvidiaGPUManager).HasVGPU)
 }
 
-// TestDetectGPUMemory covers the happy path plus the fail-open branches: a
-// per-device NVML error skips only that device, and a total < reserved reading
-// is treated as bad data and skipped, so a flaky call never fails discovery.
+// TestDetectGPUMemory covers the happy path: every discovered GPU reports v2
+// memory, so a full per-UUID map is returned with no error.
 func TestDetectGPUMemory(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	nvidiaGPUManager := NewNvidiaGPUManager().(*NvidiaGPUManager)
+	// Memory detection iterates the UUIDs already discovered by GetGPUDeviceIDs.
+	nvidiaGPUManager.GPUIDs = []string{"gpu-0", "gpu-1"}
 
-	NvmlGetDeviceCount = func() (int, error) {
-		return 3, nil
-	}
-
-	good := mock_gpu.NewMockGPUDevice(ctrl)
-	good.EXPECT().GetUUID().Return("gpu-good", nvml.SUCCESS)
-	good.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{
+	dev0 := mock_gpu.NewMockGPUDevice(ctrl)
+	dev0.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{
 		Total:    24576 * bytesPerMiB,
 		Reserved: 768 * bytesPerMiB,
 	}, nvml.SUCCESS)
+	dev1 := mock_gpu.NewMockGPUDevice(ctrl)
+	dev1.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{
+		Total:    16384 * bytesPerMiB,
+		Reserved: 512 * bytesPerMiB,
+	}, nvml.SUCCESS)
+
+	oldDeviceGetHandleByUUID := nvml.DeviceGetHandleByUUID
+	nvml.DeviceGetHandleByUUID = func(uuid string) (nvml.Device, nvml.Return) {
+		if uuid == "gpu-0" {
+			return dev0, nvml.SUCCESS
+		}
+		return dev1, nvml.SUCCESS
+	}
+	defer func() {
+		nvml.DeviceGetHandleByUUID = oldDeviceGetHandleByUUID
+	}()
+
+	memory, err := nvidiaGPUManager.DetectGPUMemory()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]uint64{"gpu-0": 23808, "gpu-1": 15872}, memory)
+}
+
+// TestDetectGPUMemoryHandleError verifies memory detection is all-or-none: a
+// device whose handle cannot be resolved by UUID fails the whole pass with an
+// error and no partial map.
+func TestDetectGPUMemoryHandleError(t *testing.T) {
+	nvidiaGPUManager := NewNvidiaGPUManager().(*NvidiaGPUManager)
+	nvidiaGPUManager.GPUIDs = []string{"gpu-nohandle"}
+
+	oldDeviceGetHandleByUUID := nvml.DeviceGetHandleByUUID
+	nvml.DeviceGetHandleByUUID = func(string) (nvml.Device, nvml.Return) {
+		return nil, nvml.ERROR_NOT_FOUND
+	}
+	defer func() {
+		nvml.DeviceGetHandleByUUID = oldDeviceGetHandleByUUID
+	}()
+
+	memory, err := nvidiaGPUManager.DetectGPUMemory()
+	assert.Error(t, err)
+	assert.Nil(t, memory)
+}
+
+// TestDetectGPUMemoryReadError verifies an NVML v2 memory read failure fails the
+// whole pass (all-or-none) rather than skipping that device.
+func TestDetectGPUMemoryReadError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	nvidiaGPUManager := NewNvidiaGPUManager().(*NvidiaGPUManager)
+	nvidiaGPUManager.GPUIDs = []string{"gpu-memerr"}
 
 	memErr := mock_gpu.NewMockGPUDevice(ctrl)
-	memErr.EXPECT().GetUUID().Return("gpu-memerr", nvml.SUCCESS)
 	memErr.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{}, nvml.ERROR_UNKNOWN)
 
+	oldDeviceGetHandleByUUID := nvml.DeviceGetHandleByUUID
+	nvml.DeviceGetHandleByUUID = func(string) (nvml.Device, nvml.Return) {
+		return memErr, nvml.SUCCESS
+	}
+	defer func() {
+		nvml.DeviceGetHandleByUUID = oldDeviceGetHandleByUUID
+	}()
+
+	memory, err := nvidiaGPUManager.DetectGPUMemory()
+	assert.Error(t, err)
+	assert.Nil(t, memory)
+}
+
+// TestDetectGPUMemoryBadData verifies a total < reserved reading is treated as a
+// hard error (all-or-none), not silently skipped.
+func TestDetectGPUMemoryBadData(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	nvidiaGPUManager := NewNvidiaGPUManager().(*NvidiaGPUManager)
+	nvidiaGPUManager.GPUIDs = []string{"gpu-baddata"}
+
 	badData := mock_gpu.NewMockGPUDevice(ctrl)
-	badData.EXPECT().GetUUID().Return("gpu-baddata", nvml.SUCCESS)
 	badData.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{
 		Total:    512 * bytesPerMiB,
 		Reserved: 1024 * bytesPerMiB,
 	}, nvml.SUCCESS)
 
-	oldDeviceGetHandleByIndex := nvml.DeviceGetHandleByIndex
-	nvml.DeviceGetHandleByIndex = func(idx int) (nvml.Device, nvml.Return) {
-		switch idx {
-		case 0:
-			return good, nvml.SUCCESS
-		case 1:
-			return memErr, nvml.SUCCESS
-		default:
-			return badData, nvml.SUCCESS
-		}
+	oldDeviceGetHandleByUUID := nvml.DeviceGetHandleByUUID
+	nvml.DeviceGetHandleByUUID = func(string) (nvml.Device, nvml.Return) {
+		return badData, nvml.SUCCESS
 	}
 	defer func() {
-		NvmlGetDeviceCount = GetDeviceCount
-		nvml.DeviceGetHandleByIndex = oldDeviceGetHandleByIndex
+		nvml.DeviceGetHandleByUUID = oldDeviceGetHandleByUUID
 	}()
 
-	memory := nvidiaGPUManager.DetectGPUMemory()
-	// Only the good device is reported; the NVML error and bad-data devices are skipped.
-	assert.Equal(t, map[string]uint64{"gpu-good": 23808}, memory)
-}
-
-// TestDetectGPUMemoryCountError verifies a device-count failure yields an empty
-// map (not nil-panic) and never fails discovery.
-func TestDetectGPUMemoryCountError(t *testing.T) {
-	nvidiaGPUManager := NewNvidiaGPUManager().(*NvidiaGPUManager)
-	NvmlGetDeviceCount = func() (int, error) {
-		return 0, errors.New("device count error")
-	}
-	defer func() {
-		NvmlGetDeviceCount = GetDeviceCount
-	}()
-	memory := nvidiaGPUManager.DetectGPUMemory()
-	assert.Empty(t, memory)
+	memory, err := nvidiaGPUManager.DetectGPUMemory()
+	assert.Error(t, err)
+	assert.Nil(t, memory)
 }
 
 func TestSetupNVMLError(t *testing.T) {
@@ -467,6 +519,51 @@ func TestSetupNVMLError(t *testing.T) {
 		InitializeNVML = InitNVML
 		ShutdownNVML = ShutdownNVMLib
 	}()
+	err := nvidiaGPUManager.Setup()
+	assert.Error(t, err)
+}
+
+// TestSetupMemoryError verifies Setup fails (all-or-none) when a GPU's memory
+// cannot be read, so the instance does not register with partial memory data.
+func TestSetupMemoryError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	nvidiaGPUManager := NewNvidiaGPUManager()
+
+	MatchFilePattern = func(string) ([]string, error) {
+		return []string{"/dev/nvidia0"}, nil
+	}
+	InitializeNVML = func() error { return nil }
+	NvmlGetDriverVersion = func() (string, error) { return "396.44", nil }
+	NvmlGetDeviceCount = func() (int, error) { return 1, nil }
+
+	mockDevice := mock_gpu.NewMockGPUDevice(ctrl)
+	mockDevice.EXPECT().GetUUID().Return("gpu-0123", nvml.SUCCESS)
+	mockDevice.EXPECT().GetVirtualizationMode().Return(nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS)
+	// The v2 memory read fails, which must fail Setup rather than register partial data.
+	mockDevice.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{}, nvml.ERROR_UNKNOWN)
+
+	oldDeviceGetHandleByIndex := nvml.DeviceGetHandleByIndex
+	nvml.DeviceGetHandleByIndex = func(int) (nvml.Device, nvml.Return) {
+		return mockDevice, nvml.SUCCESS
+	}
+	oldDeviceGetHandleByUUID := nvml.DeviceGetHandleByUUID
+	nvml.DeviceGetHandleByUUID = func(string) (nvml.Device, nvml.Return) {
+		return mockDevice, nvml.SUCCESS
+	}
+	ShutdownNVML = func() error { return nil }
+
+	defer func() {
+		MatchFilePattern = FilePatternMatch
+		InitializeNVML = InitNVML
+		NvmlGetDriverVersion = GetNvidiaDriverVersion
+		NvmlGetDeviceCount = GetDeviceCount
+		nvml.DeviceGetHandleByIndex = oldDeviceGetHandleByIndex
+		nvml.DeviceGetHandleByUUID = oldDeviceGetHandleByUUID
+		ShutdownNVML = ShutdownNVMLib
+	}()
+
 	err := nvidiaGPUManager.Setup()
 	assert.Error(t, err)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
https://github.com/aws/amazon-ecs-agent/pull/5061 introduced per-GPU memory reporting via RCI but incase of any issues in obtaining memory of a GPU, we still proceeded with RCI which would cause a scenario of half populated GPUs. This PR changes the  detection to all-or-none: if any GPU's memory cannot be read, the agent bootstrap fails rather than registering the instance with partial data.
### Implementation details
<!-- How are the changes implemented? -->
- `ecs-init/gpu/nvidia_gpu_manager.go` - DetectGPUMemory now returns (map[string]uint64, error). It reads NVML v2 memory (usable = Total − Reserved) and returns an error on the first GPU it cannot read (handle lookup, v2 read, or a Total < Reserved sanity check). Setup() treats that error like any other setup failure. Because DetectGPUMemory runs in ecs-init's pre-start, a failure exits ecs-init non-zero and the agent is never started, the instance does not register (registration is never attempted, rather than attempted and rejected).
- Same file also simplifies detection to iterate the GPU UUIDs already discovered by GetGPUDeviceIDs (n.GPUIDs, via DeviceGetHandleByUUID) instead of re-enumerating devices by index, giving device discovery a single source of truth. (Addresses review comment r3659709617 (https://github.com/aws/amazon-ecs-agent/pull/5061#discussion_r3659709617).)
- agent/gpu/nvidia_gpu_manager_unix.go - removed the per-device presence gate in SetDevices. With all-or-none, the persisted GPU state is complete or absent, so every discovered GPU carries GpuInfo.MemoryInMiB.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Verified on a g6.12xlarge ECS AL2023 GPU instance by building the generic ecs-init RPM on the box and installing it :
*  `/var/lib/ecs/gpu/nvidia-gpu-info.json` recorded GPUMemoryMiB for all 4 GPUs (22563 MiB each = 23034 total − 471 reserved).
*  The RegisterContainerInstance request (confirmed in CloudTrail) carried gpuInfo.memoryInMiB = 22563 on all 4 platform devices.
```

"platformDevices": [
--
{
"id": "GPU-fc3ea365-f01b-d3bd-92d2-33a8263d7e3c",
"type": "GPU",
"gpuInfo": {
"memoryInMiB": 22563
}
},
{
"id": "GPU-e5a6af35-4ca3-57d9-40d2-d21ac3821bb0",
"type": "GPU",
"gpuInfo": {
"memoryInMiB": 22563
}
},
{
"id": "GPU-db02cc43-b605-9740-1bab-9054ff85a601",
"type": "GPU",
"gpuInfo": {
"memoryInMiB": 22563
}
},
{
"id": "GPU-ed1056a5-3d3d-4fd1-141d-e11c2611e8e0",
"type": "GPU",
"gpuInfo": {
"memoryInMiB": 22563
}
}
]


```
New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - fail agent bootstrap when per-GPU memory cannot be read
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
