### PR TITLE
🥪 Populate StatusReason with XID code for IMPAIRED GPU status

### DIFF
--- a/agent/doctor/docker_runtime_healthcheck.go
+++ b/agent/doctor/docker_runtime_healthcheck.go
@@ -90,6 +90,12 @@ func (dhc *dockerRuntimeHealthcheck) SetHealthcheckStatus(healthStatus ecstcs.In
 	dhc.TimeStamp = nowTime
 }
 
+// GetStatusReason returns a human-readable reason for the current status. The
+// Docker runtime health check does not carry one.
+func (dhc *dockerRuntimeHealthcheck) GetStatusReason() string {
+	return ""
+}
+
 // GetHealthcheckType returns the type of this health check.
 func (dhc *dockerRuntimeHealthcheck) GetHealthcheckType() string {
 	dhc.lock.RLock()

--- a/agent/doctor/docker_runtime_healthcheck.go
+++ b/agent/doctor/docker_runtime_healthcheck.go
@@ -68,12 +68,13 @@ func (dhc *dockerRuntimeHealthcheck) RunCheck() ecstcs.InstanceHealthCheckStatus
 		seelog.Infof("[DockerRuntimeHealthcheck] Docker Ping failed with error: %v", res.Error)
 		resultStatus = ecstcs.InstanceHealthCheckStatusImpaired
 	}
-	dhc.SetHealthcheckStatus(resultStatus)
+	dhc.SetHealthcheckStatus(resultStatus, "")
 	return resultStatus
 }
 
-// SetHealthcheckStatus updates the health check status and timestamps.
-func (dhc *dockerRuntimeHealthcheck) SetHealthcheckStatus(healthStatus ecstcs.InstanceHealthCheckStatus) {
+// SetHealthcheckStatus updates the health check status and timestamps. The
+// Docker runtime check carries no status reason, so reason is ignored.
+func (dhc *dockerRuntimeHealthcheck) SetHealthcheckStatus(healthStatus ecstcs.InstanceHealthCheckStatus, reason string) {
 	dhc.lock.Lock()
 	defer dhc.lock.Unlock()
 	nowTime := time.Now()

--- a/agent/doctor/docker_runtime_healthcheck_test.go
+++ b/agent/doctor/docker_runtime_healthcheck_test.go
@@ -86,7 +86,7 @@ func TestSetHealthCheckStatus(t *testing.T) {
 	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
 	dockerRuntimeHealthCheck := NewDockerRuntimeHealthcheck(dockerClient)
 	healthCheckStatus := ecstcs.InstanceHealthCheckStatusOk
-	dockerRuntimeHealthCheck.SetHealthcheckStatus(healthCheckStatus)
+	dockerRuntimeHealthCheck.SetHealthcheckStatus(healthCheckStatus, "")
 	assert.Equal(t, ecstcs.InstanceHealthCheckStatusOk, dockerRuntimeHealthCheck.Status)
 }
 
@@ -101,7 +101,7 @@ func TestSetHealthcheckStatusChange(t *testing.T) {
 	initializationChangeTime := dockerRuntimeHealthcheck.GetStatusChangeTime()
 
 	// We update to initializing again; our StatusChangeTime remains the same.
-	dockerRuntimeHealthcheck.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusInitializing)
+	dockerRuntimeHealthcheck.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusInitializing, "")
 	updateChangeTime := dockerRuntimeHealthcheck.GetStatusChangeTime()
 	assert.Equal(t, ecstcs.InstanceHealthCheckStatusInitializing, dockerRuntimeHealthcheck.Status)
 	assert.Equal(t, initializationChangeTime, updateChangeTime)
@@ -110,7 +110,7 @@ func TestSetHealthcheckStatusChange(t *testing.T) {
 	time.Sleep(1 * time.Millisecond)
 
 	// Change status. This should change the update time too.
-	dockerRuntimeHealthcheck.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusOk)
+	dockerRuntimeHealthcheck.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusOk, "")
 	assert.Equal(t, ecstcs.InstanceHealthCheckStatusOk, dockerRuntimeHealthcheck.Status)
 	okChangeTime := dockerRuntimeHealthcheck.GetStatusChangeTime()
 	// Have we updated our change time?

--- a/agent/doctor/ebs_csi_runtime_healthcheck.go
+++ b/agent/doctor/ebs_csi_runtime_healthcheck.go
@@ -57,12 +57,12 @@ func (e *ebsCSIDaemonHealthcheck) RunCheck() ecstcs.InstanceHealthCheckStatus {
 	resp, err := e.csiClient.NodeGetCapabilities(ctx)
 	if err != nil {
 		logger.Error("EBS CSI Daemon health check failed", logger.Fields{field.Error: err})
-		e.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusImpaired)
+		e.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusImpaired, "")
 		return e.GetHealthcheckStatus()
 	}
 
 	logger.Info("EBS CSI Driver is healthy", logger.Fields{"nodeCapabilities": resp})
