### PR TITLE
Add per-GPU memory accounting to host resource manager

### DIFF
--- a/agent/api/task/gpu_memory_demand.go
+++ b/agent/api/task/gpu_memory_demand.go
@@ -1,0 +1,23 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package task
+
+// GPUMemoryDemand is a task's per-GPU memory claim, keyed by GPU UUID.
+type GPUMemoryDemand struct {
+	// MiB is the memory a task's MPS containers reserve on the GPU (the sum of
+	// their per-container caps). Meaningful only when WholeGPU is false.
+	MiB int64
+	// WholeGPU is true when a non-MPS container claims the GPU exclusively.
+	WholeGPU bool
+}

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3910,9 +3910,10 @@ func (task *Task) IsLaunchTypeFargate() bool {
 //   - Only account for hostPort
 //   - Don't need to account for awsvpc mode, each task gets its own namespace
 //
-// * GPU
-//   - Concatenate each container's gpu ids
-func (task *Task) ToHostResources() map[string]ecstypes.Resource {
+// The second return value is the per-GPU-UUID memory demand: each MPS container
+// contributes its memory cap (summed across the task's MPS containers on that
+// UUID), and a non-MPS container claims the whole GPU.
+func (task *Task) ToHostResources() (map[string]ecstypes.Resource, map[string]GPUMemoryDemand) {
 	resources := make(map[string]ecstypes.Resource)
 	// CPU
 	if task.CPU > 0 {
@@ -4005,25 +4006,36 @@ func (task *Task) ToHostResources() map[string]ecstypes.Resource {
 		StringSetValue: commonutils.Uint16SliceToStringSlice(udpPortSet),
 	}
 
-	// GPU
-	var gpus []string
+	// GPU_MEMORY: per GPU UUID, an MPS container contributes its per-container
+	// memory cap (summed across the task's MPS containers on that GPU); a non-MPS
+	// container claims the whole GPU.
+	gpuMemoryDemand := make(map[string]GPUMemoryDemand)
 	for _, c := range task.Containers {
-		gpus = append(gpus, c.GPUIDs...)
-	}
-	resources["GPU"] = ecstypes.Resource{
-		Name:           utils.Strptr("GPU"),
-		Type:           utils.Strptr("STRINGSET"),
-		StringSetValue: gpus,
+		for _, uuid := range c.GPUIDs {
+			if gpuMemoryDemand[uuid].WholeGPU {
+				// A whole-GPU UUID reached from a second container should never
+				// happen: addGPUResource binds each GPU association to exactly one
+				// container. Skip defensively.
+				continue
+			}
+			if c.UsesMPS() {
+				d := gpuMemoryDemand[uuid]
+				d.MiB += int64(c.MPSConfig.Memory)
+				gpuMemoryDemand[uuid] = d
+			} else {
+				gpuMemoryDemand[uuid] = GPUMemoryDemand{WholeGPU: true}
+			}
+		}
 	}
 	logger.Debug("Task host resources to account for", logger.Fields{
-		"taskArn":   task.Arn,
-		"CPU":       resources["CPU"].IntegerValue,
-		"MEMORY":    resources["MEMORY"].IntegerValue,
-		"PORTS_TCP": resources["PORTS_TCP"].StringSetValue,
-		"PORTS_UDP": resources["PORTS_UDP"].StringSetValue,
-		"GPU":       resources["GPU"].StringSetValue,
+		"taskArn":    task.Arn,
+		"CPU":        resources["CPU"].IntegerValue,
+		"MEMORY":     resources["MEMORY"].IntegerValue,
+		"PORTS_TCP":  resources["PORTS_TCP"].StringSetValue,
+		"PORTS_UDP":  resources["PORTS_UDP"].StringSetValue,
+		"GPU_MEMORY": gpuMemoryDemand,
 	})
-	return resources
+	return resources, gpuMemoryDemand
 }
 
 func (task *Task) HasActiveContainers() bool {

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -5643,9 +5643,9 @@ func TestToHostResources(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		calcResources := tc.task.ToHostResources()
+		calcResources, calcGPUMemory := tc.task.ToHostResources()
 
-		for _, resource := range []string{"CPU", "MEMORY", "GPU", "PORTS_TCP", "PORTS_UDP"} {
+		for _, resource := range []string{"CPU", "MEMORY", "PORTS_TCP", "PORTS_UDP"} {
 			assert.NotNil(t, calcResources[resource], fmt.Sprintf("Error converting resource %s - got nil", resource))
 		}
 
@@ -5655,18 +5655,14 @@ func TestToHostResources(t *testing.T) {
 		//MEMORY
 		assert.Equal(t, tc.expectedResources["MEMORY"].IntegerValue, calcResources["MEMORY"].IntegerValue, "Error converting task Memory resources")
 
-		//GPU
+		//GPU: emitted as per-UUID GPUMemoryDemand. The test containers are
+		// non-MPS, so each expected GPU UUID gets a whole-GPU demand.
 		for _, expectedGpu := range tc.expectedResources["GPU"].StringSetValue {
-			found := false
-			for _, calcGpu := range calcResources["GPU"].StringSetValue {
-				if expectedGpu == calcGpu {
-					found = true
-					break
-				}
-			}
-			assert.True(t, found, "Could not convert GPU port resources")
+			demand, ok := calcGPUMemory[expectedGpu]
+			assert.True(t, ok, "Could not find GPU memory demand for "+expectedGpu)
+			assert.True(t, demand.WholeGPU, "non-MPS container should claim the whole GPU")
 		}
-		assert.Equal(t, len(tc.expectedResources["GPU"].StringSetValue), len(calcResources["GPU"].StringSetValue), "Error converting task GPU resources")
+		assert.Equal(t, len(tc.expectedResources["GPU"].StringSetValue), len(calcGPUMemory), "Error converting task GPU resources")
 
 		//PORTS
 		for _, expectedPort := range tc.expectedResources["PORTS_TCP"].StringSetValue {
@@ -5694,6 +5690,120 @@ func TestToHostResources(t *testing.T) {
 		}
 		assert.Equal(t, len(tc.expectedResources["PORTS_UDP"].StringSetValue), len(calcResources["PORTS_UDP"].StringSetValue), "Error converting task UDP port resources")
 	}
+}
+
+// TestToHostResourcesGPUMemory covers the per-UUID GPU_MEMORY demand emitted by
+// ToHostResources: MPS caps are summed per UUID, a non-MPS container claims the
+// whole GPU, and separate UUIDs get separate entries.
+func TestToHostResourcesGPUMemory(t *testing.T) {
+	computePercent := uint(50)
+	cases := []struct {
+		name       string
+		containers []*apicontainer.Container
+		expected   map[string]GPUMemoryDemand // uuid -> demand
+	}{
+		{
+			name: "single MPS container",
+			containers: []*apicontainer.Container{
+				{Name: "a", GPUIDs: []string{"gpu1"}, MPSConfig: &apicontainer.MPSConfig{Memory: 4096}},
+			},
+			expected: map[string]GPUMemoryDemand{"gpu1": {MiB: 4096}},
+		},
+		{
+			name: "two MPS containers on the same GPU are summed",
+			containers: []*apicontainer.Container{
+				{Name: "a", GPUIDs: []string{"gpu1"}, MPSConfig: &apicontainer.MPSConfig{Memory: 4096, MaxComputePercent: &computePercent}},
+				{Name: "b", GPUIDs: []string{"gpu1"}, MPSConfig: &apicontainer.MPSConfig{Memory: 2048}},
+			},
+			expected: map[string]GPUMemoryDemand{"gpu1": {MiB: 6144}},
+		},
+		{
+			name: "whole-GPU container claims the whole GPU",
+			containers: []*apicontainer.Container{
+				{Name: "a", GPUIDs: []string{"gpu1"}},
+			},
+			expected: map[string]GPUMemoryDemand{"gpu1": {WholeGPU: true}},
+		},
+		{
+			name: "MPS containers on different GPUs get separate entries",
+			containers: []*apicontainer.Container{
+				{Name: "a", GPUIDs: []string{"gpu1"}, MPSConfig: &apicontainer.MPSConfig{Memory: 4096}},
+				{Name: "b", GPUIDs: []string{"gpu2"}, MPSConfig: &apicontainer.MPSConfig{Memory: 2048}},
+			},
+			expected: map[string]GPUMemoryDemand{"gpu1": {MiB: 4096}, "gpu2": {MiB: 2048}},
+		},
+		{
+			name: "whole-GPU and MPS on different GPUs in one task",
+			containers: []*apicontainer.Container{
+				{Name: "a", GPUIDs: []string{"gpu1"}},
+				{Name: "b", GPUIDs: []string{"gpu2"}, MPSConfig: &apicontainer.MPSConfig{Memory: 4096}},
+			},
+			expected: map[string]GPUMemoryDemand{"gpu1": {WholeGPU: true}, "gpu2": {MiB: 4096}},
+		},
+		{
+			name: "same GPU, MPS container then whole-GPU container",
+			containers: []*apicontainer.Container{
+				{Name: "a", GPUIDs: []string{"gpu1"}, MPSConfig: &apicontainer.MPSConfig{Memory: 4096}},
+				{Name: "b", GPUIDs: []string{"gpu1"}},
+			},
+			expected: map[string]GPUMemoryDemand{"gpu1": {WholeGPU: true}},
+		},
+		{
+			name: "same GPU, whole-GPU container then MPS container",
+			containers: []*apicontainer.Container{
+				{Name: "a", GPUIDs: []string{"gpu1"}},
+				{Name: "b", GPUIDs: []string{"gpu1"}, MPSConfig: &apicontainer.MPSConfig{Memory: 4096}},
+			},
+			expected: map[string]GPUMemoryDemand{"gpu1": {WholeGPU: true}},
+		},
+		{
+			name: "non-GPU task emits no GPU memory demand",
+			containers: []*apicontainer.Container{
+				{Name: "a"},
+			},
+			expected: map[string]GPUMemoryDemand{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := &Task{
+				Arn:                "test",
+				ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+				Containers:         tc.containers,
+			}
+			_, gpuMemory := task.ToHostResources()
+			assert.Equal(t, tc.expected, gpuMemory)
+		})
+	}
+}
+
+func TestToHostResourcesGPUMemorySurvivesRestart(t *testing.T) {
+	computePercent := uint(50)
+	task := &Task{
+		Arn:                "test",
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		Containers: []*apicontainer.Container{
+			{Name: "mps", GPUIDs: []string{"gpu1"}, MPSConfig: &apicontainer.MPSConfig{Memory: 4096, MaxComputePercent: &computePercent}},
+			{Name: "whole", GPUIDs: []string{"gpu2"}},
+		},
+	}
+	want := map[string]GPUMemoryDemand{"gpu1": {MiB: 4096}, "gpu2": {WholeGPU: true}}
+
+	// Round-trip the task through JSON the way agent restart persists and reloads it.
+	data, err := json.Marshal(task)
+	require.NoError(t, err)
+	var reloaded Task
+	require.NoError(t, json.Unmarshal(data, &reloaded))
+
+	// The fields the recompute depends on must survive the round trip.
+	require.Equal(t, []string{"gpu1"}, reloaded.Containers[0].GPUIDs)
+	require.NotNil(t, reloaded.Containers[0].MPSConfig, "MPSConfig must persist across restart")
+	assert.Equal(t, uint(4096), reloaded.Containers[0].MPSConfig.Memory)
+	require.Equal(t, []string{"gpu2"}, reloaded.Containers[1].GPUIDs)
+
+	// ToHostResources on the reloaded task must reproduce the same demand.
+	_, gpuMemory := reloaded.ToHostResources()
+	assert.Equal(t, want, gpuMemory, "GPU memory demand must be identical after restart")
 }
 
 func TestRemoveVolumes(t *testing.T) {

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -386,7 +386,6 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 		seelog.Critical("Unable to fetch host resources")
 		return exitcodes.ExitError
 	}
-	gpuIDs := []string{}
 	if agent.cfg.GPUSupportEnabled {
 		err := agent.initializeGPUManager()
 		if err != nil {
@@ -394,18 +393,7 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 			return exitcodes.ExitError
 		}
 		// Find GPUs (if any) on the instance
-		platformDevices := agent.getPlatformDevices()
-		for _, device := range platformDevices {
-			if device.Type == types.PlatformDeviceTypeGpu {
-				gpuIDs = append(gpuIDs, *device.Id)
-			}
-		}
-	}
-
-	hostResources["GPU"] = types.Resource{
-		Name:           utils.Strptr("GPU"),
-		Type:           utils.Strptr("STRINGSET"),
-		StringSetValue: gpuIDs,
+		seedGPUMemoryCapacity(hostResources, agent.getPlatformDevices())
 	}
 
 	// Create the task engine
@@ -566,6 +554,30 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 	// Start the acs session, which should block doStart
 	return agent.startACSSession(credentialsManager, taskEngine,
 		deregisterInstanceEventStream, client, state, taskHandler, doctor)
+}
+
+// seedGPUMemoryCapacity adds a GPU_MEMORY:<uuid> capacity entry to hostResources
+// for every GPU device. A device that reports no usable memory seeds 0, which
+// still admits whole-GPU tasks but refuses MPS sharing.
+func seedGPUMemoryCapacity(hostResources map[string]types.Resource, platformDevices []types.PlatformDevice) {
+	for _, device := range platformDevices {
+		if device.Type != types.PlatformDeviceTypeGpu {
+			continue
+		}
+		memoryMiB := int32(0)
+		if device.GpuInfo != nil && device.GpuInfo.MemoryInMiB != nil {
+			memoryMiB = *device.GpuInfo.MemoryInMiB
+		} else {
+			seelog.Warnf("GPU %s reported no usable memory; seeding capacity 0 "+
+				"(whole-GPU tasks allowed, MPS sharing refused); check ecs-init/NVML version", *device.Id)
+		}
+		key := engine.GPUMemoryCapacityPrefix + *device.Id
+		hostResources[key] = types.Resource{
+			Name:         utils.Strptr(key),
+			Type:         utils.Strptr("INTEGER"),
+			IntegerValue: memoryMiB,
+		}
+	}
 }
 
 // waitUntilInstanceInService Polls IMDS until the target lifecycle state indicates that the instance is going in

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -2000,13 +2000,6 @@ func getTestHostResources() map[string]ecstypes.Resource {
 		Type:           utils.Strptr("STRINGSET"),
 		StringSetValue: portsUDP,
 	}
-	//GPUs
-	gpuIDs := []string{"gpu1", "gpu2", "gpu3", "gpu4"}
-	hostResources["GPU"] = ecstypes.Resource{
-		Name:           utils.Strptr("GPU"),
-		Type:           utils.Strptr("STRINGSET"),
-		StringSetValue: gpuIDs,
-	}
 	return hostResources
 }
 
@@ -2165,4 +2158,35 @@ func TestGetIMDSCredentialsRefresher(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSeedGPUMemoryCapacity covers the mainline seeding path: a GPU that reports
+// usable memory seeds a capacity entry equal to that memory, a GPU with no
+// reported memory seeds 0, and a non-GPU device is skipped.
+func TestSeedGPUMemoryCapacity(t *testing.T) {
+	mem := int32(23040)
+	devices := []ecstypes.PlatformDevice{
+		{
+			Id:      aws.String("gpu-reported"),
+			Type:    ecstypes.PlatformDeviceTypeGpu,
+			GpuInfo: &ecstypes.GpuPlatformDeviceInfo{MemoryInMiB: &mem},
+		},
+		{
+			Id:   aws.String("gpu-unreported"),
+			Type: ecstypes.PlatformDeviceTypeGpu,
+		},
+	}
+
+	hostResources := map[string]ecstypes.Resource{}
+	seedGPUMemoryCapacity(hostResources, devices)
+
+	reported := hostResources[engine.GPUMemoryCapacityPrefix+"gpu-reported"]
+	assert.Equal(t, "INTEGER", *reported.Type)
+	assert.Equal(t, int32(23040), reported.IntegerValue)
+
+	unreported := hostResources[engine.GPUMemoryCapacityPrefix+"gpu-unreported"]
+	assert.Equal(t, "INTEGER", *unreported.Type)
+	assert.Equal(t, int32(0), unreported.IntegerValue)
+
+	assert.Len(t, hostResources, 2)
 }

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -654,7 +654,11 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 	}
 
 	imageManager.EXPECT().AddImageToCleanUpExclusionList(gomock.Eq("service_connect_agent:v1")).Times(1)
-	client.EXPECT().GetHostResources().Return(testHostResource, nil).Times(1)
+	gpuHostResource := map[string]types.Resource{}
+	for k, v := range testHostResource {
+		gpuHostResource[k] = v
+	}
+	client.EXPECT().GetHostResources().Return(gpuHostResource, nil).Times(1)
 	mockGPUManager.EXPECT().GetDevices().Return(devices).AnyTimes()
 	// The gpu-sharing-mps capability check reads these MPS facts during registration.
 	// GetGPUIDsUnsafe and GetGPUMemoryMiBUnsafe feed the AllGPUsHaveMemory gate
@@ -732,6 +736,13 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 	discoverEndpointsInvoked.Wait()
 	cancel()
 	agentW.Wait()
+
+	// GPUs with no reported memory still get a GPU_MEMORY capacity entry set to 0.
+	for _, device := range devices {
+		res, ok := gpuHostResource[engine.GPUMemoryCapacityPrefix+*device.Id]
+		assert.True(t, ok, "expected GPU_MEMORY entry for %s", *device.Id)
+		assert.Equal(t, int32(0), res.IntegerValue, "unknown-memory GPU should seed capacity 0")
+	}
 }
 
 func TestDoStartGPUManagerInitError(t *testing.T) {

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -302,13 +302,13 @@ func (engine *DockerTaskEngine) reconcileHostResources() {
 	logger.Info("Reconciling host resources")
 	for _, task := range engine.state.AllTasks() {
 		taskStatus := task.GetKnownStatus()
-		resources := task.ToHostResources()
+		resources, gpuMemory := task.ToHostResources()
 
 		// Release stopped tasks host resources
 		// Call to release here for stopped tasks should always succeed
 		// Idempotent release call
 		if taskStatus.Terminal() {
-			err := engine.hostResourceManager.release(task.Arn, resources)
+			err := engine.hostResourceManager.release(task.Arn, resources, gpuMemory)
 			if err != nil {
 				logger.Critical("Failed to release resources during reconciliation", logger.Fields{field.TaskARN: task.Arn})
 			}
@@ -319,9 +319,19 @@ func (engine *DockerTaskEngine) reconcileHostResources() {
 		// Call to consume here should always succeed
 		// Idempotent consume call
 		if !task.IsInternal && task.HasActiveContainers() {
-			consumed, err := engine.hostResourceManager.consume(task.Arn, resources)
+			consumed, err := engine.hostResourceManager.consume(task.Arn, resources, gpuMemory)
 			if err != nil || !consumed {
-				logger.Critical("Failed to consume resources for created/running tasks during reconciliation", logger.Fields{field.TaskARN: task.Arn})
+				fields := logger.Fields{field.TaskARN: task.Arn}
+				msg := "Failed to consume resources for created/running tasks during reconciliation"
+				if len(gpuMemory) > 0 {
+					// A running GPU task failing to re-consume usually means its
+					// GPU memory was not rediscovered at the same capacity after
+					// restart. The pool then under-counts usage and can over-admit
+					// new tasks onto a full GPU.
+					fields["GPU_MEMORY"] = gpuMemory
+					msg = "Failed to re-consume GPU memory for a running task during reconciliation, pool may under-count usage and over-admit new tasks"
+				}
+				logger.Critical(msg, fields)
 			}
 		}
 	}
@@ -471,8 +481,8 @@ func (engine *DockerTaskEngine) tryDequeueWaitingTasks(task *managedTask) bool {
 		engine.returnWaitingTask()
 		return true
 	}
-	taskHostResources := task.ToHostResources()
-	consumed, err := task.engine.hostResourceManager.consume(task.Arn, taskHostResources)
+	taskHostResources, taskGPUMemory := task.ToHostResources()
+	consumed, err := task.engine.hostResourceManager.consume(task.Arn, taskHostResources, taskGPUMemory)
 	if err != nil {
 		engine.failWaitingTask(err)
 		return true
@@ -1006,8 +1016,8 @@ func (engine *DockerTaskEngine) EmitTaskEvent(task *apitask.Task, reason string)
 	if task.GetKnownStatus().Terminal() {
 		// Always do (idempotent) release host resources whenever state change with
 		// known status == STOPPED is done to ensure sync between tasks and host resource manager
-		resourcesToRelease := task.ToHostResources()
-		err := engine.hostResourceManager.release(task.Arn, resourcesToRelease)
+		resourcesToRelease, gpuMemoryToRelease := task.ToHostResources()
+		err := engine.hostResourceManager.release(task.Arn, resourcesToRelease, gpuMemoryToRelease)
 		if err != nil {
 			logger.Critical("Failed to release resources after test stopped", logger.Fields{field.TaskARN: task.Arn})
 		}

--- a/agent/engine/host_resource_manager.go
+++ b/agent/engine/host_resource_manager.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sync"
 
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
@@ -27,7 +28,6 @@ import (
 
 const (
 	CPU      = "CPU"
-	GPU      = "GPU"
 	MEMORY   = "MEMORY"
 	PORTSTCP = "PORTS_TCP"
 	PORTSUDP = "PORTS_UDP"
@@ -41,6 +41,11 @@ type HostResourceManager struct {
 
 	//task.arn to boolean whether host resources consumed or not
 	taskConsumed map[string]bool
+
+	// gpuMemoryTotalMiB is the per-UUID GPU memory capacity, fixed at init
+	gpuMemoryTotalMiB map[string]int64
+	// gpuMemoryConsumed is the per-UUID GPU memory consumed by running tasks
+	gpuMemoryConsumed map[string]apitask.GPUMemoryDemand
 }
 
 type InvalidHostResource struct {
@@ -58,8 +63,8 @@ func (h *HostResourceManager) logResources(msg string, taskArn string) {
 		"MEMORY":    h.consumedResource[MEMORY].IntegerValue,
 		"PORTS_TCP": h.consumedResource[PORTSTCP].StringSetValue,
 		"PORTS_UDP": h.consumedResource[PORTSUDP].StringSetValue,
-		"GPU":       h.consumedResource[GPU].StringSetValue,
 	})
+	h.logGPUMemoryPool(msg, taskArn)
 }
 
 func (h *HostResourceManager) consumeIntType(resourceType string, resources map[string]types.Resource) {
@@ -88,7 +93,7 @@ func (h *HostResourceManager) checkTaskConsumed(taskArn string) bool {
 // false, nil -> did not consume, task should stay pending
 // false, err -> resources map has errors, task should fail as cannot schedule with 'wrong' resource map (this basically never happens)
 // true, nil -> successfully consumed, task should progress with task creation
-func (h *HostResourceManager) consume(taskArn string, resources map[string]types.Resource) (bool, error) {
+func (h *HostResourceManager) consume(taskArn string, resources map[string]types.Resource, gpuMemory map[string]apitask.GPUMemoryDemand) (bool, error) {
 	h.hostResourceManagerRWLock.Lock()
 	defer h.hostResourceManagerRWLock.Unlock()
 	defer h.logResources("Consumed resources after task consume call", taskArn)
@@ -101,7 +106,7 @@ func (h *HostResourceManager) consume(taskArn string, resources map[string]types
 		return true, nil
 	}
 
-	ok, failedResourceKeys, err := h.consumable(resources)
+	ok, failedResourceKeys, err := h.consumable(resources, gpuMemory)
 	if err != nil {
 		logger.Error("Resources failing to consume, error in task resources", logger.Fields{
 			"taskArn":   taskArn,
@@ -115,9 +120,12 @@ func (h *HostResourceManager) consume(taskArn string, resources map[string]types
 				// CPU, MEMORY
 				h.consumeIntType(resourceKey, resources)
 			} else if *resources[resourceKey].Type == "STRINGSET" {
-				// PORTS_TCP, PORTS_UDP, GPU
+				// PORTS_TCP, PORTS_UDP
 				h.consumeStringSetType(resourceKey, resources)
 			}
+		}
+		for uuid, demand := range gpuMemory {
+			h.consumeGPUMemory(uuid, demand)
 		}
 
 		// Set consumed status
@@ -160,7 +168,7 @@ func (h *HostResourceManager) checkConsumableStringSetType(resourceName string, 
 }
 
 // Checks all resources exists and their values are not nil
-func (h *HostResourceManager) checkResourcesHealth(resources map[string]types.Resource) error {
+func (h *HostResourceManager) checkResourcesHealth(resources map[string]types.Resource, gpuMemory map[string]apitask.GPUMemoryDemand) error {
 	for resourceKey, resourceVal := range resources {
 		_, ok := h.initialHostResource[resourceKey]
 		if !ok {
@@ -169,25 +177,18 @@ func (h *HostResourceManager) checkResourcesHealth(resources map[string]types.Re
 		}
 
 		// CPU, MEMORY are INTEGER;
-		// PORTS_TCP, PORTS_UDP, GPU are STRINGSET
+		// PORTS_TCP, PORTS_UDP are STRINGSET
 		// Check if either of these data types exist
 		if resourceVal.Type == nil || !(*resourceVal.Type == "INTEGER" || *resourceVal.Type == "STRINGSET") {
 			logger.Error(fmt.Sprintf("type not assigned for resource %s", resourceKey))
 			return fmt.Errorf("invalid resource type for %s", resourceKey)
 		}
+	}
 
-		// Verify resource comes from an existing pool of values - for valid gpu ids
-		if *resourceVal.Type == "STRINGSET" && resourceKey == GPU {
-			hostGpuMap := make(map[string]struct{}, len(h.initialHostResource[GPU].StringSetValue))
-			for _, v := range h.initialHostResource[GPU].StringSetValue {
-				hostGpuMap[v] = struct{}{}
-			}
-			for _, obj1 := range resourceVal.StringSetValue {
-				_, ok := hostGpuMap[obj1]
-				if !ok {
-					return fmt.Errorf("task gpu %s not found in host gpus", obj1)
-				}
-			}
+	// Each GPU-memory demand must target a GPU UUID present in the pool.
+	for uuid := range gpuMemory {
+		if _, ok := h.gpuMemoryTotalMiB[uuid]; !ok {
+			return fmt.Errorf("task gpu %s not found in host gpus", uuid)
 		}
 	}
 	return nil
@@ -197,8 +198,8 @@ func (h *HostResourceManager) checkResourcesHealth(resources map[string]types.Re
 // we have for the host resources. Should not call host resource manager lock in this func return values
 // This function returns a bool (indicating whether ALL requested resources are consumable), a list of non-consumable
 // resource keys, and error, if any.
-func (h *HostResourceManager) consumable(resources map[string]types.Resource) (bool, []string, error) {
-	err := h.checkResourcesHealth(resources)
+func (h *HostResourceManager) consumable(resources map[string]types.Resource, gpuMemory map[string]apitask.GPUMemoryDemand) (bool, []string, error) {
+	err := h.checkResourcesHealth(resources, gpuMemory)
 	if err != nil {
 		return false, nil, err
 	}
@@ -217,6 +218,12 @@ func (h *HostResourceManager) consumable(resources map[string]types.Resource) (b
 			if !consumable {
 				resourcesNotConsumable = append(resourcesNotConsumable, resourceKey)
 			}
+		}
+	}
+
+	for uuid, demand := range gpuMemory {
+		if !h.checkConsumableGPUMemory(uuid, demand) {
+			resourcesNotConsumable = append(resourcesNotConsumable, gpuMemoryResourceKey(uuid))
 		}
 	}
 
@@ -268,13 +275,13 @@ func (h *HostResourceManager) releaseStringSetType(resourceType string, resource
 // Task resource map should never have errors as it is made by task ToHostResources method
 // In cases releases fails due to errors, those resources will be failed to be released
 // by HostResourceManager
-func (h *HostResourceManager) release(taskArn string, resources map[string]types.Resource) error {
+func (h *HostResourceManager) release(taskArn string, resources map[string]types.Resource, gpuMemory map[string]apitask.GPUMemoryDemand) error {
 	h.hostResourceManagerRWLock.Lock()
 	defer h.hostResourceManagerRWLock.Unlock()
 	defer h.logResources("Consumed resources after task release call", taskArn)
 
 	if h.taskConsumed[taskArn] {
-		err := h.checkResourcesHealth(resources)
+		err := h.checkResourcesHealth(resources, gpuMemory)
 		if err != nil {
 			return err
 		}
@@ -286,6 +293,9 @@ func (h *HostResourceManager) release(taskArn string, resources map[string]types
 			if *resources[resourceKey].Type == "STRINGSET" {
 				h.releaseStringSetType(resourceKey, resources)
 			}
+		}
+		for uuid, demand := range gpuMemory {
+			h.releaseGPUMemory(uuid, demand)
 		}
 
 		// Set consumed status
@@ -342,19 +352,24 @@ func NewHostResourceManager(resourceMap map[string]types.Resource) HostResourceM
 		StringSetValue: portsUdp,
 	}
 
-	// GPUs
-	gpuIDs := []string{}
-	consumedResourceMap[GPU] = types.Resource{
-		Name:           utils.Strptr(GPU),
-		Type:           utils.Strptr("STRINGSET"),
-		StringSetValue: gpuIDs,
+	// Build the per-UUID GPU memory capacity map from the GPU_MEMORY:<uuid>
+	// capacity entries (INTEGER MiB) in the host resource map; consumed starts empty.
+	gpuMemoryTotalMiB := make(map[string]int64)
+	for key, res := range resourceMap {
+		if uuid, ok := gpuUUIDFromCapacityKey(key); ok && res.Type != nil && *res.Type == "INTEGER" {
+			gpuMemoryTotalMiB[uuid] = int64(res.IntegerValue)
+		}
 	}
+	gpuMemoryConsumed := make(map[string]apitask.GPUMemoryDemand)
 
 	logger.Info("Initializing host resource manager, initialHostResource", logger.Fields{"initialHostResource": resourceMap})
 	logger.Info("Initializing host resource manager, consumed resource", logger.Fields{"consumedResource": consumedResourceMap})
+	logger.Info("Initializing host resource manager, GPU memory pool", logger.Fields{"gpuMemoryTotalMiB": gpuMemoryTotalMiB})
 	return HostResourceManager{
 		initialHostResource: resourceMap,
 		consumedResource:    consumedResourceMap,
 		taskConsumed:        taskConsumed,
+		gpuMemoryTotalMiB:   gpuMemoryTotalMiB,
+		gpuMemoryConsumed:   gpuMemoryConsumed,
 	}
 }

--- a/agent/engine/host_resource_manager_gpu.go
+++ b/agent/engine/host_resource_manager_gpu.go
@@ -1,0 +1,156 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"fmt"
+	"strings"
+
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+)
+
+// Per-UUID GPU memory accounting, modeled like the CPU/MEMORY resources: a
+// capacity map (gpuMemoryTotalMiB) fixed at init, and a consumed map
+// (gpuMemoryConsumed) that consume/release move up and down. Each physical GPU
+// has an entry so multiple MPS tasks can share it up to its memory, while a
+// whole-GPU task takes it exclusively. Every GPU stays in the capacity map for
+// the life of the agent; consume and reclaim only change its consumed record.
+
+// GPUMemoryCapacityPrefix keys a per-GPU total-memory capacity entry in the host
+// resource map: "GPU_MEMORY:<uuid>", an INTEGER of usable MiB.
+const GPUMemoryCapacityPrefix = "GPU_MEMORY:"
+
+// gpuMemoryResourceKey is a display label for a per-UUID GPU memory demand, used
+// in the "resources not consumable" log so a blocked GPU task is identifiable.
+func gpuMemoryResourceKey(uuid string) string {
+	return GPUMemoryCapacityPrefix + uuid
+}
+
+// gpuUUIDFromCapacityKey returns the UUID from a GPU_MEMORY:<uuid> capacity key.
+func gpuUUIDFromCapacityKey(key string) (string, bool) {
+	if !strings.HasPrefix(key, GPUMemoryCapacityPrefix) {
+		return "", false
+	}
+	return strings.TrimPrefix(key, GPUMemoryCapacityPrefix), true
+}
+
+// gpuMode derives a GPU's FREE/MPS/WHOLE_GPU state from its consumed record,
+// for logging only. WHOLE_GPU is exclusive (WholeGPU true), MPS has a positive
+// share reserved, and everything else is FREE.
+func gpuMode(consumed apitask.GPUMemoryDemand) string {
+	if consumed.WholeGPU {
+		return "WHOLE_GPU"
+	}
+	if consumed.MiB > 0 {
+		return "MPS"
+	}
+	return "FREE"
+}
+
+// checkConsumableGPUMemory reports whether a demand fits. A whole-GPU request
+// needs a GPU with nothing consumed on it (no MPS share, not already exclusive).
+// An MPS share needs a GPU that is not exclusively held and still has room.
+// Keying the whole-GPU path off the consumed record is what prevents an MPS and
+// a whole-GPU task sharing a GPU.
+func (h *HostResourceManager) checkConsumableGPUMemory(uuid string, demand apitask.GPUMemoryDemand) bool {
+	total, ok := h.gpuMemoryTotalMiB[uuid]
+	if !ok {
+		return false
+	}
+	consumed := h.gpuMemoryConsumed[uuid]
+	if demand.WholeGPU {
+		// Exclusive: needs a fully free GPU (no MPS share, not already exclusive).
+		return consumed.MiB == 0 && !consumed.WholeGPU
+	}
+	if consumed.WholeGPU {
+		// Can't share an exclusively-held GPU.
+		return false
+	}
+	// A GPU whose memory was not reported has total 0. The whole-GPU branch
+	// above still admits it (it checks the consumed record, not total); an MPS
+	// share is refused here because 0 can never satisfy a positive demand.
+	return total-consumed.MiB >= demand.MiB
+}
+
+// consumeGPUMemory applies a task's GPU memory demand to the pool: a whole-GPU
+// demand marks the device exclusive, an MPS demand adds to the reserved share.
+func (h *HostResourceManager) consumeGPUMemory(uuid string, demand apitask.GPUMemoryDemand) {
+	if _, ok := h.gpuMemoryTotalMiB[uuid]; !ok {
+		// checkResourcesHealth rejects an unknown UUID before consume runs.
+		logger.Warn("GPU memory consume for unknown GPU UUID", logger.Fields{"gpuUUID": uuid})
+		return
+	}
+	consumed := h.gpuMemoryConsumed[uuid]
+	if demand.WholeGPU {
+		consumed.WholeGPU = true
+	} else {
+		consumed.MiB += demand.MiB
+	}
+	h.gpuMemoryConsumed[uuid] = consumed
+}
+
+// releaseGPUMemory reverses a demand with the identical value it was consumed
+// with, so consume and reclaim stay balanced. A GPU is derived FREE again once
+// its consumed record is back at the zero value.
+func (h *HostResourceManager) releaseGPUMemory(uuid string, demand apitask.GPUMemoryDemand) {
+	if _, ok := h.gpuMemoryTotalMiB[uuid]; !ok {
+		logger.Warn("GPU memory release for unknown GPU UUID", logger.Fields{"gpuUUID": uuid})
+		return
+	}
+	consumed := h.gpuMemoryConsumed[uuid]
+	if demand.WholeGPU {
+		consumed.WholeGPU = false
+	} else {
+		consumed.MiB -= demand.MiB
+		if consumed.MiB < 0 {
+			// consumed should never go negative since consume and release are symmetric
+			logger.Error("GPU memory over-released; clamping to 0", logger.Fields{
+				"gpuUUID":  uuid,
+				"consumed": consumed.MiB,
+			})
+			consumed.MiB = 0
+		}
+	}
+	h.gpuMemoryConsumed[uuid] = consumed
+}
+
+func (h *HostResourceManager) logGPUMemoryPool(msg string, taskArn string) {
+	if len(h.gpuMemoryTotalMiB) == 0 {
+		return
+	}
+	var b strings.Builder
+	for uuid, total := range h.gpuMemoryTotalMiB {
+		b.WriteString(formatGPUMemoryEntry(uuid, total, h.gpuMemoryConsumed[uuid]))
+	}
+	logger.Debug("GPU memory pool: "+msg, logger.Fields{
+		"taskArn": taskArn,
+		"pool":    b.String(),
+	})
+}
+
+// formatGPUMemoryEntry renders one GPU's pool snapshot token. A whole-GPU
+// consume leaves MiB at 0, so remaining is shown as 0 rather than total. A GPU
+// with total 0 had no reported memory and shows total=unknown so the snapshot
+// is not mistaken for a discovery failure.
+func formatGPUMemoryEntry(uuid string, total int64, consumed apitask.GPUMemoryDemand) string {
+	remaining := total - consumed.MiB
+	if consumed.WholeGPU {
+		remaining = 0
+	}
+	if total == 0 {
+		return fmt.Sprintf("%s{total=unknown remaining=%d mode=%s} ", uuid, remaining, gpuMode(consumed))
+	}
+	return fmt.Sprintf("%s{total=%d remaining=%d mode=%s} ", uuid, total, remaining, gpuMode(consumed))
+}

--- a/agent/engine/host_resource_manager_gpu_test.go
+++ b/agent/engine/host_resource_manager_gpu_test.go
@@ -1,0 +1,458 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"testing"
+
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// hrmWithPool builds a HostResourceManager whose GPU pool has one GPU (uuid-A)
+// with the given total capacity, an empty consumed map, everything else empty.
+func hrmWithPool(total int64) *HostResourceManager {
+	return &HostResourceManager{
+		gpuMemoryTotalMiB: map[string]int64{"uuid-A": total},
+		gpuMemoryConsumed: map[string]apitask.GPUMemoryDemand{},
+	}
+}
+
+// hrmWithPoolMulti builds a HostResourceManager whose GPU pool has the given
+// UUID->total-MiB capacity entries, for tests that need more than one GPU.
+func hrmWithPoolMulti(totals map[string]int64) *HostResourceManager {
+	return &HostResourceManager{
+		gpuMemoryTotalMiB: totals,
+		gpuMemoryConsumed: map[string]apitask.GPUMemoryDemand{},
+	}
+}
+
+// mpsDemand / wholeGPUDemand build the two demand shapes for pool tests.
+func mpsDemand(mib int64) apitask.GPUMemoryDemand { return apitask.GPUMemoryDemand{MiB: mib} }
+func wholeGPUDemand() apitask.GPUMemoryDemand     { return apitask.GPUMemoryDemand{WholeGPU: true} }
+
+// gpuRemaining derives the memory remaining on a GPU the way logGPUMemoryPool
+// displays it: total minus the consumed MPS share, or 0 when held whole-GPU.
+func gpuRemaining(h *HostResourceManager, uuid string) int64 {
+	consumed := h.gpuMemoryConsumed[uuid]
+	if consumed.WholeGPU {
+		return 0
+	}
+	return h.gpuMemoryTotalMiB[uuid] - consumed.MiB
+}
+
+// gpuModeOf derives a GPU's FREE/MPS/WHOLE_GPU state from its consumed record.
+func gpuModeOf(h *HostResourceManager, uuid string) string {
+	return gpuMode(h.gpuMemoryConsumed[uuid])
+}
+
+// gpuMemoryCapacity builds a GPU_MEMORY:<uuid> capacity resource (INTEGER MiB).
+func gpuMemoryCapacity(uuid string, mib int32) types.Resource {
+	key := GPUMemoryCapacityPrefix + uuid
+	return types.Resource{
+		Name:         utils.Strptr(key),
+		Type:         utils.Strptr("INTEGER"),
+		IntegerValue: mib,
+	}
+}
+
+// TestNewGPUMemoryCapacityMap verifies NewHostResourceManager seeds the per-UUID
+// capacity map from GPU_MEMORY:<uuid> entries and starts every GPU derived FREE
+// with an empty consumed map.
+func TestNewGPUMemoryCapacityMap(t *testing.T) {
+	resourceMap := map[string]types.Resource{
+		"CPU":    {Name: utils.Strptr("CPU"), Type: utils.Strptr("INTEGER"), IntegerValue: 2048},
+		"MEMORY": {Name: utils.Strptr("MEMORY"), Type: utils.Strptr("INTEGER"), IntegerValue: 2048},
+	}
+	resourceMap[GPUMemoryCapacityPrefix+"a"] = gpuMemoryCapacity("a", 23040)
+	resourceMap[GPUMemoryCapacityPrefix+"b"] = gpuMemoryCapacity("b", 16384)
+	hrm := NewHostResourceManager(resourceMap)
+	h := &hrm
+
+	assert.Len(t, h.gpuMemoryTotalMiB, 2)
+	assert.Equal(t, int64(23040), h.gpuMemoryTotalMiB["a"])
+	assert.Equal(t, int64(16384), h.gpuMemoryTotalMiB["b"])
+	// Consumed map starts empty; both GPUs derive FREE with full remaining.
+	assert.Empty(t, h.gpuMemoryConsumed)
+	assert.Equal(t, "FREE", gpuModeOf(h, "a"))
+	assert.Equal(t, "FREE", gpuModeOf(h, "b"))
+	assert.Equal(t, int64(23040), gpuRemaining(h, "a"))
+	assert.Equal(t, int64(16384), gpuRemaining(h, "b"))
+}
+
+func TestGPUMemoryMPSShareLifecycle(t *testing.T) {
+	h := hrmWithPool(23040)
+
+	// First MPS task: 4096 fits a FREE device.
+	assert.True(t, h.checkConsumableGPUMemory("uuid-A", mpsDemand(4096)))
+	h.consumeGPUMemory("uuid-A", mpsDemand(4096))
+	assert.Equal(t, int64(18944), gpuRemaining(h, "uuid-A"))
+	assert.Equal(t, "MPS", gpuModeOf(h, "uuid-A"))
+
+	// Second MPS task shares the same device.
+	assert.True(t, h.checkConsumableGPUMemory("uuid-A", mpsDemand(4096)))
+	h.consumeGPUMemory("uuid-A", mpsDemand(4096))
+	assert.Equal(t, int64(14848), gpuRemaining(h, "uuid-A"))
+
+	// Release both; GPU returns to FREE only when remaining is back to total.
+	h.releaseGPUMemory("uuid-A", mpsDemand(4096))
+	assert.Equal(t, "MPS", gpuModeOf(h, "uuid-A"), "still one MPS task left")
+	h.releaseGPUMemory("uuid-A", mpsDemand(4096))
+	assert.Equal(t, int64(23040), gpuRemaining(h, "uuid-A"))
+	assert.Equal(t, "FREE", gpuModeOf(h, "uuid-A"), "last MPS task left -> FREE")
+}
+
+// TestGPUMemoryMPSAsymmetricOutOfOrderRelease uses unequal shares released in
+// the opposite order they were consumed, so a bug that assumed equal shares or
+// LIFO release would surface. The GPU stays MPS until the last share is back.
+// (Edge case 4.)
+func TestGPUMemoryMPSAsymmetricOutOfOrderRelease(t *testing.T) {
+	h := hrmWithPool(10000)
+
+	h.consumeGPUMemory("uuid-A", mpsDemand(3000)) // remaining 7000
+	h.consumeGPUMemory("uuid-A", mpsDemand(5000)) // remaining 2000
+	assert.Equal(t, int64(2000), gpuRemaining(h, "uuid-A"))
+	assert.Equal(t, "MPS", gpuModeOf(h, "uuid-A"))
+
+	// Release the FIRST (smaller) share first: remaining 2000 -> 5000, still MPS.
+	h.releaseGPUMemory("uuid-A", mpsDemand(3000))
+	assert.Equal(t, int64(5000), gpuRemaining(h, "uuid-A"))
+	assert.Equal(t, "MPS", gpuModeOf(h, "uuid-A"), "one MPS share still held")
+
+	// Release the larger share: remaining back to total -> FREE.
+	h.releaseGPUMemory("uuid-A", mpsDemand(5000))
+	assert.Equal(t, int64(10000), gpuRemaining(h, "uuid-A"))
+	assert.Equal(t, "FREE", gpuModeOf(h, "uuid-A"), "last MPS share released -> FREE")
+}
+
+func TestGPUMemoryMPSOverCapacityRejected(t *testing.T) {
+	h := hrmWithPool(8192)
+	h.consumeGPUMemory("uuid-A", mpsDemand(6144))
+	// Only 2048 remains; a 4096 demand must not fit.
+	assert.False(t, h.checkConsumableGPUMemory("uuid-A", mpsDemand(4096)))
+	// But a 2048 demand fits exactly.
+	assert.True(t, h.checkConsumableGPUMemory("uuid-A", mpsDemand(2048)))
+}
+
+func TestGPUMemoryWholeGPULifecycle(t *testing.T) {
+	h := hrmWithPool(23040)
+
+	// Whole-GPU fits a FREE device and drives it to WHOLE_GPU / remaining 0.
+	assert.True(t, h.checkConsumableGPUMemory("uuid-A", wholeGPUDemand()))
+	h.consumeGPUMemory("uuid-A", wholeGPUDemand())
+	assert.Equal(t, int64(0), gpuRemaining(h, "uuid-A"))
+	assert.Equal(t, "WHOLE_GPU", gpuModeOf(h, "uuid-A"))
+	// The consumed record must stay {MiB:0, WholeGPU:true} - never a positive MiB.
+	assert.Equal(t, int64(0), h.gpuMemoryConsumed["uuid-A"].MiB)
+
+	// Release restores it to FREE / total.
+	h.releaseGPUMemory("uuid-A", wholeGPUDemand())
+	assert.Equal(t, int64(23040), gpuRemaining(h, "uuid-A"))
+	assert.Equal(t, "FREE", gpuModeOf(h, "uuid-A"))
+}
+
+func TestGPUMemoryModeMixingRejected(t *testing.T) {
+	h := hrmWithPool(23040)
+
+	// MPS task on the device -> MPS mode.
+	h.consumeGPUMemory("uuid-A", mpsDemand(4096))
+	// A whole-GPU demand must NOT fit an MPS device (mode-mixing).
+	assert.False(t, h.checkConsumableGPUMemory("uuid-A", wholeGPUDemand()))
+
+	// Conversely, a whole-GPU device rejects an MPS demand.
+	h2 := hrmWithPool(23040)
+	h2.consumeGPUMemory("uuid-A", wholeGPUDemand())
+	assert.False(t, h2.checkConsumableGPUMemory("uuid-A", mpsDemand(4096)))
+}
+
+func TestGPUMemoryUnknownUUIDNotConsumable(t *testing.T) {
+	h := hrmWithPool(23040)
+	assert.False(t, h.checkConsumableGPUMemory("uuid-does-not-exist", mpsDemand(4096)))
+	assert.False(t, h.checkConsumableGPUMemory("uuid-does-not-exist", wholeGPUDemand()))
+}
+
+func TestGPUMemoryReleaseClampsAgainstDrift(t *testing.T) {
+	h := hrmWithPool(8192)
+	h.consumeGPUMemory("uuid-A", mpsDemand(4096))
+	// Over-release (more than consumed) must not push consumed negative /
+	// remaining above total.
+	h.releaseGPUMemory("uuid-A", mpsDemand(8192))
+	assert.Equal(t, int64(8192), gpuRemaining(h, "uuid-A"))
+	assert.Equal(t, int64(0), h.gpuMemoryConsumed["uuid-A"].MiB, "consumed clamped to 0, never negative")
+	assert.Equal(t, "FREE", gpuModeOf(h, "uuid-A"))
+}
+
+// TestGPUMemoryUnknownMemory covers a GPU seeded with total 0, which is how a
+// GPU whose memory was not reported enters the pool. Whole-GPU tasks must still
+// run against it and stay exclusive; a second whole-GPU must be refused; MPS
+// shares must be refused; and release returns it to derived FREE. (Edge case 2.)
+func TestGPUMemoryUnknownMemory(t *testing.T) {
+	h := hrmWithPool(0)
+
+	// Whole-GPU fits an unknown-memory GPU and takes it exclusively.
+	assert.True(t, h.checkConsumableGPUMemory("uuid-A", wholeGPUDemand()))
+	h.consumeGPUMemory("uuid-A", wholeGPUDemand())
+	assert.Equal(t, "WHOLE_GPU", gpuModeOf(h, "uuid-A"))
+	assert.Equal(t, int64(0), gpuRemaining(h, "uuid-A"))
+
+	// A second whole-GPU request is refused: exclusivity holds (no double-book).
+	assert.False(t, h.checkConsumableGPUMemory("uuid-A", wholeGPUDemand()))
+
+	// Any MPS share can never fit an unknown-memory GPU.
+	assert.False(t, h.checkConsumableGPUMemory("uuid-A", mpsDemand(1)))
+	assert.False(t, h.checkConsumableGPUMemory("uuid-A", mpsDemand(4096)))
+
+	// Release returns it to derived FREE with remaining back at total (0).
+	h.releaseGPUMemory("uuid-A", wholeGPUDemand())
+	assert.Equal(t, "FREE", gpuModeOf(h, "uuid-A"))
+	assert.Equal(t, int64(0), gpuRemaining(h, "uuid-A"))
+}
+
+// TestGPUMemoryUnknownMemoryReconsumeStaysZero mirrors restart reconcile: a
+// whole-GPU task on an unknown-memory GPU is re-consumed, and remaining must
+// never go negative (the whole-GPU path never subtracts).
+func TestGPUMemoryUnknownMemoryReconsumeStaysZero(t *testing.T) {
+	h := hrmWithPool(0)
+	h.consumeGPUMemory("uuid-A", wholeGPUDemand())
+	h.consumeGPUMemory("uuid-A", wholeGPUDemand())
+	assert.Equal(t, int64(0), gpuRemaining(h, "uuid-A"))
+	assert.Equal(t, int64(0), h.gpuMemoryConsumed["uuid-A"].MiB)
+	assert.Equal(t, "WHOLE_GPU", gpuModeOf(h, "uuid-A"))
+}
+
+// TestGPUMemoryPerUUIDIndependence verifies that consuming one GPU leaves the
+// others untouched, including a mix of a known-memory GPU and an unknown-memory
+// (total 0) GPU on the same instance.
+func TestGPUMemoryPerUUIDIndependence(t *testing.T) {
+	h := hrmWithPoolMulti(map[string]int64{"uuid-A": 22563, "uuid-B": 0})
+
+	assert.True(t, h.checkConsumableGPUMemory("uuid-A", mpsDemand(4096)))
+	h.consumeGPUMemory("uuid-A", mpsDemand(4096))
+	assert.Equal(t, int64(18467), gpuRemaining(h, "uuid-A"))
+	assert.Equal(t, "MPS", gpuModeOf(h, "uuid-A"))
+	assert.Equal(t, int64(0), gpuRemaining(h, "uuid-B"))
+	assert.Equal(t, "FREE", gpuModeOf(h, "uuid-B"), "unknown-memory GPU untouched")
+
+	// Whole-GPU on the unknown-memory GPU is admitted and leaves A as it was.
+	assert.True(t, h.checkConsumableGPUMemory("uuid-B", wholeGPUDemand()))
+	h.consumeGPUMemory("uuid-B", wholeGPUDemand())
+	assert.Equal(t, "WHOLE_GPU", gpuModeOf(h, "uuid-B"))
+	assert.Equal(t, "MPS", gpuModeOf(h, "uuid-A"), "GPU-A unaffected by GPU-B consume")
+	assert.Equal(t, int64(18467), gpuRemaining(h, "uuid-A"))
+
+	// MPS is still refused on the unknown-memory GPU.
+	assert.False(t, h.checkConsumableGPUMemory("uuid-B", mpsDemand(4096)))
+}
+
+// TestGPUModeDerivation covers the gpuMode helper that derives the display state
+// from a consumed record (replaces the old gpuMode enum String()).
+func TestGPUModeDerivation(t *testing.T) {
+	assert.Equal(t, "FREE", gpuMode(apitask.GPUMemoryDemand{}))
+	assert.Equal(t, "MPS", gpuMode(apitask.GPUMemoryDemand{MiB: 4096}))
+	assert.Equal(t, "WHOLE_GPU", gpuMode(apitask.GPUMemoryDemand{WholeGPU: true}))
+}
+
+// ---- Edge cases the consumed-model can express that the enum could not ----
+
+// TestGPUMemoryNeverProducesIllegalCombo (edge case 1) verifies the consumed
+// record is never driven to the illegal {MiB>0, WholeGPU:true} state through the
+// normal consume/consumable paths, in both orders.
+func TestGPUMemoryNeverProducesIllegalCombo(t *testing.T) {
+	// MPS first, then a whole-GPU attempt is refused, so WholeGPU never flips.
+	h := hrmWithPool(23040)
+	h.consumeGPUMemory("uuid-A", mpsDemand(4096))
+	assert.False(t, h.checkConsumableGPUMemory("uuid-A", wholeGPUDemand()),
+		"whole-GPU must be refused on an MPS-held GPU")
+	assert.Positive(t, h.gpuMemoryConsumed["uuid-A"].MiB)
+	assert.False(t, h.gpuMemoryConsumed["uuid-A"].WholeGPU, "MPS state must not carry WholeGPU")
+
+	// Whole-GPU first, then an MPS attempt is refused, so MiB stays 0.
+	h2 := hrmWithPool(23040)
+	h2.consumeGPUMemory("uuid-A", wholeGPUDemand())
+	assert.False(t, h2.checkConsumableGPUMemory("uuid-A", mpsDemand(4096)),
+		"MPS must be refused on a whole-GPU-held GPU")
+	assert.True(t, h2.gpuMemoryConsumed["uuid-A"].WholeGPU)
+	assert.Zero(t, h2.gpuMemoryConsumed["uuid-A"].MiB, "whole-GPU state must not carry a positive MiB")
+}
+
+// TestGPUMemoryMPSFillsToExactlyZero (edge case 3) fills a known GPU to exactly
+// remaining 0 with MPS shares. Because the mode is MPS (not WHOLE_GPU), a
+// whole-GPU request is refused and further MPS is refused - the GPU is full, not
+// exclusive.
+func TestGPUMemoryMPSFillsToExactlyZero(t *testing.T) {
+	h := hrmWithPool(8192)
+	assert.True(t, h.checkConsumableGPUMemory("uuid-A", mpsDemand(8192)))
+	h.consumeGPUMemory("uuid-A", mpsDemand(8192))
+	assert.Equal(t, int64(0), gpuRemaining(h, "uuid-A"))
+	assert.Equal(t, "MPS", gpuModeOf(h, "uuid-A"), "full MPS GPU is MPS, not WHOLE_GPU")
+
+	// A whole-GPU request is refused: the GPU is not free even though remaining is 0.
+	assert.False(t, h.checkConsumableGPUMemory("uuid-A", wholeGPUDemand()))
+	// Any further MPS is refused: no room left.
+	assert.False(t, h.checkConsumableGPUMemory("uuid-A", mpsDemand(1)))
+
+	// Releasing the share returns the GPU to FREE and admits a whole-GPU task.
+	h.releaseGPUMemory("uuid-A", mpsDemand(8192))
+	assert.Equal(t, "FREE", gpuModeOf(h, "uuid-A"))
+	assert.True(t, h.checkConsumableGPUMemory("uuid-A", wholeGPUDemand()))
+}
+
+// TestGPUMemoryRestartReconsumeIdempotent (edge case 5) mirrors restart
+// reconcile: re-consuming the identical set of demands rebuilds an identical
+// consumed record, with no drift or negatives.
+func TestGPUMemoryRestartReconsumeIdempotent(t *testing.T) {
+	build := func() *HostResourceManager {
+		h := hrmWithPoolMulti(map[string]int64{"uuid-A": 14911, "uuid-B": 14911})
+		// GPU-A shared by two MPS shares; GPU-B taken whole.
+		h.consumeGPUMemory("uuid-A", mpsDemand(4096))
+		h.consumeGPUMemory("uuid-A", mpsDemand(4096))
+		h.consumeGPUMemory("uuid-B", wholeGPUDemand())
+		return h
+	}
+
+	first := build()
+	second := build()
+
+	// The two independently-built consumed maps must be identical.
+	assert.Equal(t, first.gpuMemoryConsumed, second.gpuMemoryConsumed)
+	assert.Equal(t, int64(8192), second.gpuMemoryConsumed["uuid-A"].MiB)
+	assert.Equal(t, int64(6719), gpuRemaining(second, "uuid-A"))
+	assert.Equal(t, "MPS", gpuModeOf(second, "uuid-A"))
+	assert.Equal(t, "WHOLE_GPU", gpuModeOf(second, "uuid-B"))
+	// No consumed value went negative.
+	for uuid, consumed := range second.gpuMemoryConsumed {
+		assert.GreaterOrEqual(t, consumed.MiB, int64(0), "consumed MiB negative for %s", uuid)
+	}
+}
+
+// TestConsumeReleaseGPUMemoryThroughPublicAPI drives a GPU memory demand through
+// the real consume() and release() entry points (not the internal pool helpers).
+func TestConsumeReleaseGPUMemoryThroughPublicAPI(t *testing.T) {
+	h := getTestHostResourceManager(int32(2048), int32(2048), []string{}, []string{}, []string{"gpu1"})
+
+	arn := "arn:aws:ecs:us-east-1:0:task/cluster/1"
+	gpuMemory := map[string]apitask.GPUMemoryDemand{"gpu1": mpsDemand(4096)}
+
+	consumed, err := h.consume(arn, nil, gpuMemory)
+	assert.NoError(t, err)
+	assert.True(t, consumed)
+	// getTestHostResourceManager seeds each GPU with 16384 MiB.
+	assert.Equal(t, int64(16384-4096), gpuRemaining(h, "gpu1"))
+	assert.Equal(t, "MPS", gpuModeOf(h, "gpu1"))
+
+	err = h.release(arn, nil, gpuMemory)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(16384), gpuRemaining(h, "gpu1"))
+	assert.Equal(t, "FREE", gpuModeOf(h, "gpu1"))
+}
+
+// TestConsumeGPUMemoryOverCapacityThroughPublicAPI verifies a demand larger than
+// remaining is rejected by consume() (task stays pending).
+func TestConsumeGPUMemoryOverCapacityThroughPublicAPI(t *testing.T) {
+	h := getTestHostResourceManager(int32(2048), int32(2048), []string{}, []string{}, []string{"gpu1"})
+
+	arn := "arn:aws:ecs:us-east-1:0:task/cluster/1"
+	// getTestHostResourceManager seeds 16384 MiB; ask for more.
+	gpuMemory := map[string]apitask.GPUMemoryDemand{"gpu1": mpsDemand(20000)}
+
+	consumed, err := h.consume(arn, nil, gpuMemory)
+	assert.NoError(t, err)
+	assert.False(t, consumed, "over-capacity GPU memory demand must not be consumed")
+	assert.Equal(t, int64(16384), gpuRemaining(h, "gpu1"), "pool must be unchanged on a rejected consume")
+}
+
+// TestReconsumeGPUMemoryAfterCapacityRegression documents the restart edge where
+// a GPU's memory is rediscovered lower than what its running tasks hold (e.g.
+// unreported -> total 0). consume() refuses the running task's demand, so the
+// pool under-counts and shows the GPU with room it does not physically have.
+// reconcileHostResources logs this as a Critical GPU accounting desync; the pool
+// self-heals on the next restart with good discovery.
+func TestReconsumeGPUMemoryAfterCapacityRegression(t *testing.T) {
+	// GPU rediscovered with total 0, but a running task holds 8192 MiB of MPS.
+	h := getTestHostResourceManager(int32(2048), int32(2048), []string{}, []string{}, []string{})
+	h.gpuMemoryTotalMiB["gpu1"] = 0
+
+	arn := "arn:aws:ecs:us-east-1:0:task/cluster/1"
+	gpuMemory := map[string]apitask.GPUMemoryDemand{"gpu1": mpsDemand(8192)}
+
+	consumed, err := h.consume(arn, nil, gpuMemory)
+	assert.NoError(t, err)
+	assert.False(t, consumed, "MPS demand cannot re-consume against a regressed total 0")
+	// The desync: nothing is recorded, so the GPU reads FREE with remaining 0.
+	assert.Equal(t, int64(0), gpuRemaining(h, "gpu1"))
+	assert.Equal(t, "FREE", gpuModeOf(h, "gpu1"))
+}
+
+// TestConsumeMixedCPUAndGPUMemory verifies GPU memory demand coexists with the
+// INTEGER (CPU/MEMORY) resources in a single consume call.
+func TestConsumeMixedCPUAndGPUMemory(t *testing.T) {
+	h := getTestHostResourceManager(int32(2048), int32(2048), []string{}, []string{}, []string{"gpu1"})
+
+	arn := "arn:aws:ecs:us-east-1:0:task/cluster/1"
+	resources := map[string]types.Resource{
+		"CPU":    {Name: utils.Strptr("CPU"), Type: utils.Strptr("INTEGER"), IntegerValue: 512},
+		"MEMORY": {Name: utils.Strptr("MEMORY"), Type: utils.Strptr("INTEGER"), IntegerValue: 768},
+	}
+	gpuMemory := map[string]apitask.GPUMemoryDemand{"gpu1": mpsDemand(4096)}
+
+	consumed, err := h.consume(arn, resources, gpuMemory)
+	assert.NoError(t, err)
+	assert.True(t, consumed)
+	assert.Equal(t, int32(512), h.consumedResource["CPU"].IntegerValue)
+	assert.Equal(t, int32(768), h.consumedResource["MEMORY"].IntegerValue)
+	assert.Equal(t, int64(16384-4096), gpuRemaining(h, "gpu1"))
+}
+
+// TestCheckResourcesHealthGPUMemory: a known UUID passes, an unknown UUID errors.
+func TestCheckResourcesHealthGPUMemory(t *testing.T) {
+	h := getTestHostResourceManager(int32(2048), int32(2048), []string{}, []string{}, []string{"gpu1"})
+
+	err := h.checkResourcesHealth(nil, map[string]apitask.GPUMemoryDemand{"gpu1": mpsDemand(4096)})
+	assert.NoError(t, err)
+
+	err = h.checkResourcesHealth(nil, map[string]apitask.GPUMemoryDemand{"gpu-unknown": mpsDemand(4096)})
+	assert.Error(t, err)
+}
+
+// TestGPUMemoryCapacityKeyHelpers covers the capacity key round trip used to
+// seed the pool from the host resource map.
+func TestGPUMemoryCapacityKeyHelpers(t *testing.T) {
+	uuid, ok := gpuUUIDFromCapacityKey("GPU_MEMORY:uuid-A")
+	assert.True(t, ok)
+	assert.Equal(t, "uuid-A", uuid)
+
+	_, ok = gpuUUIDFromCapacityKey("CPU")
+	assert.False(t, ok)
+}
+
+// TestFormatGPUMemoryEntry asserts the pool snapshot string for each derived
+// state. A whole-GPU device must read remaining=0 mode=WHOLE_GPU even though its
+// consumed MiB is 0, and an unknown-memory device must read total=unknown.
+func TestFormatGPUMemoryEntry(t *testing.T) {
+	assert.Equal(t, "uuid-A{total=23040 remaining=23040 mode=FREE} ",
+		formatGPUMemoryEntry("uuid-A", 23040, apitask.GPUMemoryDemand{}))
+	assert.Equal(t, "uuid-A{total=23040 remaining=18944 mode=MPS} ",
+		formatGPUMemoryEntry("uuid-A", 23040, apitask.GPUMemoryDemand{MiB: 4096}))
+	assert.Equal(t, "uuid-A{total=23040 remaining=0 mode=WHOLE_GPU} ",
+		formatGPUMemoryEntry("uuid-A", 23040, apitask.GPUMemoryDemand{WholeGPU: true}))
+	assert.Equal(t, "uuid-A{total=unknown remaining=0 mode=FREE} ",
+		formatGPUMemoryEntry("uuid-A", 0, apitask.GPUMemoryDemand{}))
+	assert.Equal(t, "uuid-A{total=unknown remaining=0 mode=WHOLE_GPU} ",
+		formatGPUMemoryEntry("uuid-A", 0, apitask.GPUMemoryDemand{WholeGPU: true}))
+}

--- a/agent/engine/host_resource_manager_test.go
+++ b/agent/engine/host_resource_manager_test.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"testing"
 
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	commonutils "github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
@@ -52,15 +53,29 @@ func getTestHostResourceManager(cpu int32, mem int32, ports []string, portsUdp [
 		StringSetValue: portsUdp,
 	}
 
-	hostResources["GPU"] = types.Resource{
-		Name:           utils.Strptr("GPU"),
-		Type:           utils.Strptr("STRINGSET"),
-		StringSetValue: gpuIDs,
+	// Give each GPU a fixed total capacity so the pool has room for the tests.
+	for _, uuid := range gpuIDs {
+		key := GPUMemoryCapacityPrefix + uuid
+		hostResources[key] = types.Resource{
+			Name:         utils.Strptr(key),
+			Type:         utils.Strptr("INTEGER"),
+			IntegerValue: int32(16384),
+		}
 	}
 
 	hostResourceManager := NewHostResourceManager(hostResources)
 
 	return &hostResourceManager
+}
+
+// getTestTaskGPUMemory returns a whole-GPU demand for each UUID, matching the
+// whole-GPU task shape getTestTaskResourceMap used to encode.
+func getTestTaskGPUMemory(gpuIDs []string) map[string]apitask.GPUMemoryDemand {
+	demand := make(map[string]apitask.GPUMemoryDemand)
+	for _, uuid := range gpuIDs {
+		demand[uuid] = apitask.GPUMemoryDemand{WholeGPU: true}
+	}
+	return demand
 }
 
 func getTestTaskResourceMap(cpu int32, mem int32, ports []string, portsUdp []string, gpuIDs []string) map[string]types.Resource {
@@ -89,11 +104,8 @@ func getTestTaskResourceMap(cpu int32, mem int32, ports []string, portsUdp []str
 		StringSetValue: portsUdp,
 	}
 
-	taskResources["GPU"] = types.Resource{
-		Name:           utils.Strptr("GPU"),
-		Type:           utils.Strptr("STRINGSET"),
-		StringSetValue: gpuIDs,
-	}
+	// GPU memory demand is returned separately by getTestTaskGPUMemory.
+	_ = gpuIDs
 
 	return taskResources
 }
@@ -110,8 +122,9 @@ func TestHostResourceConsumeSuccess(t *testing.T) {
 	taskGpuId1 := "gpu2"
 	taskGpuId2 := "gpu3"
 	taskResources := getTestTaskResourceMap(int32(512), int32(768), []string{taskPort1}, []string{taskPort2}, []string{taskGpuId1, taskGpuId2})
+	taskGPUMemory := getTestTaskGPUMemory([]string{taskGpuId1, taskGpuId2})
 
-	consumed, _ := h.consume(testTaskArn, taskResources)
+	consumed, _ := h.consume(testTaskArn, taskResources, taskGPUMemory)
 	assert.Equal(t, consumed, true, "Incorrect consumed status")
 	assert.Equal(t, h.consumedResource["CPU"].IntegerValue, int32(512), "Incorrect cpu resource accounting during consume")
 	assert.Equal(t, h.consumedResource["MEMORY"].IntegerValue, int32(768), "Incorrect memory resource accounting during consume")
@@ -121,9 +134,11 @@ func TestHostResourceConsumeSuccess(t *testing.T) {
 	assert.Equal(t, h.consumedResource["PORTS_UDP"].StringSetValue[0], "1000", "Incorrect udp port resource accounting during consume")
 	assert.Equal(t, h.consumedResource["PORTS_UDP"].StringSetValue[1], "1001", "Incorrect udp port resource accounting during consume")
 	assert.Equal(t, len(h.consumedResource["PORTS_UDP"].StringSetValue), 2, "Incorrect port resource accounting during consume")
-	assert.Equal(t, h.consumedResource["GPU"].StringSetValue[0], "gpu2", "Incorrect gpu resource accounting during consume")
-	assert.Equal(t, h.consumedResource["GPU"].StringSetValue[1], "gpu3", "Incorrect gpu resource accounting during consume")
-	assert.Equal(t, len(h.consumedResource["GPU"].StringSetValue), 2, "Incorrect gpu resource accounting during consume")
+	// gpu2/gpu3 were consumed whole-GPU; gpu1/gpu4 remain untouched.
+	assert.Equal(t, "WHOLE_GPU", gpuModeOf(h, "gpu2"), "gpu2 should be whole-GPU after consume")
+	assert.Equal(t, "WHOLE_GPU", gpuModeOf(h, "gpu3"), "gpu3 should be whole-GPU after consume")
+	assert.Equal(t, "FREE", gpuModeOf(h, "gpu1"), "gpu1 should be untouched")
+	assert.Equal(t, "FREE", gpuModeOf(h, "gpu4"), "gpu4 should be untouched")
 }
 
 func TestHostResourceConsumeFail(t *testing.T) {
@@ -138,8 +153,9 @@ func TestHostResourceConsumeFail(t *testing.T) {
 	taskGpuId1 := "gpu2"
 	taskGpuId2 := "gpu3"
 	taskResources := getTestTaskResourceMap(int32(512), int32(768), []string{taskPort1}, []string{taskPort2}, []string{taskGpuId1, taskGpuId2})
+	taskGPUMemory := getTestTaskGPUMemory([]string{taskGpuId1, taskGpuId2})
 
-	consumed, _ := h.consume(testTaskArn, taskResources)
+	consumed, _ := h.consume(testTaskArn, taskResources, taskGPUMemory)
 	assert.Equal(t, consumed, false, "Incorrect consumed status")
 	assert.Equal(t, h.consumedResource["CPU"].IntegerValue, int32(0), "Incorrect cpu resource accounting during consume")
 	assert.Equal(t, h.consumedResource["MEMORY"].IntegerValue, int32(0), "Incorrect memory resource accounting during consume")
@@ -147,7 +163,9 @@ func TestHostResourceConsumeFail(t *testing.T) {
 	assert.Equal(t, len(h.consumedResource["PORTS_TCP"].StringSetValue), 1, "Incorrect port resource accounting during consume")
 	assert.Equal(t, h.consumedResource["PORTS_UDP"].StringSetValue[0], "1000", "Incorrect udp port resource accounting during consume")
 	assert.Equal(t, len(h.consumedResource["PORTS_UDP"].StringSetValue), 1, "Incorrect port resource accounting during consume")
-	assert.Equal(t, len(h.consumedResource["GPU"].StringSetValue), 0, "Incorrect gpu resource accounting during consume")
+	// Consume failed on the port conflict, so the GPU pool must be untouched.
+	assert.Equal(t, "FREE", gpuModeOf(h, "gpu2"), "gpu2 should be untouched after failed consume")
+	assert.Equal(t, "FREE", gpuModeOf(h, "gpu3"), "gpu3 should be untouched after failed consume")
 }
 
 func TestHostResourceRelease(t *testing.T) {
@@ -162,9 +180,10 @@ func TestHostResourceRelease(t *testing.T) {
 	taskGpuId1 := "gpu2"
 	taskGpuId2 := "gpu3"
 	taskResources := getTestTaskResourceMap(int32(512), int32(768), []string{taskPort1}, []string{taskPort2}, []string{taskGpuId1, taskGpuId2})
+	taskGPUMemory := getTestTaskGPUMemory([]string{taskGpuId1, taskGpuId2})
 
-	h.consume(testTaskArn, taskResources)
-	h.release(testTaskArn, taskResources)
+	h.consume(testTaskArn, taskResources, taskGPUMemory)
+	h.release(testTaskArn, taskResources, taskGPUMemory)
 
 	assert.Equal(t, h.consumedResource["CPU"].IntegerValue, int32(0), "Incorrect cpu resource accounting during release")
 	assert.Equal(t, h.consumedResource["MEMORY"].IntegerValue, int32(0), "Incorrect memory resource accounting during release")
@@ -172,7 +191,10 @@ func TestHostResourceRelease(t *testing.T) {
 	assert.Equal(t, len(h.consumedResource["PORTS_TCP"].StringSetValue), 1, "Incorrect port resource accounting during release")
 	assert.Equal(t, h.consumedResource["PORTS_UDP"].StringSetValue[0], "1000", "Incorrect udp port resource accounting during release")
 	assert.Equal(t, len(h.consumedResource["PORTS_UDP"].StringSetValue), 1, "Incorrect udp port resource accounting during release")
-	assert.Equal(t, len(h.consumedResource["GPU"].StringSetValue), 0, "Incorrect gpu resource accounting during release")
+	// gpu2/gpu3 were consumed then released, so both return to FREE at full memory.
+	assert.Equal(t, "FREE", gpuModeOf(h, "gpu2"), "gpu2 should be FREE after release")
+	assert.Equal(t, int64(16384), gpuRemaining(h, "gpu2"), "gpu2 remaining should be restored")
+	assert.Equal(t, "FREE", gpuModeOf(h, "gpu3"), "gpu3 should be FREE after release")
 }
 
 func TestConsumable(t *testing.T) {
@@ -258,7 +280,8 @@ func TestConsumable(t *testing.T) {
 
 			resources := getTestTaskResourceMap(tc.cpu, tc.mem, commonutils.Uint16SliceToStringSlice(tc.ports),
 				commonutils.Uint16SliceToStringSlice(tc.portsUdp), tc.gpus)
-			canBeConsumed, failedResourceKeys, err := h.consumable(resources)
+			gpuMemory := getTestTaskGPUMemory(tc.gpus)
+			canBeConsumed, failedResourceKeys, err := h.consumable(resources, gpuMemory)
 			assert.Equal(t, tc.canBeConsumed, canBeConsumed,
 				"Error in checking if resources can be successfully consumed")
 			assert.Equal(t, nil, err,
@@ -275,7 +298,8 @@ func TestResourceHealthTrue(t *testing.T) {
 	h := getTestHostResourceManager(int32(2048), int32(2048), []string{hostResourcePort1}, []string{hostResourcePort2}, gpuIDs)
 
 	resources := getTestTaskResourceMap(1024, 1024, commonutils.Uint16SliceToStringSlice([]uint16{22}), commonutils.Uint16SliceToStringSlice([]uint16{1000}), []string{"gpu1", "gpu2"})
-	err := h.checkResourcesHealth(resources)
+	gpuMemory := getTestTaskGPUMemory([]string{"gpu1", "gpu2"})
+	err := h.checkResourcesHealth(resources, gpuMemory)
 	assert.NoError(t, err, "Error in checking healthy resource map status")
 }
 
@@ -287,6 +311,7 @@ func TestResourceHealthGPUFalse(t *testing.T) {
 	h := getTestHostResourceManager(int32(2048), int32(2048), []string{hostResourcePort1}, []string{hostResourcePort2}, gpuIDs)
 
 	resources := getTestTaskResourceMap(1024, 1024, commonutils.Uint16SliceToStringSlice([]uint16{22}), commonutils.Uint16SliceToStringSlice([]uint16{1000}), []string{"gpu1", "gpu5"})
-	err := h.checkResourcesHealth(resources)
+	gpuMemory := getTestTaskGPUMemory([]string{"gpu1", "gpu5"})
+	err := h.checkResourcesHealth(resources, gpuMemory)
 	assert.Error(t, err, "Error in checking unhealthy resource map status")
 }

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -661,8 +661,8 @@ func (mtask *managedTask) emitTaskEvent(task *apitask.Task, reason string) {
 	// Always do (idempotent) release host resources whenever state change with
 	// known status == STOPPED is done to ensure sync between tasks and host resource manager
 	if taskKnownStatus.Terminal() {
-		resourcesToRelease := mtask.ToHostResources()
-		err := mtask.engine.hostResourceManager.release(mtask.Arn, resourcesToRelease)
+		resourcesToRelease, gpuMemoryToRelease := mtask.ToHostResources()
+		err := mtask.engine.hostResourceManager.release(mtask.Arn, resourcesToRelease, gpuMemoryToRelease)
 		if err != nil {
 			logger.Critical("Failed to release resources after task stopped",
 				logger.Fields{field.TaskARN: mtask.Arn})

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -2507,8 +2507,8 @@ func TestTaskWaitForHostResources(t *testing.T) {
 	assert.Equal(t, topTask.Arn, "arn2")
 
 	// Remove 1 task
-	taskResources := taskEngine.managedTasks["arn0"].ToHostResources()
-	taskEngine.hostResourceManager.release("arn0", taskResources)
+	taskResources, taskGPUMemory := taskEngine.managedTasks["arn0"].ToHostResources()
+	taskEngine.hostResourceManager.release("arn0", taskResources, taskGPUMemory)
 	taskEngine.wakeUpTaskQueueMonitor()
 
 	time.Sleep(500 * time.Millisecond)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds per-GPU memory accounting to the agent's `HostResourceManager` so GPU memory can be tracked and admitted per physical GPU, as the local scheduling foundation for NVIDIA MPS GPU sharing. Each GPU is modeled as a small account `{total, remaining, mode}` (mode ∈ FREE / MPS / WHOLE_GPU). MPS tasks reserve a memory share on a GPU while a whole-GPU task takes it exclusively. This replaces the GPU allocation role previously served by the `GPU` StringSet.
### Implementation details
<!-- How are the changes implemented? -->
- New `agent/engine/host_resource_manager_gpu.go`: a per-UUID pool (`map[uuid]*gpuDeviceState`) with `{total, remaining, mode}`. Admission keys off `mode`, which makes MPS/whole-GPU mode-mixing on one GPU impossible by construction. A GPU with no reported memory is seeded total 0 and is only usable via the whole-GPU path.
- Task GPU memory demand is a dedicated `task.GPUMemoryDemand{MiB, WholeGPU}` type, returned from `ToHostResources()` as a second map alongside the CPU/MEMORY/PORTS resource map (not encoded into the SDK `ecstypes.Resource`). `consume` / `consumable` / `release` / `checkResourcesHealth` take that demand map. A non-MPS container sets `WholeGPU`; MPS containers on a GPU sum their caps into `MiB`. There is no per-task stored balance, consume and release both recompute from the task, so they stay symmetric and restart-safe.
- `doStart` seeds one pool entry per GPU from the RCI-reported per-device memory, as an `INTEGER` capacity keyed `GPU_MEMORY:<uuid>`. A GPU whose memory is not reported (older ecs-init, or an NVML query failure) is seeded with capacity 0: whole-GPU tasks still run against it, MPS sharing is refused (a cap cannot be enforced without a known total). This preserves the pre-existing whole-GPU behavior, which never depended on memory being known.
- Removes the GPU StringSet's allocation/validation role now that the pool is the source of truth for GPU admission (the StringSet is no longer used for accounting).
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
* Built a custom agent from this change and installed it on a AL2023 GPU AMI instance, then ran tasks through the accounting paths. 
* Watching the agent's per-GPU pool log confirmed the expected behavior. All GPUs seeded independently at their reported memory. A whole-GPU task drove its GPU to remaining 0 / WHOLE_GPU while the others stayed untouched. 
* A second whole-GPU task on the same GPU was refused and stayed pending until the first stopped, after which the GPU returned to FREE and the queued task consumed it. 
* Two MPS containers pinned to one GPU consumed a single summed reservation (remaining equals total minus the sum of caps). 
* An MPS-shared GPU and a whole-GPU on a different device ran simultaneously. 
* Mode isolation held both ways, so an MPS task was refused on a whole-GPU device and a whole-GPU task was refused on an MPS device. 
* After an agent restart the pool rebuilt to the same per-GPU state by re-consuming the running tasks, with no negative accounting.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Add per-GPU memory accounting to host resource manager
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
