### PR TITLE
IMDS credentials scanner/refresher: Add logging and validations

### DIFF
--- a/agent/acs/session/payload_responder.go
+++ b/agent/acs/session/payload_responder.go
@@ -170,6 +170,7 @@ func (pmHandler *payloadMessageHandler) addPayloadTasks(payload *ecsacs.PayloadM
 				loggerfield.CredentialsID: utils.TruncateString(taskIAMRoleCredentials.CredentialsID, utils.CredentialsIDLogTruncationLen),
 			})
 			apiTask.SetCredentialsID(taskIAMRoleCredentials.CredentialsID)
+			apiTask.SetTaskRoleArn(taskIAMRoleCredentials.RoleArn)
 		}
 
 		// Add ENI information to the task struct.
@@ -218,6 +219,7 @@ func (pmHandler *payloadMessageHandler) addPayloadTasks(payload *ecsacs.PayloadM
 				loggerfield.CredentialsID: utils.TruncateString(taskExecutionIAMRoleCredentials.CredentialsID, utils.CredentialsIDLogTruncationLen),
 			})
 			apiTask.SetExecutionRoleCredentialsID(taskExecutionIAMRoleCredentials.CredentialsID)
+			apiTask.SetExecutionRoleArn(taskExecutionIAMRoleCredentials.RoleArn)
 		}
 
 		validTasks = append(validTasks, apiTask)

--- a/agent/acs/session/payload_responder_test.go
+++ b/agent/acs/session/payload_responder_test.go
@@ -581,6 +581,10 @@ func TestHandlePayloadMessageTaskAddsExecutionRoles(t *testing.T) {
 	assert.Equal(t, credentialsID, addedTask.GetExecutionCredentialsID(),
 		"task execution role credentials id mismatch")
 
+	// Verify that added tasks' execution role ARN is as expected.
+	assert.Equal(t, credentialsRoleArn, addedTask.GetExecutionRoleArn(),
+		"task execution role ARN mismatch")
+
 	// Verify the credentials in the payload message was stored in the credentials manager.
 	actualCredentialsAck := <-credentialsAckSent
 	iamRoleCredentials, ok := tester.payloadMessageHandler.credentialsManager.GetTaskCredentials(credentialsID)
@@ -1111,6 +1115,7 @@ func validateTaskAndCredentials(taskCredentialsAck, expectedCredentialsAckForTas
 		NetworkMode:        apitask.BridgeNetworkMode,
 	}
 	expectedTask.SetCredentialsID(expectedTaskCredentials.CredentialsID)
+	expectedTask.SetTaskRoleArn(expectedTaskCredentials.RoleArn)
 
 	if !reflect.DeepEqual(addedTask, expectedTask) {
 		return errors.Errorf("mismatch between expected and added tasks, expected: %v, added: %v",

--- a/agent/acs/session/refresh_credentials_responder.go
+++ b/agent/acs/session/refresh_credentials_responder.go
@@ -52,6 +52,7 @@ func (cmSetter *credentialsMetadataSetter) SetTaskRoleCredentialsMetadata(
 		return err
 	}
 	task.SetCredentialsID(aws.ToString(message.RoleCredentials.CredentialsId))
+	task.SetTaskRoleArn(aws.ToString(message.RoleCredentials.RoleArn))
 	return nil
 }
 
@@ -62,6 +63,7 @@ func (cmSetter *credentialsMetadataSetter) SetExecRoleCredentialsMetadata(
 		return errors.Wrap(err, "unable to get credentials message's task")
 	}
 	task.SetExecutionRoleCredentialsID(aws.ToString(message.RoleCredentials.CredentialsId))
+	task.SetExecutionRoleArn(aws.ToString(message.RoleCredentials.RoleArn))
 
 	// Refresh domainless gMSA plugin credentials if needed.
 	err = checkAndSetDomainlessGMSATaskExecutionRoleCredentialsImpl(credentials.IAMRoleCredentialsFromACS(

--- a/agent/acs/session/refresh_credentials_responder_test.go
+++ b/agent/acs/session/refresh_credentials_responder_test.go
@@ -130,6 +130,24 @@ func TestCredentialsMessageNotAckedWhenTaskNotFound(t *testing.T) {
 		"Expected no ACK of invalid refresh credentials message when its task ARN is not in task engine")
 }
 
+// TestSetTaskRoleCredentialsMetadata tests that the task role credentials ID
+// and role ARN from the message are set on the task.
+func TestSetTaskRoleCredentialsMetadata(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTaskEngine := mock_engine.NewMockTaskEngine(ctrl)
+	task := &apitask.Task{Arn: testconst.TaskARN}
+	mockTaskEngine.EXPECT().GetTaskByArn(testconst.TaskARN).Return(task, true)
+
+	setter := NewCredentialsMetadataSetter(mockTaskEngine, testIPCompatibility)
+	err := setter.SetTaskRoleCredentialsMetadata(testRefreshCredentialsMessage)
+
+	assert.NoError(t, err)
+	assert.Equal(t, testconst.CredentialsID, task.GetCredentialsID())
+	assert.Equal(t, roleArn, task.GetTaskRoleArn())
+}
+
 // TestHandleRefreshMessageAckedWhenCredentialsUpdated tests that a credential message
 // is ACKed when the credentials are updated successfully and the domainless gMSA plugin credentials
 // are updated successfully.
@@ -184,8 +202,8 @@ func TestHandleRefreshMessageAckedWhenCredentialsUpdated(t *testing.T) {
 			}()
 
 			// Return a task from the engine for GetTaskByArn.
-			mockTaskEngine.EXPECT().GetTaskByArn(tc.taskArn).Return(
-				&apitask.Task{Arn: tc.taskArn, Containers: tc.containers}, true)
+			task := &apitask.Task{Arn: tc.taskArn, Containers: tc.containers}
+			mockTaskEngine.EXPECT().GetTaskByArn(tc.taskArn).Return(task, true)
 
 			go handleCredentialsMessage(testRefreshCredentialsMessage)
 
@@ -195,6 +213,11 @@ func TestHandleRefreshMessageAckedWhenCredentialsUpdated(t *testing.T) {
 			creds, exist := credentialsManager.GetTaskCredentials(testconst.CredentialsID)
 			assert.True(t, exist, "Expected credentials to exist for the task")
 			assert.Equal(t, expectedCredentials, creds)
+
+			// The message carries the execution role type, so the execution
+			// role metadata is expected on the task.
+			assert.Equal(t, testconst.CredentialsID, task.GetExecutionCredentialsID())
+			assert.Equal(t, roleArn, task.GetExecutionRoleArn())
 		})
 	}
 }

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -267,6 +267,16 @@ type Task struct {
 	CredentialsID                string `json:"credentialsID"`
 	credentialsRelativeURIUnsafe string
 
+	// TaskRoleArn is the ARN of the task IAM role delivered by ACS alongside
+	// the task role credentials. It is persisted so that credentials retrieved
+	// from other sources, such as IMDS, can be verified against the role they
+	// are expected to belong to.
+	TaskRoleArn string `json:"taskRoleArn,omitempty"`
+
+	// ExecutionRoleArn is the ARN of the task execution IAM role. See
+	// TaskRoleArn for why it is persisted.
+	ExecutionRoleArn string `json:"executionRoleArn,omitempty"`
+
 	// ENIs is the list of Elastic Network Interfaces assigned to this task. The
 	// TaskENIs type is helpful when decoding state files which might have stored
 	// ENIs as a single ENI object instead of a list.
@@ -3049,6 +3059,51 @@ func (task *Task) GetCredentialsIDForRoleType(roleType string) string {
 		return task.GetCredentialsID()
 	case credentials.ExecutionRoleType:
 		return task.GetExecutionCredentialsID()
+	default:
+		return ""
+	}
+}
+
+// SetTaskRoleArn sets the ARN of the task IAM role.
+func (task *Task) SetTaskRoleArn(arn string) {
+	task.lock.Lock()
+	defer task.lock.Unlock()
+
+	task.TaskRoleArn = arn
+}
+
+// GetTaskRoleArn gets the ARN of the task IAM role.
+func (task *Task) GetTaskRoleArn() string {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	return task.TaskRoleArn
+}
+
+// SetExecutionRoleArn sets the ARN of the task execution IAM role.
+func (task *Task) SetExecutionRoleArn(arn string) {
+	task.lock.Lock()
+	defer task.lock.Unlock()
+
+	task.ExecutionRoleArn = arn
+}
+
+// GetExecutionRoleArn gets the ARN of the task execution IAM role.
+func (task *Task) GetExecutionRoleArn() string {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	return task.ExecutionRoleArn
+}
+
+// GetRoleArnForRoleType returns the IAM role ARN for the given role type on
+// the task.
+func (task *Task) GetRoleArnForRoleType(roleType string) string {
+	switch roleType {
+	case credentials.ApplicationRoleType:
+		return task.GetTaskRoleArn()
+	case credentials.ExecutionRoleType:
+		return task.GetExecutionRoleArn()
 	default:
 		return ""
 	}

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -6452,6 +6452,69 @@ func TestGetCredentialsIDForRoleType(t *testing.T) {
 	}
 }
 