-	e.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusOk)
+	e.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusOk, "")
 	return e.GetHealthcheckStatus()
 }
 

--- a/agent/doctor/gpu_healthcheck.go
+++ b/agent/doctor/gpu_healthcheck.go
@@ -14,6 +14,7 @@
 package doctor
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/doctor/statustracker"
@@ -38,6 +39,11 @@ type gpuHealthcheck struct {
 	reader    *gpu.DCGMMetricsReader
 	createdAt time.Time
 	*statustracker.HealthCheckStatusTracker
+
+	// statusReason holds the reason for the current status (the XID error code,
+	// e.g. "XID_48") when the GPU is IMPAIRED; empty otherwise.
+	statusReason string
+	reasonLock   sync.RWMutex
 }
 
 // NewGPUHealthcheck creates a GPU health check backed by the shared metrics
@@ -72,6 +78,7 @@ func (ghc *gpuHealthcheck) RunCheck() ecstcs.InstanceHealthCheckStatus {
 			return ecstcs.InstanceHealthCheckStatusInitializing
 		}
 		logger.Debug("[GPUHealthcheck] GPU health status not available")
+		ghc.setStatusReason("")
 		ghc.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusInsufficientData)
 		return ecstcs.InstanceHealthCheckStatusInsufficientData
 	}
@@ -83,6 +90,7 @@ func (ghc *gpuHealthcheck) RunCheck() ecstcs.InstanceHealthCheckStatus {
 				"age":       timeNow().Sub(ts),
 				"threshold": gpuStalenessThreshold,
 			})
+			ghc.setStatusReason("")
 			ghc.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusInsufficientData)
 			return ecstcs.InstanceHealthCheckStatusInsufficientData
 		}
@@ -90,6 +98,7 @@ func (ghc *gpuHealthcheck) RunCheck() ecstcs.InstanceHealthCheckStatus {
 
 	if healthStatus.ConnectionLost {
 		logger.Warn("[GPUHealthcheck] DCGM connection lost, reporting insufficient data")
+		ghc.setStatusReason("")
 		ghc.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusInsufficientData)
 		return ecstcs.InstanceHealthCheckStatusInsufficientData
 	}
@@ -97,13 +106,32 @@ func (ghc *gpuHealthcheck) RunCheck() ecstcs.InstanceHealthCheckStatus {
 	var resultStatus ecstcs.InstanceHealthCheckStatus
 	if healthStatus.Healthy {
 		resultStatus = ecstcs.InstanceHealthCheckStatusOk
+		ghc.setStatusReason("")
 	} else {
 		logger.Warn("[GPUHealthcheck] GPU reported unhealthy", logger.Fields{
 			field.Reason: healthStatus.UnhealthyReason,
 		})
 		resultStatus = ecstcs.InstanceHealthCheckStatusImpaired
+		// dcgm-init already reports the reason as the XID error code
+		// (e.g. "XID_48"); surface it verbatim as the status reason.
+		ghc.setStatusReason(healthStatus.UnhealthyReason)
 	}
 
 	ghc.SetHealthcheckStatus(resultStatus)
 	return resultStatus
+}
+
+// setStatusReason records the reason for the current status.
+func (ghc *gpuHealthcheck) setStatusReason(reason string) {
+	ghc.reasonLock.Lock()
+	defer ghc.reasonLock.Unlock()
+	ghc.statusReason = reason
+}
+
+// GetStatusReason returns the XID error code behind an IMPAIRED GPU status
+// (e.g. "XID_48"), or the empty string when the GPU is not impaired.
+func (ghc *gpuHealthcheck) GetStatusReason() string {
+	ghc.reasonLock.RLock()
+	defer ghc.reasonLock.RUnlock()
+	return ghc.statusReason
 }

--- a/agent/doctor/gpu_healthcheck.go
+++ b/agent/doctor/gpu_healthcheck.go
@@ -14,7 +14,6 @@
 package doctor
 
 import (
-	"sync"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/doctor/statustracker"
@@ -39,11 +38,6 @@ type gpuHealthcheck struct {
 	reader    *gpu.DCGMMetricsReader
 	createdAt time.Time
 	*statustracker.HealthCheckStatusTracker
-
-	// statusReason holds the reason for the current status (the XID error code,
-	// e.g. "XID_48") when the GPU is IMPAIRED; empty otherwise.
-	statusReason string
-	reasonLock   sync.RWMutex
 }
 
 // NewGPUHealthcheck creates a GPU health check backed by the shared metrics
@@ -78,8 +72,7 @@ func (ghc *gpuHealthcheck) RunCheck() ecstcs.InstanceHealthCheckStatus {
 			return ecstcs.InstanceHealthCheckStatusInitializing
 		}
 		logger.Debug("[GPUHealthcheck] GPU health status not available")
-		ghc.setStatusReason("")
-		ghc.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusInsufficientData)
+		ghc.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusInsufficientData, "")
 		return ecstcs.InstanceHealthCheckStatusInsufficientData
 	}
 
