### PR TITLE
Add auto-merge-and-tag workflow to promote the release commit to master

### DIFF
--- a/.github/workflows/auto-merge-and-tag.yml
+++ b/.github/workflows/auto-merge-and-tag.yml
@@ -1,0 +1,130 @@
+name: Auto Merge and Tag
+
+# GitHub workflow to auto merge release PRs to master
+# - Fires when any PR merges into dev.
+# - classify (validation gate, verifies this merge came from a release branch): runs only for a merged v*-stage branch with a valid X.Y.Z semver, and fails if that PR was not opened by the release bot; otherwise promote is skipped.
+# - promote (release step): only for a real release branch; fast-forwards master to the release commit and drafts release v<X.Y.Z>. Publishing that draft is what creates the tag.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  classify:
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'v') &&
+      endsWith(github.event.pull_request.head.ref, '-stage')
+    runs-on: ubuntu-latest
+    outputs:
+      is_release: ${{ steps.check.outputs.is_release }}
+      agent_version: ${{ steps.check.outputs.agent_version }}
+    steps:
+      - name: Classify the merged branch
+        id: check
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          # create-release-pr opens the release PR with its GitHub App token, so the App's bot user is the author.
+          EXPECTED_AUTHOR: amazon-ecs-bot[bot]
+        run: |
+          set -euo pipefail
+          AGENT_VERSION="${HEAD_REF#v}"
+          AGENT_VERSION="${AGENT_VERSION%-stage}"
+          if ! [[ "$AGENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::notice::Branch '${HEAD_REF}' does not name an X.Y.Z release. Nothing to promote."
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$PR_AUTHOR" != "$EXPECTED_AUTHOR" ]]; then
+            echo "::error::Release PR for ${AGENT_VERSION} was authored by ${PR_AUTHOR}, not ${EXPECTED_AUTHOR}. Only a release PR opened by the create-release-pr workflow and authored by amazon-ecs-bot is promoted automatically."
+            exit 1
+          fi
+          echo "Recognized release version ${AGENT_VERSION}"
+          echo "is_release=true" >> "$GITHUB_OUTPUT"
+          echo "agent_version=${AGENT_VERSION}" >> "$GITHUB_OUTPUT"
+
+  promote:
+    needs: classify
+    if: needs.classify.outputs.is_release == 'true'
+    runs-on: ubuntu-latest
+    env:
+      AGENT_VERSION: ${{ needs.classify.outputs.agent_version }}
+      RELEASE_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      # Generate GH App token : must precede actions/checkout, so that we can provide necessary GH App token for checkout and merge to master later
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # We only ever push and create a release; no need for the app's pull-requests permission too.
+          permission-contents: write
+
+      - uses: actions/checkout@v7
+        with:
+          # Full history so `git show RELEASE_SHA:...` below can find that commit's tree.
+          fetch-depth: 0
+          # token: is checkout's own input; it sets the git credential every later `git` command uses (git push below).
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Check that this version has not already been released
+        env:
+          # gh reads GH_TOKEN from the environment; it does not use checkout's git credential.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          # gh release view only finds a Release object; check the tag itself too, since a tag can survive a deleted release.
+          if gh release view "v${AGENT_VERSION}" --repo "${{ github.repository }}" >/dev/null 2>&1 || \
+             gh api "repos/${{ github.repository }}/git/refs/tags/v${AGENT_VERSION}" >/dev/null 2>&1; then
+            echo "::error::Version ${AGENT_VERSION} already has a GitHub release or a v${AGENT_VERSION} tag. If it is an incomplete release or unpublished draft, delete it and re-run this workflow. IMPORTANT: NEVER delete a previously completed release or tag"
+            exit 1
+          fi
+
+      # Runs before the master push so a missing changelog section fails with master untouched.
+      - name: Extract the changelog section for this version
+        run: |
+          set -euo pipefail
+          git show "${RELEASE_SHA}:CHANGELOG.md" > /tmp/full-changelog.md
+          awk -v ver="# ${AGENT_VERSION}" '
+            $0 == ver { found = 1; next }
+            found && /^# / { exit }
+            found { print }
+          ' /tmp/full-changelog.md > /tmp/release-notes.md
+          # Test for real content, not file size: an empty section yields a blank line, which -s counts as non-empty.
+          if [[ -z "$(tr -d '[:space:]' < /tmp/release-notes.md)" ]]; then
+            echo "::error::CHANGELOG.md has no release notes under '# ${AGENT_VERSION}'"
+            exit 1
+          fi
+
+      # Fast-forward only, no --force: a rejection means dev/master diverged and the release commit isn't a master descendant.
+      - name: Fast-forward master to the release commit
+        run: |
+          set -euo pipefail
+          # A squash/rebase merge orphans the release commit from dev, so master would point off dev's history. Only a merge commit keeps it reachable.
+          git fetch origin dev
+          if ! git merge-base --is-ancestor "${RELEASE_SHA}" origin/dev; then
+            echo "::error::${RELEASE_SHA} is not on dev's history, so pushing it would diverge master from dev. The release PR must be merged as a merge commit, not squashed or rebased."
+            exit 1
+          fi
+          echo "Pushing ${RELEASE_SHA} to master..."
+          git push origin "${RELEASE_SHA}:refs/heads/master"
+
+      # Drafts the release the manual runbook would cut by hand. The v<version> tag ref appears only when someone publishes the draft.
+      - name: Draft the release for this version
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          gh release create "v${AGENT_VERSION}" \
+            --repo "${{ github.repository }}" \
+            --target "${RELEASE_SHA}" \
+            --title "Amazon ECS Agent - v${AGENT_VERSION}" \
+            --notes-file /tmp/release-notes.md \
+            --draft
+          echo "Drafted release v${AGENT_VERSION} at ${RELEASE_SHA}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Previously we have added an automation to create release PRs - https://github.com/aws/amazon-ecs-agent/pull/4892

This PR continues the release automation effort to "auto merge" release PRs once we have human approvals. The requirement of a release push is to have dev and master in sync.

This has so far been done by merging the release PR -
1) to dev by merge commit
2) to master by a push