+func TestSetAndGetTaskRoleArn(t *testing.T) {
+	task := &Task{Arn: "arn:aws:ecs:us-west-2:123:task/cluster/abc"}
+	assert.Empty(t, task.GetTaskRoleArn())
+
+	task.SetTaskRoleArn("arn:aws:iam::123:role/TaskRole")
+	assert.Equal(t, "arn:aws:iam::123:role/TaskRole", task.GetTaskRoleArn())
+}
+
+func TestSetAndGetExecutionRoleArn(t *testing.T) {
+	task := &Task{Arn: "arn:aws:ecs:us-west-2:123:task/cluster/abc"}
+	assert.Empty(t, task.GetExecutionRoleArn())
+
+	task.SetExecutionRoleArn("arn:aws:iam::123:role/ExecRole")
+	assert.Equal(t, "arn:aws:iam::123:role/ExecRole", task.GetExecutionRoleArn())
+}
+
+func TestGetRoleArnForRoleType(t *testing.T) {
+	tests := []struct {
+		name            string
+		roleArn         string
+		execRoleArn     string
+		roleType        string
+		expectedRoleArn string
+	}{
+		{
+			name:            "application role type",
+			roleArn:         "arn:aws:iam::123:role/TaskRole",
+			execRoleArn:     "arn:aws:iam::123:role/ExecRole",
+			roleType:        credentials.ApplicationRoleType,
+			expectedRoleArn: "arn:aws:iam::123:role/TaskRole",
+		},
+		{
+			name:            "execution role type",
+			roleArn:         "arn:aws:iam::123:role/TaskRole",
+			execRoleArn:     "arn:aws:iam::123:role/ExecRole",
+			roleType:        credentials.ExecutionRoleType,
+			expectedRoleArn: "arn:aws:iam::123:role/ExecRole",
+		},
+		{
+			name:            "unknown role type",
+			roleArn:         "arn:aws:iam::123:role/TaskRole",
+			execRoleArn:     "arn:aws:iam::123:role/ExecRole",
+			roleType:        "UnknownType",
+			expectedRoleArn: "",
+		},
+		{
+			name:            "role ARN not set",
+			roleType:        credentials.ApplicationRoleType,
+			expectedRoleArn: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			task := &Task{Arn: "arn:aws:ecs:us-west-2:123:task/cluster/abc"}
+			task.SetTaskRoleArn(tc.roleArn)
+			task.SetExecutionRoleArn(tc.execRoleArn)
+
+			assert.Equal(t, tc.expectedRoleArn, task.GetRoleArnForRoleType(tc.roleType))
+		})
+	}
+}
+
 func TestGetDockerResourcesPropagateTaskMemoryLimitCgroupV2(t *testing.T) {
 	origCgroupV2 := config.CgroupV2
 	defer func() { config.CgroupV2 = origCgroupV2 }()

--- a/agent/imdscreds/refresher.go
+++ b/agent/imdscreds/refresher.go
@@ -146,11 +146,22 @@ func (r *IMDSCredentialsRefresher) upsertCredential(
 		return fmt.Errorf("no credentials ID on task for role type %s", cred.RoleType)
 	}
 
+	// A credential whose role ARN differs from task state cannot be attributed
+	// to the task's role, so reject it rather than store misleading metadata.
+	roleArn := task.GetRoleArnForRoleType(cred.RoleType)
+	if roleArn == "" {
+		return fmt.Errorf("no role ARN on task for role type %s", cred.RoleType)
+	}
+	if cred.RoleArn != roleArn {
+		return fmt.Errorf("scanned credential role ARN %q does not match %q on task",
+			cred.RoleArn, roleArn)
+	}
+
 	err := r.credManager.SetTaskCredentials(&credentials.TaskIAMRoleCredentials{
 		ARN: task.Arn,
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
 			CredentialsID:   credentialsID,
-			RoleArn:         cred.RoleArn,
+			RoleArn:         roleArn,
 			AccessKeyID:     cred.AccessKeyID,
 			SecretAccessKey: cred.SecretAccessKey,
 			SessionToken:    cred.SessionToken,

--- a/agent/imdscreds/refresher.go
+++ b/agent/imdscreds/refresher.go
@@ -17,6 +17,7 @@ package imdscreds
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
@@ -63,7 +64,7 @@ func NewIMDSCredentialsRefresher(
 // Start begins the periodic IMDS credentials scan loop. It blocks until the
 // context is cancelled.
 func (r *IMDSCredentialsRefresher) Start() {
-	logger.Info("Starting IMDS credentials refresher")
+	logger.Info("IMDS credentials refresher started")
 	ticker := time.NewTicker(r.scanInterval)
 	defer ticker.Stop()
 	for {
@@ -103,6 +104,8 @@ func (r *IMDSCredentialsRefresher) refresh() {
 		return
 	}
 
+	// upsertedCredCount tallies credentials written to the credentials manager.
+	upsertedCredCount := 0
 	for _, cred := range creds {
 		task, ok := nonTerminalTasks[cred.TaskID]
 		if !ok {
@@ -113,23 +116,34 @@ func (r *IMDSCredentialsRefresher) refresh() {
 			})
 			continue
 		}
-		r.upsertCredential(task, cred)
+		if err := r.upsertCredential(task, cred); err != nil {
+			logger.Error("IMDS credentials refresh: failed to upsert credential",
+				logger.Fields{
+					field.TaskID: cred.TaskID,
+					"roleType":   cred.RoleType,
+					field.Error:  err,
+				})
+			continue
+		}
+		upsertedCredCount++
+	}
+
+	if len(creds) > 0 {
+		logger.Info("IMDS credentials refresh: scan complete", logger.Fields{
+			"retrievedCredentialCount": len(creds),
+			"upsertedCredentialCount":  upsertedCredCount,
+		})
 	}
 }
 
-// upsertCredential maps an IMDS credential to the task's role type
-// and upserts it into the credentials manager.
+// upsertCredential maps an IMDS credential to the task's role type and
+// upserts it into the credentials manager.
 func (r *IMDSCredentialsRefresher) upsertCredential(
 	task *apitask.Task, cred imds.TaskCredential,
-) {
+) error {
 	credentialsID := task.GetCredentialsIDForRoleType(cred.RoleType)
 	if credentialsID == "" {
-		logger.Warn("IMDS credentials refresh: no credentials ID for task",
-			logger.Fields{
-				field.TaskID: cred.TaskID,
-				"roleType":   cred.RoleType,
-			})
-		return
+		return fmt.Errorf("no credentials ID on task for role type %s", cred.RoleType)
 	}
 
 	err := r.credManager.SetTaskCredentials(&credentials.TaskIAMRoleCredentials{
@@ -145,12 +159,16 @@ func (r *IMDSCredentialsRefresher) upsertCredential(
 		},
 	})
 	if err != nil {
-		logger.Error("IMDS credentials refresh: failed to upsert credential",
-			logger.Fields{
-				field.TaskID: cred.TaskID,
-				field.Error:  err,
-			})
+		return fmt.Errorf("set task credentials: %w", err)
 	}
+
+	logger.Debug("IMDS credentials refresh: upserted task credential",
+		logger.Fields{
+			field.TaskID: cred.TaskID,
+			"roleType":   cred.RoleType,
+			"expiration": cred.Expiration,
+		})
+	return nil
 }
 
 // nonTerminalTasksByID returns a map of non-terminal ECS tasks keyed by the task ID.

--- a/agent/imdscreds/refresher_integ_test.go
+++ b/agent/imdscreds/refresher_integ_test.go
@@ -98,8 +98,8 @@ func TestIMDSCredentialsRefresh(t *testing.T) {
 	}()
 
 	// Simulate task payloads arriving with initial credentials.
-	addTaskToState(taskEngine, taskARN1, credID1App, "")
-	addTaskToState(taskEngine, taskARN2, credID2App, credID2Exec)
+	addTaskToState(taskEngine, taskARN1, credID1App, roleARN1, "", "")
+	addTaskToState(taskEngine, taskARN2, credID2App, roleARN2, credID2Exec, roleARN2)
 
 	setInitialTaskCredentials(t, credManager, taskARN1, credID1App, "AKID_ACS_A_APP")
 	setInitialTaskCredentials(t, credManager, taskARN2, credID2App, "AKID_ACS_B_APP")
@@ -190,7 +190,7 @@ func setupTestEngine(t *testing.T) (
 // addTaskToState adds a task to the engine's state.
 func addTaskToState(
 	taskEngine engine.TaskEngine,
-	arn, credID, execCredID string,
+	arn, credID, roleArn, execCredID, execRoleArn string,
 ) {
 	testTask := &task.Task{Arn: arn}
 	testTask.SetDesiredStatus(apitaskstatus.TaskRunning)
@@ -198,8 +198,14 @@ func addTaskToState(
 	if credID != "" {
 		testTask.SetCredentialsID(credID)
 	}
+	if roleArn != "" {
+		testTask.SetTaskRoleArn(roleArn)
+	}
 	if execCredID != "" {
 		testTask.SetExecutionRoleCredentialsID(execCredID)
+	}
+	if execRoleArn != "" {
+		testTask.SetExecutionRoleArn(execRoleArn)
 	}
 	taskEngine.(*engine.DockerTaskEngine).State().AddTask(testTask)
 }

--- a/agent/imdscreds/refresher_test.go
+++ b/agent/imdscreds/refresher_test.go
@@ -47,19 +47,32 @@ const (
 	testRoleARN3 = "arn:aws:iam::123456789012:role/TaskRole2"
 )
 
-// newTestTask creates a task with the given ARN, status, and credential IDs
-// for use in unit tests.
+// testTaskOpts configures a test task's credentials-related state.
+type testTaskOpts struct {
+	credID      string
+	roleArn     string
+	execCredID  string
+	execRoleArn string
+}
+
+// newTestTask creates a task with the given ARN, status, and
+// credentials-related state for use in unit tests.
 func newTestTask(
-	arn string, taskStatus status.TaskStatus,
-	credID, execCredID string,
+	arn string, taskStatus status.TaskStatus, opts testTaskOpts,
 ) *apitask.Task {
 	task := &apitask.Task{Arn: arn}
 	task.SetKnownStatus(taskStatus)
-	if credID != "" {
-		task.SetCredentialsID(credID)
+	if opts.credID != "" {
+		task.SetCredentialsID(opts.credID)
 	}
-	if execCredID != "" {
-		task.SetExecutionRoleCredentialsID(execCredID)
+	if opts.roleArn != "" {
+		task.SetTaskRoleArn(opts.roleArn)
+	}
+	if opts.execCredID != "" {
+		task.SetExecutionRoleCredentialsID(opts.execCredID)
+	}
+	if opts.execRoleArn != "" {
+		task.SetExecutionRoleArn(opts.execRoleArn)
 	}
 	return task
 }
@@ -84,20 +97,25 @@ func TestRefresh(t *testing.T) {
 		{
 			name: "scan error",
 			tasks: []*apitask.Task{
-				newTestTask(testTaskARN1, status.TaskRunning, testCredID1, ""),
+				newTestTask(testTaskARN1, status.TaskRunning,
+					testTaskOpts{credID: testCredID1, roleArn: testRoleARN1}),
 			},
 			scanErr: errors.New("imds unreachable"),
 		},
 		{
 			name: "all terminal tasks skips scan",
 			tasks: []*apitask.Task{
-				newTestTask(testTaskARN1, status.TaskStopped, testCredID1, ""),
+				newTestTask(testTaskARN1, status.TaskStopped,
+					testTaskOpts{credID: testCredID1, roleArn: testRoleARN1}),
 			},
 		},
 		{
 			name: "upserts task role credential",
 			tasks: []*apitask.Task{
-				newTestTask(testTaskARN1, status.TaskRunning, testCredID1, testCredID2),
+				newTestTask(testTaskARN1, status.TaskRunning, testTaskOpts{
+					credID: testCredID1, roleArn: testRoleARN1,
+					execCredID: testCredID2, execRoleArn: testRoleARN2,
+				}),
 			},
 			scanResult: []imds.TaskCredential{
 				{
@@ -128,7 +146,10 @@ func TestRefresh(t *testing.T) {
 		{
 			name: "upserts execution role credential",
 			tasks: []*apitask.Task{
-				newTestTask(testTaskARN1, status.TaskRunning, testCredID1, testCredID2),
+				newTestTask(testTaskARN1, status.TaskRunning, testTaskOpts{
+					credID: testCredID1, roleArn: testRoleARN1,
+					execCredID: testCredID2, execRoleArn: testRoleARN2,
+				}),
 			},
 			scanResult: []imds.TaskCredential{
 				{
@@ -159,7 +180,8 @@ func TestRefresh(t *testing.T) {
 		{
 			name: "skips unknown task ID",
 			tasks: []*apitask.Task{
-				newTestTask(testTaskARN1, status.TaskRunning, testCredID1, ""),
+				newTestTask(testTaskARN1, status.TaskRunning,
+					testTaskOpts{credID: testCredID1, roleArn: testRoleARN1}),
 			},
 			scanResult: []imds.TaskCredential{
 				{
@@ -172,7 +194,7 @@ func TestRefresh(t *testing.T) {
 		{
 			name: "skips credential with no credentials ID on task",
 			tasks: []*apitask.Task{
-				newTestTask(testTaskARN1, status.TaskRunning, "", ""),
+				newTestTask(testTaskARN1, status.TaskRunning, testTaskOpts{}),
 			},
 			scanResult: []imds.TaskCredential{
 				{
@@ -183,10 +205,26 @@ func TestRefresh(t *testing.T) {
 			},
 		},
 		{
+			name: "skips credential whose role ARN does not match task",
+			tasks: []*apitask.Task{
+				newTestTask(testTaskARN1, status.TaskRunning,
+					testTaskOpts{credID: testCredID1, roleArn: testRoleARN1}),
+			},
+			scanResult: []imds.TaskCredential{
+				{
+					TaskID:   testTaskID1,
+					RoleType: credentials.ApplicationRoleType,
+					RoleArn:  testRoleARN2,
+				},
+			},
+		},
+		{
 			name: "multiple tasks multiple credentials",
 			tasks: []*apitask.Task{
-				newTestTask(testTaskARN1, status.TaskRunning, testCredID1, ""),
-				newTestTask(testTaskARN2, status.TaskRunning, testCredID3, ""),
+				newTestTask(testTaskARN1, status.TaskRunning,
+					testTaskOpts{credID: testCredID1, roleArn: testRoleARN1}),
+				newTestTask(testTaskARN2, status.TaskRunning,
+					testTaskOpts{credID: testCredID3, roleArn: testRoleARN3}),
 			},
 			scanResult: []imds.TaskCredential{
 				{
@@ -238,7 +276,10 @@ func TestRefresh(t *testing.T) {
 		{
 			name: "same role ARN for task and execution role",
 			tasks: []*apitask.Task{
-				newTestTask(testTaskARN1, status.TaskRunning, testCredID1, testCredID2),
+				newTestTask(testTaskARN1, status.TaskRunning, testTaskOpts{
+					credID: testCredID1, roleArn: testRoleARN1,
+					execCredID: testCredID2, execRoleArn: testRoleARN1,
+				}),
 			},
 			scanResult: []imds.TaskCredential{
 				{
@@ -340,7 +381,8 @@ func TestUpsertCredential(t *testing.T) {
 	}{
 		{
 			name: "upserts with correct credentials",
-			task: newTestTask(testTaskARN1, status.TaskRunning, testCredID1, ""),
+			task: newTestTask(testTaskARN1, status.TaskRunning,
+				testTaskOpts{credID: testCredID1, roleArn: testRoleARN1}),
 			cred: imds.TaskCredential{
 				TaskID:          testTaskID1,
 				RoleType:        credentials.ApplicationRoleType,
@@ -365,7 +407,8 @@ func TestUpsertCredential(t *testing.T) {
 		},
 		{
 			name: "SetTaskCredentials error is returned",
-			task: newTestTask(testTaskARN1, status.TaskRunning, testCredID1, ""),
+			task: newTestTask(testTaskARN1, status.TaskRunning,
+				testTaskOpts{credID: testCredID1, roleArn: testRoleARN1}),
 			cred: imds.TaskCredential{
 				TaskID:          testTaskID1,
 				RoleType:        credentials.ApplicationRoleType,
@@ -392,7 +435,7 @@ func TestUpsertCredential(t *testing.T) {
 		},
 		{
 			name: "no credentials ID for role type, does not upsert",
-			task: newTestTask(testTaskARN1, status.TaskRunning, "", ""),
+			task: newTestTask(testTaskARN1, status.TaskRunning, testTaskOpts{}),
 			cred: imds.TaskCredential{
 				TaskID:   testTaskID1,
 				RoleType: credentials.ApplicationRoleType,
@@ -402,8 +445,44 @@ func TestUpsertCredential(t *testing.T) {
 			expectedErrSubstring: "no credentials ID on task for role type",
 		},
 		{
+			name: "no role ARN on task, does not upsert",
+			task: newTestTask(testTaskARN1, status.TaskRunning,
+				testTaskOpts{credID: testCredID1}),
+			cred: imds.TaskCredential{
+				TaskID:   testTaskID1,
+				RoleType: credentials.ApplicationRoleType,
+				RoleArn:  testRoleARN1,
+			},
+			expectedUpsert:       nil,
+			expectedErrSubstring: "no role ARN on task for role type",
+		},
+		{
+			name: "scanned role ARN does not match task, does not upsert",
+			task: newTestTask(testTaskARN1, status.TaskRunning,
+				testTaskOpts{credID: testCredID1, roleArn: testRoleARN1}),
+			cred: imds.TaskCredential{
+				TaskID:   testTaskID1,
+				RoleType: credentials.ApplicationRoleType,
+				RoleArn:  testRoleARN2,
+			},
+			expectedUpsert:       nil,
+			expectedErrSubstring: "does not match",
+		},
+		{
+			name: "scanned credential has no role ARN, does not upsert",
+			task: newTestTask(testTaskARN1, status.TaskRunning,
+				testTaskOpts{credID: testCredID1, roleArn: testRoleARN1}),
+			cred: imds.TaskCredential{
+				TaskID:   testTaskID1,
+				RoleType: credentials.ApplicationRoleType,
+			},
+			expectedUpsert:       nil,
+			expectedErrSubstring: `role ARN "" does not match`,
+		},
+		{
 			name: "unknown role type, does not upsert",
-			task: newTestTask(testTaskARN1, status.TaskRunning, testCredID1, ""),
+			task: newTestTask(testTaskARN1, status.TaskRunning,
+				testTaskOpts{credID: testCredID1, roleArn: testRoleARN1}),
 			cred: imds.TaskCredential{
 				TaskID:   testTaskID1,
 				RoleType: "UnknownType",
@@ -458,16 +537,20 @@ func TestNonTerminalTasksByID(t *testing.T) {
 		{
 			name: "filters terminal tasks",
 			tasks: []*apitask.Task{
-				newTestTask(testTaskARN1, status.TaskRunning, testCredID1, ""),
-				newTestTask(testTaskARN2, status.TaskStopped, testCredID3, ""),
+				newTestTask(testTaskARN1, status.TaskRunning,
+					testTaskOpts{credID: testCredID1, roleArn: testRoleARN1}),
+				newTestTask(testTaskARN2, status.TaskStopped,
+					testTaskOpts{credID: testCredID3, roleArn: testRoleARN3}),
 			},
 			expectedIDs: []string{testTaskID1},
 		},
 		{
 			name: "includes all non-terminal",
 			tasks: []*apitask.Task{
-				newTestTask(testTaskARN1, status.TaskRunning, testCredID1, ""),
-				newTestTask(testTaskARN2, status.TaskRunning, testCredID3, ""),
+				newTestTask(testTaskARN1, status.TaskRunning,
+					testTaskOpts{credID: testCredID1, roleArn: testRoleARN1}),
+				newTestTask(testTaskARN2, status.TaskRunning,
+					testTaskOpts{credID: testCredID3, roleArn: testRoleARN3}),
 			},
 			expectedIDs: []string{testTaskID1, testTaskID2},
 		},

--- a/agent/imdscreds/refresher_test.go
+++ b/agent/imdscreds/refresher_test.go
@@ -331,11 +331,12 @@ func TestRefresh(t *testing.T) {
 
 func TestUpsertCredential(t *testing.T) {
 	tests := []struct {
-		name           string
-		task           *apitask.Task
-		cred           imds.TaskCredential
-		expectedUpsert *credentials.TaskIAMRoleCredentials
-		upsertErr      error
+		name                 string
+		task                 *apitask.Task
+		cred                 imds.TaskCredential
+		expectedUpsert       *credentials.TaskIAMRoleCredentials
+		upsertErr            error
+		expectedErrSubstring string
 	}{
 		{
 			name: "upserts with correct credentials",
@@ -363,7 +364,7 @@ func TestUpsertCredential(t *testing.T) {
 			},
 		},
 		{
-			name: "SetTaskCredentials error is handled gracefully",
+			name: "SetTaskCredentials error is returned",
 			task: newTestTask(testTaskARN1, status.TaskRunning, testCredID1, ""),
 			cred: imds.TaskCredential{
 				TaskID:          testTaskID1,
@@ -386,7 +387,8 @@ func TestUpsertCredential(t *testing.T) {
 					RoleType:        credentials.ApplicationRoleType,
 				},
 			},
-			upsertErr: errors.New("write failed"),
+			upsertErr:            errors.New("write failed"),
+			expectedErrSubstring: "set task credentials: write failed",
 		},
 		{
 			name: "no credentials ID for role type, does not upsert",
@@ -396,7 +398,8 @@ func TestUpsertCredential(t *testing.T) {
 				RoleType: credentials.ApplicationRoleType,
 				RoleArn:  testRoleARN1,
 			},
-			expectedUpsert: nil,
+			expectedUpsert:       nil,
+			expectedErrSubstring: "no credentials ID on task for role type",
 		},
 		{
 			name: "unknown role type, does not upsert",
@@ -406,7 +409,8 @@ func TestUpsertCredential(t *testing.T) {
 				RoleType: "UnknownType",
 				RoleArn:  testRoleARN1,
 			},
-			expectedUpsert: nil,
+			expectedUpsert:       nil,
+			expectedErrSubstring: "no credentials ID on task for role type",
 		},
 	}
 
@@ -430,7 +434,12 @@ func TestUpsertCredential(t *testing.T) {
 				ctx:         context.Background(),
 				credManager: mockCredManager,
 			}
-			refresher.upsertCredential(tc.task, tc.cred)
+			err := refresher.upsertCredential(tc.task, tc.cred)
+			if tc.expectedErrSubstring == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tc.expectedErrSubstring)
 		})
 	}
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/scanner.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/scanner.go
@@ -260,6 +260,24 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 			continue
 		}
 
+		if err := validateCredential(imdsCred); err != nil {
+			logger.Error("IMDS credentials scan: invalid credential", logger.Fields{
+				field.TaskID: taskID,
+				"roleType":   roleType,
+				"namespace":  namespace,
+				field.Error:  err,
+			})
+			s.metricsFactory.New(metrics.IMDSCredentialsScannerCredentialFailureMetricName).
+				WithFields(map[string]any{
+					metricFieldNamespace: namespace,
+					metricFieldTaskID:    taskID,
+					metricFieldRoleType:  roleType,
+				}).Done(err)
+			// Invalid credential; try remaining credentials in this namespace.
+			hasErrors = true
+			continue
+		}
+
 		logger.Debug("IMDS credentials scan: fetched credential", logger.Fields{
 			field.TaskID: taskID,
 			"roleType":   roleType,
@@ -306,6 +324,29 @@ func parseCredentialKey(key string) (string, string, error) {
 		return "", "", fmt.Errorf("unexpected credential key format: %s", key)
 	}
 	return taskID, roleType, nil
+}
+
+// validateCredential reports an error when a required credential field is absent.
+// json.Unmarshal leaves fields missing from the document zero-valued, so an
+// empty value means the field was not published.
+func validateCredential(c imdsCredential) error {
+	var missing []string
+	if c.AccessKeyId == "" {
+		missing = append(missing, "AccessKeyId")
+	}
+	if c.SecretAccessKey == "" {
+		missing = append(missing, "SecretAccessKey")
+	}
+	if c.Token == "" {
+		missing = append(missing, "Token")
+	}
+	if c.Expiration == "" {
+		missing = append(missing, "Expiration")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required fields: %s", strings.Join(missing, ", "))
+	}
+	return nil
 }
 
 // getMetadata is a rate-limited wrapper around the EC2 metadata client.

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/scanner.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/credentials/imds/scanner.go
@@ -110,7 +110,7 @@ func (s *scanner) Scan(ctx context.Context) ([]TaskCredential, error) {
 
 	// No namespaces is expected when IMDS does not have ECS task credentials yet.
 	if len(namespaces) == 0 {
-		logger.Debug("No iam-ecs namespace found in IMDS")
+		logger.Debug("IMDS credentials scan: no iam-ecs namespace found")
 		return nil, nil
 	}
 
@@ -119,7 +119,7 @@ func (s *scanner) Scan(ctx context.Context) ([]TaskCredential, error) {
 	for _, ns := range namespaces {
 		nsCreds, err := s.scanNamespace(ctx, ns)
 		if err != nil {
-			logger.Error("Failed to scan IMDS namespace", logger.Fields{
+			logger.Error("IMDS credentials scan: failed to scan namespace", logger.Fields{
 				"namespace": ns,
 				field.Error: err,
 			})
@@ -197,7 +197,7 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 		return nil, fmt.Errorf("parse LastUpdated for %s: %w", namespace, err)
 	}
 	if cached, ok := s.lastUpdated[namespace]; ok && lastUpdated.Equal(cached) {
-		logger.Debug("Skipping namespace with unchanged LastUpdated", logger.Fields{
+		logger.Debug("IMDS credentials scan: skipping namespace with unchanged LastUpdated", logger.Fields{
 			"namespace": namespace,
 		})
 		return nil, nil
@@ -208,7 +208,7 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 	for key, entry := range info.TaskCredentials {
 		taskID, roleType, err := parseCredentialKey(key)
 		if err != nil {
-			logger.Error("Failed to parse credential key from IMDS", logger.Fields{
+			logger.Error("IMDS credentials scan: failed to parse credential key", logger.Fields{
 				"namespace": namespace,
 				field.Error: err,
 			})
@@ -224,7 +224,7 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 		credPath := fmt.Sprintf(credentialPathFormat, namespace, key)
 		credResp, err := s.getMetadata(ctx, credPath)
 		if err != nil {
-			logger.Error("Failed to fetch credential from IMDS", logger.Fields{
+			logger.Error("IMDS credentials scan: failed to fetch credential", logger.Fields{
 				field.TaskID: taskID,
 				"roleType":   roleType,
 				"namespace":  namespace,
@@ -243,7 +243,7 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 
 		var imdsCred imdsCredential
 		if err := json.Unmarshal([]byte(credResp), &imdsCred); err != nil {
-			logger.Error("Failed to parse credential from IMDS", logger.Fields{
+			logger.Error("IMDS credentials scan: failed to parse credential", logger.Fields{
 				field.TaskID: taskID,
 				"roleType":   roleType,
 				"namespace":  namespace,
@@ -260,6 +260,12 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 			continue
 		}
 
+		logger.Debug("IMDS credentials scan: fetched credential", logger.Fields{
+			field.TaskID: taskID,
+			"roleType":   roleType,
+			"namespace":  namespace,
+			"expiration": imdsCred.Expiration,
+		})
 		creds = append(creds, TaskCredential{
 			TaskID:          taskID,
 			RoleType:        roleType,
@@ -280,8 +286,14 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 	// Surface an error when the namespace yielded no credentials and also had
 	// failures, so callers don't mistake it for "no credentials yet".
 	if len(creds) == 0 && hasErrors {
-		return nil, fmt.Errorf("namespace %s: all credential processing failed", namespace)
+		return nil, fmt.Errorf("all credential processing failed for %s", namespace)
 	}
+
+	logger.Info("IMDS credentials scan: namespace scan complete", logger.Fields{
+		"namespace":                namespace,
+		"retrievedCredentialCount": len(creds),
+		"lastUpdated":              info.LastUpdated,
+	})
 
 	return creds, nil
 }

--- a/ecs-agent/credentials/imds/scanner.go
+++ b/ecs-agent/credentials/imds/scanner.go
@@ -260,6 +260,24 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 			continue
 		}
 
+		if err := validateCredential(imdsCred); err != nil {
+			logger.Error("IMDS credentials scan: invalid credential", logger.Fields{
+				field.TaskID: taskID,
+				"roleType":   roleType,
+				"namespace":  namespace,
+				field.Error:  err,
+			})
+			s.metricsFactory.New(metrics.IMDSCredentialsScannerCredentialFailureMetricName).
+				WithFields(map[string]any{
+					metricFieldNamespace: namespace,
+					metricFieldTaskID:    taskID,
+					metricFieldRoleType:  roleType,
+				}).Done(err)
+			// Invalid credential; try remaining credentials in this namespace.
+			hasErrors = true
+			continue
+		}
+
 		logger.Debug("IMDS credentials scan: fetched credential", logger.Fields{
 			field.TaskID: taskID,
 			"roleType":   roleType,
@@ -306,6 +324,29 @@ func parseCredentialKey(key string) (string, string, error) {
 		return "", "", fmt.Errorf("unexpected credential key format: %s", key)
 	}
 	return taskID, roleType, nil
+}
+
+// validateCredential reports an error when a required credential field is absent.
+// json.Unmarshal leaves fields missing from the document zero-valued, so an
+// empty value means the field was not published.
+func validateCredential(c imdsCredential) error {
+	var missing []string
+	if c.AccessKeyId == "" {
+		missing = append(missing, "AccessKeyId")
+	}
+	if c.SecretAccessKey == "" {
+		missing = append(missing, "SecretAccessKey")
+	}
+	if c.Token == "" {
+		missing = append(missing, "Token")
+	}
+	if c.Expiration == "" {
+		missing = append(missing, "Expiration")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required fields: %s", strings.Join(missing, ", "))
+	}
+	return nil
 }
 
 // getMetadata is a rate-limited wrapper around the EC2 metadata client.

--- a/ecs-agent/credentials/imds/scanner.go
+++ b/ecs-agent/credentials/imds/scanner.go
@@ -110,7 +110,7 @@ func (s *scanner) Scan(ctx context.Context) ([]TaskCredential, error) {
 
 	// No namespaces is expected when IMDS does not have ECS task credentials yet.
 	if len(namespaces) == 0 {
-		logger.Debug("No iam-ecs namespace found in IMDS")
+		logger.Debug("IMDS credentials scan: no iam-ecs namespace found")
 		return nil, nil
 	}
 
@@ -119,7 +119,7 @@ func (s *scanner) Scan(ctx context.Context) ([]TaskCredential, error) {
 	for _, ns := range namespaces {
 		nsCreds, err := s.scanNamespace(ctx, ns)
 		if err != nil {
-			logger.Error("Failed to scan IMDS namespace", logger.Fields{
+			logger.Error("IMDS credentials scan: failed to scan namespace", logger.Fields{
 				"namespace": ns,
 				field.Error: err,
 			})
@@ -197,7 +197,7 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 		return nil, fmt.Errorf("parse LastUpdated for %s: %w", namespace, err)
 	}
 	if cached, ok := s.lastUpdated[namespace]; ok && lastUpdated.Equal(cached) {
-		logger.Debug("Skipping namespace with unchanged LastUpdated", logger.Fields{
+		logger.Debug("IMDS credentials scan: skipping namespace with unchanged LastUpdated", logger.Fields{
 			"namespace": namespace,
 		})
 		return nil, nil
@@ -208,7 +208,7 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 	for key, entry := range info.TaskCredentials {
 		taskID, roleType, err := parseCredentialKey(key)
 		if err != nil {
-			logger.Error("Failed to parse credential key from IMDS", logger.Fields{
+			logger.Error("IMDS credentials scan: failed to parse credential key", logger.Fields{
 				"namespace": namespace,
 				field.Error: err,
 			})
@@ -224,7 +224,7 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 		credPath := fmt.Sprintf(credentialPathFormat, namespace, key)
 		credResp, err := s.getMetadata(ctx, credPath)
 		if err != nil {
-			logger.Error("Failed to fetch credential from IMDS", logger.Fields{
+			logger.Error("IMDS credentials scan: failed to fetch credential", logger.Fields{
 				field.TaskID: taskID,
 				"roleType":   roleType,
 				"namespace":  namespace,
@@ -243,7 +243,7 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 
 		var imdsCred imdsCredential
 		if err := json.Unmarshal([]byte(credResp), &imdsCred); err != nil {
-			logger.Error("Failed to parse credential from IMDS", logger.Fields{
+			logger.Error("IMDS credentials scan: failed to parse credential", logger.Fields{
 				field.TaskID: taskID,
 				"roleType":   roleType,
 				"namespace":  namespace,
@@ -260,6 +260,12 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 			continue
 		}
 
+		logger.Debug("IMDS credentials scan: fetched credential", logger.Fields{
+			field.TaskID: taskID,
+			"roleType":   roleType,
+			"namespace":  namespace,
+			"expiration": imdsCred.Expiration,
+		})
 		creds = append(creds, TaskCredential{
 			TaskID:          taskID,
 			RoleType:        roleType,
@@ -280,8 +286,14 @@ func (s *scanner) scanNamespace(ctx context.Context, namespace string) ([]TaskCr
 	// Surface an error when the namespace yielded no credentials and also had
 	// failures, so callers don't mistake it for "no credentials yet".
 	if len(creds) == 0 && hasErrors {
-		return nil, fmt.Errorf("namespace %s: all credential processing failed", namespace)
+		return nil, fmt.Errorf("all credential processing failed for %s", namespace)
 	}
+
+	logger.Info("IMDS credentials scan: namespace scan complete", logger.Fields{
+		"namespace":                namespace,
+		"retrievedCredentialCount": len(creds),
+		"lastUpdated":              info.LastUpdated,
+	})
 
 	return creds, nil
 }

--- a/ecs-agent/credentials/imds/scanner_test.go
+++ b/ecs-agent/credentials/imds/scanner_test.go
@@ -340,6 +340,29 @@ func TestScanNamespace(t *testing.T) {
 			expectLastUpdatedCached: aws.Bool(false),
 		},
 		{
+			name: "credential missing required fields",
+			setupMock: func(m *mockec2.MockEC2MetadataClient) {
+				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
+					testInfoJSON(map[string]string{key1: testRoleARN}), nil)
+				m.EXPECT().GetMetadata("iam-ecs-1/security-credentials/"+key1).Return(
+					`{"AccessKeyId": "AKID1"}`, nil)
+			},
+			expectedErrSubstring: "all credential processing failed",
+			expectedMetrics: []metricExpectation{
+				{
+					name: metrics.IMDSCredentialsScannerCredentialFailureMetricName,
+					fields: map[string]any{
+						metricFieldNamespace: "iam-ecs-1",
+						metricFieldTaskID:    testTaskID1,
+						metricFieldRoleType:  credentials.ApplicationRoleType,
+					},
+					doneErr: errMessageContains(
+						"missing required fields: SecretAccessKey, Token, Expiration"),
+				},
+			},
+			expectLastUpdatedCached: aws.Bool(false),
+		},
+		{
 			name: "invalid credential key format",
 			setupMock: func(m *mockec2.MockEC2MetadataClient) {
 				m.EXPECT().GetMetadata("iam-ecs-1/info").Return(
@@ -471,6 +494,77 @@ func TestParseCredentialKey(t *testing.T) {
 				assert.Equal(t, tc.expectedTaskID, taskID)
 				assert.Equal(t, tc.expectedRoleType, roleType)
 			}
+		})
+	}
+}
+
+func TestValidateCredential(t *testing.T) {
+	tests := []struct {
+		name                 string
+		cred                 imdsCredential
+		expectedErrSubstring string
+	}{
+		{
+			name: "all required fields present",
+			cred: imdsCredential{
+				AccessKeyId:     "AKID",
+				SecretAccessKey: "secret",
+				Token:           "token",
+				Expiration:      "2026-04-28T00:00:00Z",
+			},
+		},
+		{
+			name: "missing access key ID",
+			cred: imdsCredential{
+				SecretAccessKey: "secret",
+				Token:           "token",
+				Expiration:      "2026-04-28T00:00:00Z",
+			},
+			expectedErrSubstring: "missing required fields: AccessKeyId",
+		},
+		{
+			name: "missing secret access key",
+			cred: imdsCredential{
+				AccessKeyId: "AKID",
+				Token:       "token",
+				Expiration:  "2026-04-28T00:00:00Z",
+			},
+			expectedErrSubstring: "missing required fields: SecretAccessKey",
+		},
+		{
+			name: "missing token",
+			cred: imdsCredential{
+				AccessKeyId:     "AKID",
+				SecretAccessKey: "secret",
+				Expiration:      "2026-04-28T00:00:00Z",
+			},
+			expectedErrSubstring: "missing required fields: Token",
+		},
+		{
+			name: "missing expiration",
+			cred: imdsCredential{
+				AccessKeyId:     "AKID",
+				SecretAccessKey: "secret",
+				Token:           "token",
+			},
+			expectedErrSubstring: "missing required fields: Expiration",
+		},
+		{
+			name: "all fields missing are reported together",
+			cred: imdsCredential{},
+			expectedErrSubstring: "missing required fields: " +
+				"AccessKeyId, SecretAccessKey, Token, Expiration",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCredential(tc.cred)
+			if tc.expectedErrSubstring == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tc.expectedErrSubstring)
 		})
 	}
 }


### PR DESCRIPTION
### Summary

This PR improves the observability of the IMDS credentials refresher/scanner, and ensures a credential retrieved from IMDS is only upserted to the credentials manager when it is complete and belongs to the same role that task's credentials were issued for, during task launch.

The change is split into 2 commits for ease of review.

### Implementation details

##### Logging
- All scanner log messages carry a uniform `IMDS credentials scan:` prefix, matching the refresher's existing `IMDS credentials refresh:` convention.
- Each credential fetched from IMDS and each credential upserted into the credentials manager is logged at debug level with its task ID, role type and expiration, so a single refresh cycle can be followed end to end.
- Each namespace scan and each refresh cycle logs a summary: credentials retrieved per namespace, and retrieved versus upserted per cycle.
- `upsertCredential` returns an error instead of logging internally. The refresh loop logs every failure mode with uniform fields and severity, and counts successful upserts for the cycle summary.

##### Credential validation

- `json.Unmarshal` leaves fields absent from a document zero-valued, so a credential file missing a field parses without error. Added a new `validateCredential` method that rejects a credential missing any of `AccessKeyId`, `SecretAccessKey`, `Token` or `Expiration`, reporting every absent field in one error.

- The task and execution role ARNs delivered by ACS are persisted on the task (`TaskRoleArn`, `ExecutionRoleArn`), captured in both the payload and refresh-credentials responders, and therefore survive an agent restart alongside the credentials IDs already stored there. Before upserting creds, the IMDS credentials refresher compares the scanned credential's role ARN against the ARN recorded on the task for that role type, and rejects the credential when the role ARN does not match. The ARN from task state is what gets stored, so a credential can never overwrite a task's role attribution with an unverified value.

### Testing

New tests cover the changes: yes, added/updated both unit and integ tests.

### Description for the changelog

Enhancement - Add logging and validations to the IMDS credentials refresher/scanner (not enabled in production yet)

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No

**Does this PR include the addition of new environment variables in the README?** No

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