@@ -90,48 +83,35 @@ func (ghc *gpuHealthcheck) RunCheck() ecstcs.InstanceHealthCheckStatus {
 				"age":       timeNow().Sub(ts),
 				"threshold": gpuStalenessThreshold,
 			})
-			ghc.setStatusReason("")
-			ghc.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusInsufficientData)
+			ghc.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusInsufficientData, "")
 			return ecstcs.InstanceHealthCheckStatusInsufficientData
 		}
 	}
 
 	if healthStatus.ConnectionLost {
 		logger.Warn("[GPUHealthcheck] DCGM connection lost, reporting insufficient data")
-		ghc.setStatusReason("")
-		ghc.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusInsufficientData)
+		ghc.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusInsufficientData, "")
 		return ecstcs.InstanceHealthCheckStatusInsufficientData
 	}
 
 	var resultStatus ecstcs.InstanceHealthCheckStatus
+	// reason accompanies an IMPAIRED status. dcgm-init reports it as the XID
+	// error code (e.g. "XID_48"), surfaced verbatim. Note an instance can be
+	// IMPAIRED with an empty reason: dcgm-init also reports unhealthy on a
+	// DCGM_HEALTH_RESULT_FAIL health check, which never sets unhealthy_reason.
+	var reason string
 	if healthStatus.Healthy {
 		resultStatus = ecstcs.InstanceHealthCheckStatusOk
-		ghc.setStatusReason("")
 	} else {
 		logger.Warn("[GPUHealthcheck] GPU reported unhealthy", logger.Fields{
 			field.Reason: healthStatus.UnhealthyReason,
 		})
 		resultStatus = ecstcs.InstanceHealthCheckStatusImpaired
-		// dcgm-init already reports the reason as the XID error code
-		// (e.g. "XID_48"); surface it verbatim as the status reason.
-		ghc.setStatusReason(healthStatus.UnhealthyReason)
+		reason = healthStatus.UnhealthyReason
 	}
 
-	ghc.SetHealthcheckStatus(resultStatus)
+	// Set status and reason together so concurrent readers never observe a
+	// mismatched pair.
+	ghc.SetHealthcheckStatus(resultStatus, reason)
 	return resultStatus
-}
-
-// setStatusReason records the reason for the current status.
-func (ghc *gpuHealthcheck) setStatusReason(reason string) {
-	ghc.reasonLock.Lock()
-	defer ghc.reasonLock.Unlock()
-	ghc.statusReason = reason
-}
-
-// GetStatusReason returns the XID error code behind an IMPAIRED GPU status
-// (e.g. "XID_48"), or the empty string when the GPU is not impaired.
-func (ghc *gpuHealthcheck) GetStatusReason() string {
-	ghc.reasonLock.RLock()
-	defer ghc.reasonLock.RUnlock()
-	return ghc.statusReason
 }

