### PR TITLE
Grant CloudWatch Logs export permission on the release artifacts bucket

### DIFF
--- a/build-infrastructure/release-pipeline-stack.yml
+++ b/build-infrastructure/release-pipeline-stack.yml
@@ -899,6 +899,36 @@ Resources:
           Status: ENABLED
           StreamName: !Ref CopyCodeBuildProjectName
 
+  ReleaseArtifactsBucketLogExportPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ReleaseArtifactsBucketName
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowCloudWatchLogsExportGetBucketAcl
+            Effect: Allow
+            Principal:
+              Service: !Sub 'logs.${AWS::Region}.amazonaws.com'
+            Action: s3:GetBucketAcl
+            Resource: !Ref ReleaseArtifactsBucketArn
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref 'AWS::AccountId'
+              ArnLike:
+                aws:SourceArn: !GetAtt CodeBuildLogGroup.Arn
+          - Sid: AllowCloudWatchLogsExportPutObject
+            Effect: Allow
+            Principal:
+              Service: !Sub 'logs.${AWS::Region}.amazonaws.com'
+            Action: s3:PutObject
+            Resource: !Sub '${ReleaseArtifactsBucketArn}/*'
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref 'AWS::AccountId'
+              ArnLike:
+                aws:SourceArn: !GetAtt CodeBuildLogGroup.Arn
+
   BuildAndSignCodePipelineServiceRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
### Summary

The `LogsPuller` CodeBuild project (in `build-infrastructure/release-pipeline-stack.yml`) exports build logs to the release artifacts bucket via `aws logs create-export-task`. That call is performed by the **CloudWatch Logs service principal**, not the CodeBuild role, so the destination S3 bucket must grant the logs service `s3:GetBucketAcl` and `s3:PutObject` through a **bucket policy**. The (externally-managed) release artifacts bucket had no such policy, so every export failed:

```
An error occurred (AccessDeniedException) when calling the CreateExportTask operation:
GetBucketAcl call on the given bucket failed. Please check if CloudWatch Logs has been
granted permission to perform this operation.
```

### Implementation details

- **`build-infrastructure/release-pipeline-stack.yml`** — add an `AWS::S3::BucketPolicy` (`ReleaseArtifactsBucketLogExportPolicy`) for the release artifacts bucket granting `logs.${AWS::Region}.amazonaws.com` `s3:GetBucketAcl` (on the bucket) and `s3:PutObject` (on `/*`), scoped with `aws:SourceAccount` and `aws:SourceArn` (the `CodeBuildLogGroup`) for confused-deputy protection. It reuses the existing `ReleaseArtifactsBucketName` / `ReleaseArtifactsBucketArn` parameters and the `CodeBuildLogGroup` resource. The bucket has S3 Object Ownership = **Bucket owner enforced (ACLs disabled)**, so the policy intentionally omits the usual `s3:x-amz-acl: bucket-owner-full-control` condition (which can never match on an ACL-disabled bucket).

### Testing

- `aws cloudformation validate-template` passes on the updated template.

New tests cover the changes: no 
### Description for the changelog

Enhancement - Add the S3 bucket policy required for CloudWatch Logs to export build logs to the release artifacts bucket.

### Additional Information

**Does this PR include breaking model changes?** No.

**Does this PR include the addition of new environment variables in the README?** No.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
