### PR TITLE
Inject NVIDIA MPS env vars and pipe mount into MPS containers

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -56,6 +56,7 @@ import (
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	commonutils "github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/arn"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/mps"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 
@@ -814,6 +815,11 @@ func (task *Task) populateGPUEnvironmentVariables() {
 			gpuList := strings.Join(container.GPUIDs, ",")
 			envVars := make(map[string]string)
 			envVars[NvidiaVisibleDevicesEnvVar] = gpuList
+			if container.UsesMPS() {
+				for k, v := range mps.BuildEnv(container.MPSConfig.Memory, container.MPSConfig.MaxComputePercent) {
+					envVars[k] = v
+				}
+			}
 			container.MergeEnvironmentVariables(envVars)
 		}
 	}
@@ -2139,6 +2145,10 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 	binds, err := task.dockerHostBinds(container)
 	if err != nil {
 		return nil, &apierrors.HostConfigError{Msg: err.Error()}
+	}
+
+	if container.UsesMPS() {
+		binds = append(binds, mps.PipeDirectory+":"+mps.PipeDirectory)
 	}
 
 	resources := task.getDockerResources(container, cfg)

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/ipcompatibility"
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	commonutils "github.com/aws/amazon-ecs-agent/ecs-agent/utils"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/mps"
 	dockertypes "github.com/docker/docker/api/types"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -3628,6 +3629,99 @@ func TestPopulateGPUEnvironmentVariables(t *testing.T) {
 
 	assert.Equal(t, environment, container.Environment)
 	assert.Equal(t, map[string]string(nil), container1.Environment)
+}
+
+// TestPopulateGPUEnvironmentVariablesMPS verifies that an MPS container gets the
+// NVIDIA_VISIBLE_DEVICES var plus the per-client MPS env vars, that the compute
+// percentage is omitted when the customer did not declare it, and that a
+// whole-GPU container in the same task gets no MPS env vars.
+func TestPopulateGPUEnvironmentVariablesMPS(t *testing.T) {
+	computePercent := uint(50)
+	mpsWithCompute := &apicontainer.Container{
+		Name:      "mpsWithCompute",
+		Image:     "image:tag",
+		GPUIDs:    []string{"gpu1"},
+		MPSConfig: &apicontainer.MPSConfig{Memory: 4096, MaxComputePercent: &computePercent},
+	}
+	mpsNoCompute := &apicontainer.Container{
+		Name:      "mpsNoCompute",
+		Image:     "image:tag",
+		GPUIDs:    []string{"gpu1"},
+		MPSConfig: &apicontainer.MPSConfig{Memory: 2048},
+	}
+	wholeGPU := &apicontainer.Container{
+		Name:   "wholeGPU",
+		Image:  "image:tag",
+		GPUIDs: []string{"gpu2"},
+	}
+
+	task := &Task{
+		Arn:                "test",
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		Containers:         []*apicontainer.Container{mpsWithCompute, mpsNoCompute, wholeGPU},
+	}
+
+	task.populateGPUEnvironmentVariables()
+
+	assert.Equal(t, map[string]string{
+		NvidiaVisibleDevicesEnvVar:       "gpu1",
+		mps.PipeDirectoryEnvVar:          mps.PipeDirectory,
+		mps.PinnedDeviceMemLimitEnvVar:   "0=4096M",
+		mps.ActiveThreadPercentageEnvVar: "50",
+	}, mpsWithCompute.Environment)
+
+	// Compute percent omitted -> active-thread env var must be absent.
+	assert.Equal(t, map[string]string{
+		NvidiaVisibleDevicesEnvVar:     "gpu1",
+		mps.PipeDirectoryEnvVar:        mps.PipeDirectory,
+		mps.PinnedDeviceMemLimitEnvVar: "0=2048M",
+	}, mpsNoCompute.Environment)
+	_, ok := mpsNoCompute.Environment[mps.ActiveThreadPercentageEnvVar]
+	assert.False(t, ok, "compute percent env var must be omitted when not declared")
+
+	// Whole-GPU container: only NVIDIA_VISIBLE_DEVICES, no MPS env vars.
+	assert.Equal(t, map[string]string{
+		NvidiaVisibleDevicesEnvVar: "gpu2",
+	}, wholeGPU.Environment)
+}
+
+// TestDockerHostConfigMPSPipeMount verifies the MPS control-pipe directory is
+// bind-mounted into an MPS container and left out of a non-MPS container.
+func TestDockerHostConfigMPSPipeMount(t *testing.T) {
+	expectedBind := mps.PipeDirectory + ":" + mps.PipeDirectory
+
+	t.Run("MPS container gets the pipe mount", func(t *testing.T) {
+		testTask := &Task{
+			Arn: "test",
+			Containers: []*apicontainer.Container{
+				{
+					Name:      "mpsContainer",
+					Image:     "image:tag",
+					MPSConfig: &apicontainer.MPSConfig{Memory: 4096},
+				},
+			},
+		}
+		hostConfig, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask),
+			defaultDockerClientAPIVersion, &config.Config{})
+		assert.Nil(t, err)
+		assert.Contains(t, hostConfig.Binds, expectedBind)
+	})
+
+	t.Run("non-MPS container does not get the pipe mount", func(t *testing.T) {
+		testTask := &Task{
+			Arn: "test",
+			Containers: []*apicontainer.Container{
+				{
+					Name:  "plainContainer",
+					Image: "image:tag",
+				},
+			},
+		}
+		hostConfig, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask),
+			defaultDockerClientAPIVersion, &config.Config{})
+		assert.Nil(t, err)
+		assert.NotContains(t, hostConfig.Binds, expectedBind)
+	})
 }
 
 func TestDockerHostConfigNvidiaRuntime(t *testing.T) {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/mps/mps.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/mps/mps.go
@@ -1,0 +1,55 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mps
+
+import "fmt"
+
+const (
+	// PipeDirectory is the MPS control daemon's Unix domain socket directory. It
+	// must match what the systemd nvidia-mps.service exposes on the host and is
+	// bind mounted into each MPS container so the CUDA runtime can reach the
+	// daemon.
+	PipeDirectory = "/tmp/nvidia-mps"
+
+	// PipeDirectoryEnvVar tells the CUDA runtime where to find the MPS pipes.
+	PipeDirectoryEnvVar = "CUDA_MPS_PIPE_DIRECTORY"
+
+	// PinnedDeviceMemLimitEnvVar is the per-client hard GPU memory ceiling,
+	// enforced by the MPS server in software (zero GPU memory overhead).
+	PinnedDeviceMemLimitEnvVar = "CUDA_MPS_PINNED_DEVICE_MEM_LIMIT"
+
+	// ActiveThreadPercentageEnvVar is the per-client SM (compute) ceiling.
+	ActiveThreadPercentageEnvVar = "CUDA_MPS_ACTIVE_THREAD_PERCENTAGE"
+
+	// inContainerDeviceIndex is the device index the memory limit is keyed on.
+	inContainerDeviceIndex = 0
+)
+
+// BuildEnv returns the MPS environment variables for a single MPS container.
+func BuildEnv(memoryMiB uint, computePercent *uint) map[string]string {
+	env := map[string]string{
+		PipeDirectoryEnvVar:        PipeDirectory,
+		PinnedDeviceMemLimitEnvVar: PinnedDeviceMemLimit(memoryMiB),
+	}
+	if computePercent != nil {
+		env[ActiveThreadPercentageEnvVar] = fmt.Sprintf("%d", *computePercent)
+	}
+	return env
+}
+
+// PinnedDeviceMemLimit formats the per-client memory ceiling for the assigned
+// (in-container index 0) GPU as MPS expects it: "0=<MiB>M".
+func PinnedDeviceMemLimit(memoryMiB uint) string {
+	return fmt.Sprintf("%d=%dM", inContainerDeviceIndex, memoryMiB)
+}

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -89,6 +89,7 @@ github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper/mocks
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/firelens
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/gpu
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/httpproxy
+github.com/aws/amazon-ecs-agent/ecs-agent/utils/mps
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/net
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper/mocks

--- a/ecs-agent/utils/mps/mps.go
+++ b/ecs-agent/utils/mps/mps.go
@@ -1,0 +1,55 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mps
+
+import "fmt"
+
+const (
+	// PipeDirectory is the MPS control daemon's Unix domain socket directory. It
+	// must match what the systemd nvidia-mps.service exposes on the host and is
+	// bind mounted into each MPS container so the CUDA runtime can reach the
+	// daemon.
+	PipeDirectory = "/tmp/nvidia-mps"
+
+	// PipeDirectoryEnvVar tells the CUDA runtime where to find the MPS pipes.
+	PipeDirectoryEnvVar = "CUDA_MPS_PIPE_DIRECTORY"
+
+	// PinnedDeviceMemLimitEnvVar is the per-client hard GPU memory ceiling,
+	// enforced by the MPS server in software (zero GPU memory overhead).
+	PinnedDeviceMemLimitEnvVar = "CUDA_MPS_PINNED_DEVICE_MEM_LIMIT"
+
+	// ActiveThreadPercentageEnvVar is the per-client SM (compute) ceiling.
+	ActiveThreadPercentageEnvVar = "CUDA_MPS_ACTIVE_THREAD_PERCENTAGE"
+
+	// inContainerDeviceIndex is the device index the memory limit is keyed on.
+	inContainerDeviceIndex = 0
+)
+
+// BuildEnv returns the MPS environment variables for a single MPS container.
+func BuildEnv(memoryMiB uint, computePercent *uint) map[string]string {
+	env := map[string]string{
+		PipeDirectoryEnvVar:        PipeDirectory,
+		PinnedDeviceMemLimitEnvVar: PinnedDeviceMemLimit(memoryMiB),
+	}
+	if computePercent != nil {
+		env[ActiveThreadPercentageEnvVar] = fmt.Sprintf("%d", *computePercent)
+	}
+	return env
+}
+
+// PinnedDeviceMemLimit formats the per-client memory ceiling for the assigned
+// (in-container index 0) GPU as MPS expects it: "0=<MiB>M".
+func PinnedDeviceMemLimit(memoryMiB uint) string {
+	return fmt.Sprintf("%d=%dM", inContainerDeviceIndex, memoryMiB)
+}

--- a/ecs-agent/utils/mps/mps_test.go
+++ b/ecs-agent/utils/mps/mps_test.go
@@ -1,0 +1,58 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func uintPtr(v uint) *uint { return &v }
+
+func TestPinnedDeviceMemLimit(t *testing.T) {
+	// Always keyed on in-container device index 0, MiB value, "M" suffix.
+	assert.Equal(t, "0=1024M", PinnedDeviceMemLimit(1024))
+	assert.Equal(t, "0=1M", PinnedDeviceMemLimit(1))
+	assert.Equal(t, "0=22563M", PinnedDeviceMemLimit(22563))
+}
+
+func TestBuildEnvWithComputePercent(t *testing.T) {
+	env := BuildEnv(4096, uintPtr(50))
+	assert.Equal(t, map[string]string{
+		PipeDirectoryEnvVar:          PipeDirectory,
+		PinnedDeviceMemLimitEnvVar:   "0=4096M",
+		ActiveThreadPercentageEnvVar: "50",
+	}, env)
+}
+
+func TestBuildEnvWithoutComputePercent(t *testing.T) {
+	// When compute percent is omitted, the active-thread env var must be absent
+	// entirely (daemon default of 100% applies), not set to 0 or 100.
+	env := BuildEnv(4096, nil)
+	assert.Equal(t, map[string]string{
+		PipeDirectoryEnvVar:        PipeDirectory,
+		PinnedDeviceMemLimitEnvVar: "0=4096M",
+	}, env)
+	_, ok := env[ActiveThreadPercentageEnvVar]
+	assert.False(t, ok, "compute percent env var must be omitted when nil")
+}
+
+func TestBuildEnvComputePercentBoundaries(t *testing.T) {
+	env := BuildEnv(1, uintPtr(1))
+	assert.Equal(t, "1", env[ActiveThreadPercentageEnvVar])
+
+	env = BuildEnv(1, uintPtr(100))
+	assert.Equal(t, "100", env[ActiveThreadPercentageEnvVar])
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Injects the NVIDIA MPS per-client environment variables and the MPS control-pipe mount into MPS containers, so the limits parsed from a container's GPU sharingStrategy are actually applied at container launch.

A prior change parses a container's ACS GPU sharingStrategy into `container.MPSConfig`, but nothing yet acts on it. This wires that config through to the container: the MPS server can now enforce each container's memory and compute ceiling.
### Implementation details
<!-- How are the changes implemented? -->
For any container with MPSConfig set `container.UsesMPS()`:
*  Env injection `populateGPUEnvironmentVariables` alongside the existing `NVIDIA_VISIBLE_DEVICES`, the container receives:
    *  CUDA_MPS_PIPE_DIRECTORY (always)
    *  CUDA_MPS_PINNED_DEVICE_MEM_LIMIT, formatted 0=<MiB>M from MPSConfig.Memory
    * CUDA_MPS_ACTIVE_THREAD_PERCENTAGE from MPSConfig.MaxComputePercent, only when the customer declared it. When unset, the var is omitted entirely so the MPS daemon default (100%) applies. 
* Pipe mount `dockerHostConfig`: a bind mount of the control-pipe directory `/tmp/nvidia-mps` is added. The NVIDIA container runtime's CDI spec injects only the MPS binaries, not the pipe directory, so without this mount the injected memory limit is silently unenforced (the runtime finds no pipe and runs without MPS). 

Both hooks are gated on `UsesMPS()`, so whole-GPU and non-GPU containers are untouched.

The env-var names, the 0=<MiB>M formatting, and the omit-when-undeclared rule live in a new shared package `ecs-agent/utils/mps`
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Built a custom agent from this change and installed it on a AL2023 GPU AMI and ran some tasks carrying MPS limits (the payload was driven via a test-only mock, since the backend sharingStrategy path is not yet shipped). docker inspect confirmed the expected `CUDA_MPS_*` env vars (with compute omitted when undeclared) and the pipe-directory bind mount on MPS containers, and their absence on non-MPS containers. A workload with the memory limit set below the physical GPU memory was capped at the injected ceiling rather than the physical total, confirming the injected value is enforced.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Inject NVIDIA MPS env vars and pipe mount into MPS containers
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**No
<!-- If yes, next release should have a upgraded minor version --> 

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