--- a/agent/doctor/gpu_healthcheck_test.go
+++ b/agent/doctor/gpu_healthcheck_test.go
@@ -35,11 +35,12 @@ const (
 )
 
 type step struct {
-	write    *string // rewrite the metrics file before the check
-	remove   bool    // remove the metrics file before the check
-	now      time.Time
-	want     ecstcs.InstanceHealthCheckStatus
-	wantLast *ecstcs.InstanceHealthCheckStatus // optional GetLastHealthcheckStatus assertion
+	write      *string // rewrite the metrics file before the check
+	remove     bool    // remove the metrics file before the check
+	now        time.Time
+	want       ecstcs.InstanceHealthCheckStatus
+	wantLast   *ecstcs.InstanceHealthCheckStatus // optional GetLastHealthcheckStatus assertion
+	wantReason string                            // expected GetStatusReason after the check
 }
 
 func TestGPUHealthcheckType(t *testing.T) {
@@ -85,7 +86,7 @@ func TestGPUHealthcheckRunCheck(t *testing.T) {
 			createdAt: fresh,
 			steps: []step{{
 				write: str(`{"timestamp":"` + freshTS + `","healthy":false,"unhealthy_reason":"XID_48","gpus":[{"gpu_uuid":"GPU-001"}]}`),
-				now:   fresh, want: impaired,
+				now:   fresh, want: impaired, wantReason: "XID_48",
 			}},
 		},
 		{
@@ -157,7 +158,39 @@ func TestGPUHealthcheckRunCheck(t *testing.T) {
 			createdAt: base,
 			steps: []step{
 				{write: str(`{"timestamp":"2026-01-01T00:00:00Z","healthy":true,"gpus":[]}`), now: base, want: ok},
-				{write: str(`{"timestamp":"2026-01-01T00:00:30Z","healthy":false,"unhealthy_reason":"XID_79","gpus":[]}`), now: base.Add(30 * time.Second), want: impaired, wantLast: last(ok)},
+				{write: str(`{"timestamp":"2026-01-01T00:00:30Z","healthy":false,"unhealthy_reason":"XID_79","gpus":[]}`), now: base.Add(30 * time.Second), want: impaired, wantLast: last(ok), wantReason: "XID_79"},
+			},
+		},
+		{
+			name:      "status reason clears when IMPAIRED gives way to OK",
+			createdAt: base,
+			steps: []step{
+				{write: str(`{"timestamp":"2026-01-01T00:00:00Z","healthy":false,"unhealthy_reason":"XID_48","gpus":[]}`), now: base, want: impaired, wantReason: "XID_48"},
+				{write: str(`{"timestamp":"2026-01-01T00:00:30Z","healthy":true,"gpus":[]}`), now: base.Add(30 * time.Second), want: ok, wantReason: ""},
+			},
+		},
+		{
+			name:      "status reason clears when IMPAIRED gives way to INSUFFICIENT_DATA (connection lost)",
+			createdAt: base,
+			steps: []step{
+				{write: str(`{"timestamp":"2026-01-01T00:00:00Z","healthy":false,"unhealthy_reason":"XID_48","gpus":[]}`), now: base, want: impaired, wantReason: "XID_48"},
+				{write: str(`{"timestamp":"2026-01-01T00:00:30Z","healthy":true,"connection_lost":true,"gpus":[]}`), now: base.Add(30 * time.Second), want: insufficient, wantReason: ""},
+			},
+		},
+		{
+			name:      "status reason clears when IMPAIRED gives way to INSUFFICIENT_DATA (missing file)",
+			createdAt: base,
+			steps: []step{
+				{write: str(`{"timestamp":"2026-01-01T00:00:00Z","healthy":false,"unhealthy_reason":"XID_48","gpus":[]}`), now: base, want: impaired, wantReason: "XID_48"},
+				{remove: true, now: base.Add(30 * time.Second), want: insufficient, wantReason: ""},
+			},
+		},
+		{
+			name:      "status reason clears when IMPAIRED gives way to INSUFFICIENT_DATA (stale timestamp)",
+			createdAt: base,
+			steps: []step{
+				{write: str(`{"timestamp":"2026-01-01T00:05:00Z","healthy":false,"unhealthy_reason":"XID_48","gpus":[]}`), now: base.Add(5 * time.Minute), want: impaired, wantReason: "XID_48"},
+				{write: str(`{"timestamp":"2026-01-01T00:00:00Z","healthy":false,"unhealthy_reason":"XID_79","gpus":[]}`), now: base.Add(10 * time.Minute), want: insufficient, wantReason: ""}, // 10m old > 120s
 			},
 		},
 		{
@@ -192,6 +225,7 @@ func TestGPUHealthcheckRunCheck(t *testing.T) {
 				if s.wantLast != nil {
 					assert.Equal(t, *s.wantLast, hc.GetLastHealthcheckStatus(), "step %d last status", i)
 				}
+				assert.Equal(t, s.wantReason, hc.GetStatusReason(), "step %d status reason", i)
 			}
 		})
 	}

