### PR TITLE
Mount MPS control binary and pipe dir into the agent container

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -132,6 +132,14 @@ const (
 	modInfoSbinDir    = "/sbin/modinfo"
 	modInfoUsrSbinDir = "/usr/sbin/modinfo"
 
+	// mpsControlBinary is the NVIDIA MPS control front-end. The ECS agent execs it
+	// to health-check the MPS control daemon for the GPU-sharing functionality.
+	mpsControlBinary = "/usr/bin/nvidia-cuda-mps-control"
+
+	// mpsPipeDirectory is the MPS control daemon's socket directory. The ECS agent
+	// checks for it and reaches the daemon through it for the MPS health check.
+	mpsPipeDirectory = "/tmp/nvidia-mps"
+
 	// Docker Network options to filter for the default bridge network interface of docker
 	dockerDefaultBridgeInterfaceOption = "com.docker.network.bridge.default_bridge"
 	dockerInterfaceNameOption          = "com.docker.network.bridge.name"
@@ -486,6 +494,15 @@ func (c *client) getHostConfig(envVarsFromFiles map[string]string) *godocker.Hos
 			if nvidiaGPUDevicesPresent() {
 				// bind mount gpu info dir
 				binds = append(binds, gpu.GPUInfoDirPath+":"+gpu.GPUInfoDirPath)
+
+				// Bind mount the MPS control binary and the MPS pipe directory so the
+				// agent can health-check the MPS control daemon for GPU sharing
+				if isPathValid(mpsControlBinary, false) {
+					binds = append(binds, mpsControlBinary+":"+mpsControlBinary)
+				}
+				if isPathValid(mpsPipeDirectory, true) {
+					binds = append(binds, mpsPipeDirectory+":"+mpsPipeDirectory)
+				}
 			}
 		}
 

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -433,6 +433,145 @@ func TestStartAgentWithGPUConfig(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestStartAgentWithGPUConfigMPSMounts verifies that on a GPU instance where the
+// MPS control binary and pipe directory exist, both are bind mounted into the
+// agent container so the agent can health-check the MPS control daemon.
+func TestStartAgentWithGPUConfigMPSMounts(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	// Report every checked path as present so the MPS binds are added.
+	isPathValid = func(path string, isDir bool) bool {
+		return true
+	}
+	config.OsStat = func(name string) (os.FileInfo, error) {
+		return nil, nil
+	}
+	MatchFilePatternForGPU = func(pattern string) ([]string, error) {
+		return []string{"/dev/nvidia0"}, nil
+	}
+	defer func() {
+		isPathValid = defaultIsPathValid
+		config.OsStat = os.Stat
+		MatchFilePatternForGPU = FilePatternMatchForGPU
+	}()
+
+	envFile := "\nECS_ENABLE_GPU_SUPPORT=true\n"
+	containerID := "container id"
+
+	mockFS := NewMockfileSystem(mockCtrl)
+	mockDocker := NewMockdockerclient(mockCtrl)
+
+	mockFS.EXPECT().ReadFile(config.InstanceConfigFile()).Return([]byte(envFile), nil).AnyTimes()
+	mockFS.EXPECT().ReadFile(config.AgentConfigFile()).Return(nil, errors.New("not found")).AnyTimes()
+	mockDocker.EXPECT().CreateContainer(gomock.Any()).Do(func(opts godocker.CreateContainerOptions) {
+		var foundBinary, foundPipe bool
+		for _, bind := range opts.HostConfig.Binds {
+			if bind == mpsControlBinary+":"+mpsControlBinary {
+				foundBinary = true
+			}
+			if bind == mpsPipeDirectory+":"+mpsPipeDirectory {
+				foundPipe = true
+			}
+		}
+		assert.True(t, foundBinary, "MPS control binary should be bind mounted")
+		assert.True(t, foundPipe, "MPS pipe directory should be bind mounted read-write")
+	}).Return(&godocker.Container{
+		ID: containerID,
+	}, nil)
+	mockDocker.EXPECT().StartContainer(containerID, nil)
+	mockDocker.EXPECT().WaitContainer(containerID)
+
+	client := &client{
+		docker: mockDocker,
+		fs:     mockFS,
+	}
+
+	_, err := client.StartAgent()
+	assert.NoError(t, err)
+}
+
+// TestStartAgentWithGPUConfigMPSMountSkipped verifies that when an MPS path is
+// not present on the host (isPathValid returns false for it), only that mount is
+// skipped while the other MPS mount is still added.
+func TestStartAgentWithGPUConfigMPSMountSkipped(t *testing.T) {
+	cases := []struct {
+		name         string
+		absentPath   string
+		expectBinary bool
+		expectPipe   bool
+	}{
+		{
+			name:         "binary absent",
+			absentPath:   mpsControlBinary,
+			expectBinary: false,
+			expectPipe:   true,
+		},
+		{
+			name:         "pipe directory absent",
+			absentPath:   mpsPipeDirectory,
+			expectBinary: true,
+			expectPipe:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			// Every path is present except the one under test.
+			isPathValid = func(path string, isDir bool) bool {
+				return path != tc.absentPath
+			}
+			config.OsStat = func(name string) (os.FileInfo, error) {
+				return nil, nil
+			}
+			MatchFilePatternForGPU = func(pattern string) ([]string, error) {
+				return []string{"/dev/nvidia0"}, nil
+			}
+			defer func() {
+				isPathValid = defaultIsPathValid
+				config.OsStat = os.Stat
+				MatchFilePatternForGPU = FilePatternMatchForGPU
+			}()
+
+			envFile := "\nECS_ENABLE_GPU_SUPPORT=true\n"
+			containerID := "container id"
+
+			mockFS := NewMockfileSystem(mockCtrl)
+			mockDocker := NewMockdockerclient(mockCtrl)
+
+			mockFS.EXPECT().ReadFile(config.InstanceConfigFile()).Return([]byte(envFile), nil).AnyTimes()
+			mockFS.EXPECT().ReadFile(config.AgentConfigFile()).Return(nil, errors.New("not found")).AnyTimes()
+			mockDocker.EXPECT().CreateContainer(gomock.Any()).Do(func(opts godocker.CreateContainerOptions) {
+				var foundBinary, foundPipe bool
+				for _, bind := range opts.HostConfig.Binds {
+					if bind == mpsControlBinary+":"+mpsControlBinary {
+						foundBinary = true
+					}
+					if bind == mpsPipeDirectory+":"+mpsPipeDirectory {
+						foundPipe = true
+					}
+				}
+				assert.Equal(t, tc.expectBinary, foundBinary, "MPS control binary mount presence")
+				assert.Equal(t, tc.expectPipe, foundPipe, "MPS pipe directory mount presence")
+			}).Return(&godocker.Container{
+				ID: containerID,
+			}, nil)
+			mockDocker.EXPECT().StartContainer(containerID, nil)
+			mockDocker.EXPECT().WaitContainer(containerID)
+
+			client := &client{
+				docker: mockDocker,
+				fs:     mockFS,
+			}
+
+			_, err := client.StartAgent()
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func TestStartAgentWithGPUConfigNoDevices(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
The ECS agent runs inside a container, so it cannot see host paths that aren't explicitly mounted in. An upcoming change adds an MPS control-daemon health gate that runs inside the agent and needs to reach the daemon on the host. This change makes the two host paths that gate depends on visible inside the agent container. 
### Implementation details
<!-- How are the changes implemented? -->
In ecs-init, `getHostConfig` already adds GPU-only bind mounts inside the block gated on `ECS_ENABLE_GPU_SUPPORT=true` and `nvidiaGPUDevicesPresent()`. Adding 2 more mounts there:

* `/usr/bin/nvidia-cuda-mps-control` - the MPS control front-end which the agent execs.
* `/tmp/nvidia-mps` - the MPS control daemon's socket directory

Both mounts are guarded with `isPathValid` so they are only added when the source exists on the host, avoiding docker creating an empty host directory when the daemon is not present. The MPS binary ships in the GPU AMI. The pipe directory is created by the MPS control daemon at boot, before the agent starts.

Only GPU instances with GPU support enabled are affected, non-GPU instances are unchanged.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Built a custom agent and loaded it on a GPU instance running the latest AL2023 ECS GPU AMI. Ran a `docker inspect ecs-agent` and observed the following in the mounts section:

```
{
                "Type": "bind",
                "Source": "/usr/bin/nvidia-cuda-mps-control",
                "Destination": "/usr/bin/nvidia-cuda-mps-control",
                "Mode": "",
                "RW": true,
                "Propagation": "rprivate"
},
{
                "Type": "bind",
                "Source": "/tmp/nvidia-mps",
                "Destination": "/tmp/nvidia-mps",
                "Mode": "",
                "RW": true,
                "Propagation": "rprivate"
}
```


New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Mount MPS control binary and pipe dir into the agent container
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
