### PR TITLE
Address post-merge review comments on daemon-bridge introspection

### DIFF
--- a/ecs-agent/netlib/platform/managed_linux.go
+++ b/ecs-agent/netlib/platform/managed_linux.go
@@ -617,13 +617,9 @@ func (m *managedLinux) addDaemonBridgeNATRule(ipComp ipcompatibility.IPCompatibi
 	// Grant the daemon namespace access to the introspection server. The baseline
 	// DROP is installed at agent startup (SetupIntrospectionFirewall); the ACCEPT
 	// is added here, only now that a daemon bridge exists and the daemon owns
-	// DaemonBridgeIP, so an awsvpc task can never satisfy it. Best-effort: a
-	// failure here only means the daemon cannot reach introspection, so log and
-	// continue rather than failing daemon-bridge setup.
+	// DaemonBridgeIP, so an awsvpc task can never satisfy it.
 	if err := allowDaemonIntrospection(ipComp.IsIPv6Compatible()); err != nil {
-		logger.Warn("Failed to allow daemon introspection access", logger.Fields{
-			loggerfield.Error: err,
-		})
+		return fmt.Errorf("failed to allow daemon introspection access: %w", err)
 	}
 
 	return nil
@@ -678,9 +674,10 @@ func (m *managedLinux) StopDaemonNetNS(ctx context.Context, netNS *tasknetworkco
 	// than failing teardown.
 	//
 	// This runs BEFORE the CNI DEL below: the DEL releases the daemon's fixed
-	// address (169.254.172.2) back to the shared bridge IPAM, where a subsequent
-	// awsvpc task could be assigned it. Removing the ACCEPT first ensures that
-	// address is never simultaneously reallocatable and still allowed.
+	// addresses (DaemonBridgeIP / DaemonBridgeIPv6) back to the shared bridge
+	// IPAM, where a subsequent awsvpc task could be assigned one. Removing the
+	// ACCEPT rules first ensures those addresses are never simultaneously
+	// reallocatable and still allowed.
 	removeIntrospectionAllow := func(useIPv6 bool) {
 		if err := disallowDaemonIntrospection(useIPv6); err != nil {
 			logger.Warn("Failed to remove daemon introspection access rule", logger.Fields{


### PR DESCRIPTION
### Summary

Follow-up to #5068 addressing two non-blocking review comments.

### Implementation details

`ecs-agent/netlib/platform/managed_linux.go`:

- `allowDaemonIntrospection` failure now returns an error from `addDaemonBridgeNATRule`, matching how the NAT rules in the same function handle failure, instead of logging inline. Behavior is unchanged: the caller (`configureDaemonNetNS`) already treats the whole daemon-bridge rule setup as best-effort (it warns and continues on a non-nil return), so this is an internal-consistency cleanup rather than a behavior change.
- A comment change.

### Testing

- `make test` (unit) for `netlib/platform` passes. No behavior change, so existing coverage applies.

New tests cover the changes: no

### Description for the changelog

Housekeeping - Address review comments on daemon-bridge introspection firewall

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**

No.

**Does this PR include the addition of new environment variables in the README?**

No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
