### PR TITLE
Attach the MPS control daemon health gate to MPS tasks

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -37,6 +37,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/credentialspec"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/envFiles"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/firelens"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/mpsdaemon"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/ssmsecret"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	resourcetype "github.com/aws/amazon-ecs-agent/agent/taskresource/types"
@@ -56,6 +57,7 @@ import (
 	ni "github.com/aws/amazon-ecs-agent/ecs-agent/netlib/model/networkinterface"
 	commonutils "github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/arn"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/mps"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
@@ -535,6 +537,8 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 		return apierrors.NewResourceInitError(task.Arn, err)
 	}
 
+	task.initializeMPSDaemonResource(ctx)
+
 	task.initializeContainersV3MetadataEndpoint(utils.NewDynamicUUIDProvider())
 	task.initializeContainersV4MetadataEndpoint(utils.NewDynamicUUIDProvider())
 	task.initializeContainersV1AgentAPIEndpoint(utils.NewDynamicUUIDProvider())
@@ -815,6 +819,33 @@ func (task *Task) addGPUResource(cfg *config.Config) error {
 		}
 	}
 	return nil
+}
+
+// initializeMPSDaemonResource adds the MPS control-daemon health gate when any
+// container uses MPS, and makes each MPS container depend on the gate reaching
+// CREATED so those containers do not start until the daemon is verified serving.
+func (task *Task) initializeMPSDaemonResource(ctx context.Context) {
+	usesMPS := false
+	for _, container := range task.Containers {
+		if container.UsesMPS() {
+			usesMPS = true
+			break
+		}
+	}
+	if !usesMPS {
+		return
+	}
+
+	mpsResource := mpsdaemon.NewMPSDaemonResource(ctx, task.Arn, execwrapper.NewExec(), mps.ProbeCommand)
+	task.AddResource(mpsdaemon.ResourceName, mpsResource)
+
+	for _, container := range task.Containers {
+		if container.UsesMPS() {
+			container.BuildResourceDependency(mpsResource.GetName(),
+				resourcestatus.ResourceStatus(mpsdaemon.MPSDaemonCreated),
+				apicontainerstatus.ContainerCreated)
+		}
+	}
 }
 
 func (task *Task) isGPUEnabled() bool {

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -17,6 +17,7 @@
 package task
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -43,6 +44,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/asmsecret"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/credentialspec"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/envFiles"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/mpsdaemon"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/ssmsecret"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
@@ -3738,6 +3740,71 @@ func TestAddGPUResourceSingleMPSContainer(t *testing.T) {
 	err := task.addGPUResource(cfg)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"gpu1"}, container.GPUIDs)
+}
+
+// TestInitializeMPSDaemonResource verifies that the MPS health gate is added only
+// when a task has an MPS container, and that the gate dependency is attached to each
+// MPS container and to no other container.
+func TestInitializeMPSDaemonResource(t *testing.T) {
+	mpsContainer := func(name string, mem uint) *apicontainer.Container {
+		return &apicontainer.Container{
+			Name:                      name,
+			Image:                     "image:tag",
+			MPSConfig:                 &apicontainer.MPSConfig{Memory: mem},
+			TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
+		}
+	}
+	plainContainer := func(name string) *apicontainer.Container {
+		return &apicontainer.Container{
+			Name:                      name,
+			Image:                     "image:tag",
+			TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
+		}
+	}
+	cases := []struct {
+		name        string
+		containers  []*apicontainer.Container
+		wantGate    bool
+		wantGatedOn []string
+	}{
+		{"multiple mps containers", []*apicontainer.Container{mpsContainer("mpsA", 4096), mpsContainer("mpsB", 2048)}, true, []string{"mpsA", "mpsB"}},
+		{"no mps containers", []*apicontainer.Container{plainContainer("whole")}, false, nil},
+		{"mixed mps and non-mps", []*apicontainer.Container{mpsContainer("mps", 4096), plainContainer("plain")}, true, []string{"mps"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := &Task{
+				Arn:                "test",
+				ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+				Containers:         tc.containers,
+			}
+
+			task.initializeMPSDaemonResource(context.Background())
+
+			res := task.ResourcesMapUnsafe[mpsdaemon.ResourceName]
+			if tc.wantGate {
+				require.Len(t, res, 1, "the MPS health-gate resource must be added once")
+				assert.Equal(t, mpsdaemon.ResourceName, res[0].GetName())
+			} else {
+				assert.Empty(t, res, "no gate resource without an MPS container")
+			}
+
+			gated := make(map[string]bool, len(tc.wantGatedOn))
+			for _, n := range tc.wantGatedOn {
+				gated[n] = true
+			}
+			for _, c := range tc.containers {
+				deps := c.TransitionDependenciesMap[apicontainerstatus.ContainerCreated].ResourceDependencies
+				if gated[c.Name] {
+					require.Len(t, deps, 1, "container %s must depend on the gate", c.Name)
+					assert.Equal(t, mpsdaemon.ResourceName, deps[0].Name)
+					assert.Equal(t, resourcestatus.ResourceStatus(mpsdaemon.MPSDaemonCreated), deps[0].RequiredStatus)
+				} else {
+					assert.Empty(t, deps, "container %s must not depend on the gate", c.Name)
+				}
+			}
+		})
+	}
 }
 
 func TestPopulateGPUEnvironmentVariables(t *testing.T) {

--- a/agent/taskresource/mpsdaemon/mpsdaemon.go
+++ b/agent/taskresource/mpsdaemon/mpsdaemon.go
@@ -157,12 +157,13 @@ func (r *MPSDaemonResource) snapshotDeps() probeDeps {
 	}
 }
 
