### PR TITLE
Move MPS pipe directory to /run/mps-ecs

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper/exec.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper/exec.go
@@ -70,6 +70,7 @@ type Cmd interface {
 	AppendExtraFiles(...*os.File)
 	Args() []string
 	SetIOStreams(io.Reader, io.Writer, io.Writer)
+	SetEnv([]string)
 	Output() ([]byte, error)
 	CombinedOutput() ([]byte, error)
 }
@@ -131,6 +132,14 @@ func (c *cmdWrapper) SetIOStreams(stdin io.Reader, stdout io.Writer, stderr io.W
 	}
 	if stderr != nil {
 		c.Stderr = stderr
+	}
+}
+
+// SetEnv sets the environment for the command. A nil or empty slice leaves the
+// command inheriting the parent process environment.
+func (c *cmdWrapper) SetEnv(env []string) {
+	if len(env) > 0 {
+		c.Env = env
 	}
 }
 

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper/mocks/execwrapper_mocks.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper/mocks/execwrapper_mocks.go
@@ -141,6 +141,18 @@ func (mr *MockCmdMockRecorder) Run() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockCmd)(nil).Run))
 }
 
+// SetEnv mocks base method.
+func (m *MockCmd) SetEnv(arg0 []string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetEnv", arg0)
+}
+
+// SetEnv indicates an expected call of SetEnv.
+func (mr *MockCmdMockRecorder) SetEnv(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEnv", reflect.TypeOf((*MockCmd)(nil).SetEnv), arg0)
+}
+
 // SetIOStreams mocks base method.
 func (m *MockCmd) SetIOStreams(arg0 io.Reader, arg1, arg2 io.Writer) {
 	m.ctrl.T.Helper()

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/mps/mps.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/mps/mps.go
@@ -16,6 +16,7 @@ package mps
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -25,9 +26,8 @@ import (
 const (
 	// PipeDirectory is the MPS control daemon's Unix domain socket directory. It
 	// must match what the systemd nvidia-mps.service exposes on the host and is
-	// bind mounted into each MPS container so the CUDA runtime can reach the
-	// daemon.
-	PipeDirectory = "/tmp/nvidia-mps"
+	// bind mounted into each MPS container so the CUDA runtime can reach the daemon.
+	PipeDirectory = "/run/mps-ecs"
 
 	// PipeDirectoryEnvVar tells the CUDA runtime where to find the MPS pipes.
 	PipeDirectoryEnvVar = "CUDA_MPS_PIPE_DIRECTORY"
@@ -88,6 +88,10 @@ func ProbeControlDaemon(exec execwrapper.Exec, command string) ProbeResult {
 	// shell), so there is no shell-injection surface.
 	// nosemgrep: command-injection-exec-variable
 	cmd := exec.CommandContext(ctx, ControlBinary)
+	// The control utility locates the daemon through CUDA_MPS_PIPE_DIRECTORY in its
+	// own environment. Without this it looks in CUDA's default directory and reports
+	// the daemon as missing.
+	cmd.SetEnv(append(os.Environ(), PipeDirectoryEnvVar+"="+PipeDirectory))
 	cmd.SetIOStreams(strings.NewReader(command+"\n"), nil, nil)
 
 	start := time.Now()

--- a/ecs-agent/utils/execwrapper/exec.go
+++ b/ecs-agent/utils/execwrapper/exec.go
@@ -70,6 +70,7 @@ type Cmd interface {
 	AppendExtraFiles(...*os.File)
 	Args() []string
 	SetIOStreams(io.Reader, io.Writer, io.Writer)
+	SetEnv([]string)
 	Output() ([]byte, error)
 	CombinedOutput() ([]byte, error)
 }
@@ -131,6 +132,14 @@ func (c *cmdWrapper) SetIOStreams(stdin io.Reader, stdout io.Writer, stderr io.W
 	}
 	if stderr != nil {
 		c.Stderr = stderr
+	}
+}
+
+// SetEnv sets the environment for the command. A nil or empty slice leaves the
+// command inheriting the parent process environment.
+func (c *cmdWrapper) SetEnv(env []string) {
+	if len(env) > 0 {
+		c.Env = env
 	}
 }
 

--- a/ecs-agent/utils/execwrapper/mocks/execwrapper_mocks.go
+++ b/ecs-agent/utils/execwrapper/mocks/execwrapper_mocks.go
@@ -141,6 +141,18 @@ func (mr *MockCmdMockRecorder) Run() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockCmd)(nil).Run))
 }
 