--- a/agent/doctor/statustracker/statustracker.go
+++ b/agent/doctor/statustracker/statustracker.go
@@ -22,6 +22,7 @@ import (
 // HealthCheckStatusTracker is a helper for keeping track of current and last health check status.
 type HealthCheckStatusTracker struct {
 	status           ecstcs.InstanceHealthCheckStatus
+	statusReason     string
 	timeStamp        time.Time
 	statusChangeTime time.Time
 	lastStatus       ecstcs.InstanceHealthCheckStatus
@@ -65,15 +66,20 @@ func (e *HealthCheckStatusTracker) GetLastHealthcheckTime() time.Time {
 	return e.lastTimeStamp
 }
 
-// GetStatusReason returns a human-readable reason for the current status.
-// The base tracker has no reason; healthchecks that carry one embed this
-// tracker and override GetStatusReason.
+// GetStatusReason returns the human-readable reason accompanying the current
+// status (for example the XID error code behind an IMPAIRED GPU), or the empty
+// string when there is none. It is read under the same lock as the status so a
+// caller always observes a status and reason that were set together.
 func (e *HealthCheckStatusTracker) GetStatusReason() string {
-	return ""
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+	return e.statusReason
 }
 
-// SetHealthcheckStatus updates the health check status and timestamps.
-func (e *HealthCheckStatusTracker) SetHealthcheckStatus(healthStatus ecstcs.InstanceHealthCheckStatus) {
+// SetHealthcheckStatus updates the health check status, its accompanying reason,
+// and timestamps atomically under a single lock, so status and reason never
+// desync for concurrent readers. Pass an empty reason when there is none.
+func (e *HealthCheckStatusTracker) SetHealthcheckStatus(healthStatus ecstcs.InstanceHealthCheckStatus, reason string) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 	nowTime := e.now()
@@ -87,8 +93,9 @@ func (e *HealthCheckStatusTracker) SetHealthcheckStatus(healthStatus ecstcs.Inst
 	e.lastStatus = e.status
 	e.lastTimeStamp = e.timeStamp
 
-	// Update latest status.
+	// Update latest status and its reason.
 	e.status = healthStatus
+	e.statusReason = reason
 	e.timeStamp = nowTime
 }
 

--- a/agent/doctor/statustracker/statustracker.go
+++ b/agent/doctor/statustracker/statustracker.go
@@ -65,6 +65,13 @@ func (e *HealthCheckStatusTracker) GetLastHealthcheckTime() time.Time {
 	return e.lastTimeStamp
 }
 
+// GetStatusReason returns a human-readable reason for the current status.
+// The base tracker has no reason; healthchecks that carry one embed this
+// tracker and override GetStatusReason.
+func (e *HealthCheckStatusTracker) GetStatusReason() string {
+	return ""
+}
+
 // SetHealthcheckStatus updates the health check status and timestamps.
 func (e *HealthCheckStatusTracker) SetHealthcheckStatus(healthStatus ecstcs.InstanceHealthCheckStatus) {
 	e.lock.Lock()

--- a/agent/doctor/statustracker/statustracker_test.go
+++ b/agent/doctor/statustracker/statustracker_test.go
@@ -33,7 +33,7 @@ func TestHealthCheckStatusTracker(t *testing.T) {
 	})
 	t.Run("last status and timestamp is captured", func(t *testing.T) {
 		tracker := newHealthCheckStatusTrackerWithTimeFn(incrementalTime())
-		tracker.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusOk)
+		tracker.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusOk, "")
 
 		assert.Equal(t, ecstcs.InstanceHealthCheckStatusOk, tracker.GetHealthcheckStatus())
 		assert.Equal(t, ecstcs.InstanceHealthCheckStatusInitializing, tracker.GetLastHealthcheckStatus())
@@ -45,7 +45,7 @@ func TestHealthCheckStatusTracker(t *testing.T) {
 		tracker := newHealthCheckStatusTrackerWithTimeFn(incrementalTime())
 		// Update (but not change) status a bunch of times.
 		for i := 0; i < 10; i++ {
-			tracker.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusOk)
+			tracker.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusOk, "")
 		}
 
 		assert.Equal(t, ecstcs.InstanceHealthCheckStatusOk, tracker.GetHealthcheckStatus())
@@ -56,14 +56,29 @@ func TestHealthCheckStatusTracker(t *testing.T) {
 	})
 	t.Run("multiple updates", func(t *testing.T) {
 		tracker := newHealthCheckStatusTrackerWithTimeFn(incrementalTime())
-		tracker.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusOk)
-		tracker.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusImpaired)
+		tracker.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusOk, "")
+		tracker.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusImpaired, "XID_48")
 
 		assert.Equal(t, ecstcs.InstanceHealthCheckStatusImpaired, tracker.GetHealthcheckStatus())
 		assert.Equal(t, ecstcs.InstanceHealthCheckStatusOk, tracker.GetLastHealthcheckStatus())
 		assert.Equal(t, int64(2), tracker.GetLastHealthcheckTime().Unix())
 		assert.Equal(t, int64(3), tracker.GetHealthcheckTime().Unix())
 		assert.Equal(t, int64(3), tracker.GetStatusChangeTime().Unix())
+	})
+	t.Run("status reason is set and cleared with status", func(t *testing.T) {
+		tracker := newHealthCheckStatusTrackerWithTimeFn(incrementalTime())
+		// Default: no reason.
+		assert.Equal(t, "", tracker.GetStatusReason())
+
+		// IMPAIRED with a reason.
+		tracker.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusImpaired, "XID_48")
+		assert.Equal(t, ecstcs.InstanceHealthCheckStatusImpaired, tracker.GetHealthcheckStatus())
+		assert.Equal(t, "XID_48", tracker.GetStatusReason())
+
+		// Recovering to OK clears the reason.
+		tracker.SetHealthcheckStatus(ecstcs.InstanceHealthCheckStatusOk, "")
+		assert.Equal(t, ecstcs.InstanceHealthCheckStatusOk, tracker.GetHealthcheckStatus())
+		assert.Equal(t, "", tracker.GetStatusReason())
 	})
 }
 

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/doctor/healthcheck.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/doctor/healthcheck.go
@@ -29,4 +29,9 @@ type Healthcheck interface {
 	GetLastHealthcheckTime() time.Time
 	RunCheck() ecstcs.InstanceHealthCheckStatus
 	SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus)
