### PR TITLE
Add MPS control daemon health gate task resource

### DIFF
--- a/agent/taskresource/mpsdaemon/mpsdaemon.go
+++ b/agent/taskresource/mpsdaemon/mpsdaemon.go
@@ -1,0 +1,485 @@
+//go:build linux
+// +build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mpsdaemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
+	apierrors "github.com/aws/amazon-ecs-agent/ecs-agent/api/errors"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/mps"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/oswrapper"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
+)
+
+// Retry bounds for the health check. The daemon's systemd unit runs with
+// Restart=always and RestartSec=1, so a probe can land in the ~1s window where
+// the daemon is restarting and would answer normally a moment later. Retrying
+// keeps a task from failing for that transient case.
+const (
+	probeMaxAttempts     = 3
+	probeMinRetryDelay   = 2 * time.Second
+	probeMaxRetryDelay   = 4 * time.Second
+	probeRetryJitter     = 0.2
+	probeRetryMultiplier = 2.0
+	defaultGateTimeout   = 10 * time.Second
+)
+
+var (
+	errDaemonNotAvailable  = errors.New("MPS control daemon is not available on this instance")
+	errDaemonNotResponding = errors.New("MPS control daemon is not responding on this instance")
+	errGateNotCompleted    = errors.New("MPS control daemon verification did not complete")
+)
+
+// MPSDaemonResource verifies the NVIDIA MPS control daemon is functionally
+// serving before an MPS task's containers are allowed to be created.
+//
+// The gate matters because a client that starts while the daemon is down does
+// not fail: it bypasses MPS and talks straight to the driver, and the injected
+// CUDA_MPS_PINNED_DEVICE_MEM_LIMIT is silently ignored, so the container can
+// consume the whole GPU and starve its co-tenants with nothing logged.
+type MPSDaemonResource struct {
+	ctx     context.Context
+	taskARN string
+	// probeCommand is the control command sent to the control utility. Defaults
+	// to mps.ProbeCommand.
+	probeCommand string
+	exec         execwrapper.Exec
+	osWrapper    oswrapper.OS
+	newBackoff   func() retry.Backoff
+	gateTimeout  time.Duration
+
+	createdAt           time.Time
+	desiredStatusUnsafe resourcestatus.ResourceStatus
+	knownStatusUnsafe   resourcestatus.ResourceStatus
+	appliedStatus       resourcestatus.ResourceStatus
+	statusToTransitions map[resourcestatus.ResourceStatus]func() error
+	terminalReason      string
+	terminalReasonOnce  sync.Once
+	lock                sync.RWMutex
+}
+
+// NewMPSDaemonResource returns a new health-gate resource for a task. An empty
+// probeCommand selects mps.ProbeCommand.
+func NewMPSDaemonResource(ctx context.Context, taskARN string, exec execwrapper.Exec,
+	probeCommand string) *MPSDaemonResource {
+	r := &MPSDaemonResource{
+		ctx:          ctx,
+		taskARN:      taskARN,
+		exec:         exec,
+		probeCommand: probeCommand,
+	}
+	r.applyDefaults()
+	r.initStatusToTransitionFunction()
+	return r
+}
+
+// applyDefaults fills in the dependencies and settings that are not carried
+// across a marshal/unmarshal round trip. Callers must hold the write lock.
+func (r *MPSDaemonResource) applyDefaults() {
+	if r.ctx == nil {
+		r.ctx = context.Background()
+	}
+	if r.probeCommand == "" {
+		r.probeCommand = mps.ProbeCommand
+	}
+	if r.exec == nil {
+		r.exec = execwrapper.NewExec()
+	}
+	if r.osWrapper == nil {
+		r.osWrapper = oswrapper.NewOS()
+	}
+	if r.gateTimeout == 0 {
+		r.gateTimeout = defaultGateTimeout
+	}
+	if r.newBackoff == nil {
+		r.newBackoff = func() retry.Backoff {
+			return retry.NewExponentialBackoff(probeMinRetryDelay, probeMaxRetryDelay,
+				probeRetryJitter, probeRetryMultiplier)
+		}
+	}
+}
+
+func (r *MPSDaemonResource) initStatusToTransitionFunction() {
+	r.statusToTransitions = map[resourcestatus.ResourceStatus]func() error{
+		resourcestatus.ResourceStatus(MPSDaemonCreated): r.Create,
+	}
+}
+
+// probeDeps is a snapshot of the injected dependencies, taken under the lock so
+// a concurrent Initialize cannot be observed mid-write.
+type probeDeps struct {
+	exec         execwrapper.Exec
+	osWrapper    oswrapper.OS
+	probeCommand string
+	newBackoff   func() retry.Backoff
+	gateTimeout  time.Duration
+	parent       context.Context
+}
+
+func (r *MPSDaemonResource) snapshotDeps() probeDeps {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return probeDeps{
+		exec:         r.exec,
+		osWrapper:    r.osWrapper,
+		probeCommand: r.probeCommand,
+		newBackoff:   r.newBackoff,
+		gateTimeout:  r.gateTimeout,
+		parent:       r.ctx,
+	}
+}
+
+// Create runs the health check with a bounded retry, returning nil as soon as an
+// attempt finds the daemon serving. Any other outcome stops the task with a
+// static reason; the evidence goes to the log.
+func (r *MPSDaemonResource) Create() error {
+	// Initialize normally supplies these, but fill any gaps rather than panicking
+	// if Create is reached first.
+	r.lock.Lock()
+	r.applyDefaults()
+	r.lock.Unlock()
+
+	deps := r.snapshotDeps()
+	ctx, cancel := context.WithTimeout(deps.parent, deps.gateTimeout)
+	defer cancel()
+
+	attempt := 0
+	err := retry.RetryNWithBackoffCtx(ctx, deps.newBackoff(), probeMaxAttempts,
+		func() error {
+			attempt++
+			return r.checkOnce(attempt, deps)
+		})
+
+	// RetryNWithBackoffCtx reports nil when the context is already done, having
+	// never run the check. Nothing was verified, so fail closed: a gate that
+	// passes without probing would let the injected memory cap be ignored, which
+	// is the failure this resource exists to prevent.
+	if attempt == 0 {
+		return r.blockTask(errGateNotCompleted, "context was already done, no probe ran")
+	}
+	if err != nil {
+		// The parent going down means the agent is stopping or the task was
+		// stopped. That is not the daemon's fault, so do not report it as such.
+		if deps.parent.Err() != nil {
+			return r.blockTask(errGateNotCompleted, "abandoned while retrying")
+		}
+		return r.blockTask(err, fmt.Sprintf("no success in %d attempts", attempt))
+	}
+	return nil
+}
+
+// blockTask records the customer-facing reason and logs why.
+func (r *MPSDaemonResource) blockTask(cause error, detail string) error {
+	r.setTerminalReason(cause.Error())
+	logger.Error("MPS daemon health gate: blocking task", logger.Fields{
+		field.TaskARN: r.taskARN,
+		"detail":      detail,
+		field.Error:   cause,
+	})
+	return cause
+}
+
+// checkOnce runs one attempt: pipe-directory usability, then the probe. It does
+// not set the terminal reason; Create does that once the retry is spent, so an
+// attempt that later succeeds leaves no reason behind.
+func (r *MPSDaemonResource) checkOnce(attempt int, deps probeDeps) error {
+	// An unusable pipe directory means the agent cannot reach the daemon at all.
+	// Usually that is the daemon never having started, but it also covers the agent
+	// having started without the bind mount: ecs-init only mounts the directory if
+	// it already exists, so an agent that came up before the daemon stays blind
+	// until it is restarted. Stopping the daemon does not produce this state, since
+	// it leaves the directory behind and removes only its sockets. Retrying cannot
+	// help in either case, so this is non-retriable.
+	fi, statErr := deps.osWrapper.Stat(mps.PipeDirectory)
+	if statErr != nil || !fi.IsDir() {
+		logger.Warn("MPS daemon health gate: pipe directory unusable", logger.Fields{
+			field.TaskARN: r.taskARN,
+			"attempt":     attempt,
+			"path":        mps.PipeDirectory,
+			field.Error:   statErr,
+		})
+		return apierrors.NewRetriableError(apierrors.NewRetriable(false), errDaemonNotAvailable)
+	}
+
+	res := mps.ProbeControlDaemon(deps.exec, deps.probeCommand)
+	logger.Info("MPS daemon health gate: probe complete", logger.Fields{
+		field.TaskARN: r.taskARN,
+		"attempt":     attempt,
+		"command":     deps.probeCommand,
+		"exitCode":    res.ExitCode,
+		"stdout":      res.Stdout,
+		"latencyMs":   res.Latency.Milliseconds(),
+		"timedOut":    res.TimedOut,
+	})
+	if res.Err != nil {
+		logger.Warn("MPS daemon health gate: attempt failed", logger.Fields{
+			field.TaskARN: r.taskARN,
+			"attempt":     attempt,
+			"timedOut":    res.TimedOut,
+			field.Error:   res.Err,
+		})
+		return errDaemonNotResponding
+	}
+	return nil
+}
+
+// Cleanup is a no-op: the health gate owns no host state.
+func (r *MPSDaemonResource) Cleanup() error {
+	return nil
+}
+
+func (r *MPSDaemonResource) setTerminalReason(reason string) {
+	r.terminalReasonOnce.Do(func() {
+		r.lock.Lock()
+		defer r.lock.Unlock()
+		r.terminalReason = reason
+	})
+}
+
+// GetTerminalReason returns why the resource failed to provision.
+func (r *MPSDaemonResource) GetTerminalReason() string {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.terminalReason
+}
+
+// GetName returns the unique name of the resource.
+func (r *MPSDaemonResource) GetName() string { return ResourceName }
+
+// SetDesiredStatus sets the desired status of the resource.
+func (r *MPSDaemonResource) SetDesiredStatus(status resourcestatus.ResourceStatus) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.desiredStatusUnsafe = status
+}
+
+// GetDesiredStatus gets the desired status of the resource.
+func (r *MPSDaemonResource) GetDesiredStatus() resourcestatus.ResourceStatus {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.desiredStatusUnsafe
+}
+
+// SetKnownStatus sets the known status of the resource.
+func (r *MPSDaemonResource) SetKnownStatus(status resourcestatus.ResourceStatus) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.knownStatusUnsafe = status
+	r.updateAppliedStatusUnsafe(status)
+}
+
+func (r *MPSDaemonResource) updateAppliedStatusUnsafe(knownStatus resourcestatus.ResourceStatus) {
+	if r.appliedStatus == resourcestatus.ResourceStatus(MPSDaemonStatusNone) {
+		return
+	}
+	if r.appliedStatus <= knownStatus {
+		r.appliedStatus = resourcestatus.ResourceStatus(MPSDaemonStatusNone)
+	}
+}
+
+// GetKnownStatus gets the known status of the resource.
+func (r *MPSDaemonResource) GetKnownStatus() resourcestatus.ResourceStatus {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.knownStatusUnsafe
+}
+
+// SetCreatedAt sets the timestamp for the resource's creation time.
+func (r *MPSDaemonResource) SetCreatedAt(createdAt time.Time) {
+	if createdAt.IsZero() {
+		return
+	}
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.createdAt = createdAt
+}
+
+// GetCreatedAt gets the timestamp for the resource's creation time.
+func (r *MPSDaemonResource) GetCreatedAt() time.Time {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.createdAt
+}
+
+// DesiredTerminal returns true if the resource's desired state is terminal.
+func (r *MPSDaemonResource) DesiredTerminal() bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.desiredStatusUnsafe == resourcestatus.ResourceStatus(MPSDaemonRemoved)
+}
+
+// KnownCreated returns true when the daemon has been verified.
+func (r *MPSDaemonResource) KnownCreated() bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.knownStatusUnsafe == resourcestatus.ResourceStatus(MPSDaemonCreated)
+}
+
+// TerminalStatus returns the last transition state of the resource.
+func (r *MPSDaemonResource) TerminalStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatus(MPSDaemonRemoved)
+}
+
+// NextKnownState returns the resource's next state.
+func (r *MPSDaemonResource) NextKnownState() resourcestatus.ResourceStatus {
+	return r.GetKnownStatus() + 1
+}
+
+// ApplyTransition calls the function required to move to the specified status.
+func (r *MPSDaemonResource) ApplyTransition(nextState resourcestatus.ResourceStatus) error {
+	transitionFunc, ok := r.statusToTransitions[nextState]
+	if !ok {
+		return fmt.Errorf("resource [%s]: transition to %s impossible", r.GetName(),
+			r.StatusString(nextState))
+	}
+	return transitionFunc()
+}
+
+// SteadyState returns the transition state of the resource defined as "ready".
+func (r *MPSDaemonResource) SteadyState() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatus(MPSDaemonCreated)
+}
+
+// SetAppliedStatus sets the applied status of the resource and returns whether
+// the resource is already in a transition.
+func (r *MPSDaemonResource) SetAppliedStatus(status resourcestatus.ResourceStatus) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if r.appliedStatus != resourcestatus.ResourceStatus(MPSDaemonStatusNone) {
+		return false
+	}
+	r.appliedStatus = status
+	return true
+}
+
+// GetAppliedStatus gets the applied status of the resource.
+func (r *MPSDaemonResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.appliedStatus
+}
+
+// StatusString returns the string form of a resource status.
+func (r *MPSDaemonResource) StatusString(status resourcestatus.ResourceStatus) string {
+	return MPSDaemonStatus(status).String()
+}
+
+// DependOnTaskNetwork reports whether the resource needs task network setup.
+func (r *MPSDaemonResource) DependOnTaskNetwork() bool { return false }
+
+// RequiresExecutionRoleCredentials reports whether the resource needs execution
+// role credentials.
+func (r *MPSDaemonResource) RequiresExecutionRoleCredentials() bool { return false }
+
+func (r *MPSDaemonResource) BuildContainerDependency(containerName string,
+	satisfied apicontainerstatus.ContainerStatus, dependent resourcestatus.ResourceStatus) {
+}
+
+// GetContainerDependencies returns the resource's dependent containers; this
+// gate has none of its own.
+func (r *MPSDaemonResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
+}
+
+// Initialize re-establishes the dependencies that do not survive a marshal
+// round trip. It runs both for a freshly received task and for one restored
+// from disk after an agent restart.
+//
+// The known status is deliberately left as restored rather than reset. A
+// resource that had already reached CREATED belongs to a task whose containers
+// are running, and re-probing there could stop a healthy task because the daemon
+// happened to be restarting at that moment. A task restored before the gate ran
+// comes back as NONE and probes normally.
+func (r *MPSDaemonResource) Initialize(
+	cfg *config.Config,
+	resourceFields *taskresource.ResourceFields,
+	taskKnownStatus status.TaskStatus,
+	taskDesiredStatus status.TaskStatus) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if resourceFields != nil && resourceFields.Ctx != nil {
+		r.ctx = resourceFields.Ctx
+	}
+	r.applyDefaults()
+	r.initStatusToTransitionFunction()
+}
+
+// mpsDaemonResourceJSON is the marshalling shadow struct.
+type mpsDaemonResourceJSON struct {
+	TaskARN string `json:"taskARN"`
+	// probeCommand is deliberately not serialized: it is a package constant that
+	// only tests override, so persisting it would pin a stale value across an
+	// agent upgrade. applyDefaults supplies the current default on restore.
+	CreatedAt     *time.Time       `json:"createdAt,omitempty"`
+	DesiredStatus *MPSDaemonStatus `json:"desiredStatus"`
+	KnownStatus   *MPSDaemonStatus `json:"knownStatus"`
+}
+
+// MarshalJSON serializes the resource.
+func (r *MPSDaemonResource) MarshalJSON() ([]byte, error) {
+	if r == nil {
+		return nil, errors.New("mpsdaemon resource is nil")
+	}
+	desired := MPSDaemonStatus(r.GetDesiredStatus())
+	known := MPSDaemonStatus(r.GetKnownStatus())
+	createdAt := r.GetCreatedAt()
+	r.lock.RLock()
+	taskARN := r.taskARN
+	r.lock.RUnlock()
+	return json.Marshal(mpsDaemonResourceJSON{
+		TaskARN:       taskARN,
+		CreatedAt:     &createdAt,
+		DesiredStatus: &desired,
+		KnownStatus:   &known,
+	})
+}
+
+// UnmarshalJSON deserializes the resource. Dependencies are not part of the
+// serialized form; Initialize re-establishes them.
+func (r *MPSDaemonResource) UnmarshalJSON(b []byte) error {
+	temp := mpsDaemonResourceJSON{}
+	if err := json.Unmarshal(b, &temp); err != nil {
+		return err
+	}
+	r.lock.Lock()
+	r.taskARN = temp.TaskARN
+	r.lock.Unlock()
+	if temp.CreatedAt != nil && !temp.CreatedAt.IsZero() {
+		r.SetCreatedAt(*temp.CreatedAt)
+	}
+	if temp.DesiredStatus != nil {
+		r.SetDesiredStatus(resourcestatus.ResourceStatus(*temp.DesiredStatus))
+	}
+	if temp.KnownStatus != nil {
+		r.SetKnownStatus(resourcestatus.ResourceStatus(*temp.KnownStatus))
+	}
+	return nil
+}