+// SetEnv mocks base method.
+func (m *MockCmd) SetEnv(arg0 []string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetEnv", arg0)
+}
+
+// SetEnv indicates an expected call of SetEnv.
+func (mr *MockCmdMockRecorder) SetEnv(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEnv", reflect.TypeOf((*MockCmd)(nil).SetEnv), arg0)
+}
+
 // SetIOStreams mocks base method.
 func (m *MockCmd) SetIOStreams(arg0 io.Reader, arg1, arg2 io.Writer) {
 	m.ctrl.T.Helper()

--- a/ecs-agent/utils/mps/mps.go
+++ b/ecs-agent/utils/mps/mps.go
@@ -16,6 +16,7 @@ package mps
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -25,9 +26,8 @@ import (
 const (
 	// PipeDirectory is the MPS control daemon's Unix domain socket directory. It
 	// must match what the systemd nvidia-mps.service exposes on the host and is
-	// bind mounted into each MPS container so the CUDA runtime can reach the
-	// daemon.
-	PipeDirectory = "/tmp/nvidia-mps"
+	// bind mounted into each MPS container so the CUDA runtime can reach the daemon.
+	PipeDirectory = "/run/mps-ecs"
 
 	// PipeDirectoryEnvVar tells the CUDA runtime where to find the MPS pipes.
 	PipeDirectoryEnvVar = "CUDA_MPS_PIPE_DIRECTORY"
@@ -88,6 +88,10 @@ func ProbeControlDaemon(exec execwrapper.Exec, command string) ProbeResult {
 	// shell), so there is no shell-injection surface.
 	// nosemgrep: command-injection-exec-variable
 	cmd := exec.CommandContext(ctx, ControlBinary)
+	// The control utility locates the daemon through CUDA_MPS_PIPE_DIRECTORY in its
+	// own environment. Without this it looks in CUDA's default directory and reports
+	// the daemon as missing.
+	cmd.SetEnv(append(os.Environ(), PipeDirectoryEnvVar+"="+PipeDirectory))
 	cmd.SetIOStreams(strings.NewReader(command+"\n"), nil, nil)
 
 	start := time.Now()

--- a/ecs-agent/utils/mps/mps_test.go
+++ b/ecs-agent/utils/mps/mps_test.go
@@ -67,7 +67,7 @@ func TestBuildEnvComputePercentBoundaries(t *testing.T) {
 // newProbeMocks wires a MockExec+MockCmd so ProbeControlDaemon can run against a
 // canned CombinedOutput result. It captures the stdin reader passed to
 // SetIOStreams into gotStdin so a test can assert the command is fed on stdin.
-func newProbeMocks(t *testing.T, gotStdin *string) (*mock_execwrapper.MockExec, *mock_execwrapper.MockCmd, *gomock.Controller) {
+func newProbeMocks(t *testing.T, gotStdin *string, gotEnv *[]string) (*mock_execwrapper.MockExec, *mock_execwrapper.MockCmd, *gomock.Controller) {
 	ctrl := gomock.NewController(t)
 	mockExec := mock_execwrapper.NewMockExec(ctrl)
 	mockCmd := mock_execwrapper.NewMockCmd(ctrl)
@@ -76,6 +76,12 @@ func newProbeMocks(t *testing.T, gotStdin *string) (*mock_execwrapper.MockExec, 
 			return context.WithTimeout(parent, d)
 		})
 	mockExec.EXPECT().CommandContext(gomock.Any(), ControlBinary).Return(mockCmd)
+	mockCmd.EXPECT().SetEnv(gomock.Any()).
+		Do(func(env []string) {
+			if gotEnv != nil {
+				*gotEnv = env
+			}
+		})
 	mockCmd.EXPECT().SetIOStreams(gomock.Any(), gomock.Any(), gomock.Any()).
 		Do(func(stdin io.Reader, stdout, stderr io.Writer) {
 			if gotStdin != nil && stdin != nil {
@@ -88,7 +94,8 @@ func newProbeMocks(t *testing.T, gotStdin *string) (*mock_execwrapper.MockExec, 
 
 func TestProbeControlDaemonServing(t *testing.T) {
 	var gotStdin string
-	mockExec, mockCmd, ctrl := newProbeMocks(t, &gotStdin)
+	var gotEnv []string
+	mockExec, mockCmd, ctrl := newProbeMocks(t, &gotStdin, &gotEnv)
 	defer ctrl.Finish()
 	// Control utility exits 0 and prints the default active-thread percentage.
 	mockCmd.EXPECT().CombinedOutput().Return([]byte("100.0\n"), nil)
@@ -99,10 +106,12 @@ func TestProbeControlDaemonServing(t *testing.T) {
 	assert.False(t, res.TimedOut)
 	assert.Equal(t, "100.0", res.Stdout)
 	assert.Equal(t, ProbeCommand+"\n", gotStdin, "the probe command must be fed on stdin")
+	assert.Contains(t, gotEnv, PipeDirectoryEnvVar+"="+PipeDirectory,
+		"the probe must tell the control utility where the daemon listens")
 }
 
 func TestProbeControlDaemonNotServing(t *testing.T) {
-	mockExec, mockCmd, ctrl := newProbeMocks(t, nil)
+	mockExec, mockCmd, ctrl := newProbeMocks(t, nil, nil)
 	defer ctrl.Finish()
 	// Control utility exits nonzero: daemon not found or connection broken.
 	exitErr := &exec.ExitError{}
@@ -127,6 +136,7 @@ func TestProbeControlDaemonWedged(t *testing.T) {
 			return context.WithTimeout(parent, 0)
 		})
 	mockExec.EXPECT().CommandContext(gomock.Any(), ControlBinary).Return(mockCmd)
+	mockCmd.EXPECT().SetEnv(gomock.Any())
 	mockCmd.EXPECT().SetIOStreams(gomock.Any(), gomock.Any(), gomock.Any())
 	killErr := errors.New("signal: killed")
 	mockCmd.EXPECT().CombinedOutput().Return([]byte{}, killErr)

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -138,7 +138,7 @@ const (
 
 	// mpsPipeDirectory is the MPS control daemon's socket directory. The ECS agent
 	// checks for it and reaches the daemon through it for the MPS health check.
-	mpsPipeDirectory = "/tmp/nvidia-mps"
+	mpsPipeDirectory = "/run/mps-ecs"
 
 	// Docker Network options to filter for the default bridge network interface of docker
 	dockerDefaultBridgeInterfaceOption = "com.docker.network.bridge.default_bridge"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Point the MPS control daemon at `/run/mps-ecs` instead of CUDA's default `/tmp/nvidia-mps`. This is the agent-side change to aws/amazon-ecs-ami#771, which moved the host systemd unit.

The default path is not inert. The CUDA driver probes `/tmp/nvidia-mps` during initialization whether or not an application asked for MPS, and the NVIDIA container runtime bind mounts that directory into every GPU container when it exists. A daemon listening there therefore captures GPU workloads that never requested GPU sharing.
### Implementation details
<!-- How are the changes implemented? -->
* `ecs-agent/utils/mps`: `PipeDirectory` moves to `/run/mps-ecs`. This one constant drives the env var injected into MPS containers, the bind mount, and the health probe's search path.
* `ProbeControlDaemon` now sets `CUDA_MPS_PIPE_DIRECTORY` on the command it runs. `nvidia-cuda-mps-control` has no flag for the pipe directory and reads only its own environment, so without this the probe searches CUDA's default and reports the daemon as missing.
* `ecs-agent/utils/execwrapper`: adds `SetEnv([]string)` to the `Cmd` interface, since the wrapper previously had no way to set a subprocess environment. Mocks regenerated. 
* `ecs-init/docker`: keeps its own copy of the path for the mount it gives the agent container, updated to match.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Built a new test agent against these changes and ran it with a test ami built against aws/amazon-ecs-ami#771 and tested E2E 

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bugfix - Move MPS pipe directory to /run/mps-ecs

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