+	// GetStatusReason returns a human-readable reason for the current status
+	// (for example the XID error code behind an IMPAIRED GPU), or the empty
+	// string when there is none. It is surfaced as StatusReason on the
+	// published InstanceStatus.
+	GetStatusReason() string
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/doctor/healthcheck.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/doctor/healthcheck.go
@@ -28,10 +28,8 @@ type Healthcheck interface {
 	GetLastHealthcheckStatus() ecstcs.InstanceHealthCheckStatus
 	GetLastHealthcheckTime() time.Time
 	RunCheck() ecstcs.InstanceHealthCheckStatus
-	SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus)
-	// GetStatusReason returns a human-readable reason for the current status
-	// (for example the XID error code behind an IMPAIRED GPU), or the empty
-	// string when there is none. It is surfaced as StatusReason on the
-	// published InstanceStatus.
+	// SetHealthcheckStatus updates the status and its accompanying reason
+	// atomically. Pass an empty reason when there is none.
+	SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus, reason string)
 	GetStatusReason() string
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client/client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client/client.go
@@ -531,8 +531,10 @@ func (cs *tcsClientServer) getInstanceStatuses() []*ecstcs.InstanceStatus {
 			Status:           aws.String(healthcheck.GetHealthcheckStatus().String()),
 			Type:             aws.String(healthcheck.GetHealthcheckType()),
 		}
-		// Surface a status reason (e.g. the XID error code behind an IMPAIRED
-		// GPU) when the healthcheck provides one.
+		// Only surface a status reason (e.g. the XID error code behind an
+		// IMPAIRED GPU) when the healthcheck provides one. Leaving StatusReason
+		// as a nil pointer lets omitempty drop it from the payload, matching the
+		// backend contract of null (not "") when there is no reason.
 		if reason := healthcheck.GetStatusReason(); reason != "" {
 			instanceStatus.StatusReason = aws.String(reason)
 		}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client/client.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client/client.go
@@ -531,6 +531,11 @@ func (cs *tcsClientServer) getInstanceStatuses() []*ecstcs.InstanceStatus {
 			Status:           aws.String(healthcheck.GetHealthcheckStatus().String()),
 			Type:             aws.String(healthcheck.GetHealthcheckType()),
 		}
+		// Surface a status reason (e.g. the XID error code behind an IMPAIRED
+		// GPU) when the healthcheck provides one.
+		if reason := healthcheck.GetStatusReason(); reason != "" {
+			instanceStatus.StatusReason = aws.String(reason)
+		}
 		instanceStatuses = append(instanceStatuses, instanceStatus)
 	}
 	return instanceStatuses

--- a/ecs-agent/doctor/doctor_test.go
+++ b/ecs-agent/doctor/doctor_test.go
@@ -53,6 +53,9 @@ func (tc *trueHealthcheck) GetStatusChangeTime() time.Time {
 func (tc *trueHealthcheck) GetLastHealthcheckTime() time.Time {
 	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
 }
+func (tc *trueHealthcheck) GetStatusReason() string {
+	return ""
+}
 
 type falseHealthcheck struct{}
 
@@ -77,6 +80,9 @@ func (fc *falseHealthcheck) GetStatusChangeTime() time.Time {
 }
 func (fc *falseHealthcheck) GetLastHealthcheckTime() time.Time {
 	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
+}
+func (fc *falseHealthcheck) GetStatusReason() string {
+	return ""
 }
 
 func TestNewDoctor(t *testing.T) {

--- a/ecs-agent/doctor/doctor_test.go
+++ b/ecs-agent/doctor/doctor_test.go
@@ -34,7 +34,8 @@ type trueHealthcheck struct{}
 func (tc *trueHealthcheck) RunCheck() ecstcs.InstanceHealthCheckStatus {
 	return ecstcs.InstanceHealthCheckStatusOk
 }
-func (tc *trueHealthcheck) SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus) {}
+func (tc *trueHealthcheck) SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus, reason string) {
+}
 func (tc *trueHealthcheck) GetHealthcheckType() string {
 	return ecstcs.InstanceHealthCheckTypeAgent
 }
