### PR TITLE
Gate gpu-sharing-mps on complete per-GPU memory

### DIFF
--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -128,9 +128,9 @@ func (agent *ecsAgent) appendNvidiaDriverVersionAttribute(capabilities []types.A
 
 // appendGpuSharingMpsCapability advertises ecs.capability.gpu-sharing-mps when the
 // instance can run MPS: a GPU is present, the MPS control binary and its systemd unit
-// are installed and enabled, and the GPU is not a vGPU slice. The facts are gathered by
-// ecs-init and read from the NvidiaGPUManager; the decision itself lives in the shared
-// gpu package so the MI agent reaches the same verdict from the same inputs.
+// are installed and enabled, the GPU is not a vGPU slice, and every discovered GPU has
+// a usable-memory value. The facts are gathered by ecs-init and read from the NvidiaGPUManager;
+// the decision itself lives in the shared gpu package so the MI agent reaches the same verdict from the same inputs.
 func (agent *ecsAgent) appendGpuSharingMpsCapability(capabilities []types.Attribute) []types.Attribute {
 	if agent.resourceFields == nil || agent.resourceFields.NvidiaGPUManager == nil {
 		return capabilities
@@ -141,6 +141,7 @@ func (agent *ecsAgent) appendGpuSharingMpsCapability(capabilities []types.Attrib
 		MpsBinaryPresent:  mgr.GetMpsControlBinaryPresent(),
 		MpsServiceEnabled: mgr.GetMpsServiceEnabled(),
 		IsVGPU:            mgr.GetHasVGPU(),
+		AllGPUsHaveMemory: gpu.AllGPUMemoryReported(mgr.GetGPUIDsUnsafe(), mgr.GetGPUMemoryMiBUnsafe()),
 	}
 	advertise, conditions := gpu.ShouldAdvertiseMpsCapability(inputs)
 	if !advertise {

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -346,8 +346,9 @@ func TestAppendGpuSharingMpsCapability(t *testing.T) {
 	mpsCap := types.Attribute{Name: aws.String(capability.GPUSharingMps)}
 
 	// newManager returns a GPU manager with the given MPS facts and one device
-	// present unless gpuPresent is false.
-	newManager := func(gpuPresent, binary, service, vgpu bool) *gpu.NvidiaGPUManager {
+	// present (with usable memory) unless gpuPresent is false. haveMemory controls
+	// whether that device has a memory value, exercising the AllGPUsHaveMemory gate.
+	newManager := func(gpuPresent, binary, service, vgpu, haveMemory bool) *gpu.NvidiaGPUManager {
 		m := &gpu.NvidiaGPUManager{
 			MpsControlBinaryPresent: binary,
 			MpsServiceEnabled:       service,
@@ -355,6 +356,9 @@ func TestAppendGpuSharingMpsCapability(t *testing.T) {
 		}
 		if gpuPresent {
 			m.SetGPUIDs([]string{"gpu-0"})
+			if haveMemory {
+				m.SetGPUMemoryMiB(map[string]uint64{"gpu-0": 22563})
+			}
 			m.SetDevices()
 		}
 		return m
@@ -368,11 +372,12 @@ func TestAppendGpuSharingMpsCapability(t *testing.T) {
 		// Advertisement of gpu-sharing-mps is intentionally disabled until the MPS runtime
 		// integration lands, so the capability must NOT appear in any case.
 		// TODO: flip to true once capability advertisement is enabled
-		{"all conditions met", newManager(true, true, true, false), false},
-		{"no gpu present", newManager(false, true, true, false), false},
-		{"mps binary absent", newManager(true, false, true, false), false},
-		{"mps service disabled", newManager(true, true, false, false), false},
-		{"is vgpu", newManager(true, true, true, true), false},
+		{"all conditions met", newManager(true, true, true, false, true), false},
+		{"no gpu present", newManager(false, true, true, false, true), false},
+		{"mps binary absent", newManager(true, false, true, false, true), false},
+		{"mps service disabled", newManager(true, true, false, false, true), false},
+		{"is vgpu", newManager(true, true, true, true, true), false},
+		{"gpu present but no memory reported", newManager(true, true, true, false, false), false},
 	}
 
 	for _, tc := range cases {

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -657,9 +657,14 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 	client.EXPECT().GetHostResources().Return(testHostResource, nil).Times(1)
 	mockGPUManager.EXPECT().GetDevices().Return(devices).AnyTimes()
 	// The gpu-sharing-mps capability check reads these MPS facts during registration.
+	// GetGPUIDsUnsafe and GetGPUMemoryMiBUnsafe feed the AllGPUsHaveMemory gate
+	// condition and are evaluated eagerly wherever capabilities are built, so they
+	// must be mocked even when the other MPS gates are false.
 	mockGPUManager.EXPECT().GetMpsControlBinaryPresent().Return(false).AnyTimes()
 	mockGPUManager.EXPECT().GetMpsServiceEnabled().Return(false).AnyTimes()
 	mockGPUManager.EXPECT().GetHasVGPU().Return(false).AnyTimes()
+	mockGPUManager.EXPECT().GetGPUIDsUnsafe().Return([]string{}).AnyTimes()
+	mockGPUManager.EXPECT().GetGPUMemoryMiBUnsafe().Return(map[string]uint64{}).AnyTimes()
 
 	gomock.InOrder(
 		mockGPUManager.EXPECT().Initialize().Return(nil),

--- a/agent/gpu/mocks/gpu_manager_mocks.go
+++ b/agent/gpu/mocks/gpu_manager_mocks.go
@@ -90,6 +90,20 @@ func (mr *MockGPUManagerMockRecorder) GetGPUIDsUnsafe() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGPUIDsUnsafe", reflect.TypeOf((*MockGPUManager)(nil).GetGPUIDsUnsafe))
 }
 
+// GetGPUMemoryMiBUnsafe mocks base method.
+func (m *MockGPUManager) GetGPUMemoryMiBUnsafe() map[string]uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGPUMemoryMiBUnsafe")
+	ret0, _ := ret[0].(map[string]uint64)
+	return ret0
+}
+
+// GetGPUMemoryMiBUnsafe indicates an expected call of GetGPUMemoryMiBUnsafe.
+func (mr *MockGPUManagerMockRecorder) GetGPUMemoryMiBUnsafe() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGPUMemoryMiBUnsafe", reflect.TypeOf((*MockGPUManager)(nil).GetGPUMemoryMiBUnsafe))
+}
+
 // GetHasVGPU mocks base method.
 func (m *MockGPUManager) GetHasVGPU() bool {
 	m.ctrl.T.Helper()

--- a/agent/gpu/nvidia_gpu_manager_unix.go
+++ b/agent/gpu/nvidia_gpu_manager_unix.go
@@ -33,6 +33,7 @@ type GPUManager interface {
 	Initialize() error
 	SetGPUIDs([]string)
 	GetGPUIDsUnsafe() []string
+	GetGPUMemoryMiBUnsafe() map[string]uint64
 	SetDevices()
 	GetDevices() []types.PlatformDevice
 	SetDriverVersion(string)

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/gpu/gpu.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/gpu/gpu.go
@@ -22,6 +22,7 @@ const (
 	MpsBinaryPresent  MpsGateCondition = "mps-binary-present"
 	MpsServiceEnabled MpsGateCondition = "mps-service-enabled"
 	NotVGPU           MpsGateCondition = "not-vgpu"
+	AllGPUsHaveMemory MpsGateCondition = "all-gpus-have-memory"
 )
 
 // UnmetReason returns the message to log when a condition is not satisfied.
@@ -36,6 +37,8 @@ func (c MpsGateCondition) UnmetReason() string {
 		return "nvidia-mps systemd service is not enabled on host"
 	case NotVGPU:
 		return "instance has an NVIDIA vGPU slice, where we do not support MPS"
+	case AllGPUsHaveMemory:
+		return "not every discovered GPU reported usable memory"
 	}
 	return string(c)
 }
@@ -53,6 +56,11 @@ type MpsCapabilityInputs struct {
 	// on an errored or unknown probe keeps the gate fail-open, so a flaky probe
 	// never strips MPS from a real passthrough GPU.
 	IsVGPU bool
+	// AllGPUsHaveMemory is true only when every discovered GPU has a usable-memory
+	// value. MPS placement needs per-GPU memory for every GPU, so if any is missing
+	// we withhold the capability. Memory detection is fail-open, so
+	// a GPU whose memory could not be read is simply absent and flips this false.
+	AllGPUsHaveMemory bool
 }
 
 // ShouldAdvertiseMpsCapability reports whether ecs.capability.gpu-sharing-mps
@@ -63,6 +71,7 @@ func ShouldAdvertiseMpsCapability(in MpsCapabilityInputs) (advertise bool, condi
 		MpsBinaryPresent:  in.MpsBinaryPresent,
 		MpsServiceEnabled: in.MpsServiceEnabled,
 		NotVGPU:           !in.IsVGPU,
+		AllGPUsHaveMemory: in.AllGPUsHaveMemory,
 	}
 	advertise = true
 	for _, satisfied := range conditions {
@@ -76,7 +85,7 @@ func ShouldAdvertiseMpsCapability(in MpsCapabilityInputs) (advertise bool, condi
 
 // UnmetMpsConditions returns the unsatisfied conditions in a fixed order
 func UnmetMpsConditions(conditions map[MpsGateCondition]bool) []MpsGateCondition {
-	order := []MpsGateCondition{GPUPresent, MpsBinaryPresent, MpsServiceEnabled, NotVGPU}
+	order := []MpsGateCondition{GPUPresent, MpsBinaryPresent, MpsServiceEnabled, NotVGPU, AllGPUsHaveMemory}
 	var unmet []MpsGateCondition
 	for _, c := range order {
 		if !conditions[c] {
@@ -84,4 +93,25 @@ func UnmetMpsConditions(conditions map[MpsGateCondition]bool) []MpsGateCondition
 		}
 	}
 	return unmet
+}
+
+// AllGPUMemoryReported reports whether every discovered GPU UUID has a usable
+// memory value greater than zero. A missing entry (memory detection is fail-open,
+// so a GPU that could not be read is absent from the map) and an explicit zero
+// both fail: a GPU with no usable memory cannot run MPS. An empty gpuIDs list
+// returns false, since an MPS-capable instance must have at least one GPU with
+// reported memory.
+func AllGPUMemoryReported(gpuIDs []string, memoryMiB map[string]uint64) bool {
+	if len(gpuIDs) == 0 {
+		return false
+	}
+	for _, id := range gpuIDs {
+		// A GPU is missing from the map when memory detection could not read it
+		// (fail-open per device), and a zero value means it reported no usable
+		// memory; either way the GPU cannot run MPS.
+		if mem, ok := memoryMiB[id]; !ok || mem == 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/ecs-agent/utils/gpu/gpu.go
+++ b/ecs-agent/utils/gpu/gpu.go
@@ -22,6 +22,7 @@ const (
 	MpsBinaryPresent  MpsGateCondition = "mps-binary-present"
 	MpsServiceEnabled MpsGateCondition = "mps-service-enabled"
 	NotVGPU           MpsGateCondition = "not-vgpu"
+	AllGPUsHaveMemory MpsGateCondition = "all-gpus-have-memory"
 )
 
 // UnmetReason returns the message to log when a condition is not satisfied.
@@ -36,6 +37,8 @@ func (c MpsGateCondition) UnmetReason() string {
 		return "nvidia-mps systemd service is not enabled on host"
 	case NotVGPU:
 		return "instance has an NVIDIA vGPU slice, where we do not support MPS"
+	case AllGPUsHaveMemory:
+		return "not every discovered GPU reported usable memory"
 	}
 	return string(c)
 }
@@ -53,6 +56,11 @@ type MpsCapabilityInputs struct {
 	// on an errored or unknown probe keeps the gate fail-open, so a flaky probe
 	// never strips MPS from a real passthrough GPU.
 	IsVGPU bool
+	// AllGPUsHaveMemory is true only when every discovered GPU has a usable-memory
+	// value. MPS placement needs per-GPU memory for every GPU, so if any is missing
+	// we withhold the capability. Memory detection is fail-open, so
+	// a GPU whose memory could not be read is simply absent and flips this false.
+	AllGPUsHaveMemory bool
 }
 
 // ShouldAdvertiseMpsCapability reports whether ecs.capability.gpu-sharing-mps
@@ -63,6 +71,7 @@ func ShouldAdvertiseMpsCapability(in MpsCapabilityInputs) (advertise bool, condi
 		MpsBinaryPresent:  in.MpsBinaryPresent,
 		MpsServiceEnabled: in.MpsServiceEnabled,
 		NotVGPU:           !in.IsVGPU,
+		AllGPUsHaveMemory: in.AllGPUsHaveMemory,
 	}
 	advertise = true
 	for _, satisfied := range conditions {
@@ -76,7 +85,7 @@ func ShouldAdvertiseMpsCapability(in MpsCapabilityInputs) (advertise bool, condi
 
 // UnmetMpsConditions returns the unsatisfied conditions in a fixed order
 func UnmetMpsConditions(conditions map[MpsGateCondition]bool) []MpsGateCondition {
-	order := []MpsGateCondition{GPUPresent, MpsBinaryPresent, MpsServiceEnabled, NotVGPU}
+	order := []MpsGateCondition{GPUPresent, MpsBinaryPresent, MpsServiceEnabled, NotVGPU, AllGPUsHaveMemory}
 	var unmet []MpsGateCondition
 	for _, c := range order {
 		if !conditions[c] {
@@ -84,4 +93,25 @@ func UnmetMpsConditions(conditions map[MpsGateCondition]bool) []MpsGateCondition
 		}
 	}
 	return unmet
+}
+
+// AllGPUMemoryReported reports whether every discovered GPU UUID has a usable
+// memory value greater than zero. A missing entry (memory detection is fail-open,
+// so a GPU that could not be read is absent from the map) and an explicit zero
+// both fail: a GPU with no usable memory cannot run MPS. An empty gpuIDs list
+// returns false, since an MPS-capable instance must have at least one GPU with
+// reported memory.
+func AllGPUMemoryReported(gpuIDs []string, memoryMiB map[string]uint64) bool {
+	if len(gpuIDs) == 0 {
+		return false
+	}
+	for _, id := range gpuIDs {
+		// A GPU is missing from the map when memory detection could not read it
+		// (fail-open per device), and a zero value means it reported no usable
+		// memory; either way the GPU cannot run MPS.
+		if mem, ok := memoryMiB[id]; !ok || mem == 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/ecs-agent/utils/gpu/gpu_test.go
+++ b/ecs-agent/utils/gpu/gpu_test.go
@@ -27,6 +27,7 @@ func allMet() MpsCapabilityInputs {
 		MpsBinaryPresent:  true,
 		MpsServiceEnabled: true,
 		IsVGPU:            false, // not a vGPU -> the NotVGPU condition is satisfied
+		AllGPUsHaveMemory: true,
 	}
 }
 
@@ -36,18 +37,19 @@ func TestAllConditionsMetAdvertises(t *testing.T) {
 	assert.Empty(t, UnmetMpsConditions(conditions))
 }
 
-// TestShouldAdvertiseTruthTable exercises all 16 combinations of the four
+// TestShouldAdvertiseTruthTable exercises all 32 combinations of the five
 // boolean inputs and checks that the capability is advertised only when every
 // condition holds.
 func TestShouldAdvertiseTruthTable(t *testing.T) {
-	for i := 0; i < 16; i++ {
+	for i := 0; i < 32; i++ {
 		in := MpsCapabilityInputs{
 			GPUPresent:        i&1 != 0,
 			MpsBinaryPresent:  i&2 != 0,
 			MpsServiceEnabled: i&4 != 0,
 			IsVGPU:            i&8 != 0,
+			AllGPUsHaveMemory: i&16 != 0,
 		}
-		want := in.GPUPresent && in.MpsBinaryPresent && in.MpsServiceEnabled && !in.IsVGPU
+		want := in.GPUPresent && in.MpsBinaryPresent && in.MpsServiceEnabled && !in.IsVGPU && in.AllGPUsHaveMemory
 		advertise, _ := ShouldAdvertiseMpsCapability(in)
 		assert.Equalf(t, want, advertise, "inputs=%+v", in)
 	}
@@ -66,6 +68,7 @@ func TestSingleFailingConditionWithholds(t *testing.T) {
 		{"no binary", func(in *MpsCapabilityInputs) { in.MpsBinaryPresent = false }, MpsBinaryPresent},
 		{"service disabled", func(in *MpsCapabilityInputs) { in.MpsServiceEnabled = false }, MpsServiceEnabled},
 		{"is vgpu", func(in *MpsCapabilityInputs) { in.IsVGPU = true }, NotVGPU},
+		{"missing gpu memory", func(in *MpsCapabilityInputs) { in.AllGPUsHaveMemory = false }, AllGPUsHaveMemory},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -85,7 +88,7 @@ func TestUnmetConditionsStableOrder(t *testing.T) {
 	advertise, conditions := ShouldAdvertiseMpsCapability(in)
 	assert.False(t, advertise)
 	assert.Equal(t,
-		[]MpsGateCondition{GPUPresent, MpsBinaryPresent, MpsServiceEnabled},
+		[]MpsGateCondition{GPUPresent, MpsBinaryPresent, MpsServiceEnabled, AllGPUsHaveMemory},
 		UnmetMpsConditions(conditions))
 }
 
@@ -108,6 +111,55 @@ func TestUnmetReason(t *testing.T) {
 	assert.Equal(t, "MPS control binary not present on host", MpsBinaryPresent.UnmetReason())
 	assert.Equal(t, "nvidia-mps systemd service is not enabled on host", MpsServiceEnabled.UnmetReason())
 	assert.Equal(t, "instance has an NVIDIA vGPU slice, where we do not support MPS", NotVGPU.UnmetReason())
+	assert.Equal(t, "not every discovered GPU reported usable memory", AllGPUsHaveMemory.UnmetReason())
 	// Unknown condition falls back to its raw string.
 	assert.Equal(t, "some-unknown", MpsGateCondition("some-unknown").UnmetReason())
+}
+
+// TestAllGPUMemoryReported covers the completeness helper: every discovered GPU
+// UUID must have a usable-memory value greater than zero, or the capability is
+// withheld.
+func TestAllGPUMemoryReported(t *testing.T) {
+	cases := []struct {
+		name   string
+		gpuIDs []string
+		memory map[string]uint64
+		want   bool
+	}{
+		{
+			name:   "all gpus have memory",
+			gpuIDs: []string{"gpu-0", "gpu-1"},
+			memory: map[string]uint64{"gpu-0": 22563, "gpu-1": 22563},
+			want:   true,
+		},
+		{
+			name:   "one gpu missing from map",
+			gpuIDs: []string{"gpu-0", "gpu-1"},
+			memory: map[string]uint64{"gpu-0": 22563},
+			want:   false,
+		},
+		{
+			name:   "one gpu present but zero",
+			gpuIDs: []string{"gpu-0", "gpu-1"},
+			memory: map[string]uint64{"gpu-0": 22563, "gpu-1": 0},
+			want:   false,
+		},
+		{
+			name:   "no gpus discovered",
+			gpuIDs: nil,
+			memory: map[string]uint64{},
+			want:   false,
+		},
+		{
+			name:   "empty memory map",
+			gpuIDs: []string{"gpu-0"},
+			memory: map[string]uint64{},
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, AllGPUMemoryReported(tc.gpuIDs, tc.memory))
+		})
+	}
 }

--- a/ecs-init/gpu/nvidia_gpu_manager.go
+++ b/ecs-init/gpu/nvidia_gpu_manager.go
@@ -111,7 +111,7 @@ func (n *NvidiaGPUManager) Setup() error {
 	}
 	n.GPUIDs = gpuIDs
 	// Discover per-GPU usable memory so the agent can report it at
-	// registration for the MPS GPU-sharing feature. 
+	// registration for the MPS GPU-sharing feature.
 	n.GPUMemoryMiB = n.DetectGPUMemory()
 	// Gather the MPS facts once, after devices are known and before we persist state.
 	// HasVGPU is set per-device inside GetGPUDeviceIDs above.
@@ -234,20 +234,10 @@ func (n *NvidiaGPUManager) GetGPUDeviceIDs() ([]string, error) {
 // a workload can actually allocate under MPS.
 func (n *NvidiaGPUManager) DetectGPUMemory() map[string]uint64 {
 	memory := make(map[string]uint64)
-	count, err := NvmlGetDeviceCount()
-	if err != nil {
-		seelog.Errorf("Error getting GPU device count for memory detection: %v", err)
-		return memory
-	}
-	for i := 0; i < count; i++ {
-		device, ret := nvml.DeviceGetHandleByIndex(i)
+	for _, uuid := range n.GPUIDs {
+		device, ret := nvml.DeviceGetHandleByUUID(uuid)
 		if ret != nvml.SUCCESS {
-			seelog.Errorf("Error initializing device of index %d for memory detection: %v", i, nvml.ErrorString(ret))
-			continue
-		}
-		uuid, ret := nvml.DeviceGetUUID(device)
-		if ret != nvml.SUCCESS {
-			seelog.Errorf("Failed to get UUID for device at index %d during memory detection: %v", i, nvml.ErrorString(ret))
+			seelog.Errorf("Failed to get device handle for UUID %s during memory detection: %v", uuid, nvml.ErrorString(ret))
 			continue
 		}
 		// NVML v2 memory: usable = Total - Reserved.

--- a/ecs-init/gpu/nvidia_gpu_manager_test.go
+++ b/ecs-init/gpu/nvidia_gpu_manager_test.go
@@ -321,10 +321,10 @@ func TestGPUSetupSuccessful(t *testing.T) {
 
 	mockDevice1 := mock_gpu.NewMockGPUDevice(ctrl)
 	mockDevice2 := mock_gpu.NewMockGPUDevice(ctrl)
-	// Setup walks the devices twice: once in GetGPUDeviceIDs (UUID +
-	// virtualization mode) and once in DetectGPUMemory (UUID + v2 memory).
-	mockDevice1.EXPECT().GetUUID().Return("gpu-0123", nvml.SUCCESS).Times(2)
-	mockDevice2.EXPECT().GetUUID().Return("gpu-1234", nvml.SUCCESS).Times(2)
+	// GetGPUDeviceIDs derives each UUID (once) and probes virtualization mode;
+	// DetectGPUMemory then resolves handles by that UUID.
+	mockDevice1.EXPECT().GetUUID().Return("gpu-0123", nvml.SUCCESS)
+	mockDevice2.EXPECT().GetUUID().Return("gpu-1234", nvml.SUCCESS)
 	// The device loop now probes virtualization mode to gate MPS; these are not vGPUs.
 	mockDevice1.EXPECT().GetVirtualizationMode().Return(nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS)
 	mockDevice2.EXPECT().GetVirtualizationMode().Return(nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS)
@@ -339,10 +339,17 @@ func TestGPUSetupSuccessful(t *testing.T) {
 		Reserved: 512 * bytesPerMiB,
 	}, nvml.SUCCESS)
 
-	// Mock DeviceGetHandleByIndex
+	// GetGPUDeviceIDs enumerates by index; DetectGPUMemory resolves handles by UUID.
 	oldDeviceGetHandleByIndex := nvml.DeviceGetHandleByIndex
 	nvml.DeviceGetHandleByIndex = func(idx int) (nvml.Device, nvml.Return) {
 		if idx == 0 {
+			return mockDevice1, nvml.SUCCESS
+		}
+		return mockDevice2, nvml.SUCCESS
+	}
+	oldDeviceGetHandleByUUID := nvml.DeviceGetHandleByUUID
+	nvml.DeviceGetHandleByUUID = func(uuid string) (nvml.Device, nvml.Return) {
+		if uuid == "gpu-0123" {
 			return mockDevice1, nvml.SUCCESS
 		}
 		return mockDevice2, nvml.SUCCESS
@@ -367,6 +374,7 @@ func TestGPUSetupSuccessful(t *testing.T) {
 		NvmlGetDriverVersion = GetNvidiaDriverVersion
 		NvmlGetDeviceCount = GetDeviceCount
 		nvml.DeviceGetHandleByIndex = oldDeviceGetHandleByIndex
+		nvml.DeviceGetHandleByUUID = oldDeviceGetHandleByUUID
 		WriteContentToFile = WriteToFile
 		ShutdownNVML = ShutdownNVMLib
 		statFile = oldStatFile
@@ -393,43 +401,37 @@ func TestDetectGPUMemory(t *testing.T) {
 	defer ctrl.Finish()
 
 	nvidiaGPUManager := NewNvidiaGPUManager().(*NvidiaGPUManager)
-
-	NvmlGetDeviceCount = func() (int, error) {
-		return 3, nil
-	}
+	// Memory detection iterates the UUIDs already discovered by GetGPUDeviceIDs.
+	nvidiaGPUManager.GPUIDs = []string{"gpu-good", "gpu-memerr", "gpu-baddata"}
 
 	good := mock_gpu.NewMockGPUDevice(ctrl)
-	good.EXPECT().GetUUID().Return("gpu-good", nvml.SUCCESS)
 	good.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{
 		Total:    24576 * bytesPerMiB,
 		Reserved: 768 * bytesPerMiB,
 	}, nvml.SUCCESS)
 
 	memErr := mock_gpu.NewMockGPUDevice(ctrl)
-	memErr.EXPECT().GetUUID().Return("gpu-memerr", nvml.SUCCESS)
 	memErr.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{}, nvml.ERROR_UNKNOWN)
 
 	badData := mock_gpu.NewMockGPUDevice(ctrl)
-	badData.EXPECT().GetUUID().Return("gpu-baddata", nvml.SUCCESS)
 	badData.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{
 		Total:    512 * bytesPerMiB,
 		Reserved: 1024 * bytesPerMiB,
 	}, nvml.SUCCESS)
 
-	oldDeviceGetHandleByIndex := nvml.DeviceGetHandleByIndex
-	nvml.DeviceGetHandleByIndex = func(idx int) (nvml.Device, nvml.Return) {
-		switch idx {
-		case 0:
+	oldDeviceGetHandleByUUID := nvml.DeviceGetHandleByUUID
+	nvml.DeviceGetHandleByUUID = func(uuid string) (nvml.Device, nvml.Return) {
+		switch uuid {
+		case "gpu-good":
 			return good, nvml.SUCCESS
-		case 1:
+		case "gpu-memerr":
 			return memErr, nvml.SUCCESS
 		default:
 			return badData, nvml.SUCCESS
 		}
 	}
 	defer func() {
-		NvmlGetDeviceCount = GetDeviceCount
-		nvml.DeviceGetHandleByIndex = oldDeviceGetHandleByIndex
+		nvml.DeviceGetHandleByUUID = oldDeviceGetHandleByUUID
 	}()
 
 	memory := nvidiaGPUManager.DetectGPUMemory()
@@ -437,18 +439,34 @@ func TestDetectGPUMemory(t *testing.T) {
 	assert.Equal(t, map[string]uint64{"gpu-good": 23808}, memory)
 }
 
-// TestDetectGPUMemoryCountError verifies a device-count failure yields an empty
-// map (not nil-panic) and never fails discovery.
-func TestDetectGPUMemoryCountError(t *testing.T) {
+// TestDetectGPUMemoryHandleError verifies a device whose handle cannot be resolved
+// by UUID is skipped, while other devices are still reported.
+func TestDetectGPUMemoryHandleError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	nvidiaGPUManager := NewNvidiaGPUManager().(*NvidiaGPUManager)
-	NvmlGetDeviceCount = func() (int, error) {
-		return 0, errors.New("device count error")
+	nvidiaGPUManager.GPUIDs = []string{"gpu-good", "gpu-nohandle"}
+
+	good := mock_gpu.NewMockGPUDevice(ctrl)
+	good.EXPECT().GetMemoryInfo_v2().Return(nvml.Memory_v2{
+		Total:    24576 * bytesPerMiB,
+		Reserved: 768 * bytesPerMiB,
+	}, nvml.SUCCESS)
+
+	oldDeviceGetHandleByUUID := nvml.DeviceGetHandleByUUID
+	nvml.DeviceGetHandleByUUID = func(uuid string) (nvml.Device, nvml.Return) {
+		if uuid == "gpu-good" {
+			return good, nvml.SUCCESS
+		}
+		return nil, nvml.ERROR_NOT_FOUND
 	}
 	defer func() {
-		NvmlGetDeviceCount = GetDeviceCount
+		nvml.DeviceGetHandleByUUID = oldDeviceGetHandleByUUID
 	}()
+
 	memory := nvidiaGPUManager.DetectGPUMemory()
-	assert.Empty(t, memory)
+	assert.Equal(t, map[string]uint64{"gpu-good": 23808}, memory)
 }
 
 func TestSetupNVMLError(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Advertises `ecs.capability.gpu-sharing-mps` only when every discovered GPU has a usable per-GPU memory value. If any GPU's memory couldn't be read, the capability is withheld and the instance still registers normally for whole-GPU / non-GPU work , no registration failure. This keeps the control plane from ever marking an instance MPS-capable while missing part of the per-GPU memory picture it needs for MPS placement.

Also addresses a follow-up review comment from https://github.com/aws/amazon-ecs-agent/pull/5061#discussion_r3659709617 by simplifying DetectGPUMemory to iterate the already-discovered GPU UUIDs instead of re-enumerating devices.
### Implementation details
<!-- How are the changes implemented? -->
- `ecs-agent/utils/gpu/gpu.go` - adds `AllGPUsHaveMemory` as a fifth condition in the shared `ShouldAdvertiseMpsCapability`decider plus an `AllGPUMemoryReported(gpuIDs, memoryMiB)` helper. A GPU missing from the memory map (detection is fail-open per device) or reporting a zero value both fail the check; an empty GPU list fails too.
- `agent/gpu/nvidia_gpu_manager_unix.go`  exposes `GetGPUMemoryMiBUnsafe()` on the GPUManager interface.
- `agent/app/agent_capability_unix.go` — feeds `AllGPUMemoryReported(mgr.GetGPUIDsUnsafe()`, `mgr.GetGPUMemoryMiBUnsafe()` into the MPS capability gate. The boolean is derived at registration from the memory map ecs-init persisted; it is not itself stored.
- `ecs-init/gpu/nvidia_gpu_manager.go` - `DetectGPUMemory` now iterates the GPU UUIDs already discovered by `GetGPUDeviceIDs (n.GPUIDs)` via `DeviceGetHandleByUUID`, rather than re-enumerating by index with `NvmlGetDeviceCount + DeviceGetHandleByIndex`. Behavior is unchanged (still fail-open per device). Addresses PR #5061 comment.

The capability advertisement itself remains gated off behind the existing TODO: re-enable until the MPS runtime integration lands, so this changes the gate decision and its logging, not what is advertised today.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->yes

Cloudtrail RCI request
```
"platformDevices": [
--
{
"id": "GPU-d6212e96-038d-54c1-ae85-43af8b715957",
"type": "GPU",
"gpuInfo": {
"memoryInMiB": 22563
}
}
]
```
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Gate gpu-sharing-mps on complete per-GPU memory- #5075

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  No

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