-// Create runs the health check with a bounded retry, returning nil as soon as an
-// attempt finds the daemon serving. Any other outcome stops the task with a
-// static reason; the evidence goes to the log.
+// Create is the resource's CREATED-transition function and nothing is created. For this
+// health gate, reaching CREATED means an attempt confirmed the MPS daemon is serving.
+// It runs a bounded retry, returning nil as soon as an attempt finds the daemon serving.
+// Any other outcome stops the task with a static reason and logs the evidence.
 func (r *MPSDaemonResource) Create() error {
-	// Initialize normally supplies these, but fill any gaps rather than panicking
-	// if Create is reached first.
+	// Only tests build the resource directly; otherwise the constructor or
+	// Initialize already set these.
 	r.lock.Lock()
 	r.applyDefaults()
 	r.lock.Unlock()
@@ -336,7 +337,7 @@ func (r *MPSDaemonResource) DesiredTerminal() bool {
 	return r.desiredStatusUnsafe == resourcestatus.ResourceStatus(MPSDaemonRemoved)
 }
 
-// KnownCreated returns true when the daemon has been verified.
+// KnownCreated returns true if the daemon resource's known status is CREATED
 func (r *MPSDaemonResource) KnownCreated() bool {
 	r.lock.RLock()
 	defer r.lock.RUnlock()

--- a/agent/taskresource/mpsdaemon/mpsdaemon_unsupported.go
+++ b/agent/taskresource/mpsdaemon/mpsdaemon_unsupported.go
@@ -17,6 +17,7 @@
 package mpsdaemon
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -26,10 +27,18 @@ import (
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/ecs-agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper"
 )
 
 // MPSDaemonResource is a stub on non-Linux platforms.
 type MPSDaemonResource struct{}
+
+// NewMPSDaemonResource is a stub on non-Linux platforms; MPS is never wired there
+// (no container sets MPSConfig), so this only satisfies the cross-platform build.
+func NewMPSDaemonResource(ctx context.Context, taskARN string, exec execwrapper.Exec,
+	probeCommand string) *MPSDaemonResource {
+	return &MPSDaemonResource{}
+}
 
 func (r *MPSDaemonResource) SetDesiredStatus(status resourcestatus.ResourceStatus) {}
 func (r *MPSDaemonResource) GetDesiredStatus() resourcestatus.ResourceStatus {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Wires the MPS control daemon health gate onto MPS tasks. The gate resource landed in #5107, but nothing created it for a task. This PR attaches one MPSDaemonResource per MPS task and makes every MPS container wait for it before it can be created.
### Implementation details
<!-- How are the changes implemented? -->
`initializeMPSDaemonResource` (agent/api/task/task.go) runs in `PostUnmarshalTask`, right after `addGPUResource`. If any container in the task uses MPS, it creates the resource via `NewMPSDaemonResource`, adds it to the task, and makes each MPS container's `ContainerCreated` transition depend on the resource reaching `MPSDaemonCreated`. So a daemon that is not serving blocks the task at container creation instead of letting a container start with a `CUDA_MPS_PINNED_DEVICE_MEM_LIMIT` that would be silently ignored. Tasks with no MPS container get no resource , and non-MPS containers in a mixed task are not gated.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes


- End to end on a gamma GPU instance:
  - daemon healthy: MPS task RUNNING, injected memory cap enforced.
  - daemon down: task STOPPED with reason "MPS control daemon is not responding", no container ever created.
  - daemon restarted within the retry window: task proceeds to RUNNING.
  - daemon down past the window: "no success in 3 attempts", STOPPED.
  - new MPS task after the daemon is healthy again: RUNNING.
  - whole-GPU and non-GPU tasks with the daemon down: unaffected, no gate.
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Attach the MPS control daemon health gate to MPS tasks

### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