@@ -62,7 +63,8 @@ type falseHealthcheck struct{}
 func (fc *falseHealthcheck) RunCheck() ecstcs.InstanceHealthCheckStatus {
 	return ecstcs.InstanceHealthCheckStatusImpaired
 }
-func (fc *falseHealthcheck) SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus) {}
+func (fc *falseHealthcheck) SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus, reason string) {
+}
 func (fc *falseHealthcheck) GetHealthcheckType() string {
 	return ecstcs.InstanceHealthCheckTypeAgent
 }

--- a/ecs-agent/doctor/healthcheck.go
+++ b/ecs-agent/doctor/healthcheck.go
@@ -28,6 +28,8 @@ type Healthcheck interface {
 	GetLastHealthcheckStatus() ecstcs.InstanceHealthCheckStatus
 	GetLastHealthcheckTime() time.Time
 	RunCheck() ecstcs.InstanceHealthCheckStatus
-	SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus)
+	// SetHealthcheckStatus updates the status and its accompanying reason
+	// atomically. Pass an empty reason when there is none.
+	SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus, reason string)
 	GetStatusReason() string
 }

--- a/ecs-agent/doctor/healthcheck.go
+++ b/ecs-agent/doctor/healthcheck.go
@@ -29,9 +29,5 @@ type Healthcheck interface {
 	GetLastHealthcheckTime() time.Time
 	RunCheck() ecstcs.InstanceHealthCheckStatus
 	SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus)
-	// GetStatusReason returns a human-readable reason for the current status
-	// (for example the XID error code behind an IMPAIRED GPU), or the empty
-	// string when there is none. It is surfaced as StatusReason on the
-	// published InstanceStatus.
 	GetStatusReason() string
 }

--- a/ecs-agent/doctor/healthcheck.go
+++ b/ecs-agent/doctor/healthcheck.go
@@ -29,4 +29,9 @@ type Healthcheck interface {
 	GetLastHealthcheckTime() time.Time
 	RunCheck() ecstcs.InstanceHealthCheckStatus
 	SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus)
+	// GetStatusReason returns a human-readable reason for the current status
+	// (for example the XID error code behind an IMPAIRED GPU), or the empty
+	// string when there is none. It is surfaced as StatusReason on the
+	// published InstanceStatus.
+	GetStatusReason() string
 }

--- a/ecs-agent/tcs/client/client.go
+++ b/ecs-agent/tcs/client/client.go
@@ -531,8 +531,10 @@ func (cs *tcsClientServer) getInstanceStatuses() []*ecstcs.InstanceStatus {
 			Status:           aws.String(healthcheck.GetHealthcheckStatus().String()),
 			Type:             aws.String(healthcheck.GetHealthcheckType()),
 		}
-		// Surface a status reason (e.g. the XID error code behind an IMPAIRED
-		// GPU) when the healthcheck provides one.
+		// Only surface a status reason (e.g. the XID error code behind an
+		// IMPAIRED GPU) when the healthcheck provides one. Leaving StatusReason
+		// as a nil pointer lets omitempty drop it from the payload, matching the
+		// backend contract of null (not "") when there is no reason.
 		if reason := healthcheck.GetStatusReason(); reason != "" {
 			instanceStatus.StatusReason = aws.String(reason)
 		}

--- a/ecs-agent/tcs/client/client.go
+++ b/ecs-agent/tcs/client/client.go
@@ -531,6 +531,11 @@ func (cs *tcsClientServer) getInstanceStatuses() []*ecstcs.InstanceStatus {
 			Status:           aws.String(healthcheck.GetHealthcheckStatus().String()),
 			Type:             aws.String(healthcheck.GetHealthcheckType()),
 		}
+		// Surface a status reason (e.g. the XID error code behind an IMPAIRED
+		// GPU) when the healthcheck provides one.
+		if reason := healthcheck.GetStatusReason(); reason != "" {
+			instanceStatus.StatusReason = aws.String(reason)
+		}
 		instanceStatuses = append(instanceStatuses, instanceStatus)
 	}
 	return instanceStatuses

--- a/ecs-agent/tcs/client/client_test.go
+++ b/ecs-agent/tcs/client/client_test.go
@@ -62,7 +62,8 @@ type trueHealthcheck struct{}
 func (tc *trueHealthcheck) RunCheck() ecstcs.InstanceHealthCheckStatus {
 	return ecstcs.InstanceHealthCheckStatusOk
 }
-func (tc *trueHealthcheck) SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus) {}
+func (tc *trueHealthcheck) SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus, reason string) {
+}
 func (tc *trueHealthcheck) GetHealthcheckType() string {
 	return ecstcs.InstanceHealthCheckTypeAgent
 }
@@ -90,7 +91,8 @@ type falseHealthcheck struct{}
 func (fc *falseHealthcheck) RunCheck() ecstcs.InstanceHealthCheckStatus {
 	return ecstcs.InstanceHealthCheckStatusImpaired
 }