The result of this is that we have same Git SHAs in both branches. However this process has been manual so far.

This PR automates it using GitHub Actions.

### Implementation details
<!-- How are the changes implemented? -->

- Workflow triggers on any PR closed against `dev`, and is split into two jobs.
- `classify` decides whether the merge is a release promotion - the branch must be merged, named `v<X.Y.Z>-stage`, and parse as semver. It outputs `is_release` and the version.
- `classify` also requires the release PR to have been opened by `amazon-ecs-bot[bot]`, so only a PR that `create-release-pr` generated is promoted automatically. This one fails rather than skipping: a manually staged release is a real release, so it should be visible in the run list rather than silently doing nothing. The operator promotes `master` by hand in that case, which is the process today.
- The split into two jobs is what gives a genuine SKIPPED `promote` for every unrelated PR merged into `dev`, instead of a red X on every merge, or a green that looks the same as a real release.
- `promote` does what a human does today, in order: check the version isn't already released, extract that version's `CHANGELOG.md` section, fast-forward `master` to the release commit, then draft the release with that section as the body. Both checks run before the push, so a failed check leaves `master` untouched. Publishing the draft stays manual, and is what creates the `v<X.Y.Z>` tag.
- Everything is pinned to the release commit from the PR event (`head.sha`), so the promotion targets exactly the commit that was reviewed.
- `promote` also verifies the release commit is reachable from `dev` before pushing. Fast-forward-only looks sufficient here but isn't - a squash or rebase merge creates a new SHA and orphans the release commit, and `master` is still an ancestor of that orphan, so the push would succeed and leave `master` on a line `dev` abandoned. Without this check we would only find out at the next release.
- Uses the GitHub App token (existing `APP_ID` / `APP_PRIVATE_KEY` secrets), minted before checkout so the push to `master` carries the App's credentials rather than the default `GITHUB_TOKEN`.

Please note: this needs a paired update to master's branch protection so the App is allowed to push. Until that is applied, `promote` will fail at the push step - no release is drafted and `master` is not moved, so the manual process still works as it does today, and the job can be re-run once the protection update is in place.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Tested on my fork with protected `dev` and `master`, running the real two-workflow chain - `create-release-pr` to open the release PR, then merging it to trigger this one. Fork `dev` was reverted between cases so each ran from the same state.

**Happy path tested** - merged the release PR as a merge commit:
- `master` fast-forwarded to the release commit, and the release was drafted with that version's `CHANGELOG.md` section as its body
- Both branches ended up on the same tree, with `master` on `dev`'s history
- The draft carries no tag until it is published
- Release PR: https://github.com/prateekchaudhry/amazon-ecs-agent/pull/50

**Failure paths tested** - each stopped at its own check, with `master` untouched and nothing drafted:

Squash-merged the release PR
- Failed at the ancestor check - the squash mints a new SHA on `dev` and orphans the release commit

Release branch with no `# X.Y.Z` section in `CHANGELOG.md`
- Failed at the changelog extract, which runs before the push

Version that already had a `v<X.Y.Z>` tag but no release object
- Failed at the already-released check

Release PR opened by an author other than the release bot
- Failed at the author check in `classify`, before `promote` was reached at all

**Skipped as intended:** merging an unrelated PR into `dev`, and closing a release PR without merging it.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.

Format: [Category] Description
Categories: Feature, Enhancement, Bugfix, Housekeeping

Examples:
- Feature - Add support for ECS Exec
- Enhancement - Improve error handling in task cleanup
- Bugfix - Fixed memory leak in stats collector
- Housekeeping - Update go module dependencies

You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Housekeeping: add an action to automate merging release PRs to master.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.



