### PR TITLE
Add support for the DualStack ECR endpoint (Docker 29.x)

### DIFF
--- a/agent/dockerclient/dockerauth/ecr.go
+++ b/agent/dockerclient/dockerauth/ecr.go
@@ -101,7 +101,7 @@ func (authProvider *ecrAuthProvider) GetAuthconfig(image string,
 	}
 
 	// Try to get the auth config from cache
-	auth := authProvider.getAuthConfigFromCache(key)
+	auth := authProvider.getAuthConfigFromCache(key, image)
 	if auth != nil {
 		return *auth, nil
 	}
@@ -111,7 +111,7 @@ func (authProvider *ecrAuthProvider) GetAuthconfig(image string,
 }
 
 // getAuthconfigFromCache retrieves the token from cache
-func (authProvider *ecrAuthProvider) getAuthConfigFromCache(key cacheKey) *registry.AuthConfig {
+func (authProvider *ecrAuthProvider) getAuthConfigFromCache(key cacheKey, image string) *registry.AuthConfig {
 	token, ok := authProvider.tokenCache.Get(key.String())
 	if !ok {
 		return nil
@@ -124,7 +124,7 @@ func (authProvider *ecrAuthProvider) getAuthConfigFromCache(key cacheKey) *regis
 	}
 
 	if authProvider.IsTokenValid(cachedToken) {
-		auth, err := extractToken(cachedToken)
+		auth, err := extractToken(cachedToken, image)
 		if err != nil {
 			log.Errorf("Extract docker auth from cache failed, err: %v", err)
 			// Remove invalid token from cache
@@ -166,23 +166,61 @@ func (authProvider *ecrAuthProvider) getAuthConfigFromECR(image string, key cach
 	if ecrAuthData.AuthorizationToken != nil {
 		// Cache the new token
 		authProvider.tokenCache.Set(key.String(), ecrAuthData)
-		return extractToken(ecrAuthData)
+		return extractToken(ecrAuthData, image)
 	}
 
 	return registry.AuthConfig{}, fmt.Errorf("ecr auth: AuthorizationData is nil for %s", image)
 }
 
-func extractToken(authData *types.AuthorizationData) (registry.AuthConfig, error) {
+func extractToken(authData *types.AuthorizationData, image string) (registry.AuthConfig, error) {
 	decodedToken, err := base64.StdEncoding.DecodeString(aws.ToString(authData.AuthorizationToken))
 	if err != nil {
 		return registry.AuthConfig{}, err
 	}
 	parts := strings.SplitN(string(decodedToken), ":", 2)
+
+	// Default the ServerAddress to the ProxyEndpoint returned by ECR's
+	// GetAuthorizationToken (the regular endpoint, e.g.
+	// <account>.dkr.ecr.<region>.amazonaws.com).
+	//
+	// However, the image may reference a different-but-equivalent ECR endpoint,
+	// most notably the DualStack endpoint (<account>.dkr-ecr.<region>.on.aws).
+	// The containerd image store (default in Docker 29.x) matches registry
+	// credentials by exact host and does not normalize these ECR endpoints as
+	// the legacy graph-driver code did. If the credential's ServerAddress host
+	// does not exactly match the image's registry host, the pull fails with
+	// "no basic auth credentials".
+	//
+	// To support both the regular and DualStack ECR endpoints, set the
+	// ServerAddress to the image's actual registry host when it can be
+	// determined from the image reference.
+	serverAddress := aws.ToString(authData.ProxyEndpoint)
+	if registryHost := extractRegistryHost(image); registryHost != "" {
+		serverAddress = proxyEndpointScheme + registryHost
+	}
+
 	return registry.AuthConfig{
 		Username:      parts[0],
 		Password:      parts[1],
-		ServerAddress: aws.ToString(authData.ProxyEndpoint),
+		ServerAddress: serverAddress,
 	}, nil
+}
+
+// extractRegistryHost returns the registry host portion of an image reference.
+// e.g. "123456789012.dkr-ecr.us-west-2.on.aws/repo:tag" -> "123456789012.dkr-ecr.us-west-2.on.aws"
+// Returns an empty string if a host cannot be determined.
+func extractRegistryHost(image string) string {
+	if image == "" {
+		return ""
+	}
+	host := strings.SplitN(image, "/", 2)[0]
+	// A registry host must contain a "." or ":" (or be "localhost") to be a
+	// valid registry reference; otherwise the first path segment is a repo
+	// name on the default registry, not a host.
+	if strings.ContainsAny(host, ".:") {
+		return host
+	}
+	return ""
 }
 
 // IsTokenValid checks the token is still within it's expiration window. We early expire to allow

--- a/agent/dockerclient/dockerauth/ecr_test.go
+++ b/agent/dockerclient/dockerauth/ecr_test.go
@@ -553,3 +553,104 @@ func TestExtractECRTokenError(t *testing.T) {
 	assert.Equal(t, username, authconfig.Username)
 	assert.Equal(t, password, authconfig.Password)
 }
+
+// TestGetAuthConfigDualStackEndpoint verifies that when the image references the
+// ECR DualStack endpoint (dkr-ecr.<region>.on.aws), the returned AuthConfig's
+// ServerAddress matches the DualStack host rather than ECR's regular ProxyEndpoint.
+// This is required for the containerd image store (Docker 29.x default), which
+// matches registry credentials by exact host.
+func TestGetAuthConfigDualStackEndpoint(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_ecr.NewMockECRClient(ctrl)
+	factory := mock_ecr.NewMockECRFactory(ctrl)
+	authData := &apicontainer.ECRAuthData{
+		Region:     "us-west-2",
+		RegistryID: "012345678901",
+	}
+	// ECR's GetAuthorizationToken returns the REGULAR endpoint.
+	regularEndpoint := "012345678901.dkr.ecr.us-west-2.amazonaws.com"
+	// But the image uses the DUALSTACK endpoint.
+	dualStackImage := "012345678901.dkr-ecr.us-west-2.on.aws/myrepo:latest"
+	username := "username"
+	password := "password"
+
+	registryAuthData := &apicontainer.RegistryAuthenticationData{
+		ECRAuthData: authData,
+	}
+	provider := ecrAuthProvider{
+		factory:    factory,
+		tokenCache: async.NewLRUCache(tokenCacheSize, tokenCacheTTL),
+	}
+
+	factory.EXPECT().GetClient(authData).Return(client, nil)
+	client.EXPECT().GetAuthorizationToken(authData.RegistryID).Return(&types.AuthorizationData{
+		ProxyEndpoint:      aws.String(proxyEndpointScheme + regularEndpoint),
+		AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString([]byte(username + ":" + password))),
+	}, nil)
+
+	authconfig, err := provider.GetAuthconfig(dualStackImage, registryAuthData)
+	require.NoError(t, err)
+	assert.Equal(t, username, authconfig.Username)
+	assert.Equal(t, password, authconfig.Password)
+	// The fix: ServerAddress must be the DualStack host from the image, not the
+	// regular ProxyEndpoint, so containerd matches the credential to the pull.
+	assert.Equal(t, proxyEndpointScheme+"012345678901.dkr-ecr.us-west-2.on.aws", authconfig.ServerAddress)
+}
+
+// TestGetAuthConfigRegularEndpoint verifies the ServerAddress matches the regular
+// endpoint host when the image uses the regular ECR endpoint.
+func TestGetAuthConfigRegularEndpoint(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_ecr.NewMockECRClient(ctrl)
+	factory := mock_ecr.NewMockECRFactory(ctrl)
+	authData := &apicontainer.ECRAuthData{
+		Region:     "us-west-2",
+		RegistryID: "012345678901",
+	}
+	regularEndpoint := "012345678901.dkr.ecr.us-west-2.amazonaws.com"
+	regularImage := "012345678901.dkr.ecr.us-west-2.amazonaws.com/myrepo:latest"
+	username := "username"
+	password := "password"
+
+	registryAuthData := &apicontainer.RegistryAuthenticationData{
+		ECRAuthData: authData,
+	}
+	provider := ecrAuthProvider{
+		factory:    factory,
+		tokenCache: async.NewLRUCache(tokenCacheSize, tokenCacheTTL),
+	}
+
+	factory.EXPECT().GetClient(authData).Return(client, nil)
+	client.EXPECT().GetAuthorizationToken(authData.RegistryID).Return(&types.AuthorizationData{
+		ProxyEndpoint:      aws.String(proxyEndpointScheme + regularEndpoint),
+		AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString([]byte(username + ":" + password))),
+	}, nil)
+
+	authconfig, err := provider.GetAuthconfig(regularImage, registryAuthData)
+	require.NoError(t, err)
+	assert.Equal(t, username, authconfig.Username)
+	assert.Equal(t, password, authconfig.Password)
+	assert.Equal(t, proxyEndpointScheme+"012345678901.dkr.ecr.us-west-2.amazonaws.com", authconfig.ServerAddress)
+}
+
+// TestExtractRegistryHost verifies the registry host extraction helper.
+func TestExtractRegistryHost(t *testing.T) {
+	cases := []struct {
+		image    string
+		expected string
+	}{
+		{"012345678901.dkr-ecr.us-west-2.on.aws/repo:tag", "012345678901.dkr-ecr.us-west-2.on.aws"},
+		{"012345678901.dkr.ecr.us-west-2.amazonaws.com/repo@sha256:abc", "012345678901.dkr.ecr.us-west-2.amazonaws.com"},
+		{"registry:5000/repo", "registry:5000"},
+		{"busybox", ""},         // no host, default registry repo name
+		{"library/busybox", ""}, // no host, default registry repo path
+		{"", ""},                // empty
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.expected, extractRegistryHost(c.image), "image=%q", c.image)
+	}
+}


### PR DESCRIPTION
### Summary
Add support for pulling images from the ECR DualStack endpoint (`<account>.dkr-ecr.<region>.on.aws`) under the containerd image store, which is the default in Docker 29.x.

### Implementation details
The ECS Agent sets Docker `AuthConfig.ServerAddress` to ECR's `ProxyEndpoint` (the regular endpoint, `<account>.dkr.ecr.<region>.amazonaws.com`). Docker's legacy graph-driver image store normalized ECR endpoints, so this single credential also matched pulls from the DualStack endpoint.

Docker 29.x defaults to the containerd image store, which matches registry credentials by exact host and does not perform this normalization. Under the containerd image store, a pull from the DualStack ECR endpoint therefore has no matching credential and fails with `no basic auth credentials`.

This change sets `AuthConfig.ServerAddress` to the image's actual registry host when it can be determined from the image reference (via `extractRegistryHost`), so credentials match both the regular and DualStack ECR endpoints under containerd's exact-host matching. When a registry host cannot be determined, the behavior is unchanged (falls back to ECR's `ProxyEndpoint`), preserving compatibility with the legacy image store and older Docker versions (e.g. 25.x).

### Testing
* Added unit tests: `TestGetAuthConfigDualStackEndpoint`, `TestGetAuthConfigRegularEndpoint`, `TestExtractRegistryHost`
* `go test -tags unit ./dockerclient/dockerauth/` passes
* Validated on AL2027 with Docker 29.6.2 (containerd image store): a task pulling from the DualStack ECR endpoint now succeeds where it previously failed with `CannotPullContainerError`.

New tests cover the changes: yes

### Description for the changelog
Feature - Add support for pulling images from ECR DualStack endpoints (dkr-ecr.<region>.on.aws) under the containerd image store, the default in Docker 29.x

### Additional Information

**Does this PR include breaking model changes?**
No.

**Does this PR include the addition of new environment variables in the README?**
No.

