### PR TITLE
Add ACCELERATED_COMPUTE health check for the MPS control daemon

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -725,6 +725,9 @@ func (agent *ecsAgent) newDoctorWithHealthchecks(cluster, containerInstanceARN s
 		runtimeHealthCheck,
 	}
 
+	// register the MPS control daemon health check on MPS-capable instances
+	healthcheckList = agent.appendMpsDaemonHealthcheck(healthcheckList)
+
 	// set up the doctor and return it
 	return doctor.NewDoctor(healthcheckList, cluster, containerInstanceARN)
 }

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -126,22 +126,33 @@ func (agent *ecsAgent) appendNvidiaDriverVersionAttribute(capabilities []types.A
 	return capabilities
 }
 
+// mpsCapabilityInputs gathers the host facts the MPS gate decision is made from,
+// reading them off the NvidiaGPUManager. ok is false when there is no GPU manager, in
+// which case MPS cannot be evaluated on this instance. It is the single source of truth
+// shared by the gpu-sharing-mps capability and the MPS daemon health check.
+func (agent *ecsAgent) mpsCapabilityInputs() (gpu.MpsCapabilityInputs, bool) {
+	if agent.resourceFields == nil || agent.resourceFields.NvidiaGPUManager == nil {
+		return gpu.MpsCapabilityInputs{}, false
+	}
+	mgr := agent.resourceFields.NvidiaGPUManager
+	return gpu.MpsCapabilityInputs{
+		GPUPresent:        len(mgr.GetDevices()) > 0,
+		MpsBinaryPresent:  mgr.GetMpsControlBinaryPresent(),
+		MpsServiceEnabled: mgr.GetMpsServiceEnabled(),
+		IsVGPU:            mgr.GetHasVGPU(),
+		AllGPUsHaveMemory: gpu.AllGPUMemoryReported(mgr.GetGPUIDsUnsafe(), mgr.GetGPUMemoryMiBUnsafe()),
+	}, true
+}
+
 // appendGpuSharingMpsCapability advertises ecs.capability.gpu-sharing-mps when the
 // instance can run MPS: a GPU is present, the MPS control binary and its systemd unit
 // are installed and enabled, the GPU is not a vGPU slice, and every discovered GPU has
 // a usable-memory value. The facts are gathered by ecs-init and read from the NvidiaGPUManager;
 // the decision itself lives in the shared gpu package so the MI agent reaches the same verdict from the same inputs.
 func (agent *ecsAgent) appendGpuSharingMpsCapability(capabilities []types.Attribute) []types.Attribute {
-	if agent.resourceFields == nil || agent.resourceFields.NvidiaGPUManager == nil {
+	inputs, ok := agent.mpsCapabilityInputs()
+	if !ok {
 		return capabilities
-	}
-	mgr := agent.resourceFields.NvidiaGPUManager
-	inputs := gpu.MpsCapabilityInputs{
-		GPUPresent:        len(mgr.GetDevices()) > 0,
-		MpsBinaryPresent:  mgr.GetMpsControlBinaryPresent(),
-		MpsServiceEnabled: mgr.GetMpsServiceEnabled(),
-		IsVGPU:            mgr.GetHasVGPU(),
-		AllGPUsHaveMemory: gpu.AllGPUMemoryReported(mgr.GetGPUIDsUnsafe(), mgr.GetGPUMemoryMiBUnsafe()),
 	}
 	advertise, conditions := gpu.ShouldAdvertiseMpsCapability(inputs)
 	if !advertise {

--- a/agent/app/agent_mps_healthcheck_unix.go
+++ b/agent/app/agent_mps_healthcheck_unix.go
@@ -1,0 +1,39 @@
+//go:build linux
+// +build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package app
+
+import (
+	agentdoctor "github.com/aws/amazon-ecs-agent/agent/doctor"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/doctor"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/gpu"
+)
+
+// appendMpsDaemonHealthcheck registers the MPS control-daemon health check on exactly
+// the instances that advertise ecs.capability.gpu-sharing-mps, reusing the same
+// predicate so the instance health signal and the capability agree on what
+// MPS-capable means. A plain GPU box with no nvidia-mps.service would otherwise fail
+// every probe and report a false ACCELERATED_COMPUTE=IMPAIRED.
+func (agent *ecsAgent) appendMpsDaemonHealthcheck(list []doctor.Healthcheck) []doctor.Healthcheck {
+	inputs, ok := agent.mpsCapabilityInputs()
+	if !ok {
+		return list
+	}
+	if advertise, _ := gpu.ShouldAdvertiseMpsCapability(inputs); !advertise {
+		return list
+	}
+	return append(list, agentdoctor.NewMpsDaemonHealthcheck())
+}

--- a/agent/app/agent_mps_healthcheck_unix_test.go
+++ b/agent/app/agent_mps_healthcheck_unix_test.go
@@ -1,0 +1,83 @@
+//go:build linux && unit
+// +build linux,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/gpu"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAppendMpsDaemonHealthcheck asserts that the MPS control-daemon health check is
+// registered on exactly the instances that would advertise gpu-sharing-mps: it must be
+// appended when ShouldAdvertiseMpsCapability is satisfied and withheld otherwise, so a
+// plain GPU box never reports a false ACCELERATED_COMPUTE=IMPAIRED. It reuses the same
+// NvidiaGPUManager setup as the capability test to keep the two decisions in lockstep.
+func TestAppendMpsDaemonHealthcheck(t *testing.T) {
+	// newMpsManager returns a GPU manager carrying the given MPS facts and one device
+	// (with usable memory) unless gpuPresent is false. haveMemory controls whether that
+	// device reports a memory value, exercising the AllGPUsHaveMemory gate.
+	newMpsManager := func(gpuPresent, binary, service, vgpu, haveMemory bool) *gpu.NvidiaGPUManager {
+		m := &gpu.NvidiaGPUManager{
+			MpsControlBinaryPresent: binary,
+			MpsServiceEnabled:       service,
+			HasVGPU:                 vgpu,
+		}
+		if gpuPresent {
+			m.SetGPUIDs([]string{"gpu-0"})
+			if haveMemory {
+				m.SetGPUMemoryMiB(map[string]uint64{"gpu-0": 22563})
+			}
+			m.SetDevices()
+		}
+		return m
+	}
+
+	cases := []struct {
+		name     string
+		mgr      *gpu.NvidiaGPUManager // nil means no GPU manager on the instance
+		register bool
+	}{
+		{"all conditions met", newMpsManager(true, true, true, false, true), true},
+		{"no gpu manager", nil, false},
+		{"no gpu present", newMpsManager(false, true, true, false, true), false},
+		{"mps binary absent", newMpsManager(true, false, true, false, true), false},
+		{"mps service disabled", newMpsManager(true, true, false, false, true), false},
+		{"is vgpu", newMpsManager(true, true, true, true, true), false},
+		{"gpu present but no memory reported", newMpsManager(true, true, true, false, false), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// NvidiaGPUManager is an interface, so a typed-nil pointer would read as a
+			// non-nil interface; leave the field unset to model "no GPU manager".
+			rf := &taskresource.ResourceFields{}
+			if tc.mgr != nil {
+				rf.NvidiaGPUManager = tc.mgr
+			}
+			agent := &ecsAgent{resourceFields: rf}
+			got := agent.appendMpsDaemonHealthcheck(nil)
+			if tc.register {
+				assert.Len(t, got, 1, "the MPS health check must be registered")
+			} else {
+				assert.Empty(t, got, "the MPS health check must not be registered")
+			}
+		})
+	}
+}

--- a/agent/app/agent_mps_healthcheck_unsupported.go
+++ b/agent/app/agent_mps_healthcheck_unsupported.go
@@ -1,0 +1,27 @@
+//go:build !linux
+// +build !linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package app
+
+import (
+	"github.com/aws/amazon-ecs-agent/ecs-agent/doctor"
+)
+
+// appendMpsDaemonHealthcheck is a no-op off Linux, where the MPS control daemon and its
+// pipe directory do not exist.
+func (agent *ecsAgent) appendMpsDaemonHealthcheck(list []doctor.Healthcheck) []doctor.Healthcheck {
+	return list
+}

--- a/agent/doctor/mps_daemon_healthcheck.go
+++ b/agent/doctor/mps_daemon_healthcheck.go
@@ -1,0 +1,122 @@
+//go:build linux
+// +build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package doctor
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aws/amazon-ecs-agent/agent/doctor/statustracker"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/doctor"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/mps"
+)
+
+// mpsDaemonImpairedThreshold is the number of consecutive probe failures before the
+// instance is reported ACCELERATED_COMPUTE=IMPAIRED
+const mpsDaemonImpairedThreshold = 3
+
+type mpsDaemonHealthcheck struct {
+	*statustracker.HealthCheckStatusTracker
+
+	exec        execwrapper.Exec
+	statPipeDir func(string) (os.FileInfo, error)
+	probeCmd    string
+
+	consecutiveFailures int
+	threshold           int
+}
+
+// NewMpsDaemonHealthcheck is the constructor for the MPS control-daemon health check.
+func NewMpsDaemonHealthcheck() doctor.Healthcheck {
+	return newMpsDaemonHealthcheck(execwrapper.NewExec(), os.Stat)
+}
+
+func newMpsDaemonHealthcheck(exec execwrapper.Exec,
+	statPipeDir func(string) (os.FileInfo, error)) *mpsDaemonHealthcheck {
+	return &mpsDaemonHealthcheck{
+		HealthCheckStatusTracker: statustracker.NewHealthCheckStatusTracker(),
+		exec:                     exec,
+		statPipeDir:              statPipeDir,
+		probeCmd:                 mps.ProbeCommand,
+		threshold:                mpsDaemonImpairedThreshold,
+	}
+}
+
+// RunCheck runs one probe per tick and folds the result into the consecutive-failure
+// counter. It reports Impaired only after threshold failures in a row; any success
+// resets the counter, returning the status to Ok.
+func (m *mpsDaemonHealthcheck) RunCheck() ecstcs.InstanceHealthCheckStatus {
+	res := m.probe()
+	serving := res.Err == nil
+
+	if serving {
+		m.consecutiveFailures = 0
+	} else {
+		m.consecutiveFailures++
+	}
+
+	status := ecstcs.InstanceHealthCheckStatusOk
+	if m.consecutiveFailures >= m.threshold {
+		status = ecstcs.InstanceHealthCheckStatusImpaired
+	}
+
+	switch {
+	case status == ecstcs.InstanceHealthCheckStatusImpaired:
+		logger.Error("MPS control daemon health check impaired", logger.Fields{
+			"consecutiveFailures": m.consecutiveFailures,
+			"timedOut":            res.TimedOut,
+			field.Error:           res.Err,
+		})
+	case !serving:
+		logger.Warn("MPS control daemon probe failed, below impairment threshold", logger.Fields{
+			"consecutiveFailures": m.consecutiveFailures,
+			"timedOut":            res.TimedOut,
+			field.Error:           res.Err,
+		})
+	default:
+		logger.Debug("MPS control daemon is serving")
+	}
+
+	m.SetHealthcheckStatus(status)
+	return m.GetHealthcheckStatus()
+}
+
+// probe runs the pipe-directory pre-check and, if it passes, a single control-daemon
+// probe. The daemon is serving when the returned result has a nil Err. An unusable
+// pipe directory counts as this tick's failure and skips the exec; it can recover on a
+// later tick.
+func (m *mpsDaemonHealthcheck) probe() mps.ProbeResult {
+	fi, err := m.statPipeDir(mps.PipeDirectory)
+	if err != nil {
+		return mps.ProbeResult{Err: err}
+	}
+	if !fi.IsDir() {
+		return mps.ProbeResult{
+			Err: fmt.Errorf("mps pipe directory %s is not a directory", mps.PipeDirectory),
+		}
+	}
+	return mps.ProbeControlDaemon(m.exec, m.probeCmd)
+}
+
+// GetHealthcheckType returns the type of this health check.
+func (m *mpsDaemonHealthcheck) GetHealthcheckType() string {
+	return ecstcs.InstanceHealthCheckTypeAcceleratedCompute
+}

--- a/agent/doctor/mps_daemon_healthcheck_test.go
+++ b/agent/doctor/mps_daemon_healthcheck_test.go
@@ -1,0 +1,228 @@
+//go:build unit && linux
+// +build unit,linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package doctor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
+	mock_execwrapper "github.com/aws/amazon-ecs-agent/ecs-agent/utils/execwrapper/mocks"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/mps"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+// dirInfo is a stub os.FileInfo that reports itself as a directory.
+type dirInfo struct{ os.FileInfo }
+
+func (dirInfo) IsDir() bool { return true }
+
+// dirStat reports the pipe directory as present, or statErr if non-nil.
+func dirStat(statErr error) func(string) (os.FileInfo, error) {
+	return func(string) (os.FileInfo, error) {
+		if statErr != nil {
+			return nil, statErr
+		}
+		return dirInfo{}, nil
+	}
+}
+
+// expectProbe queues the exec call sequence ProbeControlDaemon makes for one probe. A
+// non-nil err makes that probe a failure with exit code 1 (daemon not serving).
+func expectProbe(mockExec *mock_execwrapper.MockExec, mockCmd *mock_execwrapper.MockCmd,
+	out []byte, err error) {
+	mockExec.EXPECT().NewExecContextWithTimeout(gomock.Any(), mps.ProbeTimeout).
+		DoAndReturn(func(parent context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+			return context.WithTimeout(parent, d)
+		})
+	mockExec.EXPECT().CommandContext(gomock.Any(), mps.ControlBinary).Return(mockCmd)
+	mockCmd.EXPECT().SetEnv(gomock.Any())
+	mockCmd.EXPECT().SetIOStreams(gomock.Any(), gomock.Any(), gomock.Any())
+	mockCmd.EXPECT().CombinedOutput().Return(out, err)
+	if err != nil {
+		mockExec.EXPECT().ConvertToExitError(err).Return(&exec.ExitError{}, true)
+		mockExec.EXPECT().GetExitCode(gomock.Any()).Return(1)
+	}
+}
+
+// expectTimeoutProbe queues one probe that hangs past the deadline: the context is
+// already expired, so ctx.Err() reports DeadlineExceeded and the result is TimedOut.
+func expectTimeoutProbe(mockExec *mock_execwrapper.MockExec, mockCmd *mock_execwrapper.MockCmd) {
+	mockExec.EXPECT().NewExecContextWithTimeout(gomock.Any(), mps.ProbeTimeout).
+		DoAndReturn(func(parent context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+			return context.WithTimeout(parent, 0)
+		})
+	mockExec.EXPECT().CommandContext(gomock.Any(), mps.ControlBinary).Return(mockCmd)
+	mockCmd.EXPECT().SetEnv(gomock.Any())
+	mockCmd.EXPECT().SetIOStreams(gomock.Any(), gomock.Any(), gomock.Any())
+	killErr := errors.New("signal: killed")
+	mockCmd.EXPECT().CombinedOutput().Return([]byte{}, killErr)
+	mockExec.EXPECT().ConvertToExitError(killErr).Return(nil, false)
+}
+
+var probeFailErr = errors.New("Cannot find MPS control daemon process")
+
+func TestMpsGetHealthcheckType(t *testing.T) {
+	hc := NewMpsDaemonHealthcheck()
+	assert.Equal(t, ecstcs.InstanceHealthCheckTypeAcceleratedCompute, hc.GetHealthcheckType())
+}
+
+func TestMpsInitialHealth(t *testing.T) {
+	hc := NewMpsDaemonHealthcheck()
+	assert.Equal(t, ecstcs.InstanceHealthCheckStatusInitializing, hc.GetHealthcheckStatus())
+}
+
+// tickKind is the outcome one health-check tick observes when it probes the daemon.
+type tickKind int
+
+const (
+	tickServing     tickKind = iota // daemon responds; the probe succeeds
+	tickFailure                     // probe runs but the daemon is not serving (exit 1)
+	tickTimeout                     // probe hangs past the deadline
+	tickPipeMissing                 // pipe directory absent; the exec is skipped
+)
+
+// tick pairs a probe outcome with the instance status the check must report after it.
+type tick struct {
+	kind tickKind
+	want ecstcs.InstanceHealthCheckStatus
+}
+
+// TestMpsRunCheckSequences drives RunCheck through sequences of probe outcomes and
+// asserts the reported status after every tick. Because a serving tick zeroes the
+// counter, a status-only assertion still proves the reset semantics: a failure that
+// follows a success reports Ok where an unbroken streak of the same length would be
+// Impaired.
+func TestMpsRunCheckSequences(t *testing.T) {
+	const (
+		ok       = ecstcs.InstanceHealthCheckStatusOk
+		impaired = ecstcs.InstanceHealthCheckStatusImpaired
+	)
+	cases := []struct {
+		name  string
+		ticks []tick
+	}{
+		{
+			// Anti-flap: below the threshold a failing probe must not report IMPAIRED,
+			// so a short restart that lands on a tick is absorbed.
+			name:  "below threshold stays ok",
+			ticks: []tick{{tickFailure, ok}, {tickFailure, ok}},
+		},
+		{
+			name:  "third consecutive failure impaired",
+			ticks: []tick{{tickFailure, ok}, {tickFailure, ok}, {tickFailure, impaired}},
+		},
+		{
+			// The fourth tick is Ok only because the success zeroed the counter; an
+			// unbroken streak of four failures would have been Impaired by tick three.
+			name:  "success resets counter",
+			ticks: []tick{{tickFailure, ok}, {tickFailure, ok}, {tickServing, ok}, {tickFailure, ok}},
+		},
+		{
+			// A single success mid-streak keeps the count from ever reaching the
+			// threshold, so the instance never reports Impaired.
+			name: "single success mid streak resets",
+			ticks: []tick{{tickFailure, ok}, {tickFailure, ok}, {tickServing, ok},
+				{tickFailure, ok}, {tickFailure, ok}},
+		},
+		{
+			// A timeout is a failure like any other, and three in a row cross the threshold.
+			name:  "timeout counts as failure",
+			ticks: []tick{{tickTimeout, ok}, {tickTimeout, ok}, {tickTimeout, impaired}},
+		},
+		{
+			// A missing pipe directory skips the exec and counts as one failure. Unlike
+			// the task gate this is not fail-closed, so three such ticks report Impaired
+			// and a later serving probe resets to Ok.
+			name: "pipe directory missing counts as failure then recovers",
+			ticks: []tick{{tickPipeMissing, ok}, {tickPipeMissing, ok},
+				{tickPipeMissing, impaired}, {tickServing, ok}},
+		},
+		{
+			// Recovery: once past the threshold a serving probe returns the instance to Ok.
+			name: "recovery returns to ok",
+			ticks: []tick{{tickFailure, ok}, {tickFailure, ok}, {tickFailure, impaired},
+				{tickServing, ok}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockExec := mock_execwrapper.NewMockExec(ctrl)
+			mockCmd := mock_execwrapper.NewMockCmd(ctrl)
+
+			pipePresent := true
+			statErr := errors.New("no such file or directory")
+			hc := newMpsDaemonHealthcheck(mockExec, func(string) (os.FileInfo, error) {
+				if pipePresent {
+					return dirInfo{}, nil
+				}
+				return nil, statErr
+			})
+
+			for i, tk := range tc.ticks {
+				pipePresent = tk.kind != tickPipeMissing
+				switch tk.kind {
+				case tickServing:
+					expectProbe(mockExec, mockCmd, []byte("100.0\n"), nil)
+				case tickFailure:
+					expectProbe(mockExec, mockCmd, []byte(""), probeFailErr)
+				case tickTimeout:
+					expectTimeoutProbe(mockExec, mockCmd)
+				case tickPipeMissing:
+					// probe short-circuits on the stat error; no exec is expected.
+				}
+				assert.Equalf(t, tk.want, hc.RunCheck(), "tick %d", i)
+			}
+		})
+	}
+}
+
+// The transition back to Ok must be observable to the publisher, which sends only on
+// change: GetStatusChangeTime advances on recovery.
+func TestMpsRecoveryTransitionAdvancesStatusChangeTime(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockExec := mock_execwrapper.NewMockExec(ctrl)
+	mockCmd := mock_execwrapper.NewMockCmd(ctrl)
+	for i := 0; i < mpsDaemonImpairedThreshold; i++ {
+		expectProbe(mockExec, mockCmd, []byte(""), probeFailErr)
+	}
+	expectProbe(mockExec, mockCmd, []byte("100.0\n"), nil)
+
+	hc := newMpsDaemonHealthcheck(mockExec, dirStat(nil))
+
+	hc.RunCheck()
+	hc.RunCheck()
+	assert.Equal(t, ecstcs.InstanceHealthCheckStatusImpaired, hc.RunCheck())
+	impairedAt := hc.GetStatusChangeTime()
+
+	// A distinct clock reading, so the recovery transition timestamp is provably newer.
+	time.Sleep(time.Millisecond)
+
+	assert.Equal(t, ecstcs.InstanceHealthCheckStatusOk, hc.RunCheck())
+	assert.True(t, hc.GetStatusChangeTime().After(impairedAt),
+		"recovery is a status change and must advance GetStatusChangeTime")
+	assert.Equal(t, ecstcs.InstanceHealthCheckStatusImpaired, hc.GetLastHealthcheckStatus())
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add an `ACCELERATED_COMPUTE` doctor health check that reports the instance `IMPAIRED` when the NVIDIA MPS control daemon is persistently unavailable. Today the per-task MPS health gate refuses individual MPS tasks when the daemon is down, but nothing tells the control plane the instance itself is unhealthy, so it keeps routing MPS tasks to a box that rejects them one by one. This check surfaces a persistently broken daemon as an instance-level health signal on DescribeContainerInstances and the "ECS Container Instance Health Change" EventBridge event.

### Implementation details
<!-- How are the changes implemented? -->
- `agent/doctor/mps_daemon_healthcheck.go` - the health check. Runs the MPS control-daemon probe once per doctor tick and carries its own consecutive-failure counter: it reports `IMPAIRED` only after 3 consecutive failures and resets on a single success, so a brief RestartSec=1 systemd bounce does not flap. `GetHealthcheckType()` returns `ACCELERATED_COMPUTE`. Reuses the existing MPS probe (pipe-directory pre-check + one ProbeControlDaemon, 3s timeout); a nonzero exit or a timeout (wedged daemon) both count as a failure.
- `agent/app/agent_mps_healthcheck_unix.go` - registers the check on MPS-capable instances via the shared `gpu.ShouldAdvertiseMpsCapability` predicate.
- `agent/app/agent_mps_healthcheck_unsupported.go` - no-op so non-Linux builds are unaffected.
- `agent/app/agent.go` - wiring in `newDoctorWithHealthchecks`.
- `agent/app/agent_capability_unix.go` - extracted `mpsCapabilityInputs()` so the `gpu-sharing-mps` capability and the health check decide from the same host facts (single source of truth). No behavior change to the capability.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

Live E2E on a EC2 GPU instance:

* `systemctl stop nvidia-mps.service`: failures 1 and 2 stay Ok, failure 3 → IMPAIRED, after restart → OK.


Fault → IMPAIRED was ~75s (3 failures at the ~25s heartbeat tick); recovery is immediate on the first successful probe.
```
DescribeContainerInstances --include CONTAINER_INSTANCE_HEALTH 

"healthStatus": { "overallStatus": "IMPAIRED", "details": [
    { "type": "ACCELERATED_COMPUTE", "status": "IMPAIRED", "lastStatusChange": "..." },
    { "type": "CONTAINER_RUNTIME",   "status": "OK" } ] }

The "ECS Container Instance Health Change" EventBridge event 

(capacityProviderName: null, ec2InstanceId set, full healthChecks[]):
{ "detail-type": "ECS Container Instance Health Change", "source": "aws.ecs",
  "detail": { "capacityProviderName": null, "ec2InstanceId": "i-...",
    "overallStatus": "IMPAIRED",
    "healthChecks": [ { "type": "ACCELERATED_COMPUTE", "status": "IMPAIRED", ... },
                      { "type": "CONTAINER_RUNTIME", "status": "OK", ... } ] } }
```
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Add ACCELERATED_COMPUTE health check for the MPS control daemon
### Additional Information

**Does this PR include breaking model changes? If so, Have you added transformation functions?** No
<!-- If yes, next release should have a upgraded minor version -->  

**Does this PR include the addition of new environment variables in the README?** No
<!-- 
If it is a sensitive variable, add it to this blocklist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L63
If it is not a sensitive variable, add it to the allowlist in ecs-logs-collector here: https://github.com/aws/amazon-ecs-logs-collector/blob/b0958c2aa424c6dc578d5a8def4422c51791a076/ecs-logs-collector.sh#L66
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