-func (fc *falseHealthcheck) SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus) {}
+func (fc *falseHealthcheck) SetHealthcheckStatus(status ecstcs.InstanceHealthCheckStatus, reason string) {
+}
 func (fc *falseHealthcheck) GetHealthcheckType() string {
 	return ecstcs.InstanceHealthCheckTypeAgent
 }

--- a/ecs-agent/tcs/client/client_test.go
+++ b/ecs-agent/tcs/client/client_test.go
@@ -81,6 +81,9 @@ func (tc *trueHealthcheck) GetStatusChangeTime() time.Time {
 func (tc *trueHealthcheck) GetLastHealthcheckTime() time.Time {
 	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
 }
+func (tc *trueHealthcheck) GetStatusReason() string {
+	return ""
+}
 
 type falseHealthcheck struct{}
 
@@ -105,6 +108,9 @@ func (fc *falseHealthcheck) GetStatusChangeTime() time.Time {
 }
 func (fc *falseHealthcheck) GetLastHealthcheckTime() time.Time {
 	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
+}
+func (fc *falseHealthcheck) GetStatusReason() string {
+	return "XID_48"
 }
 
 var testCreds = credentials.NewStaticCredentialsProvider("test-id", "test-secret", "test-token")
@@ -846,6 +852,7 @@ func TestGetInstanceStatuses(t *testing.T) {
 		LastUpdated:      (*utils.Timestamp)(aws.Time(falseCheck.GetLastHealthcheckTime())),
 		Status:           aws.String(falseCheck.GetHealthcheckStatus().String()),
 		Type:             aws.String(falseCheck.GetHealthcheckType()),
+		StatusReason:     aws.String(falseCheck.GetStatusReason()),
 	}
 
 	testcases := []struct {
@@ -903,6 +910,7 @@ func TestGetPublishInstanceStatusRequest(t *testing.T) {
 		LastUpdated:      (*utils.Timestamp)(aws.Time(falseCheck.GetLastHealthcheckTime())),
 		Status:           aws.String(falseCheck.GetHealthcheckStatus().String()),
 		Type:             aws.String(falseCheck.GetHealthcheckType()),
+		StatusReason:     aws.String(falseCheck.GetStatusReason()),
 	}
 
 	testcases := []struct {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

When the ACCELERATED_COMPUTE health check reports an IMPAIRED instance status, surface the XID error code (e.g. "XID_48") that dcgm-init already writes into the shared metrics file as the InstanceStatus StatusReason.

- Add GetStatusReason() to the doctor.Healthcheck interface, with a default (empty) implementation on the shared status tracker and the docker runtime check.
- gpuHealthcheck forwards UnhealthyReason on IMPAIRED and clears it on OK/INSUFFICIENT_DATA so a stale XID never lingers.
- tcs client populates InstanceStatus.StatusReason when non-empty.

### Implementation details
<!-- How are the changes implemented? -->

Besides the vendored files, here's the files that have been modified:

#### `agent/doctor/statustracker`
- `statustracker.go`: add `GetStatusReason()`

#### `agent/doctor/`
- `docker_runtime_healthcheck.go`: add `GetStatusReason()`
- `gpu_healthcheck.go`: add `GetStatusReason()`, set StatusReason to be DCGM client's reported `UnhealthyReason`, otherwise set StatusReason to be "".
- `gpu_healthcheck_test.go`: add test cases to check that status reason is cleared when `IMPAIRED` -> non-`IMPAIRED` status

#### `ecs-agent/doctor/`
- `doctor_test.go`: add `GetStatusReason()`
- `healthcheck.go`: add `GetStatusReason()`

#### `ecs-agent/tcs/client/`
- `client.go`: attach StatusReason to `InstanceStatus` message payload
- `client_test.go`: add `StatusReason` to tests

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

```
            "healthStatus": {
                "overallStatus": "OK",
                "details": [
                    {
                        "type": "ACCELERATED_COMPUTE",
                        "status": "OK",
                        "lastUpdated": "2026-08-07T00:12:24+00:00",
                        "lastStatusChange": "2026-08-07T00:08:44+00:00"
                    },
                    {
                        "type": "CONTAINER_RUNTIME",
                        "status": "OK",
                        "lastUpdated": "2026-08-07T00:12:24+00:00",
                        "lastStatusChange": "2026-08-07T00:08:44+00:00"
                    }
                ]
            }
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement - Add StatusReason with XID code when ACCELERATED_COMPUTE reports IMPAIRED

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
<!-- If yes, next release should have a upgraded minor version -->  
No
**Does this PR include the addition of new environment variables in the README?**
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->
No
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
