### PR TITLE
Allow MPS containers to colocate on a shared GPU

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -774,19 +774,26 @@ func (task *Task) applyFirelensSetup(cfg *config.Config, resourceFields *taskres
 func (task *Task) addGPUResource(cfg *config.Config) error {
 	if cfg.GPUSupportEnabled {
 		for _, association := range task.Associations {
-			// One GPU can be associated with only one container
-			// That is why validating if association.Containers is of length 1
 			if association.Type == GPUAssociationType {
-				if len(association.Containers) != 1 {
+				// Multiple containers may share a GPU only when all of them use MPS;
+				// otherwise a GPU is exclusive to a single container. All containers in the
+				// association receive the same device.
+				allMPS, err := task.allAssociationContainersMPS(association)
+				if err != nil {
+					return err
+				}
+				if len(association.Containers) != 1 && !allMPS {
 					return fmt.Errorf("could not associate multiple containers to GPU %s", association.Name)
 				}
 
-				container, ok := task.ContainerByName(association.Containers[0])
-				if !ok {
-					return fmt.Errorf("could not find container with name %s for associating GPU %s",
-						association.Containers[0], association.Name)
+				for _, containerName := range association.Containers {
+					container, ok := task.ContainerByName(containerName)
+					if !ok {
+						return fmt.Errorf("could not find container with name %s for associating GPU %s",
+							containerName, association.Name)
+					}
+					container.GPUIDs = append(container.GPUIDs, association.Name)
 				}
-				container.GPUIDs = append(container.GPUIDs, association.Name)
 			}
 		}
 		// For external instances, GPU IDs are handled by resources struct
@@ -806,6 +813,26 @@ func (task *Task) isGPUEnabled() bool {
 		}
 	}
 	return false
+}
+
+// allAssociationContainersMPS reports whether every container in the association
+// uses MPS. It errors if a named container isn't in the task (a malformed
+// association); a non-MPS container just returns false.
+func (task *Task) allAssociationContainersMPS(association Association) (bool, error) {
+	if len(association.Containers) == 0 {
+		return false, nil
+	}
+	for _, containerName := range association.Containers {
+		container, ok := task.ContainerByName(containerName)
+		if !ok {
+			return false, fmt.Errorf("could not find container with name %s for associating GPU %s",
+				containerName, association.Name)
+		}
+		if !container.UsesMPS() {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func (task *Task) populateGPUEnvironmentVariables() {

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -3603,6 +3603,142 @@ func TestAddGPUResourceWithInvalidContainer(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestAddGPUResourceMPSColocation verifies that multiple MPS containers sharing
+// one GPU association are allowed (the relaxed one-container-per-GPU rule) and
+// that each container is assigned the single shared GPU UUID.
+func TestAddGPUResourceMPSColocation(t *testing.T) {
+	containerA := &apicontainer.Container{
+		Name:      "model-a",
+		Image:     "image:tag",
+		MPSConfig: &apicontainer.MPSConfig{Memory: 12288},
+	}
+	containerB := &apicontainer.Container{
+		Name:      "model-b",
+		Image:     "image:tag",
+		MPSConfig: &apicontainer.MPSConfig{Memory: 6144},
+	}
+
+	task := &Task{
+		Arn:                "test",
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		Containers:         []*apicontainer.Container{containerA, containerB},
+		Associations: []Association{
+			{
+				Containers: []string{"model-a", "model-b"},
+				Name:       "gpu1",
+				Type:       "gpu",
+			},
+		},
+	}
+
+	cfg := &config.Config{GPUSupportEnabled: true, NvidiaRuntime: config.DefaultNvidiaRuntime}
+	err := task.addGPUResource(cfg)
+	assert.NoError(t, err, "two MPS containers colocated on one GPU must be allowed")
+	// Both containers pinned to the same single UUID; neither gets a second GPU.
+	assert.Equal(t, []string{"gpu1"}, containerA.GPUIDs)
+	assert.Equal(t, []string{"gpu1"}, containerB.GPUIDs)
+}
+
+// TestAddGPUResourceNonMPSMultiContainerRejected verifies the whole-GPU
+// one-container-per-GPU pin is preserved: a GPU association naming multiple
+// non-MPS containers is still rejected.
+func TestAddGPUResourceNonMPSMultiContainerRejected(t *testing.T) {
+	task := &Task{
+		Arn:                "test",
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		Containers: []*apicontainer.Container{
+			{Name: "c1", Image: "image:tag"},
+			{Name: "c2", Image: "image:tag"},
+		},
+		Associations: []Association{
+			{
+				Containers: []string{"c1", "c2"},
+				Name:       "gpu1",
+				Type:       "gpu",
+			},
+		},
+	}
+
+	cfg := &config.Config{GPUSupportEnabled: true}
+	err := task.addGPUResource(cfg)
+	assert.Error(t, err, "non-MPS GPU association must still reject multiple containers")
+}
+
+// TestAddGPUResourceMixedMPSMultiContainerRejected verifies that if even one
+// container in a multi-container GPU association is not an MPS container, the
+// whole association keeps the one-container-per-GPU pin and is rejected.
+func TestAddGPUResourceMixedMPSMultiContainerRejected(t *testing.T) {
+	task := &Task{
+		Arn:                "test",
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		Containers: []*apicontainer.Container{
+			{Name: "mps", Image: "image:tag", MPSConfig: &apicontainer.MPSConfig{Memory: 4096}},
+			{Name: "whole", Image: "image:tag"},
+		},
+		Associations: []Association{
+			{
+				Containers: []string{"mps", "whole"},
+				Name:       "gpu1",
+				Type:       "gpu",
+			},
+		},
+	}
+
+	cfg := &config.Config{GPUSupportEnabled: true}
+	err := task.addGPUResource(cfg)
+	assert.Error(t, err, "a mixed MPS/non-MPS GPU association must be rejected")
+}
+
+// TestAddGPUResourceMalformedAssociationSurfacesDistinctError verifies that a
+// GPU association naming a container not present in the task fails with the
+// "could not find container" error (a malformed payload) rather than the generic
+// "could not associate multiple containers" error.
+func TestAddGPUResourceMalformedAssociationSurfacesDistinctError(t *testing.T) {
+	task := &Task{
+		Arn:                "test",
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		Containers: []*apicontainer.Container{
+			{Name: "mps", Image: "image:tag", MPSConfig: &apicontainer.MPSConfig{Memory: 4096}},
+		},
+		Associations: []Association{
+			{
+				Containers: []string{"mps", "ghost"}, // "ghost" is not in the task
+				Name:       "gpu1",
+				Type:       "gpu",
+			},
+		},
+	}
+
+	cfg := &config.Config{GPUSupportEnabled: true}
+	err := task.addGPUResource(cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "could not find container with name ghost",
+		"a missing container must surface as a malformed-association error, not the generic reject")
+}
+
+// TestAddGPUResourceSingleMPSContainer verifies the single-container path is
+// unchanged for an MPS container (regression guard for the relaxed loop).
+func TestAddGPUResourceSingleMPSContainer(t *testing.T) {
+	container := &apicontainer.Container{
+		Name:      "solo",
+		Image:     "image:tag",
+		MPSConfig: &apicontainer.MPSConfig{Memory: 4096},
+	}
+	task := &Task{
+		Arn:                "test",
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		Containers:         []*apicontainer.Container{container},
+		Associations: []Association{
+			{Containers: []string{"solo"}, Name: "gpu1", Type: "gpu"},
+		},
+	}
+
+	cfg := &config.Config{GPUSupportEnabled: true}
+	err := task.addGPUResource(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"gpu1"}, container.GPUIDs)
+}
+
 func TestPopulateGPUEnvironmentVariables(t *testing.T) {
 	container := &apicontainer.Container{
 		Name:   "myName",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Lets multiple NVIDIA MPS containers in a task share a single physical GPU. Previously a GPU association was pinned one-container-per-GPU; MPS GPU sharing requires several containers to run on the same device, so this relaxes that pin for the MPS case.
### Implementation details
<!-- How are the changes implemented? -->
addGPUResource loops over the task's GPU associations and adds each association's GPU UUID to the GPUIDs of the container it names. Today it rejects any association with more than one container, and only reads association.Containers[0].

Changes:

- The multi-container check now also allows the association through when every container in it is MPS: if `len(association.Containers) != 1 && !task.allAssociationContainersMPS(association)`. A non-MPS association still hits the same rejection.
- Loop over all of association.Containers instead of just [0], giving each container the shared UUID (association.Name). No container gets more than one GPU, so the one-UUID-per-container assumption the runtime relies on (remapping to in-container device 0) still holds.
-  New `allAssociationContainersMPS` helper: true only when every named container is MPS `container.UsesMPS()`. A mix of MPS and non-MPS containers is rejected, since a whole-GPU container can't share a device.

Single-container associations and multi-container non-MPS associations are unaffected, error message included. The only new case is a GPU association naming multiple containers that are all MPS.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Built a custom agent from this change and installed it on an AL2023 GPU AMI, then ran a task defining two MPS containers pinned to one GPU (the association was driven via a test mock, since the backend path that places MPS containers on a shared GPU is not yet shipped). docker inspect confirmed both containers were assigned the same
single GPU UUID. A two-container non-MPS task on the same GPU was still rejected with the unchanged "could not associate multiple containers to GPU" error.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Allow MPS containers to colocate on a shared GPU
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
