### PR TITLE
fix(handlers): raise fault rate limit to 1 rps

### DIFF
--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -357,9 +357,13 @@ func registerFaultHandlers(
 	seelog.Debug("Successfully set up Fault TMDS handlers")
 }
 
+// faultHandlerRateLimit is the maximum number of fault handler requests per
+// second permitted by the tollbooth rate limiter.
+const faultHandlerRateLimit = 1.0
+
 // Creates a tollbooth ratelimiter for the Fault Handler APIs
 func createRateLimiter() *limiter.Limiter {
-	lmt := tollbooth.NewLimiter(0.2, nil)
+	lmt := tollbooth.NewLimiter(faultHandlerRateLimit, nil)
 	lmt.SetMessage("You have reached maximum request limit")
 	return lmt
 }

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -4434,3 +4434,12 @@ func testRegisterFaultHandler(t *testing.T, tcs []networkFaultTestCase, tmdsEndp
 		})
 	}
 }
+
+func TestCreateRateLimiter(t *testing.T) {
+	lmt := createRateLimiter()
+	require.NotNil(t, lmt)
+
+	assert.Equal(t, 1.0, lmt.GetMax(),
+		"fault handler rate limit should be 1 request per second")
+	assert.Equal(t, "You have reached maximum request limit", lmt.GetMessage())
+}


### PR DESCRIPTION
### Summary

add-sources issues sequential HTTP calls that contend with each other and with start/stop/check on the shared tollbooth rate limiter for the fault TMDS handlers. At 0.2 rps (one request every five seconds) legitimate fault-injection workflows are throttled by the limiter itself. Raise the rate to 1 rps and pull the value out into a named constant.

### Implementation details

`agent/handlers/task_server_setup.go` gains `const faultHandlerRateLimit = 1.0` and passes it into `tollbooth.NewLimiter` inside `createRateLimiter()`. No other call site changes: every fault TMDS handler already routes through this one `createRateLimiter()` factory.

### Testing

New unit test `TestCreateRateLimiter` in `agent/handlers/task_server_setup_test.go` asserts `lmt.GetMax() == 1.0` and `lmt.GetMessage() == "You have reached maximum request limit"`.

Verified on `i-0c581b16296d39602` (t3.large, AL2023 ECS-optimized) in cluster `agent-1106-probe`, us-east-1:

Unit test:

```
$ go test -tags unit -mod vendor -count=1 -timeout 300s -v -run '^TestCreateRateLimiter$' ./handlers/
=== RUN   TestCreateRateLimiter
--- PASS: TestCreateRateLimiter (0.00s)
PASS
ok      github.com/aws/amazon-ecs-agent/agent/handlers  0.021s
```

Runtime probe against the patched agent binary. `sudo make release-agent` produced `ecs-agent-v1.106.1.tar` (MAKE_EXIT=0), `docker load`ed, ECS restarted, container instance re-registered. Task `ratelimit-probe-479d5ccb:1` (`networkMode=host`, `enableFaultInjection=true`, image `public.ecr.aws/amazonlinux/amazonlinux:2023`) started on the instance. `POST /fault/v1/network-latency/start` returned `HTTP 200 {"Status":"running"}`. Then two phases of `POST /fault/v1/network-latency/add-sources`:

Phase 1: six requests spaced ~1 s apart (1 rps).

```
phase1 #1 @ 18:34:46.241  ip=198.51.100.1  HTTP=200  body={"Status":"running"}
phase1 #2 @ 18:34:47.269  ip=198.51.100.2  HTTP=200  body={"Status":"running"}
phase1 #3 @ 18:34:48.295  ip=198.51.100.3  HTTP=200  body={"Status":"running"}
phase1 #4 @ 18:34:49.319  ip=198.51.100.4  HTTP=200  body={"Status":"running"}
phase1 #5 @ 18:34:50.341  ip=198.51.100.5  HTTP=200  body={"Status":"running"}
phase1 #6 @ 18:34:51.363  ip=198.51.100.6  HTTP=200  body={"Status":"running"}
```

6/6 admitted. 1 rps sits under the new limit.

Phase 2: fifteen requests spaced ~0.2 s apart (~5 rps).

```
phase2 #1  @ 18:34:52.389  ip=198.51.100.10  HTTP=200  body={"Status":"running"}
phase2 #2  @ 18:34:52.611  ip=198.51.100.11  HTTP=429  body=You have reached maximum request limit
phase2 #3  @ 18:34:52.825  ip=198.51.100.12  HTTP=429  body=You have reached maximum request limit
phase2 #4  @ 18:34:53.044  ip=198.51.100.13  HTTP=429  body=You have reached maximum request limit
phase2 #5  @ 18:34:53.259  ip=198.51.100.14  HTTP=429  body=You have reached maximum request limit
phase2 #6  @ 18:34:53.476  ip=198.51.100.15  HTTP=200  body={"Status":"running"}
phase2 #7  @ 18:34:53.700  ip=198.51.100.16  HTTP=429  body=You have reached maximum request limit
phase2 #8  @ 18:34:53.914  ip=198.51.100.17  HTTP=429  body=You have reached maximum request limit
phase2 #9  @ 18:34:54.129  ip=198.51.100.18  HTTP=429  body=You have reached maximum request limit
phase2 #10 @ 18:34:54.344  ip=198.51.100.19  HTTP=429  body=You have reached maximum request limit
phase2 #11 @ 18:34:54.558  ip=198.51.100.20  HTTP=200  body={"Status":"running"}
phase2 #12 @ 18:34:54.784  ip=198.51.100.21  HTTP=429  body=You have reached maximum request limit
phase2 #13 @ 18:34:54.999  ip=198.51.100.22  HTTP=429  body=You have reached maximum request limit
phase2 #14 @ 18:34:55.214  ip=198.51.100.23  HTTP=429  body=You have reached maximum request limit
phase2 #15 @ 18:34:55.428  ip=198.51.100.24  HTTP=429  body=You have reached maximum request limit
```

3/15 admitted, 12/15 throttled with the `"You have reached maximum request limit"` body set by `createRateLimiter()`. The three admissions land at 18:34:52.389, 53.476, 54.558; spacing 1.087 s. Observed steady-state throughput under saturation ≈ 1 req/s, matching the compiled `Max=1.0`.

`POST /fault/v1/network-latency/stop` returned `HTTP 200 {"Status":"stopped"}`.

New tests cover the changes: yes

### Description for the changelog

Enhancement - Raise fault TMDS handler rate limit from 0.2 rps to 1 rps

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?**

No. The change is a numeric constant inside one factory function and has no protocol or state surface.

**Does this PR include the addition of new environment variables in the README?**

No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

