### PR TITLE
Add retry on volume plugin mount timeout during container start

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -124,6 +124,12 @@ const (
 	stopContainerBackoffMultiplier = 1.3
 	stopContainerMaxRetryCount     = 5
 
+	startContainerBackoffMin        = 5 * time.Second
+	startContainerBackoffMax        = 30 * time.Second
+	startContainerBackoffJitter     = 0.2
+	startContainerBackoffMultiplier = 2.0
+	maxVolumeMountRetries           = 10
+
 	// mediaTypeManifestV1 specifies the media type for v1 manifest
 	mediaTypeManifestV1 = "application/vnd.docker.distribution.manifest.v1+json"
 	// mediaTypeSignedManifestV1 specifies the media type for signed v1 manifest
@@ -2235,7 +2241,24 @@ func (engine *DockerTaskEngine) startContainer(task *apitask.Task, container *ap
 	}
 
 	startContainerBegin := time.Now()
-	dockerContainerMD := client.StartContainer(engine.ctx, dockerID, engine.cfg.ContainerStartTimeout)
+	startCtx, startCancel := context.WithTimeout(engine.ctx, engine.cfg.ContainerStartTimeout)
+	defer startCancel()
+
+	var dockerContainerMD dockerapi.DockerContainerMetadata
+	backoff := retry.NewExponentialBackoff(startContainerBackoffMin, startContainerBackoffMax, startContainerBackoffJitter, startContainerBackoffMultiplier)
+	retry.RetryNWithBackoffCtx(startCtx, backoff, maxVolumeMountRetries, func() error {
+		dockerContainerMD = client.StartContainer(startCtx, dockerID, engine.cfg.ContainerStartTimeout)
+		// Retry when StartContainer times out due to volume plugin mount operation timeout
+		if dockerContainerMD.Error != nil && isVolumePluginMountTimeout(dockerContainerMD.Error) {
+			logger.Warn("Container start failed due to volume plugin mount timeout, will retry", logger.Fields{
+				field.TaskID:    task.GetID(),
+				field.Container: container.Name,
+				field.Error:     dockerContainerMD.Error,
+			})
+			return dockerContainerMD.Error
+		}
+		return nil
+	})
 	if dockerContainerMD.Error != nil {
 		return dockerContainerMD
 	}
@@ -2908,6 +2931,18 @@ func (engine *DockerTaskEngine) updateMetadataFile(task *apitask.Task, cont *api
 			field.Container: cont.Container.Name,
 		})
 	}
+}
+
+// isVolumePluginMountTimeout returns true if the error from StartContainer indicates
+// that the Docker volume plugin's Mount RPC timed out. This happens when the ECS
+// volume plugin's global lock is held for too long due to concurrent mounts.
+func isVolumePluginMountTimeout(err apierrors.NamedError) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "VolumeDriver.Mount") &&
+		strings.Contains(errStr, "context deadline exceeded")
 }
 
 func getContainerHostIP(networkSettings *types.NetworkSettings) (string, bool) {

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -5544,3 +5544,106 @@ func TestSetAWSLogsDualStackEndpoint(t *testing.T) {
 		})
 	}
 }
