### PR TITLE
Add MPS control-daemon health probe

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/mps/mps.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/mps/mps.go
@@ -13,7 +13,14 @@
 
 package mps
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper"
+)
 
 const (
 	// PipeDirectory is the MPS control daemon's Unix domain socket directory. It
@@ -34,7 +41,79 @@ const (
 
 	// inContainerDeviceIndex is the device index the memory limit is keyed on.
 	inContainerDeviceIndex = 0
+
+	// ControlBinary is the MPS control utility. Execing it with a control
+	// command checks daemon readiness. It talks to the daemon socket under
+	// CUDA_MPS_PIPE_DIRECTORY.
+	ControlBinary = "/usr/bin/nvidia-cuda-mps-control"
+
+	// ProbeCommand is the control command fed to the control utility. It answers
+	// even before any MPS client exists, and the utility exit code reflects daemon
+	// reachability regardless of the command, so it serves as a liveness check.
+	ProbeCommand = "get_default_active_thread_percentage"
+
+	// ProbeTimeout bounds the probe exec. A wedged daemon accepts the socket
+	// connection but never replies, hanging the control utility. The context
+	// timeout turns that hang into a failure.
+	ProbeTimeout = 3 * time.Second
 )
+
+// ProbeResult captures what one health-probe exec observed.
+type ProbeResult struct {
+	// ExitCode is the control utility exit code. 0 means the daemon is serving. A
+	// positive value is the utility's own nonzero exit, meaning the daemon is not
+	// serving (e.g. 1 "Cannot find MPS control daemon process"). -1 means the
+	// process could not be run or was killed by the context timeout (TimedOut is
+	// true and Err is set).
+	ExitCode int
+	// Stdout is the trimmed combined stdout/stderr of the probe.
+	Stdout string
+	// Latency is the wall-clock time the probe exec took.
+	Latency time.Duration
+	// TimedOut is true when the context deadline fired.
+	TimedOut bool
+	// Err is non-nil when the daemon is not functionally serving.
+	Err error
+}
+
+// ProbeControlDaemon reports whether the MPS control daemon is serving: it feeds
+// command to the control utility on stdin and treats exit code 0 within
+// ProbeTimeout as serving.
+func ProbeControlDaemon(exec execwrapper.Exec, command string) ProbeResult {
+	ctx, cancel := exec.NewExecContextWithTimeout(context.Background(), ProbeTimeout)
+	defer cancel()
+
+	// ControlBinary is a fixed constant path and no arguments are passed. command
+	// is fed on stdin, not as an argument, and exec runs the binary directly (no
+	// shell), so there is no shell-injection surface.
+	// nosemgrep: command-injection-exec-variable
+	cmd := exec.CommandContext(ctx, ControlBinary)
+	cmd.SetIOStreams(strings.NewReader(command+"\n"), nil, nil)
+
+	start := time.Now()
+	out, err := cmd.CombinedOutput()
+
+	result := ProbeResult{
+		Stdout:  strings.TrimSpace(string(out)),
+		Latency: time.Since(start),
+	}
+	if err == nil {
+		return result
+	}
+
+	result.TimedOut = ctx.Err() == context.DeadlineExceeded
+	if exitErr, ok := exec.ConvertToExitError(err); ok {
+		result.ExitCode = exec.GetExitCode(exitErr)
+	} else {
+		result.ExitCode = -1
+	}
+	if result.TimedOut {
+		result.Err = fmt.Errorf("mps control daemon probe timed out after %s (daemon wedged?): %w", ProbeTimeout, err)
+	} else {
+		result.Err = fmt.Errorf("mps control daemon probe failed (exit %d, output %q): %w", result.ExitCode, result.Stdout, err)
+	}
+	return result
+}
 
 // BuildEnv returns the MPS environment variables for a single MPS container.
 func BuildEnv(memoryMiB uint, computePercent *uint) map[string]string {

--- a/ecs-agent/utils/mps/mps.go
+++ b/ecs-agent/utils/mps/mps.go
@@ -13,7 +13,14 @@
 
 package mps
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper"
+)
 
 const (
 	// PipeDirectory is the MPS control daemon's Unix domain socket directory. It
@@ -34,7 +41,79 @@ const (
 
 	// inContainerDeviceIndex is the device index the memory limit is keyed on.
 	inContainerDeviceIndex = 0
+
+	// ControlBinary is the MPS control utility. Execing it with a control
+	// command checks daemon readiness. It talks to the daemon socket under
+	// CUDA_MPS_PIPE_DIRECTORY.
+	ControlBinary = "/usr/bin/nvidia-cuda-mps-control"
+
+	// ProbeCommand is the control command fed to the control utility. It answers
+	// even before any MPS client exists, and the utility exit code reflects daemon
+	// reachability regardless of the command, so it serves as a liveness check.
+	ProbeCommand = "get_default_active_thread_percentage"
+
+	// ProbeTimeout bounds the probe exec. A wedged daemon accepts the socket
+	// connection but never replies, hanging the control utility. The context
+	// timeout turns that hang into a failure.
+	ProbeTimeout = 3 * time.Second
 )
+
+// ProbeResult captures what one health-probe exec observed.
+type ProbeResult struct {
+	// ExitCode is the control utility exit code. 0 means the daemon is serving. A
+	// positive value is the utility's own nonzero exit, meaning the daemon is not
+	// serving (e.g. 1 "Cannot find MPS control daemon process"). -1 means the
+	// process could not be run or was killed by the context timeout (TimedOut is
+	// true and Err is set).
+	ExitCode int
+	// Stdout is the trimmed combined stdout/stderr of the probe.
+	Stdout string
+	// Latency is the wall-clock time the probe exec took.
+	Latency time.Duration
+	// TimedOut is true when the context deadline fired.
+	TimedOut bool
+	// Err is non-nil when the daemon is not functionally serving.
+	Err error
+}
+
+// ProbeControlDaemon reports whether the MPS control daemon is serving: it feeds
+// command to the control utility on stdin and treats exit code 0 within
+// ProbeTimeout as serving.
+func ProbeControlDaemon(exec execwrapper.Exec, command string) ProbeResult {
+	ctx, cancel := exec.NewExecContextWithTimeout(context.Background(), ProbeTimeout)
+	defer cancel()
+
+	// ControlBinary is a fixed constant path and no arguments are passed. command
+	// is fed on stdin, not as an argument, and exec runs the binary directly (no
+	// shell), so there is no shell-injection surface.
+	// nosemgrep: command-injection-exec-variable
+	cmd := exec.CommandContext(ctx, ControlBinary)
+	cmd.SetIOStreams(strings.NewReader(command+"\n"), nil, nil)
+
+	start := time.Now()
+	out, err := cmd.CombinedOutput()
+
+	result := ProbeResult{
+		Stdout:  strings.TrimSpace(string(out)),
+		Latency: time.Since(start),
+	}
+	if err == nil {
+		return result
+	}
+
+	result.TimedOut = ctx.Err() == context.DeadlineExceeded
+	if exitErr, ok := exec.ConvertToExitError(err); ok {
+		result.ExitCode = exec.GetExitCode(exitErr)
+	} else {
+		result.ExitCode = -1
+	}
+	if result.TimedOut {
+		result.Err = fmt.Errorf("mps control daemon probe timed out after %s (daemon wedged?): %w", ProbeTimeout, err)
+	} else {
+		result.Err = fmt.Errorf("mps control daemon probe failed (exit %d, output %q): %w", result.ExitCode, result.Stdout, err)
+	}
+	return result
+}
 
 // BuildEnv returns the MPS environment variables for a single MPS container.
 func BuildEnv(memoryMiB uint, computePercent *uint) map[string]string {

--- a/ecs-agent/utils/mps/mps_test.go
+++ b/ecs-agent/utils/mps/mps_test.go
@@ -14,8 +14,15 @@
 package mps
 
 import (
+	"context"
+	"errors"
+	"io"
+	"os/exec"
 	"testing"
+	"time"
 
+	mock_execwrapper "github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper/mocks"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -55,4 +62,78 @@ func TestBuildEnvComputePercentBoundaries(t *testing.T) {
 
 	env = BuildEnv(1, uintPtr(100))
 	assert.Equal(t, "100", env[ActiveThreadPercentageEnvVar])
+}
+
+// newProbeMocks wires a MockExec+MockCmd so ProbeControlDaemon can run against a
+// canned CombinedOutput result. It captures the stdin reader passed to
+// SetIOStreams into gotStdin so a test can assert the command is fed on stdin.
+func newProbeMocks(t *testing.T, gotStdin *string) (*mock_execwrapper.MockExec, *mock_execwrapper.MockCmd, *gomock.Controller) {
+	ctrl := gomock.NewController(t)
+	mockExec := mock_execwrapper.NewMockExec(ctrl)
+	mockCmd := mock_execwrapper.NewMockCmd(ctrl)
+	mockExec.EXPECT().NewExecContextWithTimeout(gomock.Any(), ProbeTimeout).
+		DoAndReturn(func(parent context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+			return context.WithTimeout(parent, d)
+		})
+	mockExec.EXPECT().CommandContext(gomock.Any(), ControlBinary).Return(mockCmd)
+	mockCmd.EXPECT().SetIOStreams(gomock.Any(), gomock.Any(), gomock.Any()).
+		Do(func(stdin io.Reader, stdout, stderr io.Writer) {
+			if gotStdin != nil && stdin != nil {
+				b, _ := io.ReadAll(stdin)
+				*gotStdin = string(b)
+			}
+		})
+	return mockExec, mockCmd, ctrl
+}
+
+func TestProbeControlDaemonServing(t *testing.T) {
+	var gotStdin string
+	mockExec, mockCmd, ctrl := newProbeMocks(t, &gotStdin)
+	defer ctrl.Finish()
+	// Control utility exits 0 and prints the default active-thread percentage.
+	mockCmd.EXPECT().CombinedOutput().Return([]byte("100.0\n"), nil)
+
+	res := ProbeControlDaemon(mockExec, ProbeCommand)
+	assert.NoError(t, res.Err, "a serving daemon must produce no error")
+	assert.Equal(t, 0, res.ExitCode)
+	assert.False(t, res.TimedOut)
+	assert.Equal(t, "100.0", res.Stdout)
+	assert.Equal(t, ProbeCommand+"\n", gotStdin, "the probe command must be fed on stdin")
+}
+
+func TestProbeControlDaemonNotServing(t *testing.T) {
+	mockExec, mockCmd, ctrl := newProbeMocks(t, nil)
+	defer ctrl.Finish()
+	// Control utility exits nonzero: daemon not found or connection broken.
+	exitErr := &exec.ExitError{}
+	mockCmd.EXPECT().CombinedOutput().Return([]byte("connection failed"), exitErr)
+	mockExec.EXPECT().ConvertToExitError(exitErr).Return(exitErr, true)
+	mockExec.EXPECT().GetExitCode(exitErr).Return(1)
+
+	res := ProbeControlDaemon(mockExec, ProbeCommand)
+	assert.Error(t, res.Err, "a non-serving daemon must produce an error")
+	assert.Equal(t, 1, res.ExitCode)
+	assert.False(t, res.TimedOut)
+}
+
+func TestProbeControlDaemonWedged(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockExec := mock_execwrapper.NewMockExec(ctrl)
+	mockCmd := mock_execwrapper.NewMockCmd(ctrl)
+	// A zero-duration timeout makes the context deadline fire immediately.
+	mockExec.EXPECT().NewExecContextWithTimeout(gomock.Any(), ProbeTimeout).
+		DoAndReturn(func(parent context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+			return context.WithTimeout(parent, 0)
+		})
+	mockExec.EXPECT().CommandContext(gomock.Any(), ControlBinary).Return(mockCmd)
+	mockCmd.EXPECT().SetIOStreams(gomock.Any(), gomock.Any(), gomock.Any())
+	killErr := errors.New("signal: killed")
+	mockCmd.EXPECT().CombinedOutput().Return([]byte{}, killErr)
+	mockExec.EXPECT().ConvertToExitError(killErr).Return(nil, false)
+
+	res := ProbeControlDaemon(mockExec, ProbeCommand)
+	assert.Error(t, res.Err, "a wedged daemon must produce an error")
+	assert.True(t, res.TimedOut, "a deadline-killed probe must report TimedOut")
+	assert.Equal(t, -1, res.ExitCode, "a non-ExitError failure must report exit code -1")
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds a functional health probe for the NVIDIA MPS control daemon to the shared lib. `ProbeControlDaemon` execs the MPS control utility with a control command and reports whether the daemon is serving, distinguishing three outcomes: serving (exit 0), not serving (positive exit code from the utility), and wedged (the utility hangs and is caught by a timeout).

This is the first PR in a stack that adds an MPS daemon health gate to the agent:
1. This PR: the probe primitive.
2. An MPSDaemonResource TaskResource that wraps the probe in a bounded retry and gates task launch.
3. Wiring that attaches the resource to MPS tasks only.

ProbeControlDaemon is exported but has no caller in this PR by design.
### Implementation details
<!-- How are the changes implemented? -->
- `ProbeControlDaemon(exec, command)` runs `/usr/bin/nvidia-cuda-mps-control` under a 3s context timeout, feeding the control command on stdin, and returns a `ProbeResult{ExitCode, Stdout, Latency, TimedOut, Err}`.
- A wedged daemon accepts the socket connection but never replies, so the utility hangs. The context timeout converts that hang into TimedOut=true, which is the failure mode systemd liveness cannot detect. Exit code, output, and latency are captured so a caller can surface them as a task stop reason.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
- The probe was tested end to end as part of the health-gate integration testing: a healthy daemon passed, a stopped daemon was refused via the exit-1 path, and a SIGSTOP-wedged daemon was refused via the timeout path (probe returned TimedOut=true at ~3s per attempt while systemd still reported the unit active).
New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Add MPS control-daemon health probe
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
