### PR TITLE
🤺 Gate dcgm-init build to >= AL2023 only

### DIFF
--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -20,6 +20,13 @@
 %global running_semaphore %{_localstatedir}/run/ecs-init.was-running
 %global gobuild_tag %{nil}
 %endif
+
+# dcgm-init is only built and packaged on AL2023.
+%if 0%{?amzn} == 2023
+%bcond_without dcgm # with
+%else
+%bcond_with dcgm # without
+%endif
 %global _cachedir %{_localstatedir}/cache
 %global no_exec_perm 644
 %global debug_package %{nil}
@@ -281,12 +288,16 @@ required routes among its preparation steps.
 # each of these should build for arm and amd arch
 make release-agent-internal
 ./scripts/gobuild.sh %{gobuild_tag}
+%if %{with dcgm}
 make build-dcgm-init
+%endif
 
 %install
 install -D amazon-ecs-init %{buildroot}%{_libexecdir}/amazon-ecs-init
 install -D amazon-ecs-volume-plugin %{buildroot}%{_libexecdir}/amazon-ecs-volume-plugin
+%if %{with dcgm}
 install -D amazon-dcgm-init %{buildroot}%{_libexecdir}/dcgm-init
+%endif
 install -m %{no_exec_perm} -D scripts/amazon-ecs-init.1 %{buildroot}%{_mandir}/man1/amazon-ecs-init.1
 
 mkdir -p %{buildroot}%{_sysconfdir}/ecs
@@ -311,7 +322,9 @@ mkdir -p %{buildroot}%{_sharedstatedir}/ecs/data
 install -m %{no_exec_perm} -D %{SOURCE2} $RPM_BUILD_ROOT/%{_unitdir}/ecs.service
 install -m %{no_exec_perm} -D %{SOURCE3} $RPM_BUILD_ROOT/%{_unitdir}/amazon-ecs-volume-plugin.service
 install -m %{no_exec_perm} -D %{SOURCE4} $RPM_BUILD_ROOT/%{_unitdir}/amazon-ecs-volume-plugin.socket
+%if %{with dcgm}
 install -m %{no_exec_perm} -D %{SOURCE8} $RPM_BUILD_ROOT/%{_unitdir}/dcgm-init.service
+%endif
 %else
 install -m %{no_exec_perm} -D %{SOURCE1} %{buildroot}%{_sysconfdir}/init/ecs.conf
 install -m %{no_exec_perm} -D %{SOURCE5} %{buildroot}%{_sysconfdir}/init/amazon-ecs-volume-plugin.conf
@@ -321,7 +334,9 @@ install -m %{no_exec_perm} -D %{SOURCE5} %{buildroot}%{_sysconfdir}/init/amazon-
 %{_libexecdir}/amazon-ecs-init
 %{_mandir}/man1/amazon-ecs-init.1*
 %{_libexecdir}/amazon-ecs-volume-plugin
+%if %{with dcgm}
 %{_libexecdir}/dcgm-init
+%endif
 %dir %{_sysconfdir}/ecs
 %config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config
 %config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config.json
@@ -336,7 +351,9 @@ install -m %{no_exec_perm} -D %{SOURCE5} %{buildroot}%{_sysconfdir}/init/amazon-
 %{_unitdir}/ecs.service
 %{_unitdir}/amazon-ecs-volume-plugin.service
 %{_unitdir}/amazon-ecs-volume-plugin.socket
+%if %{with dcgm}
 %{_unitdir}/dcgm-init.service
+%endif
 %else
 %{_sysconfdir}/init/ecs.conf
 %{_sysconfdir}/init/amazon-ecs-volume-plugin.conf
@@ -348,12 +365,16 @@ ln -sf %{basename:%{agent_image}} %{_cachedir}/ecs/ecs-agent.tar
 %if %{with systemd}
 %systemd_post ecs
 %systemd_post amazon-ecs-volume-plugin.service
+%if %{with dcgm}
 %systemd_post dcgm-init.service
+%endif
 
 %postun
 %systemd_postun ecs
 %systemd_postun_with_restart amazon-ecs-volume-plugin
+%if %{with dcgm}
 %systemd_postun_with_restart dcgm-init
+%endif
 
 %else
 %triggerun -- docker

--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -21,8 +21,8 @@
 %global gobuild_tag %{nil}
 %endif
 
-# dcgm-init is only built and packaged on AL2023.
-%if 0%{?amzn} == 2023
+# dcgm-init is only built and packaged on AL2023 and above.
+%if 0%{?amzn} >= 2023
 %bcond_without dcgm # with
 %else
 %bcond_with dcgm # without


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Introduces a single %{with dcgm} build condition (defined via %bcond, mirroring the existing systemd idiom) that is enabled only when %{?amzn} >= 2023. Every dcgm-init site — build step, install, systemd unit install, %files entries, and %systemd_post/%systemd_postun_with_restart scriptlets — now gates on it. On AL2 the RPM no longer attempts to build, install, or package dcgm-init.

### Implementation details
<!-- How are the changes implemented? -->

Modified `ecs-agent.spec`.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

Copied this repository and branch with new `ecs-agent.spec` modifications on AL2023 and AL2 instances: 

AL2 instance (on `t3.medium`): 

Ran the following commands to setup
```
sudo yum install -y docker-25.0.8
sudo yum install -y rpm-build make gcc git wget rpmdevtools
# have to specifically install golang 1.25.11
sudo yum install -y golang-1.25.11-1.amzn2.0.1 golang-bin-1.25.11-1.amzn2.0.1 golang-src-1.25.11-1.amzn2.0.1   
sudo make PWD="$(pwd)" amazon-linux-rpm-codebuild
```

Then I ran the following command and got the following response: 
```
sh-4.2$ rpm -qlp ./ecs-init-1.104.0-1.amzn2.x86_64.rpm
/etc/ecs
/etc/ecs/ecs.config
/etc/ecs/ecs.config.json
/usr/lib/systemd/system/amazon-ecs-volume-plugin.service
/usr/lib/systemd/system/amazon-ecs-volume-plugin.socket
/usr/lib/systemd/system/ecs.service
/usr/libexec/amazon-ecs-init
/usr/libexec/amazon-ecs-volume-plugin
/usr/share/man/man1/amazon-ecs-init.1.gz
/var/cache/ecs/ecs-agent-v1.104.0.tar
/var/cache/ecs/ecs-agent.tar
/var/cache/ecs/state
/var/lib/ecs/data
/var/lib/ecs/deps/daemons/ebs-csi-driver
/var/lib/ecs/deps/daemons/ebs-csi-driver/ebs-csi-driver.tar
```

AL2023 instance: 
```
dev-dsk-amytoz-2b-858adc57 % rpm -qlp ./ecs-init-1.104.0-1.amzn2023int.x86_64.rpm | grep dcgm-init
/usr/lib/systemd/system/dcgm-init.service
/usr/libexec/dcgm-init
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement - Gate dcgm-init build to AL2023 only

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No
**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