+
+func TestIsVolumePluginMountTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      apierrors.NamedError
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "volume plugin mount timeout",
+			err:      dockerapi.CannotStartContainerError{FromError: fmt.Errorf("error waiting for VolumeDriver.Mount: context deadline exceeded")},
+			expected: true,
+		},
+		{
+			name:     "unrelated start error",
+			err:      dockerapi.CannotStartContainerError{FromError: fmt.Errorf("OCI runtime create failed")},
+			expected: false,
+		},
+		{
+			name:     "only VolumeDriver.Mount without deadline",
+			err:      dockerapi.CannotStartContainerError{FromError: fmt.Errorf("VolumeDriver.Mount returned error")},
+			expected: false,
+		},
+		{
+			name:     "only context deadline without VolumeDriver.Mount",
+			err:      dockerapi.CannotStartContainerError{FromError: fmt.Errorf("context deadline exceeded")},
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isVolumePluginMountTimeout(tc.err))
+		})
+	}
+}
+
+func TestStartContainerRetriesOnVolumePluginMountTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, _, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+
+	sleepTask := testdata.LoadTask("sleep5")
+	container := sleepTask.Containers[0]
+	container.SetRuntimeID(containerID)
+
+	// Add container to state so getDockerID works
+	taskEngine.(*DockerTaskEngine).state.AddTask(sleepTask)
+	taskEngine.(*DockerTaskEngine).state.AddContainer(&apicontainer.DockerContainer{
+		DockerID:   containerID,
+		DockerName: "test-container",
+		Container:  container,
+	}, sleepTask)
+
+	mountTimeoutErr := dockerapi.CannotStartContainerError{
+		FromError: fmt.Errorf("error waiting for VolumeDriver.Mount: context deadline exceeded"),
+	}
+
+	// First call fails with volume plugin mount timeout, second call succeeds
+	gomock.InOrder(
+		client.EXPECT().StartContainer(gomock.Any(), containerID, gomock.Any()).Return(
+			dockerapi.DockerContainerMetadata{Error: mountTimeoutErr}),
+		client.EXPECT().StartContainer(gomock.Any(), containerID, gomock.Any()).Return(
+			dockerapi.DockerContainerMetadata{DockerID: containerID}),
+	)
+
+	metadata := taskEngine.(*DockerTaskEngine).startContainer(sleepTask, container)
+	assert.NoError(t, metadata.Error)
+	assert.Equal(t, containerID, metadata.DockerID)
+}
+
+func TestStartContainerNoRetryOnNonVolumeError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, _, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+
+	sleepTask := testdata.LoadTask("sleep5")
+	container := sleepTask.Containers[0]
+	container.SetRuntimeID(containerID)
+
+	taskEngine.(*DockerTaskEngine).state.AddTask(sleepTask)
+	taskEngine.(*DockerTaskEngine).state.AddContainer(&apicontainer.DockerContainer{
+		DockerID:   containerID,
+		DockerName: "test-container",
+		Container:  container,
+	}, sleepTask)
+
+	nonVolumeErr := dockerapi.CannotStartContainerError{
+		FromError: fmt.Errorf("OCI runtime create failed"),
+	}
+
+	// Only one call - no retry for non-volume errors
+	client.EXPECT().StartContainer(gomock.Any(), containerID, gomock.Any()).Return(
+		dockerapi.DockerContainerMetadata{Error: nonVolumeErr}).Times(1)
+
+	metadata := taskEngine.(*DockerTaskEngine).startContainer(sleepTask, container)
+	assert.Error(t, metadata.Error)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

The ECS volume plugin serializes mount operations behind a global lock. When many EFS volumes are mounted concurrently across tasks, If a volume operation is taking longer than usual then no new requests can be processed by the plugin which can result in new task starts timing out, causing CannotStartContainerError with 'context deadline exceeded'.

This PR prevents tasks from permanently failing when multiple EFS volumes are being mounted concurrently by adding retry with exponential backoff (5s→30s, up to 10 attempts) in the ECS agent's `startContainer` path. The total retry time is bounded by `ECS_CONTAINER_START_TIMEOUT` (default 3 minutes) so it never exceeds the customer's configured start timeout.


### Implementation details
<!-- How are the changes implemented? -->

- Add retry logic to `startContainer()` in `docker_task_engine.go` where the volume plugin mount timeout actually surfaces (during `docker start`, not volume creation)

- Wrap the `StartContainer` call in a `RetryNWithBackoffCtx` loop with a shared timeout context (`startCtx`) bounded by `ContainerStartTimeout`

- Retry up to 10 times with exponential backoff (5s→30s, 20% jitter, 2× multiplier) when the error matches both `VolumeDriver.Mount` and `context deadline exceeded`

- The effective number of retries is controlled by `ECS_CONTAINER_START_TIMEOUT`: with the default 3-minute timeout ，customers with many concurrent EFS volumes can increase the start timeout to allow more retries


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes
During manual testing, I validate that the retry logic in `startContainer()` successfully recovers from volume plugin mount timeouts under concurrent EFS load(10 concurrent tasks × 3 EFS volumes), across different `ECS_CONTAINER_START_TIMEOUT` values.

Setup: 4 ECS clusters, each with 1 EC2 instance and 20-second mount delay inject on all instances.

| Cluster | Tasks Started Successfully | Tasks Failed | Retry Count |
| --- | --- | --- | --- |
| **control** (stock agent, 3min) | **0 / 10** | 10 / 10 | 0 |
| **3min** (patched, 3min) | **1 / 10** | 9 / 10 | 4 |
| **10min** (patched, 10min) | **5 / 10** | 5 / 10 | 14 |
| **20min** (patched, 20min) | **10 / 10** | 0 / 10 | 21 |


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Add retry for EFS volume creation to handle plugin timeout errors caused by concurrent mount operation

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.、

Short-term solution for aws/containers-roadmap#2319