--- a/agent/taskresource/mpsdaemon/mpsdaemon_test.go
+++ b/agent/taskresource/mpsdaemon/mpsdaemon_test.go
@@ -1,0 +1,563 @@
+//go:build linux && unit
+// +build linux,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mpsdaemon
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper"
+	mock_execwrapper "github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper/mocks"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/mps"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/oswrapper"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MPSDaemonResource must satisfy the task resource contract.
+var _ taskresource.TaskResource = (*MPSDaemonResource)(nil)
+
+const testTaskARN = "arn:aws:ecs:us-west-2:123456789012:task/cluster/abc123"
+
+// dirInfo is a stub os.FileInfo that reports itself as a directory.
+type dirInfo struct{ os.FileInfo }
+
+func (dirInfo) IsDir() bool { return true }
+
+// fileInfo is a stub os.FileInfo that reports itself as a regular file.
+type fileInfo struct{ os.FileInfo }
+
+func (fileInfo) IsDir() bool { return false }
+
+// newTestResource builds a resource with a stub filesystem and a retry schedule
+// short enough that exhausting the budget does not slow the test. statErr nil
+// means the pipe directory is present.
+// statOS adapts a stat function to oswrapper.OS. Only Stat is exercised by the
+// gate, so the embedded interface is left nil; any other call would panic, which
+// is the desired signal if the gate ever grows a new dependency on os.
+type statOS struct {
+	oswrapper.OS
+	stat func(string) (os.FileInfo, error)
+}
+
+func (s statOS) Stat(path string) (os.FileInfo, error) { return s.stat(path) }
+
+// dirStat reports the pipe directory as present, or statErr if non-nil.
+func dirStat(statErr error) func(string) (os.FileInfo, error) {
+	return func(string) (os.FileInfo, error) {
+		if statErr != nil {
+			return nil, statErr
+		}
+		return dirInfo{}, nil
+	}
+}
+
+func newTestResource(exec execwrapper.Exec, statErr error) *MPSDaemonResource {
+	return newTestResourceWithStat(exec, dirStat(statErr))
+}
+
+// newTestResourceWithStat lets a test supply its own Stat behaviour for the cases
+// that need to count or vary the call.
+func newTestResourceWithStat(exec execwrapper.Exec, stat func(string) (os.FileInfo, error)) *MPSDaemonResource {
+	r := NewMPSDaemonResource(context.Background(), testTaskARN, exec, mps.ProbeCommand)
+	r.osWrapper = statOS{stat: stat}
+	r.newBackoff = func() retry.Backoff {
+		return retry.NewExponentialBackoff(time.Millisecond, 2*time.Millisecond, 0, 1)
+	}
+	return r
+}
+
+// expectProbe queues the call sequence ProbeControlDaemon makes for one attempt.
+func expectProbe(mockExec *mock_execwrapper.MockExec, mockCmd *mock_execwrapper.MockCmd,
+	out []byte, err error) {
+	mockExec.EXPECT().NewExecContextWithTimeout(gomock.Any(), mps.ProbeTimeout).
+		DoAndReturn(func(parent context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+			return context.WithTimeout(parent, d)
+		})
+	mockExec.EXPECT().CommandContext(gomock.Any(), mps.ControlBinary).Return(mockCmd)
+	// SetEnv carries CUDA_MPS_PIPE_DIRECTORY to the control utility.
+	mockCmd.EXPECT().SetEnv(gomock.Any())
+	mockCmd.EXPECT().SetIOStreams(gomock.Any(), gomock.Any(), gomock.Any())
+	mockCmd.EXPECT().CombinedOutput().Return(out, err)
+	if err != nil {
+		mockExec.EXPECT().ConvertToExitError(err).Return(&exec.ExitError{}, true)
+		mockExec.EXPECT().GetExitCode(gomock.Any()).Return(1)
+	}
+}
+
+func TestCreatePassesWhenDaemonServing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockExec := mock_execwrapper.NewMockExec(ctrl)
+	mockCmd := mock_execwrapper.NewMockCmd(ctrl)
+	expectProbe(mockExec, mockCmd, []byte("100.0\n"), nil)
+
+	r := newTestResource(mockExec, nil)
+
+	assert.NoError(t, r.Create(), "a serving daemon must let the gate pass")
+	assert.Empty(t, r.GetTerminalReason(), "a passing gate must record no terminal reason")
+}
+
+// A missing pipe directory means the daemon never started. The probe must be
+// skipped entirely so the task reason names that case specifically.
+func TestCreateBlocksWhenPipeDirectoryMissing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	// No probe calls are queued, so any exec use fails the test.
+	mockExec := mock_execwrapper.NewMockExec(ctrl)
+
+	statCalls := 0
+	r := newTestResourceWithStat(mockExec, func(string) (os.FileInfo, error) {
+		statCalls++
+		return nil, errors.New("no such file or directory")
+	})
+
+	err := r.Create()
+
+	require.Error(t, err, "a missing pipe directory must block the task")
+	// The error is wrapped non-retriable to stop the retry loop, and
+	// DefaultRetriableError has no Unwrap, so compare the message rather than the
+	// identity. The message is what the customer sees.
+	assert.Equal(t, errDaemonNotAvailable.Error(), err.Error())
+	assert.Equal(t, errDaemonNotAvailable.Error(), r.GetTerminalReason(),
+		"the terminal reason is what surfaces as the task's stopped reason")
+	assert.NotContains(t, r.GetTerminalReason(), mps.PipeDirectory,
+		"host paths must not reach the customer-facing reason")
+	assert.Equal(t, 1, statCalls,
+		"the daemon creates the pipe directory and nothing removes it, so this cannot "+
+			"clear on retry and must fail fast")
+}
+
+func TestCreateBlocksWhenDaemonNotServing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockExec := mock_execwrapper.NewMockExec(ctrl)
+	mockCmd := mock_execwrapper.NewMockCmd(ctrl)
+	probeErr := errors.New("Cannot find MPS control daemon process")
+	for i := 0; i < probeMaxAttempts; i++ {
+		expectProbe(mockExec, mockCmd, []byte(""), probeErr)
+	}
+
+	r := newTestResource(mockExec, nil)
+
+	err := r.Create()
+
+	require.Error(t, err, "a daemon that is not serving must block the task")
+	assert.Equal(t, errDaemonNotResponding, err)
+	assert.Equal(t, errDaemonNotResponding.Error(), r.GetTerminalReason())
+}
+
+// The retry exists for this case: the daemon is mid-restart on the first attempt
+// and answering by the next one. systemd restarts it with RestartSec=1, so a
+// task must not fail for a window that closes on its own.
+func TestCreateRecoversWhenDaemonRestarts(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockExec := mock_execwrapper.NewMockExec(ctrl)
+	mockCmd := mock_execwrapper.NewMockCmd(ctrl)
+	expectProbe(mockExec, mockCmd, []byte(""), errors.New("Cannot find MPS control daemon process"))
+	expectProbe(mockExec, mockCmd, []byte("100.0\n"), nil)
+
+	r := newTestResource(mockExec, nil)
+
+	assert.NoError(t, r.Create(), "the gate must ride over a daemon restart")
+	assert.Empty(t, r.GetTerminalReason(),
+		"an attempt that later succeeds must leave no terminal reason behind")
+}
+
+// A wedged daemon accepts the connection and never replies. The reason must say
+// so, because it is a different operator problem from a daemon that is absent.
+func TestCreateBlocksWhenDaemonWedged(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockExec := mock_execwrapper.NewMockExec(ctrl)
+	mockCmd := mock_execwrapper.NewMockCmd(ctrl)
+	for i := 0; i < probeMaxAttempts; i++ {
+		// An already expired context makes ctx.Err() report DeadlineExceeded.
+		mockExec.EXPECT().NewExecContextWithTimeout(gomock.Any(), mps.ProbeTimeout).
+			DoAndReturn(func(parent context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+				return context.WithTimeout(parent, 0)
+			})
+		mockExec.EXPECT().CommandContext(gomock.Any(), mps.ControlBinary).Return(mockCmd)
+		mockCmd.EXPECT().SetEnv(gomock.Any())
+		mockCmd.EXPECT().SetIOStreams(gomock.Any(), gomock.Any(), gomock.Any())
+		killErr := errors.New("signal: killed")
+		mockCmd.EXPECT().CombinedOutput().Return([]byte{}, killErr)
+		mockExec.EXPECT().ConvertToExitError(killErr).Return(nil, false)
+	}
+
+	r := newTestResource(mockExec, nil)
+
+	err := r.Create()
+
+	require.Error(t, err, "a wedged daemon must block the task")
+	assert.Equal(t, errDaemonNotResponding, err,
+		"a wedged daemon is reported as not responding; the timeout detail goes to the log")
+}
+
+// An already-cancelled context makes the retry helper return before running the
+// check at all. The gate must NOT pass in that case: verifying nothing and
+// reporting success would let the injected memory cap be silently ignored.
+func TestCreateFailsClosedWhenContextAlreadyCancelled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	// No probe is queued: any exec use would be an unexpected call.
+	mockExec := mock_execwrapper.NewMockExec(ctrl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	statCalls := 0
+	r := newTestResourceWithStat(mockExec, func(string) (os.FileInfo, error) {
+		statCalls++
+		return dirInfo{}, nil
+	})
+	r.ctx = ctx
+
+	err := r.Create()
+
+	require.Error(t, err, "a gate that verified nothing must not report success")
+	assert.Equal(t, errGateNotCompleted, err)
+	assert.Zero(t, statCalls, "the check never ran, which is exactly why this must fail")
+	assert.False(t, r.KnownCreated(), "the resource must not be treated as verified")
+}
+
+// Cancellation part way through must not blame the daemon for a task the caller
+// stopped, because this reason is customer facing.
+func TestCreateDoesNotBlameDaemonWhenCancelledMidRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockExec := mock_execwrapper.NewMockExec(ctrl)
+	mockCmd := mock_execwrapper.NewMockCmd(ctrl)
+	expectProbe(mockExec, mockCmd, []byte(""), errors.New("Cannot find MPS control daemon process"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r := newTestResourceWithStat(mockExec, func(string) (os.FileInfo, error) { cancel(); return dirInfo{}, nil })
+	r.ctx = ctx
+
+	err := r.Create()
+
+	require.Error(t, err)
+	assert.Equal(t, errGateNotCompleted, err)
+	assert.NotEqual(t, errDaemonNotResponding.Error(), r.GetTerminalReason(),
+		"a task the caller stopped must not be reported as a daemon failure")
+}
+
+// A probe that already succeeded means the gate did its job, so later
+// cancellation must not turn a verified gate into a failure.
+func TestCreateSucceedsWhenCancelledAfterVerification(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockExec := mock_execwrapper.NewMockExec(ctrl)
+	mockCmd := mock_execwrapper.NewMockCmd(ctrl)
+	expectProbe(mockExec, mockCmd, []byte("100.0\n"), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Cancel inside the attempt, so cancellation is in effect by the time Create
+	// evaluates the result of a probe that succeeded.
+	r := newTestResourceWithStat(mockExec, func(string) (os.FileInfo, error) { cancel(); return dirInfo{}, nil })
+	r.ctx = ctx
+
+	err := r.Create()
+
+	assert.NoError(t, err, "a gate that verified the daemon has done its job")
+	assert.Empty(t, r.GetTerminalReason())
+}
+
+// The gate timeout and the retry budget interact in a way worth pinning. The
+// timeout only decides whether another attempt starts, so when probes burn their
+// full timeout the budget is truncated rather than honoured. These assertions fail
+// if anyone changes the numbers without revisiting the comments that describe it.
+func TestRetryBudgetAgainstGateTimeout(t *testing.T) {
+	require.GreaterOrEqual(t, probeMaxAttempts, 1, "a budget of zero attempts would spin")
+
+	// Sum of the delays between attempts, with jitter at its maximum since jitter is
+	// only ever added.
+	var delays time.Duration
+	base := probeMinRetryDelay
+	for i := 0; i < probeMaxAttempts-1; i++ {
+		delays += time.Duration(float64(base) * (1 + probeRetryJitter))
+		if base*time.Duration(probeRetryMultiplier) < probeMaxRetryDelay {
+			base *= time.Duration(probeRetryMultiplier)
+		} else {
+			base = probeMaxRetryDelay
+		}
+	}
+
+	// The case the schedule is tuned for: an absent daemon fails the probe at once,
+	// so only the delays matter and every attempt runs inside the timeout.
+	assert.Less(t, delays, defaultGateTimeout,
+		"with fast-failing probes every attempt must fit inside the gate timeout")
+	assert.Greater(t, delays, time.Second,
+		"the budget must outlast a 1s daemon restart, which is the reason the retry exists")
+
+	// The wedged case: every probe burns mps.ProbeTimeout and the budget no longer
+	// fits, so the timeout truncates it. This is documented behaviour, not an
+	// aspiration, and the assertion is deliberately the way round it is.
+	worst := delays + time.Duration(probeMaxAttempts)*mps.ProbeTimeout
+	assert.Greater(t, worst, defaultGateTimeout,
+		"a wedged daemon exceeds the gate timeout; the comments on defaultGateTimeout say so")
+
+	// How many attempts actually start before the deadline in that case.
+	var elapsed time.Duration
+	attempts := 0
+	base = probeMinRetryDelay
+	for attempts < probeMaxAttempts && elapsed < defaultGateTimeout {
+		attempts++
+		elapsed += mps.ProbeTimeout
+		if attempts < probeMaxAttempts {
+			elapsed += time.Duration(float64(base) * (1 + probeRetryJitter))
+			if base*time.Duration(probeRetryMultiplier) < probeMaxRetryDelay {
+				base *= time.Duration(probeRetryMultiplier)
+			} else {
+				base = probeMaxRetryDelay
+			}
+		}
+	}
+	assert.Equal(t, 2, attempts,
+		"a wedged daemon gets 2 of the 3 attempts, so \"no success in 2 attempts\" is expected in logs")
+}
+
+// The default backoff must produce delays at or above their base, since jitter is
+// only ever added.
+func TestDefaultBackoff(t *testing.T) {
+	b := NewMPSDaemonResource(context.Background(), testTaskARN, nil, "").newBackoff()
+	first := b.Duration()
+	assert.GreaterOrEqual(t, first, probeMinRetryDelay)
+	assert.LessOrEqual(t, first, time.Duration(float64(probeMinRetryDelay)*(1+probeRetryJitter)))
+}
+
+// The gate timing out is not the parent being cancelled: the daemon really did
+// fail to answer, so the reason must name the daemon rather than an incomplete
+// verification.
+func TestCreateReportsDaemonWhenGateTimesOut(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockExec := mock_execwrapper.NewMockExec(ctrl)
+	mockCmd := mock_execwrapper.NewMockCmd(ctrl)
+	// Only one attempt is queued; the deadline must stop the retry before a second.
+	expectProbe(mockExec, mockCmd, []byte(""), errors.New("Cannot find MPS control daemon process"))
+
+	r := newTestResource(mockExec, nil)
+	r.gateTimeout = 5 * time.Millisecond
+	// A delay longer than the gate timeout, so the deadline expires during it.
+	r.newBackoff = func() retry.Backoff {
+		return retry.NewExponentialBackoff(50*time.Millisecond, 50*time.Millisecond, 0, 1)
+	}
+
+	err := r.Create()
+
+	require.Error(t, err)
+	assert.Equal(t, errDaemonNotResponding, err,
+		"a gate that timed out with a live parent must report the daemon, not an incomplete check")
+	assert.NotEqual(t, errGateNotCompleted.Error(), r.GetTerminalReason())
+}
+
+// Initialize takes the cancellable context from ResourceFields on the restart
+// path, where the constructor's context is not available.
+func TestInitializeAdoptsResourceFieldsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r := &MPSDaemonResource{}
+
+	r.Initialize(nil, &taskresource.ResourceFields{Ctx: ctx}, 0, 0)
+
+	assert.Equal(t, ctx, r.ctx, "Initialize must adopt the ResourceFields context")
+}
+
+func TestStatusTransitions(t *testing.T) {
+	r := NewMPSDaemonResource(context.Background(), testTaskARN, nil, "")
+
+	assert.Equal(t, ResourceName, r.GetName())
+	assert.Equal(t, resourcestatus.ResourceStatus(MPSDaemonCreated), r.SteadyState())
+	assert.Equal(t, resourcestatus.ResourceStatus(MPSDaemonRemoved), r.TerminalStatus())
+	assert.Equal(t, "CREATED", r.StatusString(resourcestatus.ResourceStatus(MPSDaemonCreated)))
+	assert.False(t, r.DependOnTaskNetwork())
+	assert.False(t, r.RequiresExecutionRoleCredentials())
+	assert.Nil(t, r.GetContainerDependencies(resourcestatus.ResourceStatus(MPSDaemonCreated)))
+	assert.NoError(t, r.Cleanup(), "the gate owns no host state, so cleanup cannot fail")
+
+	assert.False(t, r.KnownCreated())
+	r.SetKnownStatus(resourcestatus.ResourceStatus(MPSDaemonCreated))
+	assert.True(t, r.KnownCreated())
+
+	assert.False(t, r.DesiredTerminal())
+	r.SetDesiredStatus(resourcestatus.ResourceStatus(MPSDaemonRemoved))
+	assert.True(t, r.DesiredTerminal())
+
+	// Only the CREATED transition is defined.
+	err := r.ApplyTransition(resourcestatus.ResourceStatus(MPSDaemonRemoved))
+	assert.Error(t, err, "an undefined transition must be rejected")
+	assert.Contains(t, err.Error(), "impossible")
+}
+
+func TestMarshalUnmarshalRoundTrip(t *testing.T) {
+	created := time.Now().UTC().Truncate(time.Second)
+	r := NewMPSDaemonResource(context.Background(), testTaskARN, nil, mps.ProbeCommand)
+	r.SetCreatedAt(created)
+	r.SetKnownStatus(resourcestatus.ResourceStatus(MPSDaemonCreated))
+	r.SetDesiredStatus(resourcestatus.ResourceStatus(MPSDaemonCreated))
+
+	b, err := r.MarshalJSON()
+	require.NoError(t, err)
+
+	restored := &MPSDaemonResource{}
+	require.NoError(t, restored.UnmarshalJSON(b))
+
+	assert.Equal(t, testTaskARN, restored.taskARN)
+	assert.Empty(t, restored.probeCommand,
+		"probeCommand is not serialized; applyDefaults supplies the current default")
+	assert.Equal(t, created, restored.GetCreatedAt())
+	assert.Equal(t, resourcestatus.ResourceStatus(MPSDaemonCreated), restored.GetKnownStatus(),
+		"a verified gate must stay verified across a restart rather than re-probing a running task")
+	assert.Equal(t, resourcestatus.ResourceStatus(MPSDaemonCreated), restored.GetDesiredStatus())
+}
+
+// Dependencies are not serialized, so a resource restored from disk has none
+// until Initialize runs. Without it the resource would be unusable after an
+// agent restart.
+func TestInitializeRestoresDependenciesAfterUnmarshal(t *testing.T) {
+	source := NewMPSDaemonResource(context.Background(), testTaskARN, nil, mps.ProbeCommand)
+	b, err := source.MarshalJSON()
+	require.NoError(t, err)
+
+	restored := &MPSDaemonResource{}
+	require.NoError(t, restored.UnmarshalJSON(b))
+	assert.Nil(t, restored.exec, "unmarshal alone must not produce dependencies")
+	assert.Nil(t, restored.osWrapper)
+	assert.Empty(t, restored.probeCommand)
+
+	restored.Initialize(nil, nil, 0, 0)
+
+	assert.NotNil(t, restored.exec, "Initialize must re-establish the exec dependency")
+	assert.NotNil(t, restored.osWrapper)
+	assert.NotNil(t, restored.newBackoff)
+	assert.Equal(t, mps.ProbeCommand, restored.probeCommand)
+	assert.NotNil(t, restored.statusToTransitions[resourcestatus.ResourceStatus(MPSDaemonCreated)],
+		"Initialize must rebuild the transition table, which is not serialized")
+}
+
+// An empty probe command must fall back to the shared default rather than
+// running the control utility with no command.
+func TestProbeCommandDefaults(t *testing.T) {
+	assert.Equal(t, mps.ProbeCommand, NewMPSDaemonResource(context.Background(), testTaskARN, nil, "").probeCommand)
+	assert.Equal(t, "get_server_list",
+		NewMPSDaemonResource(context.Background(), testTaskARN, nil, "get_server_list").probeCommand)
+}
+
+// Create must not panic on a resource restored from disk that never had
+// Initialize called, even though nothing does that today.
+func TestCreateOnUninitializedResourceDoesNotPanic(t *testing.T) {
+	source := NewMPSDaemonResource(context.Background(), testTaskARN, nil, "")
+	b, err := source.MarshalJSON()
+	require.NoError(t, err)
+	restored := &MPSDaemonResource{}
+	require.NoError(t, restored.UnmarshalJSON(b))
+
+	// Inject stubs before calling Create. Without them applyDefaults would install
+	// the real os.Stat and exec wrapper, and on a host where the pipe directory
+	// exists this test would exec the actual control binary with the production
+	// backoff.
+	restored.osWrapper = statOS{stat: func(string) (os.FileInfo, error) { return nil, errors.New("no such file") }}
+	restored.newBackoff = func() retry.Backoff {
+		return retry.NewExponentialBackoff(time.Millisecond, time.Millisecond, 0, 1)
+	}
+
+	assert.NotPanics(t, func() { _ = restored.Create() })
+}
+
+// A regular file where the pipe directory should be is not a usable daemon socket
+// directory.
+func TestCreateBlocksWhenPipeDirectoryIsAFile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockExec := mock_execwrapper.NewMockExec(ctrl)
+
+	r := newTestResourceWithStat(mockExec, func(string) (os.FileInfo, error) { return fileInfo{}, nil })
+
+	err := r.Create()
+
+	require.Error(t, err, "a non-directory must block the task")
+	assert.Equal(t, errDaemonNotAvailable.Error(), err.Error())
+}
+
+func TestMarshalJSONOnNilReceiver(t *testing.T) {
+	var r *MPSDaemonResource
+	_, err := r.MarshalJSON()
+	assert.Error(t, err, "marshalling a nil resource must error rather than panic")
+}
+
+func TestUnmarshalJSONTolerance(t *testing.T) {
+	for _, tc := range []struct{ name, in string }{
+		{"empty object", `{}`},
+		{"null status", `{"knownStatus":null}`},
+		{"only task arn", `{"taskARN":"arn"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &MPSDaemonResource{}
+			assert.NoError(t, r.UnmarshalJSON([]byte(tc.in)))
+		})
+	}
+
+	r := &MPSDaemonResource{}
+	assert.Error(t, r.UnmarshalJSON([]byte(`{"knownStatus":`)), "malformed JSON must error")
+}
+
+func TestStatusUnmarshalRejectsBadInput(t *testing.T) {
+	var s MPSDaemonStatus
+
+	require.NoError(t, s.UnmarshalJSON([]byte("null")))
+	assert.Equal(t, MPSDaemonStatusNone, s, "null means the zero state")
+
+	assert.Error(t, s.UnmarshalJSON([]byte("42")), "a non-string status must be rejected")
+	assert.Equal(t, MPSDaemonStatusNone, s)
+
+	assert.Error(t, s.UnmarshalJSON([]byte(`"BOGUS"`)), "an unknown status must be rejected")
+	assert.Equal(t, MPSDaemonStatusNone, s)
+
+	// A one-character body must not be indexed out of range.
+	assert.Error(t, s.UnmarshalJSON([]byte(`"`)))
+}
+
+func TestAppliedStatus(t *testing.T) {
+	r := NewMPSDaemonResource(context.Background(), testTaskARN, nil, "")
+	created := resourcestatus.ResourceStatus(MPSDaemonCreated)
+
+	assert.Equal(t, resourcestatus.ResourceStatus(MPSDaemonStatusNone), r.GetAppliedStatus())
+	assert.True(t, r.SetAppliedStatus(created), "a free resource accepts a transition")
+	assert.Equal(t, created, r.GetAppliedStatus())
+	assert.False(t, r.SetAppliedStatus(created), "a resource already transitioning refuses another")
+
+	// Reaching the applied status clears it so the next transition can be applied.
+	r.SetKnownStatus(created)
+	assert.Equal(t, resourcestatus.ResourceStatus(MPSDaemonStatusNone), r.GetAppliedStatus())
+}
+
+func TestNextKnownState(t *testing.T) {
+	r := NewMPSDaemonResource(context.Background(), testTaskARN, nil, "")
+	assert.Equal(t, resourcestatus.ResourceStatus(MPSDaemonCreated), r.NextKnownState())
+	r.SetKnownStatus(resourcestatus.ResourceStatus(MPSDaemonCreated))
+	assert.Equal(t, resourcestatus.ResourceStatus(MPSDaemonRemoved), r.NextKnownState())
+}

--- a/agent/taskresource/mpsdaemon/mpsdaemon_unsupported.go
+++ b/agent/taskresource/mpsdaemon/mpsdaemon_unsupported.go
@@ -1,0 +1,88 @@
+//go:build !linux
+// +build !linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mpsdaemon
+
+import (
+	"errors"
+	"time"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
+)
+
+// MPSDaemonResource is a stub on non-Linux platforms.
+type MPSDaemonResource struct{}
+
+func (r *MPSDaemonResource) SetDesiredStatus(status resourcestatus.ResourceStatus) {}
+func (r *MPSDaemonResource) GetDesiredStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+func (r *MPSDaemonResource) SetKnownStatus(status resourcestatus.ResourceStatus) {}
+func (r *MPSDaemonResource) GetKnownStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+func (r *MPSDaemonResource) SetCreatedAt(t time.Time) {}
+func (r *MPSDaemonResource) GetCreatedAt() time.Time  { return time.Time{} }
+
+// Create fails closed. GPU sharing is rejected for non-Linux platforms before a
+// task reaches an instance, so this is unreachable in practice; it exists so the
+// package compiles and so a wiring mistake cannot silently skip the gate.
+func (r *MPSDaemonResource) Create() error {
+	return errors.New("MPS GPU sharing is not supported on this platform")
+}
+func (r *MPSDaemonResource) Cleanup() error        { return nil }
+func (r *MPSDaemonResource) GetName() string       { return ResourceName }
+func (r *MPSDaemonResource) DesiredTerminal() bool { return false }
+func (r *MPSDaemonResource) KnownCreated() bool    { return false }
+func (r *MPSDaemonResource) TerminalStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+func (r *MPSDaemonResource) NextKnownState() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+func (r *MPSDaemonResource) ApplyTransition(nextState resourcestatus.ResourceStatus) error {
+	return errors.New("mps daemon health gate: unsupported platform")
+}
+func (r *MPSDaemonResource) SteadyState() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+func (r *MPSDaemonResource) SetAppliedStatus(status resourcestatus.ResourceStatus) bool { return false }
+func (r *MPSDaemonResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+func (r *MPSDaemonResource) StatusString(status resourcestatus.ResourceStatus) string { return "NONE" }
+func (r *MPSDaemonResource) GetTerminalReason() string                                { return "" }
+func (r *MPSDaemonResource) DependOnTaskNetwork() bool                                { return false }
+func (r *MPSDaemonResource) RequiresExecutionRoleCredentials() bool                   { return false }
+func (r *MPSDaemonResource) BuildContainerDependency(containerName string,
+	satisfied apicontainerstatus.ContainerStatus, dependent resourcestatus.ResourceStatus) {
+}
+func (r *MPSDaemonResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
+}
+func (r *MPSDaemonResource) Initialize(
+	cfg *config.Config,
+	resourceFields *taskresource.ResourceFields,
+	taskKnownStatus status.TaskStatus,
+	taskDesiredStatus status.TaskStatus) {
+}
+func (r *MPSDaemonResource) MarshalJSON() ([]byte, error) { return []byte("{}"), nil }
+func (r *MPSDaemonResource) UnmarshalJSON(b []byte) error { return nil }

--- a/agent/taskresource/mpsdaemon/mpsdaemonstatus.go
+++ b/agent/taskresource/mpsdaemon/mpsdaemonstatus.go
@@ -1,0 +1,82 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mpsdaemon
+
+import (
+	"errors"
+	"strings"
+
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+)
+
+// ResourceName is the key used in the task resources map. It lives here because
+// this file has no build tag, so both the Linux resource and the stub share it.
+const ResourceName = "mps-daemon-health"
+
+// MPSDaemonStatus defines the resource statuses for the MPS daemon health gate.
+type MPSDaemonStatus resourcestatus.ResourceStatus
+
+const (
+	// MPSDaemonStatusNone is the zero state of the resource.
+	MPSDaemonStatusNone MPSDaemonStatus = iota
+	// MPSDaemonCreated is the state where the MPS control daemon has been verified
+	// as functionally serving. Named CREATED to match every other task resource's
+	// steady state and the TaskResource.KnownCreated method.
+	MPSDaemonCreated
+	// MPSDaemonRemoved is the terminal state.
+	MPSDaemonRemoved
+)
+
+var mpsDaemonStatusMap = map[string]MPSDaemonStatus{
+	"NONE":    MPSDaemonStatusNone,
+	"CREATED": MPSDaemonCreated,
+	"REMOVED": MPSDaemonRemoved,
+}
+
+// String returns a human readable string representation of the status.
+func (s MPSDaemonStatus) String() string {
+	for str, status := range mpsDaemonStatusMap {
+		if status == s {
+			return str
+		}
+	}
+	return "NONE"
+}
+
+// MarshalJSON overrides the logic for JSON-encoding the status.
+func (s *MPSDaemonStatus) MarshalJSON() ([]byte, error) {
+	if s == nil {
+		return nil, nil
+	}
+	return []byte(`"` + s.String() + `"`), nil
+}
+
+// UnmarshalJSON overrides the logic for parsing the JSON-encoded status.
+func (s *MPSDaemonStatus) UnmarshalJSON(b []byte) error {
+	if strings.ToLower(string(b)) == "null" {
+		*s = MPSDaemonStatusNone
+		return nil
+	}
+	if len(b) < 2 || b[0] != '"' || b[len(b)-1] != '"' {
+		*s = MPSDaemonStatusNone
+		return errors.New("mps daemon status unmarshal: status must be a string or null; got " + string(b))
+	}
+	status, ok := mpsDaemonStatusMap[string(b[1:len(b)-1])]
+	if !ok {
+		*s = MPSDaemonStatusNone
+		return errors.New("mps daemon status unmarshal: unrecognized status " + string(b))
+	}
+	*s = status
+	return nil
+}

--- a/agent/taskresource/types/types.go
+++ b/agent/taskresource/types/types.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/envFiles"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/firelens"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/fsxwindowsfileserver"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/mpsdaemon"
 	ssmsecretres "github.com/aws/amazon-ecs-agent/agent/taskresource/ssmsecret"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 )
@@ -48,6 +49,8 @@ const (
 	EnvironmentFilesKey = envFiles.ResourceName
 	// FSxWindowsFileServerKey is the string used in resources map to represent fsxwindowsfileserver resource
 	FSxWindowsFileServerKey = fsxwindowsfileserver.ResourceName
+	// MPSDaemonKey is the string used in resources map to represent the MPS control daemon health gate
+	MPSDaemonKey = mpsdaemon.ResourceName
 )
 
 // ResourcesMap represents the map of resource type to the corresponding resource
@@ -91,6 +94,8 @@ func unmarshalResource(key string, value json.RawMessage, result map[string][]ta
 		return unmarshalEnvironmentFilesKey(key, value, result)
 	case FSxWindowsFileServerKey:
 		return unmarshalFSxWindowsFileServerKey(key, value, result)
+	case MPSDaemonKey:
+		return unmarshalMPSDaemonKey(key, value, result)
 	default:
 		return errors.New("Unsupported resource type")
 	}
@@ -253,6 +258,24 @@ func unmarshalFSxWindowsFileServerKey(key string, value json.RawMessage, result 
 			return err
 		}
 		result[key] = append(result[key], res)
+	}
+	return nil
+}
+
+func unmarshalMPSDaemonKey(key string, value json.RawMessage, result map[string][]taskresource.TaskResource) error {
+	var resources []json.RawMessage
+	err := json.Unmarshal(value, &resources)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range resources {
+		mpsResource := &mpsdaemon.MPSDaemonResource{}
+		err := mpsResource.UnmarshalJSON(r)
+		if err != nil {
+			return err
+		}
+		result[key] = append(result[key], mpsResource)
 	}
 	return nil
 }

--- a/agent/taskresource/types/types_linux_test.go
+++ b/agent/taskresource/types/types_linux_test.go
@@ -17,6 +17,7 @@
 package types
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	cgroupres "github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/firelens"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/mpsdaemon"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 )
 
@@ -65,4 +67,28 @@ func TestMarshalUnmarshalFirelensResource(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, unMarshalledFirelensResources[0].GetDesiredStatus(), resourcestatus.ResourceCreated)
 	assert.Equal(t, unMarshalledFirelensResources[0].GetKnownStatus(), resourcestatus.ResourceStatusNone)
+}
+
+func TestMarshalUnmarshalMPSDaemonResource(t *testing.T) {
+	resources := make(map[string][]taskresource.TaskResource)
+
+	gates := []taskresource.TaskResource{
+		mpsdaemon.NewMPSDaemonResource(context.Background(),
+			"arn:aws:ecs:us-west-2:123456789012:task/cluster/abc123", nil, ""),
+	}
+	gates[0].SetDesiredStatus(resourcestatus.ResourceCreated)
+	gates[0].SetKnownStatus(resourcestatus.ResourceStatusNone)
+
+	resources[MPSDaemonKey] = gates
+	data, err := json.Marshal(resources)
+	require.NoError(t, err)
+
+	var unMarshalledResource ResourcesMap
+	err = json.Unmarshal(data, &unMarshalledResource)
+	assert.NoError(t, err, "unmarshal mps daemon resource from data failed")
+	restored, ok := unMarshalledResource[MPSDaemonKey]
+	assert.True(t, ok, "mps daemon resource not found in the resource map")
+	assert.Equal(t, mpsdaemon.ResourceName, restored[0].GetName())
+	assert.Equal(t, resourcestatus.ResourceCreated, restored[0].GetDesiredStatus())
+	assert.Equal(t, resourcestatus.ResourceStatusNone, restored[0].GetKnownStatus())
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/oswrapper/generate_mocks.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/oswrapper/generate_mocks.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package oswrapper
+
+//go:generate mockgen -destination=mocks/oswrapper_mocks.go -copyright_file=../../../scripts/copyright_file github.com/aws/amazon-ecs-agent/ecs-agent/utils/oswrapper OS,File

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/oswrapper/os.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/oswrapper/os.go
@@ -1,0 +1,81 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package oswrapper
+
+import "os"
+
+// OS wraps methods from the 'os' package for testing
+type OS interface {
+	Create(string) (File, error)
+	OpenFile(string, int, os.FileMode) (File, error)
+	Rename(string, string) error
+	MkdirAll(string, os.FileMode) error
+	RemoveAll(string) error
+	IsNotExist(error) bool
+	Stat(string) (os.FileInfo, error)
+	Setenv(string, string)
+	Unsetenv(string)
+}
+
+// File wraps methods for os.File type
+type File interface {
+	Name() string
+	Close() error
+	Chmod(os.FileMode) error
+	Write([]byte) (int, error)
+	Sync() error
+}
+
+type _os struct {
+}
+
+func NewOS() OS {
+	return &_os{}
+}
+
+func (*_os) Create(name string) (File, error) {
+	return os.Create(name)
+}
+
+func (*_os) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+func (*_os) Rename(name1 string, name2 string) error {
+	return os.Rename(name1, name2)
+}
+
+func (*_os) MkdirAll(name string, perm os.FileMode) error {
+	return os.MkdirAll(name, perm)
+}
+
+func (*_os) RemoveAll(name string) error {
+	return os.RemoveAll(name)
+}
+
+func (*_os) IsNotExist(err error) bool {
+	return os.IsNotExist(err)
+}
+
+func (*_os) Stat(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}
+
+func (*_os) Setenv(env string, val string) {
+	os.Setenv(env, val)
+}
+
+func (*_os) Unsetenv(env string) {
+	os.Unsetenv(env)
+}

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -94,6 +94,7 @@ github.com/aws/amazon-ecs-agent/ecs-agent/utils/net
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/netlinkwrapper/mocks
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/netwrapper
+github.com/aws/amazon-ecs-agent/ecs-agent/utils/oswrapper
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry/mock
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime


### PR DESCRIPTION
### Summary

Adds `MPSDaemonResource`, a task resource that gates NVIDIA MPS tasks on the MPS control daemon being functionally available before their containers are created.

A container that starts while the daemon is down does not fail. It bypasses MPS, talks straight to the driver, and the agent-injected `CUDA_MPS_PINNED_DEVICE_MEM_LIMIT` is silently ignored, so it can consume a whole shared GPU and starve its co-tenants with nothing logged. 

### Implementation details

**The resource.** `MPSDaemonResource` (`agent/taskresource/mpsdaemon`) implements the `TaskResource` interface with a three-state machine, `NONE -> CREATED -> REMOVED`, where `CREATED` is the steady state and the only transition that does work: it is wired to `Create`. `Cleanup` is a no-op because the gate owns no host state, and `TerminalStatus`/`NextKnownState` follow the `cgroup` shape so the task engine drives it like any other resource.

**Where it sits in the lifecycle.** `Create` runs during task provisioning, before container creation. The task-level wiring (separate PR) attaches one resource per MPS task and makes every container depend on it reaching `CREATED` before `ContainerCreated`  so a daemon that is not serving blocks the task rather than letting a container start with a cap that will be ignored. Depending on creation rather than pull lets the image download proceed while the probe runs.

**The check** (`checkOnce`, one attempt) is two stages. First it stats `mps.PipeDirectory` (`/run/mps-ecs`) through an injected `oswrapper.OS`; an unusable directory means the agent cannot reach the daemon at all. Then it execs `nvidia-cuda-mps-control` via the already-merged `mps.ProbeControlDaemon`, whose exit code reflects daemon reachability. Splitting the two lets the stopped reason distinguish "not available" from "not responding", which are different operator problems.

**The retry.** `Create` wraps `checkOnce` in `RetryNWithBackoffCtx` (3 attempts, ~2s then ~4s apart), bounded by a gate-level context timeout. The daemon's unit uses `Restart=always`/`RestartSec=1`, so a probe can land in the ~1s window where it is legitimately restarting; retrying rides over that. This is a **task resource** rather than an inline check in the task-start path precisely because that retry must run in the per-task goroutine.

### Testing

New tests cover the changes: yes.

End-to-end a  GPU instance with the task-level wiring stacked on top. Confirmed the gate blocks MPS tasks with a readable reason, no container ever starts in the blocked case, and whole-GPU and non-GPU tasks are unaffected.

### Description for the changelog

Enhancement - Add MPS control daemon health gate task resource 
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
